### PR TITLE
Installation on postgres

### DIFF
--- a/admin/install/createdb.php
+++ b/admin/install/createdb.php
@@ -79,8 +79,10 @@ if (!$database_exists) //Database named in config-defaults.php does not exist
         break;
         case 'mssql_n':
         case 'odbc_mssql':
-		case 'mssqlnative':
+        case 'mssqlnative':
         case 'odbtp': $createDb=$connect->Execute("CREATE DATABASE [$dbname];");
+        break;
+        case 'postgres': $createDb=$connect->Execute("CREATE DATABASE \"$dbname\" ENCODING 'UTF8'");
         break;
         default: $createDb=$connect->Execute("CREATE DATABASE $dbname");
     }


### PR DESCRIPTION
Hi,

I just wanted to install LimeSurvey on my postgres and noticed it didnt work with
a specific db name i wanted. The commit fixes the (quoting) issue and also specifies
utf8 encoding.

Best,
  Stephan

PS: There is also another bug that seems to be based on the SVN->git migration: git
cannot handle empty directories. So the directory upload/templates was missing after
a fresh installation (based on the git repo) and so I got a PHP error on some pages
until I created the dir.
Two solutions for this:
1. add a dummy file into upload/templates
2. recommended, in PHP: check if the dir exists, and if not, create it.
