### PR TITLE
Missing parameter in _getTokenIds?

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1019,7 +1019,7 @@ class tokens extends Survey_Common_Action
         $aSurveyLangs = Survey::model()->findByPk($iSurveyId)->additionalLanguages;
         $sBaseLanguage = Survey::model()->findByPk($iSurveyId)->language;
         array_unshift($aSurveyLangs, $sBaseLanguage);
-        $aTokenIds = $this->_getTokenIds($aTokenIds);
+        $aTokenIds = $this->_getTokenIds($aTokenIds, $iSurveyId);
         $aTokenFields = getTokenFieldsAndNames($iSurveyId, true);
         $iAttributes = 0;
         if (getEmailFormat($iSurveyId) == 'html')
@@ -2022,7 +2022,7 @@ class tokens extends Survey_Common_Action
         $this->_renderWrappedTemplate('token', array('tokenbar', 'tokenform'), $aData);
     }
 
-    private function _getTokenIds($aTokenIds)
+    private function _getTokenIds($aTokenIds, $iSurveyId)
     {
         // CHECK TO SEE IF A TOKEN TABLE EXISTS FOR THIS SURVEY
         $bTokenExists = tableExists('{{tokens_' . $iSurveyId . '}}');


### PR DESCRIPTION
The member function _getTokenIds in application/controllers/admin/tokens.php references a $iSurveyId variable which is not declared or initialised anywhere. The only reference to the function seems to be on line 1022, where such a variable is available. Adjusting the method to take an extra survey Id parameter seems to fix the problem I encountered when working with tokens in v2.0b1
