### PR TITLE
Fix PHP notice that breaks participants display

### DIFF
--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -1047,6 +1047,7 @@ class participantsaction extends Survey_Common_Action
         if (Yii::app()->session['USER_RIGHT_SUPERADMIN'])
         {
             $records = Participants::model()->getParticipants($page, $limit);
+            $aData =  new stdClass;
             $aData->page = $page;
             $aData->records = Participants::model()->count();
             $aData->total = ceil($aData->records / $limit);


### PR DESCRIPTION
Invalid JSON:
Strict Standards: Creating default object from empty value in C:\Users\Aaron Schmitz\Desktop\LimeSurvey\application\controllers\admin\participantsaction.php on line 1051
{ "page":"1","records":"0","total":0 } (Error 200)
Could not process your query.
