### PR TITLE
Fixed issue #6453: The generic image url was used instead of the adminim...

### DIFF
--- a/application/controllers/admin/conditionsaction.php
+++ b/application/controllers/admin/conditionsaction.php
@@ -2051,7 +2051,7 @@ class conditionsaction extends Survey_Common_Action {
     {
         global $max;
         $clang = Yii::app()->lang;
-        $imageurl = Yii::app()->getConfig("imageurl");
+        $imageurl = Yii::app()->getConfig("adminimageurl");
 
         if(!isset($max))
         {


### PR DESCRIPTION
Fixed issue #6453: The generic image url was used instead of the adminimage url. The generic one does not take styles into account, the admin-one does.
