### PR TITLE
Add modules folder to the import path for the default Yii config file.

### DIFF
--- a/application/config/config-sample.php
+++ b/application/config/config-sample.php
@@ -30,6 +30,7 @@ return array(
 		'application.core.*',
 		'application.models.*',
 		'application.controllers.*',
+        'application.modules.*',
 	),
 
 	'components' => array(


### PR DESCRIPTION
This line needs to be in the config file for my question objects to work. Since the default is copied when 2.0 is installed, it makes sense to include this path in the original distribution of 2.0.
