### PR TITLE
Fixed issue: Invalid images paths

### DIFF
--- a/application/controllers/admin/assessments.php
+++ b/application/controllers/admin/assessments.php
@@ -98,7 +98,7 @@ class Assessments extends Survey_Common_Action
         $surveyinfo = getSurveyInfo($iSurveyID);
         $aData['clang'] = $clang;
         $aData['surveyinfo'] = $surveyinfo;
-        $aData['imageurl'] = Yii::app()->getConfig('imageurl');
+        $aData['imageurl'] = Yii::app()->getConfig('adminimageurl');
         $aData['surveyid'] = $iSurveyID;
         $aData['headings'] = $headings;
         $aData['assessments'] = $assessments;


### PR DESCRIPTION
Causing two images url errors in admin assessment page.
