### PR TITLE
Added SURVEYURL inside replacement array list

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -992,6 +992,10 @@
                     $aReplacementVars["FIRSTNAME"]=$oTokenInformation->firstname;
                     $aReplacementVars["LASTNAME"]=$oTokenInformation->lastname;
                     $aReplacementVars["TOKEN"]=$clienttoken;
+                    // added survey url in replacement vars
+                    $surveylink = Yii::app()->createAbsoluteUrl("/survey/index/sid/{$surveyid}",array('lang'=>$_SESSION['survey_'.$surveyid]['s_lang'],'token'=>$clienttoken));
+                    $aReplacementVars['SURVEYURL'] = $surveylink;
+                    
                     $attrfieldnames=getAttributeFieldNames($surveyid);
                     foreach ($attrfieldnames as $attr_name)
                     {


### PR DESCRIPTION
For below given Bug raised, have made change in frontend_helper.php file for adding a SURVEYURL inside replacement array list to be used at the confirmation template. 

http://bugs.limesurvey.org/view.php?id=7663

Currently the {SURVEYURL} parameter is not allowed to be used in the CONFIRMATION email. 
For this specific client, we need the applicant to be able to go back to their Questionnaire to update details later.
As a reminder of their link, we want to send them the SURVEYURL in the CONFIRMATION email.
As example, the email will say something like:
Thank you for completing the XYZ questionnaire. To update your information at a later stage, please click on {SURVEYURL}

This together with the setting "Allow editing responses after completion" = Yes and "Send confirmation emails?" = Yes, allows for above functionality to become useful.
