### PR TITLE
RPC Routine to delete responses of particular token in a survey.

### DIFF
--- a/application/controllers/admin/remotecontrol.php
+++ b/application/controllers/admin/remotecontrol.php
@@ -705,7 +705,7 @@ class remotecontrol_handle
 
 		return $oResponses;
 		
-	}
+   }
 	
     /**
      * RPC routine to get survey summary, regarding token usage and survey participation.
@@ -2369,6 +2369,92 @@ class remotecontrol_handle
         return base64_encode($sFileData);
     }
 
+    /**
+     * RPC Routine to delete responses of particular token in a survey.
+     * Returns array
+     *
+     * @access public
+     * @param string $sSessionKey Auth credentials
+     * @param int $iSurveyID Id of the survey that participants belong
+     * @param string $sToken unique token id of specific participant
+     * @param string $sLanguageCode The language to be used
+     * @return array Result of the change action
+     */
+    public function delete_responses($sSessionKey, $iSurveyID, $sToken, $sLanguageCode=''){
+    	// check sessionKey is valid or not
+       
+        if ($this->_checkSessionKey($sSessionKey))
+    	{
+    		$oSurvey = Survey::model()->findByPk($iSurveyID);
+    		if (!isset($oSurvey))
+    			return array('status' => 'Error: Invalid survey ID');
+    		 
+                if(hasSurveyPermission($iSurveyID,'responses','delete'))
+                {
+                    // get response id from response table using token
+                    
+                    $oResult = Survey_dynamic::model($iSurveyID)->findByAttributes(array('token' => $sToken));
+                    if($oResult){
+                        // get survey info using surveyId
+                        $thissurvey=getSurveyInfo($iSurveyID,$sLanguageCode);
+                            $iResponseID = (int) $oResult['id'];
+                            if($iResponseID){
+                                // delete the files 
+                                $uploaddir = Yii::app()->getConfig('uploaddir') ."/surveys/{$iSurveyID}/files/";
+                                $fieldmap = createFieldMap($iSurveyID, 'full' ,false, false, $sLanguageCode);
+                                $fuqtquestions = array();
+                                // find all fuqt questions
+                                foreach ($fieldmap as $field)
+                                {
+                                    if ($field['type'] == "|" && strpos($field['fieldname'], "_filecount") == 0)
+                                        $fuqtquestions[] = $field['fieldname'];
+                                }
+
+                                if (!empty($fuqtquestions))
+                                {
+                                    // find all responses (filenames) to the fuqt questions
+                                    $filearray = Survey_dynamic::model($iSurveyID)->findAllByAttributes(array('id' => $iResponseID));
+                                    $filecount = 0;
+                                    foreach ($filearray as $metadata)
+                                    {
+                                        foreach ($metadata as $aData)
+                                        {
+                                            $phparray = json_decode_ls($aData);
+                                            if (is_array($phparray))
+                                            {
+                                                foreach ($phparray as $file)
+                                                {
+                                                    @unlink($uploaddir . $file['filename']);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                               
+                                // delete the row
+                                Survey_dynamic::model($iSurveyID)->deleteByPk($iResponseID);
+                                // delete timings if savetimings is set
+                                if(isset( $thissurvey['savetimings'] ) && $thissurvey['savetimings'] == "Y"){
+                                    Survey_timings::model($iSurveyID)->deleteByPk($iResponseID);
+                                }
+                                
+                              return array('iSurveyID'=>$iSurveyID);
+                              
+                            }else{
+                             return array('status' => 'Response Id not found');   
+                            }
+                    }else{
+                        return array('status' => 'No responses for this token');
+                    }
+                }
+                else
+                {
+                    return array('status' => 'No permission');
+                }
+    	}
+    	else
+            return array('status' => 'Invalid Session Key');
+    }
 
     /**
      * Tries to login with username and password


### PR DESCRIPTION
Added delete_responses API routine, will delete responses of the participant, its files, response timings if available

This function will delete Responses for the token passed, 
It will delete all the response related files from the server,
Delete all responses from the table for the Token if available,
Delete Response timings, if available in the table.
