### PR TITLE
New feature: add php-func strtotime() to EM

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -2839,8 +2839,45 @@ hi there!~strtolower(c)
 HI THERE!~strtoupper(c)
 3600~strtotime("27 Mar 1976 8:20")-strtotime("1976/03/27 7:20")
 10~(strtotime("13 Apr 2013")-strtotime("2013-04-03"))/60/60/24
-1000000000~strtotime("9 Sep 2001 01:46:40 UTC")
-1000000060~strtotime("2001/9/9 02:47:40 CET")
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("05 Nov 1985"))
+HOURS PASSED SINCE 1970~round(strtotime("now")/60/60)
+~""
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("11/5/85"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("8/9/10"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("8/9/2010"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("2010/8/9"))
+~""
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("85-11-5"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("10-8-9"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("9-8-2010"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("2010-8-9"))
+~""
+1985-11-05 00:53:20~date("Y-m-d H:i:s",strtotime("85-11-5 0:53:20"))
+2010-08-09 00:53:20~date("Y-m-d H:i:s",strtotime("10-8-9 0:53:20"))
+2010-08-09 11:12:13~date("Y-m-d H:i:s",strtotime("9-8-2010 11:12:13"))
+2010-08-09 11:12:13~date("Y-m-d H:i:s",strtotime("2010-8-9 11:12:13"))
+~""
+Today 11:11:59~date("Y-m-d H:i:s",strtotime("11.11.59"))
+Today 9:08:10~date("Y-m-d H:i:s",strtotime("9.8.10"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("9.8.2010"))
+~""
+1985-11-05 00:53:20~date("Y-m-d H:i:s",strtotime("5.11.85 0:53:20"))
+2010-08-09 11:12:13~date("Y-m-d H:i:s",strtotime("9.8.2010 11:12:13"))
+~""
+1970-01-01 00:00:00~date("Y-m-d H:i:s",strtotime("70-01-01"))
+1999-01-01 00:00:00~date("Y-m-d H:i:s",strtotime("99-01-01"))
+2001-01-01 00:00:00~date("Y-m-d H:i:s",strtotime("01-01-01"))
+1902-01-01 00:00:00~date("Y-m-d H:i:s",strtotime("1902-01-01"))
+~""
+today 2:15:00~date("Y-m-d H:i:s",strtotime("2:15:00"))
+Some dates that are not (correctly) parsed:~"Some dates that are not (correctly) parsed:"
+1969-01-19 00:00:00~date("Y-m-d H:i:s",strtotime("69-01-19"))
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("85/11/5"))
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("5-11-85"))
+2010-08-09 00:00:00~date("Y-m-d H:i:s",strtotime("2010.8.9"))
+1985-11-05 00:00:00~date("Y-m-d H:i:s",strtotime("85.11.5"))
+1985-11-05 00:53:20~date("Y-m-d H:i:s",strtotime("85.11.5 0:53:20"))
+2010-08-09 11:12:13~date("Y-m-d H:i:s",strtotime("9.8.10 11:12:13"))
 678~substr('1234567890',5,3)
 15~sum(1,2,3,4,5)
 15~sum(one,two,three,four,five)

--- a/scripts/expressions/em_javascript.js
+++ b/scripts/expressions/em_javascript.js
@@ -2057,6 +2057,9 @@ function strstr (haystack, needle, bool) {
 }
 
 function strtotime (text, now) {
+    /* 2013-06-12: taken from phpjs.org
+       and adapted for limesurvey */
+
     // Convert string representation of date and time to a timestamp
     //
     // version: 1109.2015
@@ -2087,24 +2090,105 @@ function strtotime (text, now) {
         .replace(/[\t\r\n]/g, '')
         .toLowerCase();
 
-    var parsed;
-
+    // in contrast to php, js Date.parse function interprets: 
+    // dates given as yyyy-mm-dd as in timezone: UTC, 
+    // dates with "." or "-" as MDY instead of DMY
+	// dates with two-digit years differently
+    // etc...etc...
+    // ...therefore we manually parse lots of common date formats
+    var match = text.match(/^(\d{1,4})([\-\.\/\:])(\d{1,2})([\-\.\/\:])(\d{1,4})(?:\s(\d{1,2}):(\d{2})?:?(\d{2})?)?(?:\s([A-Z]+)?)?$/);
+    if (match && match[2]==match[4]) {
+        if (match[1]>1901) {
+            switch (match[2]) {
+                case '-': {  // YYYY-M-D
+                    if (match[3]>12 | match[5]>31) return(0);
+                    return new Date(match[1], parseInt(match[3], 10) - 1, match[5],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+                case '.': {  // YYYY.M.D is not parsed by strtotime()
+                    return(0);
+                    break;
+                }
+                case '/': {  // YYYY/M/D
+                    if (match[3]>12 | match[5]>31) return(0);
+                    return new Date(match[1], parseInt(match[3], 10) - 1, match[5],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+            }
+        }
+        else if (match[5]>1901) {
+            switch (match[2]) {
+                case '-': {  // D-M-YYYY
+                    if (match[3]>12 | match[1]>31) return(0);
+                    return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+                case '.': {  // D.M.YYYY
+                    if (match[3]>12 | match[1]>31) return(0);
+                    return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+                case '/': {  // M/D/YYYY
+                    if (match[1]>12 | match[3]>31) return(0);
+                    return new Date(match[5], parseInt(match[1], 10) - 1, match[3],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+            }
+        }
+        else {
+            switch (match[2]) {
+                case '-': {  // YY-M-D
+                    if (match[3]>12 | match[5]>31 | (match[1] < 70 & match[1]>38)) return(0);
+                    var year = match[1] >= 0 && match[1] <= 38 ? +match[1] + 2000 : match[1];
+                    return new Date(year, parseInt(match[3], 10) - 1, match[5],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+                case '.': {  // D.M.YY or H.MM.SS
+                    if (match[5]>=70) {    // D.M.YY
+                        if (match[3]>12 | match[1]>31) return(0);
+                        return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
+                        match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    }
+                    else if (match[5]<60 & !(match[6])) {  // H.MM.SS
+                        if (match[1]>23 | match[3]>59) return(0);
+                        var today = new Date();
+                        return new Date(today.getFullYear(), today.getMonth(), today.getDate(),
+                        match[1] || 0, match[3] || 0, match[5] || 0, match[9] || 0) / 1000;
+                    }
+                    else  return(0);  // invalid format, cannot be parsed
+                    break;
+                }
+                case '/': {  // M/D/YY
+                    if (match[1]>12 | match[3]>31 | (match[5] < 70 & match[5]>38)) return(0);
+                    var year = match[5] >= 0 && match[5] <= 38 ? +match[5] + 2000 : match[5];
+                    return new Date(year, parseInt(match[1], 10) - 1, match[3],
+                    match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000;
+                    break;
+                }
+                case ':': {  // HH:MM:SS
+                    if (match[1]>23 | match[3]>59 | match[5]>59) return(0);
+                    var today = new Date();
+                    return new Date(today.getFullYear(), today.getMonth(), today.getDate(),
+                    match[1] || 0, match[3] || 0, match[5] || 0) / 1000;
+                    break;
+                }
+            }
+        }
+    }
+    
+    
+    // other formats and "now" should be parsed by Date.parse()
     if (text === 'now')
         return now === null || isNaN(now) ? new Date().getTime() / 1000 | 0 : now | 0;
     else if (!isNaN(parse = Date.parse(text)))
         return parse / 1000 | 0;
-    if (text === 'now')
-        return new Date().getTime() / 1000; // Return seconds, not milli-seconds
-    else if (!isNaN(parsed = Date.parse(text)))
-        return parsed / 1000;
-
-    var match = text.match(/^(\d{2,4})-(\d{2})-(\d{2})(?:\s(\d{1,2}):(\d{2})(?::\d{2})?)?(?:\.(\d+)?)?$/);
-    if (match) {
-        var year = match[1] >= 0 && match[1] <= 69 ? +match[1] + 2000 : match[1];
-        return new Date(year, parseInt(match[2], 10) - 1, match[3],
-            match[4] || 0, match[5] || 0, match[6] || 0, match[7] || 0) / 1000;
-    }
-
+    
     var date = now ? new Date(now * 1000) : new Date();
     var days = {
         'sun': 0,


### PR DESCRIPTION
Update: rewrote and fixed javascript part, added test cases to em_core_helper.php. Should be working fine now!

(Implemented T White's suggestions in this new version.)

facilitates the calculation with dates/times in expression manager. E.g.
calculation of difference in days between two dates entered in previous
questions of the survey

The function makes life much easier. Instead of
{mktime(0,0,0,substr(date1,3,2),substr(date1,0,2),substr(date1,6,4))}
one can just use {strtotime(date)}.

moreover, strtotime can deal with a lot of different date/time formats.
So, things like (strtotime(2013/12/23)-strtotime(1 Apr 1976))/3600/24 to calculate the number of days between two dates is easily done.
