### PR TITLE
Updated feature #7882: Monday first day in calender

### DIFF
--- a/scripts/date.js
+++ b/scripts/date.js
@@ -16,6 +16,7 @@ $(document).ready(function(){
             defaultDate: +0,
             minDate:new Date(range[0],0,1),
             maxDate: new Date(range[1],11,31),
+            firstDay: "1",
             duration: 'fast'
             }, $.datepicker.regional[language]);
     });


### PR DESCRIPTION
DEV: Datepicker showed Sunday as first day of week
DEV: Changed this to Monday (which is pretty much standard)
DEV: (see http://bugs.limesurvey.org/view.php?id=7882)
