### PR TITLE
Fixed issue #7915: Export to R -> Bug with answers containing double quotes

### DIFF
--- a/application/controllers/admin/export.php
+++ b/application/controllers/admin/export.php
@@ -787,6 +787,7 @@ class export extends Survey_Common_Action {
                         $str = "";
                         foreach ( $answers as $answer )
                         {
+                            $answer['value'] = str_replace("\"", "\\\"", $answer['value']); // Escape double quotes
                             $str .= ", \"{$answer['value']}\"";
                         }
 


### PR DESCRIPTION
Escape double quotes in R export.

I hope this time my commit has the right format...
