### PR TITLE
fixed issue #7912: EM test page broken in 2.05

### DIFF
--- a/application/controllers/admin/expressions.php
+++ b/application/controllers/admin/expressions.php
@@ -61,7 +61,7 @@ class Expressions extends Survey_Common_Action {
                 App()->getClientScript()->registerScript("emscript", "ExprMgr_process_relevance_and_tailoring();", CClientScript::POS_LOAD);
                 break;
             case 'unit':
-                App()->getClientScript()->registerScript("emscript", "compute();", CClientScript::POS_LOAD);
+                App()->getClientScript()->registerScript("emscript", "recompute();", CClientScript::POS_LOAD);
                 break;
         }
     }


### PR DESCRIPTION
dev: column with JS result were missing from EM test page
dev: http://localhost/github/limesurvey/index.php/admin/expressions/sa/unit
