### PR TITLE
New feature #7145: validation field for date/time question

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3294,7 +3294,7 @@ function questionAttributes($returnByName=false)
         "caption"=>$clang->gT('Equals sum value'));
 
         $qattributes["em_validation_q"]=array(
-        "types"=>":;ABCEFKMNPQRSTU",
+        "types"=>":;ABCDEFKMNPQRSTU",
         'category'=>$clang->gT('Logic'),
         'sortorder'=>200,
         'inputtype'=>'textarea',
@@ -3302,7 +3302,7 @@ function questionAttributes($returnByName=false)
         "caption"=>$clang->gT('Question validation equation'));
 
         $qattributes["em_validation_q_tip"]=array(
-        "types"=>":;ABCEFKMNPQRSTU",
+        "types"=>":;ABCDEFKMNPQRSTU",
         'category'=>$clang->gT('Logic'),
         'sortorder'=>210,
         'inputtype'=>'textarea',

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -2413,6 +2413,7 @@
                                 case 'S': //SHORT FREE TEXT
                                 case 'T': //LONG FREE TEXT
                                 case 'U': //HUGE FREE TEXT
+                                case 'D': //DATE
                                     if ($this->sgqaNaming)
                                     {
                                         $sq_name = '!(' . preg_replace('/\bthis\b/',substr($sq['jsVarName'],4), $em_validation_q) . ')';
@@ -3301,7 +3302,7 @@
                 }
 
                 if (!is_null($rowdivid) || $type == 'L' || $type == 'N' || $type == '!' || !is_null($preg)
-                || $type == 'S' || $type == 'T' || $type == 'U' || $type == '|') {
+                || $type == 'S' || $type == 'D' || $type == 'T' || $type == 'U' || $type == '|') {
                     if (!isset($q2subqInfo[$questionNum])) {
                         $q2subqInfo[$questionNum] = array(
                         'qid' => $questionNum,
@@ -3338,7 +3339,7 @@
                         }
                     }
                     else if ($type == 'N'
-                        || $type == 'S' || $type == 'T' || $type == 'U')    // for $preg
+                        || $type == 'S' || $type == 'D' || $type == 'T' || $type == 'U')    // for $preg
                         {
                             $q2subqInfo[$questionNum]['subqs'][] = array(
                             'varName' => $varName,
@@ -6530,6 +6531,7 @@
                         {
                             case 'N':
                             case 'S':
+                            case 'D':
                             case 'T':
                             case 'U':
                                 $valParts[] = "\n  if(isValidOther" . $arg['qid'] . "){\n";


### PR DESCRIPTION
DEV: added "validation" and respective tip field to the advanced attributes
DEV: of the date/time question and changed em_manager_helper so field is evaluated
DEV: and EM color coding is applied.
DEV: In connection with strtotime() one can for example enforce that only dates
DEV: before "today" are entered: strtotime(self)<=strtotime("now")
