### PR TITLE
Fixed issue #8065: Answer code conversion to '0'

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1547,7 +1547,7 @@ function fixMovedQuestionConditions($qid,$oldgid,$newgid) //Function rewrites th
 function returnGlobal($stringname,$bRestrictToString=false)
 {
     $urlParam=Yii::app()->request->getParam($stringname); 
-    if(!isset($urlParam) && $aCookies=Yii::app()->request->getCookies() && $stringname!='sid')
+    if(is_null($urlParam) && $aCookies=Yii::app()->request->getCookies() && $stringname!='sid')
     {
         if(isset($aCookies[$stringname]))
         {
@@ -1555,7 +1555,7 @@ function returnGlobal($stringname,$bRestrictToString=false)
         } 
     }
     $bUrlParamIsArray=is_array($urlParam);// Needed to array map or if $bRestrictToString
-    if (isset($urlParam) && $stringname!='' && (!$bUrlParamIsArray || !$bRestrictToString))
+    if (!is_null($urlParam) && $stringname!='' && (!$bUrlParamIsArray || !$bRestrictToString))
     {
         if ($stringname == 'sid' || $stringname == "gid" || $stringname == "oldqid" ||
         $stringname == "qid" || $stringname == "tid" ||


### PR DESCRIPTION
DEV: when exporting to CSV/EXCEL etc. and conversion
DEV: of Y or N to '0' was chosen, values were wrongly
DEV: exported as 'missing values' (empty)
DEV:
DEV: nasty php typing problem....probably same problem
DEV: with issue #8039
