### PR TITLE
Fixed issue #8039: Problems with subquestion code '0'

### DIFF
--- a/application/helpers/viewHelper.php
+++ b/application/helpers/viewHelper.php
@@ -122,7 +122,7 @@ class viewHelper
             if(isset($field['title']) && $field['title'])
             {
                 $questioncode=$field['title'];
-                if(isset($field['aid']) && $field['aid'])
+                if(isset($field['aid']) && $field['aid']!="")
                 {
                     if(is_array($option['separator'])){ // Count ?
                         $questioncode.=$option['separator'][0].$field['aid'].$option['separator'][1];

--- a/application/libraries/PluginManager/LimesurveyApi.php
+++ b/application/libraries/PluginManager/LimesurveyApi.php
@@ -158,7 +158,7 @@
                     {
                         $code = $fieldmap[$key]['title'];
                         // Add subquestion code if needed
-                        if (array_key_exists('aid', $fieldmap[$key]) && !empty($fieldmap[$key]['aid'])) {
+                        if (array_key_exists('aid', $fieldmap[$key]) && isset($fieldmap[$key]['aid']) && $fieldmap[$key]['aid']!='') {
                             $code .= '_' . $fieldmap[$key]['aid'];
                         }
                         // Only add if the code does not exist yet and is not empty


### PR DESCRIPTION
DEV: Both described issues were separate incidences of
DEV: the same thing: php empty()/($var) treat the '0'
DEV: as not set or empty.
DEV: isset() on the other hand also returns "" as true.
DEV: I am afraid this problem may be present more often in
DEV: the code. Maybe implement a custom function
DEV: is_set() which also returns FALSE for "" but TRUE for '0'
