### PR TITLE
Feature/2.05/new pluginevent

### DIFF
--- a/application/libraries/PluginManager/PluginEvent.php
+++ b/application/libraries/PluginManager/PluginEvent.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * 
- * 
- * @property	$model						Model instance if the event was Triggered by changes on a Model (save,delete)
- * @property 	$filterCriteria				On Model Bulk operations this will contain CDBCriteria which was used to filter the Model records for the subjects of the bulk operation.
- */
-
 class PluginEvent
 {
     /**


### PR DESCRIPTION
Updated feature Plugin Added new PluginEvents raisable by LSActiveRecord subclasses
Dev Model classes derived from LSActiveRecord now raise a generic Model event which can be used to register for any changes of the given Type e.g. beforeSave on a model now raises a "before{classname}Save" and a "beforeModelSave" PluginEvent
Dev Each Model Derived from LSActiveRecord now raises a "after{classname}Save" and "afterModelSave" PluginEvent
