### PR TITLE
Fixed CDbCommand "Syntax error or access violation"  when inserting a si...

### DIFF
--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -602,8 +602,8 @@ class index extends CAction {
         if (!isset($_SESSION['survey_'.$surveyid]['srid']) && $thissurvey['anonymized'] == "N" && $thissurvey['active'] == "Y" && isset($token) && $token !='')
         {
             // load previous answers if any (dataentry with nosubmit)
-            $sQuery="SELECT id,submitdate,lastpage FROM {$thissurvey['tablename']} WHERE {$thissurvey['tablename']}.token='{$token}' order by id desc";
-            $aRow = Yii::app()->db->createCommand($sQuery)->queryRow();
+            $sQuery="SELECT id,submitdate,lastpage FROM {$thissurvey['tablename']} WHERE {$thissurvey['tablename']}.token=:token order by id desc";
+            $aRow = Yii::app()->db->createCommand($sQuery)->bindValues(array(':token' => $token))->queryRow();
             if ( $aRow )
             {
                 if(($aRow['submitdate']==''  && $thissurvey['tokenanswerspersistence'] == 'Y' )|| ($aRow['submitdate']!='' && $thissurvey['alloweditaftercompletion'] == 'Y'))


### PR DESCRIPTION
This is a follow up for #118. When the user inputs a single quote for instance - CDbCommand would create a 500 and throw a `CDbCommand failed to execute the SQL statement: SQLSTATE[42000]`

This issue was the problem that lead to the sql injection finding in the first place.

This pull requests claims to fix this.
