### PR TITLE
Fixed issue #8161: (quexml-pdf) field lengths

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -1344,12 +1344,8 @@ function quexml_export($surveyi, $quexmllan)
                     $question->appendChild($response);
                     break;
                 case "S": //SHORT FREE TEXT
-                    // default is fieldlength of 25 characters. If field length is set and larger than 50 use longtext field
-                    $iFieldlength=quexml_get_lengthth($qid,"maximum_chars",25);
-                    if ($iFieldlength<=50)
-                        $response->appendChild(QueXMLCreateFree("text",$iFieldlength,""));
-                    else 
-                        $response->appendChild(QueXMLCreateFree("longtext",40,""));
+                    // default is fieldlength of 25 characters.
+                    $response->appendChild(QueXMLCreateFree("text",quexml_get_lengthth($qid,"maximum_chars","25"),""));
                     $question->appendChild($response);
                     break;
                 case "T": //LONG FREE TEXT


### PR DESCRIPTION
Dev: multi-flexi array text and number questions now honor
Dev: maximum_chars attribute.
Dev: Short free text question: when no maximum_chars value
Dev: is given in attributes, field length defaults to 25, with values
Dev: values above 50 (two lines of text), a text box will be used
Dev: instead of the "form-type" text field.
