### PR TITLE
Fixed issue #8181: printable_help missing in tsv export

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8625,6 +8625,7 @@ EOD;
             'other_replace_text',
             'page_break',
             'prefix',
+            'printable_help',
             'public_statistics',
             'random_group',
             'random_order',


### PR DESCRIPTION
Dev: field needed to be listed in LimeExpressionManager::TSVSurveyExport
