### PR TITLE
Fixed issue #6502: Unable to import multi-lang surveys (.txt)

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8956,6 +8956,8 @@ EOD;
 
                         $row = array();
                         $row['class'] = 'G';
+                        //create a group code to allow proper importing of multi-lang survey TSVs
+                        $row['type/scale']='G'.$gseq;
                         $row['name'] = $ginfo['group_name'];
                         $row['relevance'] = $grelevance;
                         $row['text'] = $gtext;


### PR DESCRIPTION
Dev: groups are now exported with a unique identifier.
Dev: older multi-lang .txt files should also be properly
Dev: imported. Here we make up an identifier during
Dev: import.
