### PR TITLE
On token admin page, hide buttons the user isn't allowed to use

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -272,6 +272,13 @@ class tokens extends Survey_Common_Action
         {
             self::_newtokentable($iSurveyId);
         }
+
+	/* build JS variable to hide buttons forbidden for the current user */
+	$aData['showDelButton'] = hasSurveyPermission($iSurveyId, 'tokens', 'delete')?'true':'false';
+	$aData['showInviteButton'] = hasSurveyPermission($iSurveyId, 'tokens', 'update')?'true':'false';
+	$aData['showBounceButton'] = hasSurveyPermission($iSurveyId, 'tokens', 'update')?'true':'false';
+	$aData['showRemindButton'] = hasSurveyPermission($iSurveyId, 'tokens', 'update')?'true':'false';
+
         // Javascript
         $this->getController()->_js_admin_includes(Yii::app()->getConfig('adminscripts') . "tokens.js");
         $this->getController()->_js_admin_includes(Yii::app()->getConfig('generalscripts') . "jquery/jquery.multiselect.min.js");

--- a/application/views/admin/token/browse.php
+++ b/application/views/admin/token/browse.php
@@ -75,6 +75,10 @@
     var invitemsg = "<?php echo $clang->eT("Send invitation emails to the selected entries (if they have not yet been sent an invitation email)"); ?>"
     var remindmsg = "<?php echo $clang->eT("Send reminder email to the selected entries (if they have already received the invitation email)"); ?>"
     var inviteurl = "<?php echo Yii::app()->getController()->createUrl("admin/tokens/sa/email/action/invite/surveyid/{$surveyid}/tokenids/|"); ?>";
+    var showDelButton = <?php echo $showDelButton?>;
+    var showBounceButton = <?php echo $showBounceButton?>;
+    var showInviteButton = <?php echo $showInviteButton?>;
+    var showRemindButton = <?php echo $showRemindButton?>;
     <?php if (!hasGlobalPermission('USER_RIGHT_PARTICIPANT_PANEL')){?>
     var bParticipantPanelPermission=false;
     <?php 

--- a/scripts/admin/tokens.js
+++ b/scripts/admin/tokens.js
@@ -212,7 +212,7 @@ $(document).ready(function() {
         deltitle: sDelTitle,
         refreshtitle: sRefreshTitle,
         add:false,
-        del:true,
+        del:showDelButton,
         edit:false,
         refresh: true,
         search: false
@@ -331,39 +331,45 @@ $(document).ready(function() {
             });
         }
     });
-    $("#displaytokens").navButtonAdd('#pager',{
-        caption:"",
-        title:invitemsg,
-        buttonicon:'ui-icon-mail-closed',
-        onClickButton:function(){
-            window.open(inviteurl+$("#displaytokens").getGridParam("selarrrow").join("|"), "_blank")
-        }
-    });
-    $("#displaytokens").navButtonAdd('#pager',{
-        caption:"",
-        title:remindmsg,
-        buttonicon:'ui-icon-mail-open',
-        onClickButton:function(){
-            window.open(remindurl+$("#displaytokens").getGridParam("selarrrow").join("|"), "_blank")
-        }
-    });                 
-    $("#displaytokens").navButtonAdd('#pager', {
-        caption:"",
-        title:sBounceProcessing,
-        buttonicon:'ui-bounceprocessing',
-        onClickButton:function(){
-            $("#dialog-modal").dialog({
-                title: "Summary",
-                modal: true,
-                autoOpen: false,
-                height: 200,
-                width: 400,
-                show: 'blind',
-                hide: 'blind'
-            });
-            checkbounces();
-        }
-    });
+    if(showInviteButton) {
+        $("#displaytokens").navButtonAdd('#pager',{
+            caption:"",
+            title:invitemsg,
+            buttonicon:'ui-icon-mail-closed',
+            onClickButton:function(){
+                window.open(inviteurl+$("#displaytokens").getGridParam("selarrrow").join("|"), "_blank")
+            }
+        });
+    }
+    if(showRemindButton) {
+        $("#displaytokens").navButtonAdd('#pager',{
+            caption:"",
+            title:remindmsg,
+            buttonicon:'ui-icon-mail-open',
+            onClickButton:function(){
+                window.open(remindurl+$("#displaytokens").getGridParam("selarrrow").join("|"), "_blank")
+            }
+        });
+    }
+    if(showBounceButton) {
+        $("#displaytokens").navButtonAdd('#pager', {
+            caption:"",
+            title:sBounceProcessing,
+            buttonicon:'ui-bounceprocessing',
+            onClickButton:function(){
+                $("#dialog-modal").dialog({
+                    title: "Summary",
+                    modal: true,
+                    autoOpen: false,
+                    height: 200,
+                    width: 400,
+                    show: 'blind',
+                    hide: 'blind'
+                });
+                checkbounces();
+            }
+        });
+    }
     if (bParticipantPanelPermission==true)
     {
         $("#displaytokens").navSeparatorAdd("#pager",{});        


### PR DESCRIPTION
On the token administration page, all controls are always displayed, even if the current user has read-only rights.
The use of those controls is checked server-side but nothing is done to hide those buttons from the user.
This patch attemps to solve this problem.

Steps to reproduce:
- log-in as admin
- create a user with read-only rights
- create an invite-only survey
- generate some tokens
- log-in as the read-only user
- goto token management
- you'll see buttons like "delete" that you won't be able to use, because rights will be checked by the server-side code

Before:

![token_admin_controls](https://f.cloud.github.com/assets/3476089/1279807/10cd6e2c-2f41-11e3-8dba-a0d1bc70b6c4.png)

After:

![perm_read_only](https://f.cloud.github.com/assets/3476089/1279838/23cb518c-2f42-11e3-8e79-f2895ab6e0e0.png)
