### PR TITLE
Fixed #06783: GCI: Deprecated <center> tag used to align button on print answers page

### DIFF
--- a/application/controllers/PrintanswersController.php
+++ b/application/controllers/PrintanswersController.php
@@ -80,11 +80,11 @@ class PrintanswersController extends LSYii_Controller {
             sendCacheHeaders();
             doHeader();
             echo templatereplace(file_get_contents(getTemplatePath($thistpl).'/startpage.pstpl'),array(),$redata);
-            echo "<center><br />\n"
-            ."\t<font color='RED'><strong>".$clang->gT("Error")."</strong></font><br />\n"
+            echo "<div class='sessionexpired'><br />\n"
+            ."\t<span class='errormandatory'>".$clang->gT("Error")."</span><br />\n"
             ."\t".$clang->gT("We are sorry but your session has expired.")."<br />".$clang->gT("Either you have been inactive for too long, you have cookies disabled for your browser, or there were problems with your connection.")."<br />\n"
             ."\t".sprintf($clang->gT("Please contact %s ( %s ) for further assistance."),$siteadminname,$siteadminemail)."\n"
-            ."</center><br />\n";
+            ."</div><br />\n";
             echo templatereplace(file_get_contents(getTemplatePath($thistpl).'/endpage.pstpl'),array(),$redata);
             doFooter();
             exit;
@@ -110,7 +110,7 @@ class PrintanswersController extends LSYii_Controller {
         //OK. IF WE GOT THIS FAR, THEN THE SURVEY EXISTS AND IT IS ACTIVE, SO LETS GET TO WORK.
         //SHOW HEADER
         $printoutput = CHtml::form(array("printanswers/view/surveyid/{$surveyid}/printableexport/pdf"), 'post')
-        ."<center><input type='submit' value='".$clang->gT("PDF export")."'id=\"exportbutton\"/><input type='hidden' name='printableexport' /></center></form>";
+        ."<div class='pdfexport'><input type='submit' value='".$clang->gT("PDF export")."'id=\"exportbutton\"/><input type='hidden' name='printableexport' /></div></form>";
         if($printableexport == 'pdf')
         {
             //require (Yii::app()->getConfig('rootdir').'/application/config/tcpdf.php');

--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -234,9 +234,9 @@ class RegisterController extends LSYii_Controller {
             $query = "UPDATE {{tokens_$surveyid}}\n"
             ."SET sent='$today' WHERE tid=$tid";
             $result=dbExecuteAssoc($query) or show_error("Unable to execute this query : $query<br />");     //Checked
-            $html="<center>".$clang->gT("Thank you for registering to participate in this survey.")."<br /><br />\n".$clang->gT("An email has been sent to the address you provided with access details for this survey. Please follow the link in that email to proceed.")."<br /><br />\n".$clang->gT("Survey administrator")." {ADMINNAME} ({ADMINEMAIL})";
+            $html="<div class='thankyou'>".$clang->gT("Thank you for registering to participate in this survey.")."<br /><br />\n".$clang->gT("An email has been sent to the address you provided with access details for this survey. Please follow the link in that email to proceed.")."<br /><br />\n".$clang->gT("Survey administrator")." {ADMINNAME} ({ADMINEMAIL})";
             $html=ReplaceFields($html, $fieldsarray);
-            $html .= "<br /><br /></center>\n";
+            $html .= "<br /><br /></div>\n";
         }
         else
         {

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -708,8 +708,8 @@ class SurveyRuntimeHelper {
         {
             //SURVEY DOES NOT EXIST. POLITELY EXIT.
             echo templatereplace(file_get_contents($sTemplatePath."startpage.pstpl"), array(), $redata);
-            echo "\t<center><br />\n";
-            echo "\t" . $clang->gT("Sorry. There is no matching survey.") . "<br /></center>&nbsp;\n";
+            echo "\t<div class='nosurvey'><br />\n";
+            echo "\t" . $clang->gT("Sorry. There is no matching survey.") . "<br /></div>&nbsp;\n";
             echo templatereplace(file_get_contents($sTemplatePath."endpage.pstpl"), array(), $redata);
             doFooter();
             exit;

--- a/application/views/admin/export/statistics_view.php
+++ b/application/views/admin/export/statistics_view.php
@@ -2,7 +2,7 @@
     if (!$surveyid)
     {
         //need to have a survey id
-        echo "<center>You have not selected a survey!</center>";
+        echo "<div class='nosurvey'>".$clang->gT("You have not selected a survey!")."</div>";
         exit;
     }
 ?>

--- a/templates/basic/template.css
+++ b/templates/basic/template.css
@@ -1245,3 +1245,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/bluengrey/template.css
+++ b/templates/bluengrey/template.css
@@ -1569,3 +1569,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/citronade/template.css
+++ b/templates/citronade/template.css
@@ -599,3 +599,9 @@ table.printouttable{width:99%}
 .em_regex_validation{display: none;}
 .em_regex_validation.error {display: block;}
 .em_sum_range{margin:0.5em 0;}
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/clear_logo/template.css
+++ b/templates/clear_logo/template.css
@@ -1308,3 +1308,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/default/template.css
+++ b/templates/default/template.css
@@ -1604,3 +1604,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+	text-align: center;
+}

--- a/templates/eirenicon/template.css
+++ b/templates/eirenicon/template.css
@@ -1474,3 +1474,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/limespired/template.css
+++ b/templates/limespired/template.css
@@ -1537,3 +1537,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/mint_idea/template.css
+++ b/templates/mint_idea/template.css
@@ -1566,3 +1566,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/sherpa/template.css
+++ b/templates/sherpa/template.css
@@ -1423,3 +1423,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}

--- a/templates/vallendar/template.css
+++ b/templates/vallendar/template.css
@@ -1389,3 +1389,9 @@ span.hide-tip div.error {
     color: red;
     display: block;
 }
+
+/* Various classes currently used to center content */
+.nosurvey, .thankyou, .pdfexport, .sessionexpired
+{
+  text-align: center;
+}


### PR DESCRIPTION
I searched for the &lt;center&gt; tag all over the PHP code where it was still present in only 5 places.

The center tag was replaced by a div having a class that does currently only the centering in the CSS.
I created 4 distinct classes since I cannot predict how the styling would evolve in each specific case.

I did not change the pstpl files in the templates basic, bluengrey and clear_logo.

A similar clean up for the &lt;font&gt; tag would lead to 101 files being altered. I did not take that huge a risk!
