### PR TITLE
remotecontrol API - JSON-RPC

### DIFF
--- a/application/libraries/LSjsonRPCServer.php
+++ b/application/libraries/LSjsonRPCServer.php
@@ -8,7 +8,7 @@
 	 * @param object $object
 	 * @return boolean
 	 */
-	public static function handle($object) { 
+	public static function handle($object) {
         // checks if a JSON-RCP request has been received
 		if (
 			$_SERVER['REQUEST_METHOD'] != 'POST' ||
@@ -18,10 +18,6 @@
 			// This is not a JSON-RPC request
 			return false;
 		}
-<<<<<<< HEAD
-		
-=======
->>>>>>> branch 'master' of https://github.com/VincentBiragnet/LimeSurvey.git
 		// reads the input data
 		$request = json_decode(file_get_contents('php://input'),true);
 		
@@ -39,7 +35,7 @@
 				$response = array (
 									'id' => $id,
 									'result' => $result,
-									'error' => NULL,
+									'error' => NULL
 									);
 			} else {
 				$response = array (


### PR DESCRIPTION
Hi, 

I had problem with the api and the way I build my json request. Parameters in my json wasn't ordered the way limesurvey wanted and some optional parameters were missing. I think that my request had to be legal anyway. 
So I decided to update limesurvey's code accordingly.

So now, with my commit:
1) parameter order is no more mandatory for parameters
2) default values are added if API call omits some optional parameters

I'd be glad if you accept this change,

Kind regards,

Vincent
