### PR TITLE
Fixed issue: repeatheadings didn't work with array_filter

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6727,6 +6727,19 @@
                     {
                         $rowdividList[$sq['rowdivid']] = $sq['result'];
 
+                        // make sure to update array_filter headings
+                        if( ! empty($LEM->qattr[$arg['qid']]['array_filter'])) {
+                            $repeatheadings = Yii::app()->getConfig("repeatheadings");
+                            if( ! empty($LEM->qattr[$arg['qid']]['repeat_headings'])) {
+                                $repeatheadings = $LEM->qattr[$arg['qid']]['repeat_headings'];
+                            }
+                            if($repeatheadings > 0)
+                            {
+                                $relParts[] = "updateHeadings($('#question".$arg['qid']."').find('table.question'), "
+                                .$repeatheadings.");\n";
+                            }
+                        }
+                        // end
                         $relParts[] = "  if ( " . $sq['relevancejs'] . " ) {\n";
                         if ($afHide)
                         {

--- a/scripts/expressions/em_javascript.js
+++ b/scripts/expressions/em_javascript.js
@@ -2916,3 +2916,21 @@ function time () {
     // *     results 1: timeStamp > 1000000000 && timeStamp < 2000000000
     return Math.floor(new Date().getTime() / 1000);
 }
+
+// updates the deadings of a dynamic table
+function updateHeadings(tab, rep)
+{
+    tab.find('.repeat').remove();
+    var header = tab.find('thead>tr');
+    var trs = tab.find('tr:visible');
+    trs.each(function(i, tr)
+    {
+        // fix line colors
+        $(tr).removeClass('array1').removeClass('array2').addClass('array' + (1 + i % 2));
+        // add heading but not for the first and the last rows
+        if(i != 0 && i % rep == 0 && i != trs.length-1)
+        {
+            header.clone().addClass('repeat').addClass('headings').insertAfter(tr);
+        }
+    });
+}


### PR DESCRIPTION
Dev: repeated headings for array questions are generated as static HTML. In a case where an array question has an array filter, all the repeated headings are displayed even if no questions are visible.
Dev: added a javascript function updateHeadings and hooked it in
LEMrelXX in order to dynamically update array headings.

Before patch :
![before](https://f.cloud.github.com/assets/3476089/1390007/f01d4902-3be5-11e3-817a-ee3f9c3bf4f9.png)
After patch :
![after](https://f.cloud.github.com/assets/3476089/1390008/f3225cb4-3be5-11e3-9bcb-d717668f678a.png)
