### PR TITLE
Fix: Word export encoding was said to be latin, but is in fact UTF-8

### DIFF
--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -159,7 +159,7 @@ class Authdb extends AuthPluginBase
                 break;
                 
             case 'doc':
-                $event->set('label', gT("Microsoft Word (Latin charset)"));
+                $event->set('label', gT("Microsoft Word (UTF-8 charset)"));
                 $event->set('onclick', 'document.getElementById("ansfull").checked=true;document.getElementById("ansabbrev").disabled=true;');
                 break;
             

--- a/application/helpers/admin/export/DocWriter.php
+++ b/application/helpers/admin/export/DocWriter.php
@@ -27,7 +27,8 @@ class DocWriter extends Writer
         }
         
         
-        $sOutput = '<style>
+        $sOutput = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <style>
         table {
         border-collapse:collapse;
         }


### PR DESCRIPTION
Dev: by default Word uses local 8-bit encodings (CP-1252 for Europe etc.) but LimeSurvey exports UTF-8 without specifying the encoding in the resulting document. This patch adds a tag setting charset to UTF-8 in the resulting .doc. It also corrects the label of the export option from latin to UTF-8.

I tested this fix with Word 2002, Word 2010, Libre Office 3 and Libre Office 4 : all seem to take into account the charset tag I added and display the document correctly.

Before :
![before](https://f.cloud.github.com/assets/3476089/1391246/fc64d4e6-3bf9-11e3-9734-e80c8c128fc7.png)
After :
![after](https://f.cloud.github.com/assets/3476089/1391251/0558dad4-3bfa-11e3-92ef-74d86cb7fd40.png)
