### PR TITLE
Escape user input in json

### DIFF
--- a/scripts/uploader.js
+++ b/scripts/uploader.js
@@ -215,13 +215,13 @@ function passJSON(fieldname, show_title, show_comment, pos) {
             json += '{';
 
             if ($("#"+fieldname+"_show_title").val() == 1)
-                json += '"title":"' +$("#"+fieldname+"_title_"  +i).val().replace(/"/g, '\\"')+'",';
+                json += '"title":"' +escapeHtml($("#"+fieldname+"_title_"  +i).val().replace(/"/g, '\"'))+'",';
             if ($("#"+fieldname+"_show_comment").val() == 1)
-                json += '"comment":"'+$("#"+fieldname+"_comment_"+i).val().replace(/"/g, '\\"')+'",';
+                json += '"comment":"'+escapeHtml($("#"+fieldname+"_comment_"+i).val().replace(/"/g, '\"'))+'",';
             json += '"size":"'   +$("#"+fieldname+"_size_"   +i).val()+'",'+
-                    '"name":"'   +$("#"+fieldname+"_name_"   +i).val()+'",'+
-                    '"filename":"'   +$("#"+fieldname+"_filename_"   +i).val()+'",'+
-                    '"ext":"'    +$("#"+fieldname+"_ext_"    +i).val()+'"}';
+                '"name":"'   +escapeHtml($("#"+fieldname+"_name_"   +i).val())+'",'+
+                '"filename":"'   +escapeHtml($("#"+fieldname+"_filename_"   +i).val())+'",'+
+                '"ext":"'    +$("#"+fieldname+"_ext_"    +i).val()+'"}';
 
             filecount += 1;
         }


### PR DESCRIPTION
This prevents broken json objects from being saved to the database.

The upload process saves the json object as a value of a hidden input in the HTML markup of the page.  When a user has a single quote in the title, filename, or comment, the resulting value can create invalid markup.

Take this for example:

```
<input type='hidden' id='693963X7X16' name='693963X7X16' value='[{ "title":"test's","comment":"testcomment","size":"65.435","name":"Homer-Doughnut.jpg","filename":"fu_s4i55hsmibyuazz","ext":"jpg" }]' />
```

Here, you can see that the `title` in the json object contains a single quote, which closes the value attribute of the input early.

Because of this, when the form is submitted, only `[{ "title":"test's` is saved to the database, resulting in corrupted data.
