### PR TITLE
Feature request #8596: Allow empty dates for RemoteControl add_response

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2186,16 +2186,22 @@ class remotecontrol_handle
             //set required values if not set
 
             // @todo: Some of this is part of the validation and should be done in the model instead
-            if (!isset($aResponseData['submitdate']))
+            if (array_key_exists('submitdate', $aResponseData) && empty($aResponseData['submitdate']))
+                unset($aResponseData['submitdate']);
+            else if (!isset($aResponseData['submitdate']))
                 $aResponseData['submitdate'] = date("Y-m-d H:i:s");
             if (!isset($aResponseData['startlanguage']))
                 $aResponseData['startlanguage'] = getBaseLanguageFromSurveyID($iSurveyID);
 
             if ($oSurvey->datestamp=='Y')
             {
-                if (!isset($aResponseData['datestamp']))
+                if (array_key_exists('datestamp', $aResponseData) && empty($aResponseData['datestamp']))
+                    unset($aResponseData['datestamp']);
+                else if (!isset($aResponseData['datestamp']))
                     $aResponseData['datestamp'] = date("Y-m-d H:i:s");
-                if (!isset($aResponseData['startdate']))
+                if (array_key_exists('startdate', $aResponseData) && empty($aResponseData['startdate']))
+                    unset($aResponseData['startdate']);
+                else if (!isset($aResponseData['startdate']))
                     $aResponseData['startdate'] = date("Y-m-d H:i:s");
             }
 


### PR DESCRIPTION
This would be helpful for prefilling answers using RemoteControl API instead of passing them in the URL.  I don't think it should cause issues with existing implementations.  For each date, if it is not passed in the date will still be set to the current date.  If a date is passed in it will be set, and if it is passed in with a value of false, null, etc. the date field will not be populated.  

Before this change it's not possible to use add_response without having all of the dates set, even if you pass  a date in as false, null, '', etc.
