### PR TITLE
Fixed issue #08818: Comparison operators (< and >) get converted to HTML...

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -2156,10 +2156,8 @@ class ExpressionManager {
      */
     public function asSplitStringOnExpressions($src)
     {
-         
         $parts = preg_split($this->RDP_ExpressionRegex,$src,-1,(PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE));
-        
-        
+
         $count = count($parts);
         $tokens = array();
         $inSQString=false;
@@ -2302,7 +2300,11 @@ class ExpressionManager {
                     }
                     break;
                 default:
-                    $thistoken[] = $parts[$j];
+                    if($curlyDepth>0 && !$inDQString && !$inSQString)
+                        $thistoken[] = html_entity_decode($parts[$j],ENT_NOQUOTES);// Replace &lt: and &gt;
+                    else
+                        $thistoken[] = $parts[$j];
+                    //$thistoken[] = $parts[$j];
                     break;
             }
         }


### PR DESCRIPTION
...-entities in expressions

Dev: second solution : leave $lt; and $gt; but replace it in EM core
