### PR TITLE
New feature #8659: Configurable proxy for comfort update

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -552,6 +552,16 @@ $config['InsertansUnsupportedtypes'] = array();
 */
 $config['updatenotification'] = 'both';
 
+// Proxy settings for ComfortUpdate
+/**
+* Set these if you are behind a proxy and want to update LS using ComfortUpdate
+*
+* $proxy_host_name Your proxy server name (string)
+* $proxy_host_port Your proxy server port (int)
+*/
+$config['proxy_host_name'] = '';
+$config['proxy_host_port'] = 80;
+
 
 // === Advanced Setup
 // The following parameters need information from config.php

--- a/application/controllers/admin/update.php
+++ b/application/controllers/admin/update.php
@@ -106,6 +106,8 @@ class update extends Survey_Common_Action
 
     private function _requestChangelog(httpRequestIt $http, $buildnumber, $updaterversion)
     {
+        $http->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+        $http->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
         $http->timeout = 0;
         $http->data_timeout = 0;
         $http->user_agent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)';
@@ -118,6 +120,8 @@ class update extends Survey_Common_Action
     
     private function _requestChangedFiles(httpRequestIt $http, $buildnumber, $updaterversion)
     {
+        $http->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+        $http->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
         $http->timeout = 0;
         $http->data_timeout = 0;
         $http->user_agent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)';
@@ -344,6 +348,9 @@ class update extends Survey_Common_Action
         $downloaderror=false;
         Yii::import('application.libraries.admin.http.httpRequestIt');
         $http=new httpRequestIt;
+        
+        $http->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+        $http->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
 
         // Allow redirects
         $http->follow_redirect=1;
@@ -453,6 +460,9 @@ class update extends Survey_Common_Action
         Yii::import('application.libraries.admin.http.httpRequestIt');
         $oHTTPRequest=new httpRequestIt;
         
+        $oHTTPRequest->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+        $oHTTPRequest->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
+
         /* Connection timeout */
         $oHTTPRequest->timeout=0;
         /* Data transfer timeout */
@@ -504,6 +514,9 @@ class update extends Survey_Common_Action
         $downloaderror=false;
         Yii::import('application.libraries.admin.http.httpRequestIt');
         $oHTTPRequest=new httpRequestIt;
+
+        $oHTTPRequest->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+        $oHTTPRequest->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
 
         // Allow redirects
         $oHTTPRequest->follow_redirect=1;

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5602,6 +5602,8 @@ function getUpdateInfo()
     Yii::import('application.libraries.admin.http.httpRequestIt');
     $http=new httpRequestIt;
 
+    $http->proxy_host_name = Yii::app()->getConfig("proxy_host_name","");
+    $http->proxy_host_port = Yii::app()->getConfig("proxy_host_port",80);
     $http->timeout=0;
     $http->data_timeout=0;
     $http->user_agent="LimeSurvey ".Yii::app()->getConfig("versionnumber")." build ".Yii::app()->getConfig("buildnumber");


### PR DESCRIPTION
Proxy settings for comfort update used to be hard coded in httpRequestIt.php (which is hard to reach for the average human being and potentially overwritten during an update process).
