### PR TITLE
Fixed Issue #9031: get_summary will return correct completed_responses fixed.

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -556,7 +556,7 @@ class remotecontrol_handle
                  {
                      if (tableExists('{{survey_' . $iSurveyID . '}}'))
                      {
-                         $aSummary['completed_responses']=SurveyDynamic::model($iSurveyID)->countByAttributes(array('submitdate' => null));
+                         $aSummary['completed_responses']=SurveyDynamic::model($iSurveyID)->count('submitdate IS NOT NULL');
                          $aSummary['incomplete_responses']=SurveyDynamic::model($iSurveyID)->countByAttributes(array('submitdate' => null));
                          $aSummary['full_responses']=SurveyDynamic::model($iSurveyID)->count();
                      }


### PR DESCRIPTION
get_summary remote control routine was not returning correct number of count of complete and incomplete responses for a survey. fixed the issue
