### PR TITLE
New feature : use shortest url with urlFormat path

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -18,7 +18,7 @@ $route['<_sid:\d+>/lang-<_lang:\w+[-\w]+>/tk-<_token:\w+>/*'] = "survey/index/si
 $route['<_sid:\d+>/lang-<_lang:\w+[-\w]+>/*'] = "survey/index/sid/<_sid>/lang/<_lang>";
 $route['<_sid:\d+>/tk-<_token:\w+>/*'] = "survey/index/sid/<_sid>/token/<_token>";
 $route['<_sid:\d+>/*'] = "survey/index/sid/<_sid>";
-$route['<sid:\d+>'] = array('survey/index','urlSuffix'=>'.html','matchValue'=>true);
+$route['<sid:\d+>'] = array('survey/index','matchValue'=>true);
 
 //Admin Routes
 $route['admin/index'] = "admin";
@@ -32,10 +32,11 @@ $route['admin/labels/<_action:\w+>/<_lid:\d+>'] = "admin/labels/index/<_action>/
 //Expression Manager tests
 $route['admin/expressions'] = "admin/expressions/index";
 
-//optout
+//optout - optin
 $route['optout/<_sid:\d+>/(:any)/(:any)'] = "optout/index/<_sid>/$2/$3";
-$route['optout/<surveyid:\d+>/*'] = array('optout/index','matchValue'=>true);
-$route['statistics_user/<surveyid:\d+>'] =  array('statistics_user/action','urlSuffix'=>'.html','matchValue'=>true);
+$route['optout/tokens/<surveyid:\d+>'] = array('optout/tokens','matchValue'=>true);
+$route['optin/tokens/<surveyid:\d+>'] = array('optin/tokens','matchValue'=>true);
+$route['statistics_user/<surveyid:\d+>'] =  array('statistics_user/action','matchValue'=>true);
 
 $route['<_controller:\w+>/<_action:\w+>'] = '<_controller>/<_action>';
 


### PR DESCRIPTION
Dev: this replace array('survey/index', 'sid' => $survey->sid, 'lang' => App()->lang->langcode) by /$sid/lang/language
Dev: same behaviour than 2.0 or 1.92 with modrewrite=1
Dev: maybe some other default rules to add : actually surveyurl + statistics_ur + optout url (maybe partially)
Dev: need more testing ? urlFormat get not changed
