### PR TITLE
Update token.php to fix 'token' validation error

### DIFF
--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -86,7 +86,7 @@
 
 			$this->token = randomChars($length);
 			$counter = 0;
-			while (!$this->validate('token'))
+			while (!$this->validate(array('token')))
 			{
 				$this->token = randomChars($length);
 				$counter++;


### PR DESCRIPTION
According to:
http://www.yiiframework.com/doc/api/1.1/CModel#validate-detail

Using string in validation function will make the framework validates all attributes which result in misleading validation errors. In this case if 'Token' model has other validation errors for example email error, LimeSurvey will throw 'Failed to create unique token in 10 attempts.'. This will lead user to think it is about 'token' attribute.

So changing into array is a must so the function ,generateToken(), will perform what it is designed for.
