### PR TITLE
better url for direct plugin

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -32,6 +32,9 @@ $route['admin/labels/<_action:\w+>/<_lid:\d+>'] = "admin/labels/index/<_action>/
 //Expression Manager tests
 $route['admin/expressions'] = "admin/expressions/index";
 
+// Plugins direct route
+$route['plugin/<plugin:\w+>/<function:\w+>']=array('plugins/direct');
+
 //optout - optin
 $route['optout/<_sid:\d+>/(:any)/(:any)'] = "optout/index/<_sid>/$2/$3";
 $route['optout/tokens/<surveyid:\d+>'] = array('optout/tokens','matchValue'=>true);


### PR DESCRIPTION
With 

```
    'urlManager' => array(
        'urlFormat' => 'path',
        'rules' => require('routes.php'),
        'showScriptName' => false,
    ),
```

example.org/plugin/myplugin/function?other=other ...

with 'showScriptName' => true,
example.org/index.php/plugin/myplugin/function?other=other ...

With get (and scriptname) : get never be beautiful : no change
