### PR TITLE
Allow the 1.x style urls to still work on 2.x

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,10 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
 
+    # Make the 1.x version URLs still work
+    RewriteCond %{QUERY_STRING} sid=(\d+)&lang=(\w+)
+    RewriteRule ^index.php /index.php/%1/lang-%2? [R=301,L]
+
     # if a directory or a file exists, use it directly
     RewriteCond %{REQUEST_FILENAME} !-f
 

--- a/.htaccess
+++ b/.htaccess
@@ -13,7 +13,8 @@
     RewriteCond %{QUERY_STRING} sid=(\d+)&lang=(\w+)&token=(\w+)$
     RewriteRule ^index.php /index.php/survey/index/sid/%1/token/%3/lang/%2/newtest/Y? [R=301,L]
 
-    # if a directory or a file exists, use it directly RewriteCond %{REQUEST_FILENAME} !-f
+    # if a directory or a file exists, use it directly
+    RewriteCond %{REQUEST_FILENAME} !-f
 
     # otherwise forward it to index.php
     RewriteRule . index.php

--- a/.htaccess
+++ b/.htaccess
@@ -1,12 +1,19 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
 
-    # Make the 1.x version URLs still work
-    RewriteCond %{QUERY_STRING} sid=(\d+)&lang=(\w+)
+    # JUST SID
+    RewriteCond %{QUERY_STRING} sid=(\d+)$
+    RewriteRule ^index.php /index.php/%1? [R=301,L]
+
+    # SID AND LANG
+    RewriteCond %{QUERY_STRING} sid=(\d+)&lang=(\w+)$
     RewriteRule ^index.php /index.php/%1/lang-%2? [R=301,L]
 
-    # if a directory or a file exists, use it directly
-    RewriteCond %{REQUEST_FILENAME} !-f
+    # SID, LANG AND TOKEN
+    RewriteCond %{QUERY_STRING} sid=(\d+)&lang=(\w+)&token=(\w+)$
+    RewriteRule ^index.php /index.php/survey/index/sid/%1/token/%3/lang/%2/newtest/Y? [R=301,L]
+
+    # if a directory or a file exists, use it directly RewriteCond %{REQUEST_FILENAME} !-f
 
     # otherwise forward it to index.php
     RewriteRule . index.php


### PR DESCRIPTION
I recently upgraded from 1.x to 2.x, and today users started to complain that the URLs that they had in sites and documents stopped working. I tried to fix it with mod_rewrite, so here it is

What this does it: 
/index.php?sid=85725&lang=pt
is redirected to:
/index.php/85725/lang-pt