### PR TITLE
New feature : limesurvey form action url contains surveyid

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -962,11 +962,11 @@ class SurveyRuntimeHelper {
         $hiddenfieldnames = implode("|", $inputnames);
 
         if (isset($upload_file) && $upload_file)
-            echo CHtml::form(array("survey/index"), 'post',array('enctype'=>'multipart/form-data','id'=>'limesurvey','name'=>'limesurvey', 'autocomplete'=>'off'))."\n
+            echo CHtml::form(array("/survey/index","sid"=>$surveyid), 'post',array('enctype'=>'multipart/form-data','id'=>'limesurvey','name'=>'limesurvey', 'autocomplete'=>'off'))."\n
             <!-- INPUT NAMES -->
             <input type='hidden' name='fieldnames' value='{$hiddenfieldnames}' id='fieldnames' />\n";
         else
-            echo CHtml::form(array("survey/index"), 'post',array('id'=>'limesurvey', 'name'=>'limesurvey', 'autocomplete'=>'off'))."\n
+            echo CHtml::form(array("/survey/index","sid"=>$surveyid), 'post',array('id'=>'limesurvey', 'name'=>'limesurvey', 'autocomplete'=>'off'))."\n
             <!-- INPUT NAMES -->
             <input type='hidden' name='fieldnames' value='{$hiddenfieldnames}' id='fieldnames' />\n";
         // <-- END FEATURE - SAVE

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -884,7 +884,7 @@ function buildsurveysession($surveyid,$preview=false)
             }
 
             echo "<p class='captcha'>".gT("Please confirm access to survey by answering the security question below and click continue.")."</p>"
-            .CHtml::form(array("/survey/index/sid/{$surveyid}"), 'post', array('class'=>'captcha'))."
+            .CHtml::form(array("/survey/index","sid"=>$surveyid), 'post', array('class'=>'captcha'))."
             <table align='center'>
             <tr>
             <td align='right' valign='middle'>
@@ -961,7 +961,7 @@ function buildsurveysession($surveyid,$preview=false)
             echo '<div id="wrapper"><p id="tokenmessage">'.gT("This is a controlled survey. You need a valid token to participate.")."<br />";
             echo gT("If you have been issued a token, please enter it in the box below and click continue.")."</p>
             <script type='text/javascript'>var focus_element='#token';</script>"
-            .CHtml::form(array("/survey/index/sid/{$surveyid}"), 'post', array('id'=>'tokenform','autocomplete'=>'off'))."
+            .CHtml::form(array("/survey/index","sid"=>$surveyid), 'post', array('id'=>'tokenform','autocomplete'=>'off'))."
             <ul>
             <li>";?>
             <label for='token'><?php eT("Token:");?></label><input class='text <?php echo $kpclass?>' id='token' type='password' name='token' value='' />
@@ -2039,7 +2039,7 @@ function checkCompletedQuota($surveyid,$return=false)
         $sQuotaStep= isset($_SESSION['survey_'.$surveyid]['step'])?$_SESSION['survey_'.$surveyid]['step']:0; // Surely not needed
         $sNavigator = CHtml::htmlButton(gT("Previous"),array('type'=>'submit','id'=>"moveprevbtn",'value'=>$sQuotaStep,'name'=>'move','accesskey'=>'p','class'=>"submit button"));
         //$sNavigator .= " ".CHtml::htmlButton(gT("Submit"),array('type'=>'submit','id'=>"movesubmit",'value'=>"movesubmit",'name'=>"movesubmit",'accesskey'=>'l','class'=>"submit button"));
-        $quotaMessage.= CHtml::form(array("/survey/index"), 'post', array('id'=>'limesurvey','name'=>'limesurvey'));
+        $quotaMessage.= CHtml::form(array("/survey/index","sid"=>$surveyid), 'post', array('id'=>'limesurvey','name'=>'limesurvey'));
         $quotaMessage.= templatereplace(file_get_contents($sTemplatePath."/navigator.pstpl"),array('NAVIGATOR'=>$sNavigator,'SAVE'=>''),$redata);
         $quotaMessage.= CHtml::hiddenField('sid',$surveyid);
         $quotaMessage.= CHtml::hiddenField('token',$sClientToken);// Did we really need it ?
@@ -2163,7 +2163,7 @@ function display_first_page() {
     $sTemplatePath=$_SESSION['survey_'.$surveyid]['templatepath'];
 
     echo templatereplace(file_get_contents($sTemplatePath."startpage.pstpl"),array(),$redata,'frontend_helper[2757]');
-    echo CHtml::form(array("/survey/index"), 'post', array('id'=>'limesurvey','name'=>'limesurvey','autocomplete'=>'off'));
+    echo CHtml::form(array("/survey/index","sid"=>$surveyid), 'post', array('id'=>'limesurvey','name'=>'limesurvey','autocomplete'=>'off'));
     echo "\n\n<!-- START THE SURVEY -->\n";
 
     echo templatereplace(file_get_contents($sTemplatePath."welcome.pstpl"),array(),$redata,'frontend_helper[2762]')."\n";

--- a/application/views/admin/survey/surveySummary_view.php
+++ b/application/views/admin/survey/surveySummary_view.php
@@ -12,7 +12,7 @@
             <strong><?php echo $clang->gT("Survey URL") ." - ".getLanguageNameFromCode($surveyinfo['language'],false).":";?></strong>
         </td>
         <td>
-        <?php $tmp_url = $this->createAbsoluteUrl("/survey/index/sid/{$surveyinfo['sid']}/lang/{$surveyinfo['language']}"); ?>
+        <?php $tmp_url = $this->createAbsoluteUrl("survey/index",array("sid"=>$surveyinfo['sid'],"lang"=>$surveyinfo['language'])); ?>
         <a href='<?php echo $tmp_url?>' target='_blank'><?php echo $tmp_url; ?></a>
         </td>
     </tr>
@@ -24,7 +24,7 @@
                 <strong><?php echo getLanguageNameFromCode($langname,false).":";?></strong>
             </td>
             <td>
-            <?php $tmp_url = $this->createAbsoluteUrl("/survey/index/sid/{$surveyinfo['sid']}/lang/{$langname}"); ?>
+            <?php $tmp_url = $this->createAbsoluteUrl("/survey/index",array("sid"=>$surveyinfo['sid'],"lang"=>$langname)); ?>
             <a href='<?php echo $tmp_url?>' target='_blank'><?php echo $tmp_url; ?></a>
             </td>
         </tr>

--- a/application/views/admin/survey/surveybar_view.php
+++ b/application/views/admin/survey/surveybar_view.php
@@ -33,22 +33,25 @@
         </div>
         <ul class='sf-menu'>
             <?php if($activated || $surveycontent) { ?>
-                <?php if($onelanguage) { ?>
-                    <li><a accesskey='d' target='_blank' href="<?php echo $this->createUrl("survey/index/sid/$surveyid/newtest/Y/lang/$baselang"); ?>" >
-                            <img src='<?php echo $sImageURL;?>do.png' alt='<?php echo $icontext;?>' />
-                        </a></li>
-                    <?php } else { ?>
-                    <li><a accesskey='d' target='_blank' href="<?php echo $this->createUrl("survey/index/sid/$surveyid/newtest/Y/lang/$baselang"); ?>" >
-                            <img src='<?php echo $sImageURL;?>do.png' alt='<?php echo $icontext;?>' />
-                        </a><ul>
-                            <?php foreach ($languagelist as $tmp_lang) { ?>
-                                <li><a accesskey='d' target='_blank' href='<?php echo $this->createUrl("survey/index/sid/$surveyid/newtest/Y/lang/$tmp_lang");?>'>
-                                    <img src='<?php echo $sImageURL;?>do_30.png' alt=''/> <?php echo getLanguageNameFromCode($tmp_lang,false);?></a></li>
-                                <?php } ?>
-                        </ul>
-                    </li>
+            <li><a accesskey='d' target='_blank' href="<?php echo $this->createUrl("survey/index",array("sid"=>$surveyid,"newtest"=>"Y")); ?>" >
+                    <img src='<?php echo $sImageURL;?>do.png' alt='<?php echo $icontext;?>' />
+                </a>
+                <?php if(count($languagelist)>1) { ?>
+                <ul>
+                    <?php foreach ($languagelist as $tmp_lang) { ?>
+                        <li><a accesskey='d' target='_blank' href='<?php echo $this->createUrl("survey/index",array('sid'=>$surveyid,'newtest'=>"Y",'lang'=>$tmp_lang));?>'>
+                            <img src='<?php echo $sImageURL;?>do_30.png' alt=''/> <?php echo getLanguageNameFromCode($tmp_lang,false);?></a>
+                        </li>
                     <?php } ?>
+                </ul>
                 <?php } ?>
+            </li>
+            <?php } else { ?>
+            <li><a accesskey='d' target='_blank' href="<?php echo $this->createUrl("survey/index/sid/$surveyid/newtest/Y/lang/$baselang"); ?>" >
+                    <img src='<?php echo $sImageURL;?>do.png' alt='<?php echo $icontext;?>' />
+                </a>
+            </li>
+            <?php } ?>
                 
             <?php if($surveylocale || $surveysettings || $surveysecurity || $quotas || $assessments || $surveycontent) { ?>
             <li><a href='#'>


### PR DESCRIPTION
See https://github.com/LimeSurvey/LimeSurvey/pull/219

This update action url for survey form

Move to /survey/index to the url with id inside. 
Tested with get and path

With:

```
    'urlManager' => array(
        'urlFormat' => 'path',
        'showScriptName' => false,
    ),
```

url is /1234, really more clean :)

See : http://bugs.limesurvey.org/view.php?id=9111 too
And another think : this allow easily a send url by email
