### PR TITLE
Fixed issue #9026: If empty survey, export 1 empty record

### DIFF
--- a/application/helpers/admin/export/Writer.php
+++ b/application/helpers/admin/export/Writer.php
@@ -395,6 +395,18 @@ abstract class Writer implements IWriter
         }
         //Output the results.
         $sFile='';
+        
+        // If empty survey, prepare an empty responses array, and output just 1 empty record with header.
+        if ($survey->responses->rowCount == 0)
+        {
+             foreach ($oOptions->selectedColumns as $column)
+             {
+             	$elementArray[]="";
+             }
+        	$this->outputRecord($headers, $elementArray, $oOptions);
+        }
+        		
+        // If no empty survey, render/export responses array.
         foreach($survey->responses as $response)
         {
             $elementArray = array();


### PR DESCRIPTION
This is done to  avoid blank results.

A blank page was returned when exporting empty surveys, because no content was given to output. 
Headers were not returned neither (as contrary to the expected), as headers are written before the first record. As no records were given, no headers were written.

By providing an empty record, headers are written and output matches expectations.
