### PR TITLE
set CHtmlPurifier options via setOptions()

### DIFF
--- a/application/core/LSYii_Validators.php
+++ b/application/core/LSYii_Validators.php
@@ -102,7 +102,7 @@ class LSYii_Validators extends CValidator {
     public function xssFilter($value)
     {
         $filter = new CHtmlPurifier();
-        $filter->options = array(
+        $filter->setOptions(array(
             'AutoFormat.RemoveEmpty'=>false,
             'CSS.AllowTricky'=>true, // Allow display:none; (and other)
             'HTML.SafeObject'=>true, // To allow including youtube
@@ -117,7 +117,7 @@ class LSYii_Validators extends CValidator {
                 'nntp' => true,
                 'news' => true,
                 )
-        );
+        ));
         // To allow script BUT purify : HTML.Trusted=true (plugin idea for admin or without XSS filtering ?)
 
         /** Start to get complete filtered value with  url decode {QCODE} (bug #09300). This allow only question number in url, seems OK with XSS protection **/

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -4713,10 +4713,10 @@ function XSSFilterArray(&$array)
     if(Yii::app()->getConfig('filterxsshtml') && !Permission::model()->hasGlobalPermission('superadmin','read'))
     {
         $filter = new CHtmlPurifier();
-        $filter->options = array('URI.AllowedSchemes'=>array(
+        $filter->setOptions(array('URI.AllowedSchemes'=>array(
         'http' => true,
         'https' => true,
-        ));
+        )));
         foreach($array as &$value)
         {
             $value = $filter->purify($value);


### PR DESCRIPTION
The API for CHtmlPurifier has changed. The former public attribute options is now private (and renamed to _options) and has to be set via CHtmlPurifier::setOptions($options).