### PR TITLE
Fixed issue #9332: Date question + debug > 1 : broken Reorder survey

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -979,7 +979,7 @@ class SurveyAdmin extends Survey_Common_Action
     {
         // Prepare data for the view
         $sBaseLanguage = Survey::model()->findByPk($iSurveyID)->language;
-
+        LimeExpressionManager::StartSurvey($iSurveyID, 'survey');
         LimeExpressionManager::StartProcessingPage(true, Yii::app()->baseUrl);
 
         $aGrouplist = QuestionGroup::model()->getGroups($iSurveyID);


### PR DESCRIPTION
LimeExpressionManager::StartSurvey was missing, so the index 'surveyls_dateformat'was not set in the $LEM->surveyOptions array.
