### PR TITLE
Fix crash when exporting answer to PDF (not admin GUI)

### DIFF
--- a/application/helpers/pdfHelper.php
+++ b/application/helpers/pdfHelper.php
@@ -61,8 +61,7 @@ class pdfHelper
             $lg['a_meta_dir'] = 'ltr';
         }
         $lg['a_meta_language'] = $language;
-        $pdflang = new Limesurvey_lang($language);
-        $lg['w_page']=$pdflang->gT("page");
+        $lg['w_page']=gT("page");
 
         return array('pdffont'=>$pdffont,'pdffontsize'=>$pdffontsize,'lg'=>$lg);
     }


### PR DESCRIPTION
After sending survey, "Print answers" -> "Export to PDF", LimeSurvey crashed.

Error persists when exporting answers to PDF from admin export tool.
