### PR TITLE
qanda_helper.php: remove doubled size for answer

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -5376,7 +5376,7 @@ function do_array_multiflexi($ia)
     {
         $answerwidth=20;
     }
-    $columnswidth=100-($answerwidth*2);
+    $columnswidth=100-($answerwidth);
 
     $lquery = "SELECT * FROM {{questions}} WHERE parent_qid={$ia[0]}  AND language='".$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']."' and scale_id=1 ORDER BY question_order";
     $lresult = dbExecuteAssoc($lquery);


### PR DESCRIPTION
The doubled size for answer columns in do_array_multiflexi() is wrong. 20% width are missing from the table and if you have the answer table at 100% width the last column will get the additional 20% and it get's to large.
Example:
$answerwidth=20:
$columnswidth=100-($answerwidth*2)=60;
with $numrows = 2;
$cellwidth=$columnswidth/$numrows=60/2 = 30;
=> columns: 20% answer text, 30% row, 30% row
=> 80% total, so the browser adds the missing 20% to the last column
Result: 20% answer text, 30% row, 50% row
I should have created an issue for this...