### PR TITLE
Fixed issue #9171 : Unable to subscribe to event

### DIFF
--- a/application/controllers/admin/authentication.php
+++ b/application/controllers/admin/authentication.php
@@ -110,14 +110,14 @@ class Authentication extends Survey_Common_Action
                  
         /* Adding beforeLogout event */
         $beforeLogout = new PluginEvent('beforeLogout');
-        App()->getPluginManager()->dispatchEvent($beforeLogout, array($plugin));
+        App()->getPluginManager()->dispatchEvent($beforeLogout);
 
         App()->user->logout();
         App()->user->setFlash('loginmessage', gT('Logout successful.'));
 
         /* Adding afterLogout event */
         $event = new PluginEvent('afterLogout');
-        App()->getPluginManager()->dispatchEvent($event, array($plugin));
+        App()->getPluginManager()->dispatchEvent($event);
         
         $this->getController()->redirect(array('/admin/authentication/sa/login'));
     }

--- a/application/core/LSUserIdentity.php
+++ b/application/core/LSUserIdentity.php
@@ -66,7 +66,7 @@ class LSUserIdentity extends CUserIdentity {
                 // Delegate actual authentication to plugin
                 $authEvent = new PluginEvent('newUserSession', $this);
                 $authEvent->set('identity', $this);
-                App()->getPluginManager()->dispatchEvent($authEvent, array($this->plugin));
+                App()->getPluginManager()->dispatchEvent($authEvent);
                 $pluginResult = $authEvent->get('result');
                 if ($pluginResult instanceof LSAuthResult) {
                     $result = $pluginResult;

--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -108,16 +108,6 @@ class AuthLDAP extends AuthPluginBase
             ->addContent(CHtml::tag('li', array(), "<label for='password'>"  . gT("Password") . "</label><input name='password' id='password' type='password' size='40' maxlength='40' value='' />"));
     }
 
-    public function afterLoginFormSubmit()
-    {
-        // Here we handle post data        
-        $request = $this->api->getRequest();
-        if ($request->getIsPostRequest()) {
-            $this->setUsername( $request->getPost('user'));
-            $this->setPassword($request->getPost('password'));
-        }
-    }
-    
     /**
      * Modified getPluginSettings since we have a select box that autosubmits
      * and we only want to show the relevant options.
@@ -166,6 +156,13 @@ class AuthLDAP extends AuthPluginBase
 
     public function newUserSession()
     {
+        // Do nothing if this user is not Authdb type
+        $identity = $this->getEvent()->get('identity');
+        if ($identity->plugin != 'AuthLDAP')
+        {
+            return;
+        }
+
         // Here we do the actual authentication       
         $username = $this->getUsername();
         $password = $this->getPassword();

--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -75,18 +75,15 @@ class Authdb extends AuthPluginBase
              ->addContent(CHtml::tag('li', array(), "<label for='password'>"  . gT("Password") . "</label>".CHtml::passwordField('password',$sPassword,array('size'=>40,'maxlength'=>40))));
     }
 
-    public function afterLoginFormSubmit()
-    {
-        // Here we handle post data        
-        $request = $this->api->getRequest();
-        if ($request->getIsPostRequest()) {
-            $this->setUsername( $request->getPost('user'));
-            $this->setPassword($request->getPost('password'));
-        }
-    }
-
     public function newUserSession()
     {
+        // Do nothing if this user is not Authdb type
+        $identity = $this->getEvent()->get('identity');
+        if ($identity->plugin != 'Authdb')
+        {
+            return;
+        }
+
         // Here we do the actual authentication       
         $username = $this->getUsername();
         $password = $this->getPassword();

--- a/application/core/plugins/Authwebserver/Authwebserver.php
+++ b/application/core/plugins/Authwebserver/Authwebserver.php
@@ -72,6 +72,13 @@ class Authwebserver extends AuthPluginBase
     
     public function newUserSession()
     {
+        // Do nothing if this user is not Authdb type
+        $identity = $this->getEvent()->get('identity');
+        if ($identity->plugin != 'Authwebserver')
+        {
+            return;
+        }
+
         /* @var $identity LSUserIdentity */
         $sUser = $this->getUserName();
 

--- a/application/libraries/PluginManager/AuthPluginBase.php
+++ b/application/libraries/PluginManager/AuthPluginBase.php
@@ -34,7 +34,22 @@ abstract class AuthPluginBase extends PluginBase {
     {
         return $this->_username;
     }
-    
+
+    /**
+     * Set username and password
+     *
+     * @return null
+     */
+    public function afterLoginFormSubmit()
+    {
+        // Here we handle post data
+        $request = $this->api->getRequest();
+        if ($request->getIsPostRequest()) {
+            $this->setUsername( $request->getPost('user'));
+            $this->setPassword($request->getPost('password'));
+        }
+    }
+
     /**
      * Set authentication result to success for the given user object.
      * 


### PR DESCRIPTION
Dev : Target not anymore needed for auth plugins events, every auth plugin knows if he has to process event
Dev : This way, auth events (i.e. afterLogout) can be processed also by other plugins
Dev : Method afterLoginFormSubmit can be in parent class (preventing code duplication)
