### PR TITLE
Fixed issue #9413 - Let print answer if user can read responses.

### DIFF
--- a/application/controllers/PrintanswersController.php
+++ b/application/controllers/PrintanswersController.php
@@ -95,17 +95,7 @@
             //Ensure Participants printAnswer setting is set to true or that the logged user have read permissions over the responses.
             if ($aSurveyInfo['printanswers'] == 'N' && !Permission::model()->hasSurveyPermission($iSurveyID,'responses','read'))
             {
-                sendCacheHeaders();
-                doHeader();
-                echo templatereplace(file_get_contents(getTemplatePath($sTemplate).'/startpage.pstpl'),array());
-                echo "<center><br />\n"
-                ."\t<font color='RED'><strong>".$clang->gT("Error")."</strong></font><br />\n"
-                ."\t".$clang->gT("We are sorry but you are not allowed to print the answers.")."<br />\n"
-                ."\t".sprintf($clang->gT("Please contact %s ( %s ) for further assistance."), Yii::app()->getConfig("siteadminname"), Yii::app()->getConfig("siteadminemail"))."\n"
-                ."</center><br />\n";
-                echo templatereplace(file_get_contents(getTemplatePath($sTemplate).'/endpage.pstpl'),array());
-                doFooter();
-                exit;
+                throw new CHttpException(401, 'You are not allowed to print answers.');
             }
             
             //CHECK IF SURVEY IS ACTIVATED AND EXISTS


### PR DESCRIPTION
Do not exit controller if user has read permissions over responses.
As so allow to print if setting "Participant may print answers" is set to true or if user has read permission over responses.
