### PR TITLE
New feature #9431: Create LDAP users taking email and full name from LDAP

### DIFF
--- a/application/controllers/admin/authentication.php
+++ b/application/controllers/admin/authentication.php
@@ -154,12 +154,24 @@ class Authentication extends Survey_Common_Action
                 $aData['errormsg'] = $this->getController()->lang->gT('User name and/or email not found!');
                 $aData['maxattempts'] = '';
                 $this->_renderWrappedTemplate('authentication', 'error', $aData);
+                return;
             }
-            else
+
+            $sPassword = $aFields[0]['password'];
+            if (gettype($sPassword) == 'resource')
             {
-                $aData['message'] = $this->_sendPasswordEmail($sEmailAddr, $aFields);
-                $this->_renderWrappedTemplate('authentication', 'message', $aData);
+                $sPassword=stream_get_contents($sPassword,-1,0);
             }
+            if ($sPassword == AuthPluginBase::LDAP_INVALID_PASSWORD_TEXT)
+            {
+                $aData['errormsg'] = $this->getController()->lang->gT('User is configured for LDAP authentication, contact your Administrator');
+                $aData['maxattempts'] = '';
+                $this->_renderWrappedTemplate('authentication', 'error', $aData);
+                return;
+            }
+
+            $aData['message'] = $this->_sendPasswordEmail($sEmailAddr, $aFields);
+            $this->_renderWrappedTemplate('authentication', 'message', $aData);
         }
     }
 

--- a/application/controllers/admin/useraction.php
+++ b/application/controllers/admin/useraction.php
@@ -85,24 +85,27 @@ class UserAction extends Survey_Common_Action
         $new_user = flattenText(Yii::app()->request->getPost('new_user'), false, true);
         $new_email = flattenText(Yii::app()->request->getPost('new_email'), false, true);
         $new_full_name = flattenText(Yii::app()->request->getPost('new_full_name'), false, true);
+        $sUserType = flattenText(Yii::app()->request->getPost('user_type'), false, true);
         $aViewUrls = array();
-        $valid_email = true;
-        if (!validateEmailAddress($new_email)) {
-            $valid_email = false;
-            $aViewUrls['message'] = array('title' => $clang->gT("Failed to add user"), 'message' => $clang->gT("The email address is not valid."), 'class'=> 'warningheader');
-        }
         if (empty($new_user)) {
             $aViewUrls['message'] = array('title' => $clang->gT("Failed to add user"), 'message' => $clang->gT("A username was not supplied or the username is invalid."), 'class'=> 'warningheader');
         }
         elseif (User::model()->find("users_name=:users_name",array(':users_name'=>$new_user))) {
             $aViewUrls['message'] = array('title' => $clang->gT("Failed to add user"), 'message' => $clang->gT("The username already exists."), 'class'=> 'warningheader');
         }
-        elseif ($valid_email)
+        else
         {
-            $new_pass = createPassword();
-            $iNewUID = User::model()->insertUser($new_user, $new_pass, $new_full_name, Yii::app()->session['loginID'], $new_email);
+            $event = new PluginEvent('createNewUser');
+            App()->getPluginManager()->dispatchEvent($event);
 
-            if ($iNewUID) {
+            if ($event->get('errorCode') != AuthPluginBase::ERROR_NONE)
+            {
+                $aViewUrls['message'] = array('title' => $event->get('errorMessageTitle'), 'message' => $event->get('errorMessageBody'), 'class'=> 'warningheader');
+            }
+            else
+            {
+                $iNewUID = $event->get('newUserID');
+                $new_pass = $event->get('newPassword');
                 // add default template to template rights for user
                 Permission::model()->insertSomeRecords(array('uid' => $iNewUID, 'permission' => Yii::app()->getConfig("defaulttemplate"), 'entity'=>'template', 'read_p' => 1, 'entity_id'=>0));
                 // add new user to userlist
@@ -120,7 +123,8 @@ class UserAction extends Survey_Common_Action
                 $body .= sprintf($clang->gT("this is an automated email to notify that a user has been created for you on the site '%s'."), Yii::app()->getConfig("sitename")) . "<br /><br />\n";
                 $body .= $clang->gT("You can use now the following credentials to log into the site:") . "<br />\n";
                 $body .= $clang->gT("Username") . ": " . htmlspecialchars($new_user) . "<br />\n";
-                if (Yii::app()->getConfig("auth_webserver") === false) { // authent is not delegated to web server
+                // authent is not delegated to web server or LDAP server
+                if (Yii::app()->getConfig("auth_webserver") === false  && $sUserType != 'LDAP') {
                     // send password (if authorized by config)
                     if (Yii::app()->getConfig("display_user_password_in_email") === true) {
                         $body .= $clang->gT("Password") . ": " . $new_pass . "<br />\n";
@@ -157,10 +161,6 @@ class UserAction extends Survey_Common_Action
                 $aViewUrls['mboxwithredirect'][] = $this->_messageBoxWithRedirect($clang->gT("Add user"), $sHeader, $classMsg, $extra,
                 $this->getController()->createUrl("admin/user/sa/setuserpermissions"), $clang->gT("Set user permissions"),
                 array('action' => 'setuserpermissions', 'user' => $new_user, 'uid' => $iNewUID));
-            }
-            else
-            {
-                $aViewUrls['mboxwithredirect'][] = $this->_messageBoxWithRedirect($clang->gT("Failed to add user"), $clang->gT("The user name already exists."), 'warningheader');
             }
         }
 
@@ -370,7 +370,16 @@ class UserAction extends Survey_Common_Action
                 $oRecord = User::model()->findByPk($postuserid);
                 $oRecord->email= $this->escape($email);
                 $oRecord->full_name= $this->escape($full_name);
-                if (!empty($sPassword))
+                if (gettype($oRecord->password) == 'resource')
+                {
+                    $sSavedPassword = stream_get_contents($oRecord->password,-1,0);
+                }
+                else
+                {
+                    $sSavedPassword = $oRecord->password;
+                }
+                // Don't modify password if it is empty or user is marked as exclusive LDAP authentication
+                if (!empty($sPassword) && $sSavedPassword != AuthPluginBase::LDAP_INVALID_PASSWORD_TEXT)
                 {
                     $oRecord->password= hash('sha256', $sPassword);
                 }
@@ -379,6 +388,10 @@ class UserAction extends Survey_Common_Action
                 if (empty($sPassword)) {
                     $extra = $clang->gT("Username") . ": {$oRecord->users_name}<br />" . $clang->gT("Password") . ": (" . $clang->gT("Unchanged") . ")<br />\n";
                     $aViewUrls['mboxwithredirect'][] = $this->_messageBoxWithRedirect($clang->gT("Editing user"), $clang->gT("Success!"), "successheader", $extra);
+                }
+                elseif ($sSavedPassword == AuthPluginBase::LDAP_INVALID_PASSWORD_TEXT) {
+                    $extra = $clang->gT("Username") . ": {$oRecord->users_name}<br />" . $clang->gT("Email address") . ": {$oRecord->email}<br />" . $clang->gT("Full name") . ": {$oRecord->full_name}<br />" . $clang->gT("Password") . ": (" . $clang->gT("Unchanged [LDAP user]") . ")<br />\n";
+                    $aViewUrls['mboxwithredirect'][] = $this->_messageBoxWithRedirect($clang->gT("Editing user"), $clang->gT("Password was not modified"), "successheader", $extra);
                 }
                 elseif ($uresult && !empty($sPassword)) // When saved successfully
                 {

--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -72,8 +72,16 @@ class AuthLDAP extends AuthPluginBase
                 'label' => 'Optional DN of the LDAP account used to search for the end-user\'s DN. An anonymous bind is performed if empty.'
                 ),
         'bindpwd' => array(
-                'type' => 'string',
+                'type' => 'password',
                 'label' => 'Password of the LDAP account used to search for the end-user\'s DN if previoulsy set.'
+                ),
+        'mailattribute' => array(
+                'type' => 'string',
+                'label' => 'LDAP attribute of email address'
+                ),
+        'fullnameattribute' => array(
+                'type' => 'string',
+                'label' => 'LDAP attribute of full name address'
                 ),
         'is_default' => array(
                 'type' => 'checkbox',
@@ -87,10 +95,172 @@ class AuthLDAP extends AuthPluginBase
         /**
          * Here you should handle subscribing to the events your plugin will handle
          */
+        $this->subscribe('createNewUser');
         $this->subscribe('beforeLogin');
         $this->subscribe('newLoginForm');
         $this->subscribe('afterLoginFormSubmit');
         $this->subscribe('newUserSession');
+    }
+
+    /**
+     * Create a LDAP user
+     *
+     * @return unknown_type
+     */
+    public function createNewUser()
+    {
+        // Do nothing if the user to be added is not LDAP type
+        if (flattenText(Yii::app()->request->getPost('user_type')) != 'LDAP')
+        {
+            return;
+        }
+
+        $oEvent = $this->getEvent();
+        $new_user = flattenText(Yii::app()->request->getPost('new_user'), false, true);
+
+        // Get configuration settings:
+        $ldapserver     = $this->get('server');
+        $ldapport       = $this->get('ldapport');
+        $ldapmode       = $this->get('ldapmode');
+        $searchuserattribute    = $this->get('searchuserattribute');
+        $extrauserfilter      = $this->get('extrauserfilter');
+        $usersearchbase   = $this->get('usersearchbase');
+        $binddn         = $this->get('binddn');
+        $bindpwd        = $this->get('bindpwd');
+        $mailattribute = $this->get('mailattribute');
+        $fullnameattribute = $this->get('fullnameattribute');
+
+        // Try to connect
+        $ldapconn = $this->createConnection();
+        if (!is_resource($ldapconn))
+        {
+            $oEvent->set('errorCode',self::ERROR_LDAP_CONNECTION);
+            $oEvent->set('errorMessageTitle','');
+            $oEvent->set('errorMessageBody',$ldapconn['errorMessage']);
+            return;
+        }
+
+        if (empty($ldapmode) || $ldapmode=='simplebind')
+        {
+            $oEvent->set('errorCode',self::ERROR_LDAP_MODE);
+            $oEvent->set('errorMessageTitle',gT("Failed to add user"));
+            $oEvent->set('errorMessageBody',gT("Simple bind LDAP configuration doesn't allow LDAP user creation"));
+            return;
+        }
+
+        // Search email address and full name
+        if (empty($binddn))
+        {
+            // There is no account defined to do the LDAP search,
+            // let's use anonymous bind instead
+            $ldapbindsearch = @ldap_bind($ldapconn);
+        }
+        else
+        {
+            // An account is defined to do the LDAP search, let's use it
+            $ldapbindsearch = @ldap_bind($ldapconn, $binddn, $bindpwd);
+        }
+        if (!$ldapbindsearch) {
+            $oEvent->set('errorCode',self::ERROR_LDAP_NO_BIND);
+            $oEvent->set('errorMessageTitle',gT('Could not connect to LDAP server.'));
+            $oEvent->set('errorMessageBody',gT(ldap_error($ldapconn)));
+            ldap_close($ldapconn); // all done? close connection
+            return;
+        }
+        // Now prepare the search fitler
+        if ( $extrauserfilter != "")
+        {
+            $usersearchfilter = "(&($searchuserattribute=$new_user)$extrauserfilter)";
+        }
+        else
+        {
+            $usersearchfilter = "($searchuserattribute=$new_user)";
+        }
+        // Search for the user
+        $dnsearchres = ldap_search($ldapconn, $usersearchbase, $usersearchfilter, array($mailattribute,$fullnameattribute));
+        $rescount=ldap_count_entries($ldapconn,$dnsearchres);
+        if ($rescount == 1)
+        {
+            $userentry=ldap_get_entries($ldapconn, $dnsearchres);
+            $new_email = flattenText($userentry[0][$mailattribute][0]);
+            $new_full_name = flattenText($userentry[0][strtolower($fullnameattribute)][0]);
+        }
+        else
+        {
+            $oEvent->set('errorCode',self::ERROR_LDAP_NO_SEARCH_RESULT);
+            $oEvent->set('errorMessageTitle',gT('Username not found in LDAP server'));
+            $oEvent->set('errorMessageBody',gT('Verify username and try again'));
+            ldap_close($ldapconn); // all done? close connection
+            return;
+        }
+
+        if (!validateEmailAddress($new_email))
+        {
+            $oEvent->set('errorCode',self::ERROR_INVALID_EMAIL);
+            $oEvent->set('errorMessageTitle',gT("Failed to add user"));
+            $oEvent->set('errorMessageBody',gT("The email address is not valid."));
+            return;
+        }
+        $new_pass = self::LDAP_INVALID_PASSWORD_TEXT;
+        $iNewUID = User::model()->insertUser($new_user, $new_pass, $new_full_name, Yii::app()->session['loginID'], $new_email, false);
+        if (!$iNewUID)
+        {
+            $oEvent->set('errorCode',self::ERROR_ALREADY_EXISTING_USER);
+            $oEvent->set('errorMessageTitle','');
+            $oEvent->set('errorMessageBody',gT("Failed to add user"));
+            return;
+        }
+        $oEvent->set('newUserID',$iNewUID);
+        $oEvent->set('newPassword',$new_pass);
+        $oEvent->set('errorCode',self::ERROR_NONE);
+    }
+
+
+    /**
+     * Create LDAP connection
+     *
+     * @return mixed
+     */
+    private function createConnection()
+    {
+        // Get configuration settings:
+        $ldapserver     = $this->get('server');
+        $ldapport       = $this->get('ldapport');
+        $ldapver        = $this->get('ldapversion');
+        $ldaptls        = $this->get('ldaptls');
+        $ldapoptreferrals = $this->get('ldapoptreferrals');
+
+        if (empty($ldapport)) {
+            $ldapport = 389;
+        }
+
+        // Try to connect
+        $ldapconn = ldap_connect($ldapserver, (int) $ldapport);
+        if (false == $ldapconn) {
+            return [ "errorCode" => 1, "errorMessage" => gT('Error creating LDAP connection') ];
+        }
+
+        // using LDAP version
+        if ($ldapver === null)
+        {
+            // If the version hasn't been set, default = 2
+            $ldapver = 2;
+        }
+
+        ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, $ldapver);
+        ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, $ldapoptreferrals);
+
+        if (!empty($ldaptls) && $ldaptls == '1' && $ldapver == 3 && preg_match("/^ldaps:\/\//", $ldapserver) == 0 )
+        {
+            // starting TLS secure layer
+            if(!ldap_start_tls($ldapconn))
+            {
+                ldap_close($ldapconn); // all done? close connection
+                return [ "errorCode" => 100, 'errorMessage' => ldap_error($ldapconn) ];
+            }
+        }
+
+        return $ldapconn;
     }
 
     public function beforeLogin()
@@ -148,6 +318,8 @@ class AuthLDAP extends AuthPluginBase
                 unset($aPluginSettings['binddn']);
                 unset($aPluginSettings['bindpwd']);
                 unset($aPluginSettings['ldapoptreferrals']);
+                unset($aPluginSettings['mailattribute']);
+                unset($aPluginSettings['fullnameattribute']);
             }
         }
         
@@ -171,7 +343,7 @@ class AuthLDAP extends AuthPluginBase
 
         if ($user === null && $this->autoCreate === false)
         {
-            // If the user doesnt exist ín the LS database, he can not login
+            // If the user doesnt exist in the LS database, he can not login
             $this->setAuthFailure(self::ERROR_USERNAME_INVALID);
             return;
         }
@@ -187,9 +359,6 @@ class AuthLDAP extends AuthPluginBase
         // Get configuration settings:
         $ldapserver 		= $this->get('server');
         $ldapport   		= $this->get('ldapport');
-        $ldapver    		= $this->get('ldapversion');
-        $ldaptls    		= $this->get('ldaptls');
-        $ldapoptreferrals	= $this->get('ldapoptreferrals');
         $ldapmode    		= $this->get('ldapmode');
         $suffix     		= $this->get('domainsuffix');
         $prefix     		= $this->get('userprefix');
@@ -199,37 +368,12 @@ class AuthLDAP extends AuthPluginBase
         $binddn     		= $this->get('binddn');
         $bindpwd     		= $this->get('bindpwd');
 
-
-
-        if (empty($ldapport)) {
-            $ldapport = 389;
-        }
-
         // Try to connect
-        $ldapconn = ldap_connect($ldapserver, (int) $ldapport);
-        if (false == $ldapconn) {
-            $this->setAuthFailure(1, gT('Could not connect to LDAP server.'));
+        $ldapconn = $this->createConnection();
+        if (!is_resource($ldapconn))
+        {
+            $this->setAuthFailure($ldapconn['errorCode'], gT($ldapconn['errorMessage']));
             return;
-        }
-
-        // using LDAP version
-        if ($ldapver === null)
-        {
-            // If the version hasn't been set, default = 2
-            $ldapver = 2;
-        }
-        ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, $ldapver);
-        ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, $ldapoptreferrals);
-
-        if (!empty($ldaptls) && $ldaptls == '1' && $ldapver == 3 && preg_match("/^ldaps:\/\//", $ldapserver) == 0 )
-        {
-            // starting TLS secure layer
-            if(!ldap_start_tls($ldapconn))
-            {
-                $this->setAuthFailure(100, ldap_error($ldapconn));
-                ldap_close($ldapconn); // all done? close connection
-                return;
-            }
         }
 
         if (empty($ldapmode) || $ldapmode=='simplebind')

--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -14,6 +14,7 @@ class Authdb extends AuthPluginBase
         /**
          * Here you should handle subscribing to the events your plugin will handle
          */
+        $this->subscribe('createNewUser');
         $this->subscribe('beforeLogin');
         $this->subscribe('newLoginForm');
         $this->subscribe('afterLoginFormSubmit');
@@ -25,6 +26,43 @@ class Authdb extends AuthPluginBase
         $this->subscribe('listExportOptions');
         $this->subscribe('newExport');
         
+    }
+
+    /**
+     * Create a DB user
+     *
+     * @return unknown_type
+     */
+    public function createNewUser()
+    {
+        // Do nothing if the user to be added is not DB type
+        if (flattenText(Yii::app()->request->getPost('user_type')) != 'DB')
+        {
+            return;
+        }
+        $oEvent = $this->getEvent();
+        $new_user = flattenText(Yii::app()->request->getPost('new_user'), false, true);
+        $new_email = flattenText(Yii::app()->request->getPost('new_email'), false, true);
+        if (!validateEmailAddress($new_email))
+        {
+            $oEvent->set('errorCode',self::ERROR_INVALID_EMAIL);
+            $oEvent->set('errorMessageTitle',gT("Failed to add user"));
+            $oEvent->set('errorMessageBody',gT("The email address is not valid."));
+            return;
+        }
+        $new_full_name = flattenText(Yii::app()->request->getPost('new_full_name'), false, true);
+        $new_pass = createPassword();
+        $iNewUID = User::model()->insertUser($new_user, $new_pass, $new_full_name, Yii::app()->session['loginID'], $new_email);
+        if (!$iNewUID)
+        {
+            $oEvent->set('errorCode',self::ERROR_ALREADY_EXISTING_USER);
+            $oEvent->set('errorMessageTitle','');
+            $oEvent->set('errorMessageBody',gT("Failed to add user"));
+            return;
+        }
+        $oEvent->set('newUserID',$iNewUID);
+        $oEvent->set('newPassword',$new_pass);
+        $oEvent->set('errorCode',self::ERROR_NONE);
     }
 
     public function beforeDeactivate()

--- a/application/libraries/PluginManager/AuthPluginBase.php
+++ b/application/libraries/PluginManager/AuthPluginBase.php
@@ -6,12 +6,22 @@ abstract class AuthPluginBase extends PluginBase {
      * are copied from LSUserIdentity and CBaseUserIdentity for easier access.
      */
     const ERROR_NONE = 0;
-	const ERROR_USERNAME_INVALID = 1;
-	const ERROR_PASSWORD_INVALID = 2;
+    const ERROR_USERNAME_INVALID = 1;
+    const ERROR_PASSWORD_INVALID = 2;
     const ERROR_IP_LOCKED_OUT = 98;
     const ERROR_UNKNOWN_HANDLER = 99;
     const ERROR_UNKNOWN_IDENTITY = 100;
-    
+    const ERROR_INVALID_EMAIL = 110;
+    const ERROR_ALREADY_EXISTING_USER = 120;
+    const ERROR_LDAP_CONNECTION = 130;
+    const ERROR_LDAP_MODE = 135;
+    const ERROR_LDAP_NO_EMAIL = 140;
+    const ERROR_LDAP_NO_FULLNAME = 150;
+    const ERROR_LDAP_NO_BIND = 160;
+    const ERROR_LDAP_NO_SEARCH_RESULT = 170;
+
+    const LDAP_INVALID_PASSWORD_TEXT = "INVALID_PASSWORD-LDAP_USER";
+
     protected $_username = null;
     protected $_password = null;
     

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -69,6 +69,26 @@
         }
         
         /**
+         * Return the status of plugin (true/active or false/desactive)
+         *
+         * @param sPluginName Plugin name
+         * @return boolean
+         */
+        public function isPluginActive($sPluginName)
+        {
+            $pluginModel = Plugin::model();
+            $record = $pluginModel->findByAttributes(array('name' => $sPluginName));
+            if ($record == false)
+            {
+                return false;
+            }
+            else
+            {
+                return $record->active;
+            }
+        }
+
+        /**
          * Returns the storage instance of type $storageClass.
          * If needed initializes the storage object.
          * @param string $storageClass

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -145,11 +145,21 @@ class User extends LSActiveRecord
     * @access public
     * @return string
     */
-    public static function insertUser($new_user, $new_pass,$new_full_name,$parent_user,$new_email)
+    public static function insertUser($new_user, $new_pass,$new_full_name,$parent_user,$new_email,$bHashPassword=true)
     {
         $oUser = new self;
         $oUser->users_name = $new_user;
-        $oUser->password = hash('sha256', $new_pass);
+
+        // This param is a temporary solution until issue #8865 is fixed because
+        // we will be able to recognize LDAP users by an attribute
+        if ($bHashPassword)
+        {
+            $oUser->password = hash('sha256', $new_pass);
+        }
+        else
+        {
+            $oUser->password = $new_pass;
+        }
         $oUser->full_name = $new_full_name;
         $oUser->parent_id = $parent_user;
         $oUser->lang = 'auto';

--- a/application/views/admin/user/editusers.php
+++ b/application/views/admin/user/editusers.php
@@ -128,11 +128,22 @@
 <?php if(Permission::model()->hasGlobalPermission('superadmin','read') || Permission::model()->hasGlobalPermission('users','create')) { ?>
     <?php echo CHtml::form(array('admin/user/sa/adduser'), 'post');?>            
         <table class='users'><tr class='oddrow'>
-                <th><?php $clang->eT("Add user:");?></th>
-                <td style='width:20%'><input type='text' name='new_user' /></td>
-                <td style='width:20%'><input type='text' name='new_email' /></td>
-                <td style='width:20%'><input type='text' name='new_full_name' /></td><td style='width:8%'>&nbsp;</td>
-                <td style='width:15%'><input type='submit' value='<?php $clang->eT("Add user");?>' />
-                    <input type='hidden' name='action' value='adduser' /></td>
+                <?php if (App()->getPluginManager()->isPluginActive('AuthLDAP')) {
+                          echo "<td style='width:15%'>";
+                          echo CHtml::dropDownList('user_type', 'DB', array('DB' => gT("Internal or LDAP authentication"), 'LDAP' => gT("LDAP authentication")));
+                          echo "</td>";
+                      }
+                      else
+                      {
+                          echo "<td style='width:15%'>&nbsp;</td>";
+                          echo "<input type='hidden' id='user_type' name='user_type' value='DB'/>";
+                      }
+                ?>
+                <td style='width:20%'><input type='text' id='new_user' name='new_user' /></td>
+                <td style='width:20%'><input type='text' id='new_email' name='new_email' /></td>
+                <td style='width:20%'><input type='text' id='new_full_name' name='new_full_name' /></td>
+                <td style='width:20%'><input type='submit' value='<?php $clang->eT("Add user");?>' />
+                <input type='hidden' name='action' value='adduser' /></td>
+                <td style='width:5%'>&nbsp;</td>
             </tr></table></form><br />
-    <?php } ?>
+<?php } ?>

--- a/scripts/admin/users.js
+++ b/scripts/admin/users.js
@@ -16,4 +16,17 @@ $(document).ready(function(){
         $("input[type=checkbox]").prop("checked",!tog);
         tog=!tog;
     });
+
+    $("#user_type").change(UsertypeChange);
+    UsertypeChange();
 });
+
+
+function UsertypeChange(ui,evt)
+{
+    ldap_user=($("#user_type").val()=='LDAP');
+    if (ldap_user==true) {ldap_user='disabled';}
+    else {ldap_user='';}
+    $("#new_email").prop('disabled',ldap_user);
+    $("#new_full_name").prop('disabled',ldap_user);
+}


### PR DESCRIPTION
A new type of users can be created:

*  Full name and email address are taken from LDAP at creation time (user and/or admins can change them later).
*  The only authentication method they can use is LDAP.
*  They can't modify their internal DB password
*  Admins can't modify their internal DB password
*  They can't reset their password using "forgotten password" funcionality
*  They don't receive any password in welcome email