### PR TITLE
Add support for hook_get_auth_webserver_permissions

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -206,6 +206,31 @@ $config['auth_webserver_autocreate_permissions'] = Array(
 //			'htmleditormode' => 'inline');
 //}
 
+//hook_get_auth_webserver_permissions
+// The optionnal 'hook_get_auth_webserver_permissions' function is for advanced user usage only.
+// It is used to customize the permissions of the imported user
+// If set, the this function will overwrite the auth_webserver_autocreate_permissions
+// defined above by its return value
+//
+// You can use any external DB in order to build permissions for the user_name passed as the first parameter
+// A dummy example for the 'hook_get_auth_webserver_permissions' function is given below:
+//
+//function hook_get_auth_webserver_permissions($user_name)
+//{
+//    if ($user_name === "dani")
+//    {
+//        return Array('superadmin' => Array('read'=>true));
+//    } else {
+//        return Array(
+//            'surveys' => array(
+//                'create'=>true,
+//                'read'=>true,
+//                'update'=>true,
+//                'delete'=>true)
+//        );
+//    }
+//}
+
 
 // filterxsshtml
 // Enables filtering of suspicious html tags in survey, group, questions

--- a/application/core/plugins/Authwebserver/Authwebserver.php
+++ b/application/core/plugins/Authwebserver/Authwebserver.php
@@ -113,7 +113,15 @@ class Authwebserver extends AuthPluginBase
             if ($oUser->save())
             {
                 $permission=new Permission;
-                $permission->setPermissions($oUser->uid, 0, 'global', $this->api->getConfigKey('auth_webserver_autocreate_permissions'), true);
+                if (function_exists("hook_get_auth_webserver_permissions"))
+                {
+                    $aUserPermissions = hook_get_auth_webserver_permissions($sUser);
+                }
+                else
+                {
+                    $aUserPermissions = $this->api->getConfigKey('auth_webserver_autocreate_permissions');
+                }
+                $permission->setPermissions($oUser->uid, 0, 'global', $aUserPermissions, true);
 
                 // read again user from newly created entry
                 $this->setAuthSuccess($oUser);


### PR DESCRIPTION
Just like hook_get_auth_webserver_profile, hook_get_auth_webserver_permissions can be used to customize the permissions of a newly imported users. This reintroduce the possibility to create users with diffrent permissions which has been removed when switching to the new permission table (see for example https://github.com/LimeSurvey/LimeSurvey/commit/a9b30bc9aa0ac422caa68ca8466cc05ef2dadee5)