### PR TITLE
Added alternate PDF font for Croatian language

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -353,6 +353,7 @@ $config['alternatepdffontfile']=array(
     'ro'=>'dejavusans',
     'ru'=>'dejavusans',
     'sr'=>'dejavusans',
+    'hr'=>'freesans',
 );
 /**
 *  $notsupportlanguages - array of language where no font was found for PDF


### PR DESCRIPTION
Default one breaks Croatian specific letters.