### PR TITLE
Remote logout URL

### DIFF
--- a/application/core/plugins/Authwebserver/Authwebserver.php
+++ b/application/core/plugins/Authwebserver/Authwebserver.php
@@ -137,7 +137,6 @@ class Authwebserver extends AuthPluginBase
 	$logoutURL = $this->get('logout_url');
         if (!empty($logoutURL))
 	{
-	//header("Location: https://sondages.auf.org/mellon/logout?ReturnTo=https://auf.org/");
 	header("Location: $logoutURL");
 	exit;
 	}

--- a/application/core/plugins/Authwebserver/Authwebserver.php
+++ b/application/core/plugins/Authwebserver/Authwebserver.php
@@ -20,7 +20,11 @@ class Authwebserver extends AuthPluginBase
                 'type' => 'checkbox',
                 'label' => 'Check to make default authentication method (This disable Default LimeSurvey authentification by database)',
                 'default' => true,
-                )
+         ),
+	'logout_url' => array(
+		'type' => 'string',
+		'label' => 'Remote auth logout URL (LimeSurvey will redirect to this URL after local logout)',
+	),
     );
     
     public function __construct(PluginManager $manager, $id) {
@@ -31,6 +35,7 @@ class Authwebserver extends AuthPluginBase
          */
         $this->subscribe('beforeLogin');
         $this->subscribe('newUserSession');
+	$this->subscribe('afterLogout');
     }
 
     public function beforeLogin()
@@ -127,5 +132,14 @@ class Authwebserver extends AuthPluginBase
         
     }  
     
-    
+    public function afterLogout()
+    {
+	$logoutURL = $this->get('logout_url');
+        if (!empty($logoutURL))
+	{
+	//header("Location: https://sondages.auf.org/mellon/logout?ReturnTo=https://auf.org/");
+	header("Location: $logoutURL");
+	exit;
+	}
+    }    
 }


### PR DESCRIPTION
Just now Limesurvey can start a session with remote auth but users can't close this remote session using the logout button. this PR try to solve it if you can close this remote session in a specific URL.

After to destroy the Limesurvey session it redirects to a remote URL when a remote webserver (ex: apache with  mod_mellon auth plugin) will destroy the remote session.



