### PR TITLE
New feature: RemoteControl get_question_properties returns also default value

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1348,6 +1348,7 @@ class remotecontrol_handle
                 array_push($aBasicDestinationFields,'attributes')    ;
                 array_push($aBasicDestinationFields,'attributes_lang')    ;
                 array_push($aBasicDestinationFields,'answeroptions')    ;
+                array_push($aBasicDestinationFields,'defaultvalue');
                 $aQuestionSettings=array_intersect($aQuestionSettings,$aBasicDestinationFields);
 
                 if (empty($aQuestionSettings))
@@ -1424,7 +1425,11 @@ class remotecontrol_handle
                         else
                             $aResult['answeroptions']='No available answer options';
                     }
-                    else
+                    else if ($sPropertyName == 'defaultvalue')
+                    {
+					    $aResult['defaultvalue'] = DefaultValue::model()->findByAttributes(array('qid' => $iQuestionID, 'language'=> $sLanguage))->defaultvalue;
+					}
+					else
                     {
                             $aResult[$sPropertyName]=$oQuestion->$sPropertyName;
                     }


### PR DESCRIPTION
Function `get_question_properties` in RemoteControl 2 API now can be able to return `defaultvalue` upon request.

Users must add `defaultvalue` to `$aQuestionSettings` in order to get this value.
However, the default value is an _answer code_ in case users need assessment value they need to match the default value to data in `answeroptions` with this one. Because `answeroptions` also return `assessment_value`.