### PR TITLE
Fixed issue : unable to show different name than class name

### DIFF
--- a/application/libraries/PluginManager/LimesurveyApi.php
+++ b/application/libraries/PluginManager/LimesurveyApi.php
@@ -26,7 +26,7 @@
          */
         protected function getTableName(iPlugin $plugin, $tableName)
         {
-            return App()->getDb()->tablePrefix . strtolower($plugin->getName()) . "_$tableName";
+            return App()->getDb()->tablePrefix . strtolower(get_class($plugin)) . "_$tableName";
         }
         /**
         * Sets a flash message to be shown to the user.


### PR DESCRIPTION
Dev: $plugin->name is used to show to user, must be tranlatable for example
Dev: using get_class to use Class name