### PR TITLE
Fixed issue #9591: Sometimes date_max / date_min validations for date/t...

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -1516,7 +1516,7 @@
                                     }
 
                                     $sq_name = ($this->sgqaNaming)?$sq['rowdivid'].".NAOK":$sq['varName'].".NAOK";
-                                    $sq_name = '(is_empty(' . $sq_name . ') || ('. $sq_name . ' >= ' . $date_min . '))';// Leave mandatory to mandatory attribute
+                                    $sq_name = '(is_empty(' . $sq_name . ') || ('. $sq_name . ' >= date("Y-m-d H:i", strtotime(' . $date_min . ')) ))';// Leave mandatory to mandatory attribute
                                     $subqValidSelector = '';
                                     break;
                                 default:
@@ -1585,7 +1585,7 @@
                                     }
 
                                     $sq_name = ($this->sgqaNaming)?$sq['rowdivid'].".NAOK":$sq['varName'].".NAOK";
-                                    $sq_name = '(is_empty(' . $sq_name . ') || is_empty(' . $date_max . ') || ('. $sq_name . ' <= ' . $date_max . '))';// Leave mandatory to mandatory attribute
+                                    $sq_name = '(is_empty(' . $sq_name . ') || is_empty(' . $date_max . ') || ('. $sq_name . ' <= date("Y-m-d H:i", strtotime(' . $date_max . ')) ))';// Leave mandatory to mandatory attribute
                                     $subqValidSelector = '';
                                     break;
                                 default:


### PR DESCRIPTION
...ime questions doesn't allow to use the maximum date expected.

- Reformat expression held into date_max / date_min into "Y-m-d H:i" format, so comparison can be done among equals format.