### PR TITLE
Fixed issue #9591: Sometimes date_max / date_min validations for date/ti...

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -1568,7 +1568,7 @@
                                     }
 
                                     $sq_name = ($this->sgqaNaming)?$sq['rowdivid'].".NAOK":$sq['varName'].".NAOK";
-                                    $sq_name = '(is_empty(' . $sq_name . ') || ('. $sq_name . ' >= ' . $date_min . '))';
+                                    $sq_name = '(is_empty(' . $sq_name . ') || ('. $sq_name . ' >= date("Y-m-d H:i", strtotime(' . $date_min . ')) ))';
                                     $subqValidSelector = '';
                                     break;
                                 default:
@@ -1637,7 +1637,7 @@
                                     }
 
                                     $sq_name = ($this->sgqaNaming)?$sq['rowdivid'].".NAOK":$sq['varName'].".NAOK";
-                                    $sq_name = '(is_empty(' . $sq_name . ') || is_empty(' . $date_max . ') || ('. $sq_name . ' <= ' . $date_max . '))';
+                                    $sq_name = '(is_empty(' . $sq_name . ') || is_empty(' . $date_max . ') || ('. $sq_name . ' <= date("Y-m-d H:i", strtotime(' . $date_max . ')) ))';
                                     $subqValidSelector = '';
                                     break;
                                 default:


### PR DESCRIPTION
...me questions doesn't allow to use the maximum date expected.

- Reformat expression held into date_max / date_min into "Y-m-d H:i" format, so comparison can be done among equals format.
- Now min_date / max_date supports all the date formats correctly parsed by strtotime: YYYY-MM-DD, YYYY/MM/DD, DD.MM.YYYY, MM/DD/YYYY, DD-MM-YYYY, US natural language, ...