### PR TITLE
Fixed Issue: delete_question API method shuffled questions, not keeping ...

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -160,7 +160,7 @@
         */
         public static function updateSortOrder($gid, $surveyid)
         {
-            $questions = self::model()->findAllByAttributes(array('gid' => $gid, 'sid' => $surveyid, 'language' => Survey::model()->findByPk($surveyid)->language));
+            $questions = self::model()->findAllByAttributes(array('gid' => $gid, 'sid' => $surveyid, 'language' => Survey::model()->findByPk($surveyid)->language), array('order'=>'question_order') );
             $p = 0;
             foreach ($questions as $question)
             {


### PR DESCRIPTION
...its original order.

Questions were retrieved from DB without asking for any order cirteria.
So they were ordered considering the QID (the same order as they were created).