### PR TITLE
Dev: Added extra fields returned for list_groups and list_questions API.

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1752,7 +1752,7 @@ class remotecontrol_handle
 
                 foreach ($oGroupList as $oGroup)
                 {
-                    $aData[]= array('id'=>$oGroup->primaryKey,'group_name'=>$oGroup->attributes['group_name']);
+                    $aData[]= array('id'=>$oGroup->primaryKey,'group_name'=>$oGroup->attributes['group_name'], 'group_order'=>$oGroup->attributes['group_order']);
                 }
                 return $aData;
             }
@@ -1877,7 +1877,7 @@ class remotecontrol_handle
 
                 foreach ($aQuestionList as $oQuestion)
                 {
-                    $aData[]= array('id'=>$oQuestion->primaryKey,'title'=>$oQuestion->attributes['title'],'type'=>$oQuestion->attributes['type'], 'question'=>$oQuestion->attributes['question']);
+                    $aData[]= array('id'=>$oQuestion->primaryKey,'title'=>$oQuestion->attributes['title'],'type'=>$oQuestion->attributes['type'], 'question'=>$oQuestion->attributes['question'], 'gid'=>$oQuestion->attributes['gid'], 'question_order'=>$oQuestion->attributes['question_order'], 'relevance'=>$oQuestion->attributes['relevance']);
                 }
                 return $aData;
             }

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1752,7 +1752,7 @@ class remotecontrol_handle
 
                 foreach ($oGroupList as $oGroup)
                 {
-                    $aData[]= array('id'=>$oGroup->primaryKey,'group_name'=>$oGroup->attributes['group_name'], 'group_order'=>$oGroup->attributes['group_order']);
+                    $aData[]= array('id'=>$oGroup->primaryKey) + $oGroup->attributes;
                 }
                 return $aData;
             }
@@ -1877,7 +1877,7 @@ class remotecontrol_handle
 
                 foreach ($aQuestionList as $oQuestion)
                 {
-                    $aData[]= array('id'=>$oQuestion->primaryKey,'title'=>$oQuestion->attributes['title'],'type'=>$oQuestion->attributes['type'], 'question'=>$oQuestion->attributes['question'], 'gid'=>$oQuestion->attributes['gid'], 'question_order'=>$oQuestion->attributes['question_order'], 'relevance'=>$oQuestion->attributes['relevance']);
+                    $aData[]= array('id'=>$oQuestion->primaryKey) + $oQuestion->attributes;
                 }
                 return $aData;
             }


### PR DESCRIPTION
- Returning more info will make listing more useful.
- Although the content returned may be longer, it may avoid lot of extra calls for group or question details.
- As for example, to list questions in the right order, before one needed to get question properties for every question listed, seeking the question_order.