### PR TITLE
Feature: make AuthLDAP support multiple Base DNs for "Search and Bind"

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -66,7 +66,7 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
                 ),
         'usersearchbase' => array(
                 'type' => 'string',
-                'label' => 'Base DN for the user search operation'
+                'label' => 'Base DN for the user search operation. Multiple bases may be separated by a semicolon (;)'
                 ),
         'extrauserfilter' => array(
                 'type' => 'string',
@@ -181,15 +181,21 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
             $usersearchfilter = "($searchuserattribute=$new_user)";
         }
         // Search for the user
-        $dnsearchres = ldap_search($ldapconn, $usersearchbase, $usersearchfilter, array($mailattribute,$fullnameattribute));
-        $rescount=ldap_count_entries($ldapconn,$dnsearchres);
-        if ($rescount == 1)
-        {
-            $userentry=ldap_get_entries($ldapconn, $dnsearchres);
-            $new_email = flattenText($userentry[0][$mailattribute][0]);
-            $new_full_name = flattenText($userentry[0][strtolower($fullnameattribute)][0]);
-        }
-        else
+	$userentry = false;
+	// try each semicolon-separated search base in order
+	foreach(explode(";",$usersearchbase) as $usb)
+	{
+          $dnsearchres = ldap_search($ldapconn, $usersearchbase, $usersearchfilter, array($mailattribute,$fullnameattribute));
+          $rescount=ldap_count_entries($ldapconn,$dnsearchres);
+          if ($rescount == 1)
+          {
+              $userentry=ldap_get_entries($ldapconn, $dnsearchres);
+              $new_email = flattenText($userentry[0][$mailattribute][0]);
+              $new_full_name = flattenText($userentry[0][strtolower($fullnameattribute)][0]);
+	      break;
+          }
+	}
+	if(!$userentry)
         {
             $oEvent->set('errorCode',self::ERROR_LDAP_NO_SEARCH_RESULT);
             $oEvent->set('errorMessageTitle',gT('Username not found in LDAP server'));


### PR DESCRIPTION
Dev: split $usersearchbase on semicolon (;)
Dev: loop over the values as DN when trying to authenticate via LDAP

With this patch, you can specify multiple Base DNs to authenticate
against in "Search and Bind" mode. LS will try to find the login in any
one of these DNs. They are tried in order.