### PR TITLE
Fixed issue : enforce the mandatory token field + show warning if the import csv file contains ignored columns  

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1218,6 +1218,7 @@ class tokens extends Survey_Common_Action
             foreach ($languages as $language)
                 $captions[$language][$fieldname] = $_POST["caption_{$fieldname}_$language"];
         }
+
         Survey::model()->updateByPk($iSurveyId, array('attributedescriptions' => json_encode($fieldcontents)));
         foreach ($languages as $language)
         {

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1218,7 +1218,6 @@ class tokens extends Survey_Common_Action
             foreach ($languages as $language)
                 $captions[$language][$fieldname] = $_POST["caption_{$fieldname}_$language"];
         }
-
         Survey::model()->updateByPk($iSurveyId, array('attributedescriptions' => json_encode($fieldcontents)));
         foreach ($languages as $language)
         {
@@ -1926,7 +1925,11 @@ class tokens extends Survey_Common_Action
                 $filterblankemail = (Yii::app()->request->getPost('filterblankemail') && Yii::app()->request->getPost('filterblankemail') == 'on');
             }
 
-            $attrfieldnames = getAttributeFieldNames($iSurveyId);
+	    $allattrfieldnames = GetParticipantAttributes($iSurveyId);
+	    $attrfieldnames = array_keys($allattrfieldnames);
+	    $missingfieldnames = array("firstname","lastname","email");
+	    $missingfieldflag = false;
+
             $duplicatelist = array();
             $invalidemaillist = array();
             $invalidformatlist = array();
@@ -2010,11 +2013,24 @@ class tokens extends Survey_Common_Action
                                 $firstline[$index] = $aReplacedFields[$fieldname];
                             }
                         }
+			// get list of mandatory attributes
+			foreach ($allattrfieldnames as $fieldname => $attrname)
+			{
+			    if (strcasecmp($attrname["mandatory"],"Y") == 0) 
+			    {
+				if(!in_array($fieldname, $firstline))
+			    	    $missingfieldflag = true;
+				array_push($missingfieldnames, $fieldname);
+			    }
+			}
                         if (!in_array('firstname', $firstline) || !in_array('lastname', $firstline) || !in_array('email', $firstline))
                         {
+			    $missingfieldflag = true;
+                        }
+			if($missingfieldflag) {
                             $recordcount = count($tokenlistarray);
                             break;
-                        }
+			}
                     }
                     else
                     {
@@ -2136,7 +2152,9 @@ class tokens extends Survey_Common_Action
                 $aData['xz'] = $xz;
                 $aData['xv'] = $xv;
                 $aData['recordcount'] = $recordcount;
-                $aData['firstline'] = $firstline;
+                $aData['missingfieldnames'] = $missingfieldnames;
+                $aData['missingfieldflag'] = $missingfieldflag;
+                $aData['ignoredcolumns'] = $ignoredcolumns;
                 $aData['duplicatelist'] = $duplicatelist;
                 $aData['invalidformatlist'] = $invalidformatlist;
                 $aData['invalidemaillist'] = $invalidemaillist;

--- a/application/views/admin/token/csvpost.php
+++ b/application/views/admin/token/csvpost.php
@@ -3,8 +3,8 @@
     <?php if (empty($tokenlistarray)) { ?>
         <div class='warningheader'><?php $clang->eT("Failed to open the uploaded file!"); ?></div>
         <?php } ?>
-    <?php if (!in_array('firstname', $firstline) || !in_array('lastname', $firstline) || !in_array('email', $firstline)) { ?>
-        <div class='warningheader'><?php printf($clang->gT("Error: Your uploaded file is missing one or more of the mandatory columns (%s)"),"firstname, lastname, email"); ?></div>
+    <?php if ( $missingfieldflag )  { ?>
+        <div class='warningheader'><?php printf($clang->gT("Error: Your uploaded file is missing one or more of the mandatory columns (%s)"),implode(",",$missingfieldnames)); ?></div>
         <?php } ?>
     <?php if ($xz != 0) { ?>
         <div class='successheader'><?php $clang->eT("Successfully created token entries"); ?></div>
@@ -18,7 +18,7 @@
         <li><?php printf($clang->gT("%s records imported"), $xz); ?></li>
     </ul>
 
-    <?php if (!empty($duplicatelist) || !empty($invalidformatlist) || !empty($invalidemaillist) || !empty($errorlist)) { ?>
+    <?php if (!empty($duplicatelist) || !empty($invalidformatlist) || !empty($invalidemaillist) || !empty($errorlist) || !empty($ignoredcolumns)) { ?>
 
         <div class='warningheader'><?php $clang->eT('Warnings'); ?></div>
 
@@ -30,6 +30,19 @@
                     <div class='badtokenlist' id='duplicateslist' style='display: none;'>
                         <ul>
                             <?php foreach ($duplicatelist as $aData) { ?>
+                                <li><?php echo $aData; ?></li>
+                                <?php } ?>
+                        </ul>
+                    </div>
+                </li>
+                <?php } ?>
+            <?php if (!empty($ignoredcolumns)) { ?>
+                <li>
+                    <?php printf($clang->gT("%s columns ignored"), count($ignoredcolumns)); ?>
+                    [<a href='#' onclick='$("#ignoredcolumns").toggle();'><?php $clang->eT("List"); ?></a>]
+                    <div class='badtokenlist' id='ignoredcolumns' style='display: none;'>
+                        <ul>
+                            <?php foreach ($ignoredcolumns as $aData) { ?>
                                 <li><?php echo $aData; ?></li>
                                 <?php } ?>
                         </ul>


### PR DESCRIPTION
Hello,

Bug: 
- When check the mandatory option of token field, the csv file that does not contain that field can be imported. (these token fields are like firstname/lastname/field as the mandatory fields )
- When user import csv file that contains ignored columns, limesurvey should show the warning to the user.  

Patch:
- Generate a list containing all the mandatory fields and trigger an error if the csv file is not in the right format.
-  Show number of ignored columns to user ( %s collumns ignored )
