### PR TITLE
Fixed issue: lack the full name of the sender in the " from" field when using JSON-PRC

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -165,6 +165,8 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 		$from =  $fieldsarray["{ADMINEMAIL}"];
 		if($from ==  '')
 			$from = Yii::app()->getConfig('siteadminemail');
+		elseif (!empty($fieldsarray["{ADMINNAME}"]))
+                        $from = $fieldsarray["{ADMINNAME}"]." <".$from.">";
 
 		foreach ($attributes as $attributefield)
 		{


### PR DESCRIPTION
Hello,

Bug:
- When sending an invitation via the web user interface, the mail client receiving the mail has the "from" field with the following format:
"HIS_NAME < his_email >", ex: Administartor < admin@example.com >

- When using RPC-JSON API for sending an invitation or reminding users, they get the a mail that does not have the name in the "from" field, just only their email address. Ex: admin@example.com

Patch:
- Correct the "from" field to the standard format when using RPC-JSON API , means "name < email >"

Truc