### PR TITLE
Feature: Add file attachement function for RPC method

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -120,32 +120,7 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 	array_unshift($aSurveyLangs, $oSurvey->language);
 
 	$thisSurvey = getSurveyInfo($iSurveyID);
-	$aRelevantAttachments = array();
-
-	if (isset($thisSurvey['attachments']))
-	{
-		$aAttachments = unserialize($thisSurvey['attachments']);
-		if (!empty($aAttachments))
-		{
-			if($sType == 'invite')
-				$sTemplate = "invitation";
-			else if ($sType == 'remind')
-				$sTemplate = "reminder";
-
-			if (isset($aAttachments[$sTemplate]))
-			{
-				foreach ($aAttachments[$sTemplate] as $aAttachment)
-				{
-					if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance']))
-					{
-						$aRelevantAttachments[] = $aAttachment['url'];
-					}
-				}
-			}
-		}
-	}
-
-
+	
 	//Convert result to associative array to minimize SurveyLocale access attempts
 	foreach($oSurveyLocale as $rows)
 	{
@@ -177,6 +152,32 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			$to[] = ($aTokenRow['firstname'] . " " . $aTokenRow['lastname'] . " <{$sEmailaddress}>");
 		}
 
+		$aRelevantAttachments = array();
+
+                if (isset($thisSurvey['attachments']))
+                {
+                        $aAttachments = unserialize($thisSurvey['attachments']);
+                        if (!empty($aAttachments))
+                        {
+                                if($sType == 'invite') {
+                                        $sTemplate = "invitation";
+                                }else if ($sType == 'remind') {
+                                        $sTemplate = "reminder";
+                                }
+                                if (isset($aAttachments[$sTemplate]))
+                                {
+                                        LimeExpressionManager::singleton()->loadTokenInformation($thisSurvey['sid'], $aTokenRow['token']);
+                                        
+                                        foreach ($aAttachments[$sTemplate] as $aAttachment)
+                                        {
+                                                if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance']))
+                                                {
+                                                        $aRelevantAttachments[] = $aAttachment['url'];
+                                                }
+                                        }
+                                }
+                        }
+                }
 
 		//Populate attributes
 		$fieldsarray["{SURVEYNAME}"] = $aSurveyLocaleData[$sTokenLanguage]['surveyls_title'];


### PR DESCRIPTION
Hello,

I have created a mail template with a file attachment.
When i send an invitation email via the web interface to an user, that user receives a mail with the attached file.

But when i use the JSON-RPC method, the attached file is missing in the client 's side.

This patch adds the feature that is missing when using the JSON-RPC method.

Truc