### PR TITLE
Fixed issue: anomaly of slider

### DIFF
--- a/scripts/numeric-slider.js
+++ b/scripts/numeric-slider.js
@@ -51,6 +51,8 @@ function doNumericSlider(qID,jsonOptions) {
 				step: parseFloat(jsonOptions.slider_step),
 				create: function() {
 					$('#slider-callout-'+myfname).appendTo($('#container-'+myfname+' .ui-slider-handle').get(0));
+					startvalue=''+startvalue;
+					startvalue=startvalue.replace(/\./,LSvar.sLEMradix);
 				},
 				slide: function( event, ui ) {
 					displayvalue=''+ui.value;


### PR DESCRIPTION
Hello,

Bug:
- Create a survey with a group
- Create only one question that uses the slider as the attached image

![slider](https://cloud.githubusercontent.com/assets/486471/7915537/7218e8b0-087e-11e5-9d2a-98ec3476595e.jpg)

- Move the cursor A to the value 2
- Move the cursor B to the value 7
- Do not move the cursor C.

- Click "envoyer" to send the result to the server.

Result: the validation check fails because the value of the inputs is not good.

Debug: value of A is 2, value of B is 7 but the value of C is "null" in server side. It should normally be "0" in this case.

Patch: 
- Initialize all the value of cursors to real value.

I see in the code that you already did it but it was not enough because error occurs when "jsonOptions.slider_displaycallout" is set to "false". 

			if(havevalue || ( startvalue && jsonOptions.slider_displaycallout)){

