### PR TITLE
Extra forward slash in front of jstoolbox/date.js

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -947,7 +947,7 @@ function do_date($ia)
         };";
     App()->getClientScript()->registerScript("sDateLangvarJS",$sDateLangvarJS,CClientScript::POS_HEAD);
     App()->getClientScript()->registerScriptFile(Yii::app()->getConfig("generalscripts").'date.js');
-    App()->getClientScript()->registerScriptFile(Yii::app()->getConfig("third_party").'/jstoolbox/date.js');
+    App()->getClientScript()->registerScriptFile(Yii::app()->getConfig("third_party").'jstoolbox/date.js');
     $checkconditionFunction = "checkconditions";
 
     $dateformatdetails = getDateFormatDataForQID($aQuestionAttributes,$thissurvey);


### PR DESCRIPTION
This extra forward slash in front of the jstoolbox/date.js call was causing 500 internal server errors in our setup which is RHEL 6, Apache 2.2.15 and PHP 5.3.3

Requested URL was "/third_party//jstoolbox/date.js".

This was breaking the datepicker for date questions.