### PR TITLE
[bugfix] auto-calculate the conditions when reordering the questions in the groups

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -1027,7 +1027,8 @@ class SurveyAdmin extends Survey_Common_Action
                 $gid = (int)substr($parent, 1);
                 if (!isset($questionorder[$gid]))
                     $questionorder[$gid] = 0;
-                $question = Question::model()->getQuestionById($qid);
+				$sBaseLanguage = Survey::model()->findByPk($iSurveyID)->language;
+				$question = Question::model()->findByPk(array("qid"=>$qid,'language'=>$sBaseLanguage));
                 $oldgid = $question['gid'];
                 if($oldgid != $gid) {
                         fixMovedQuestionConditions($qid,$oldgid,$gid,$iSurveyID);

--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -1027,7 +1027,8 @@ class SurveyAdmin extends Survey_Common_Action
                 $gid = (int)substr($parent, 1);
                 if (!isset($questionorder[$gid]))
                     $questionorder[$gid] = 0;
-                $oldgid=Question::model()->getQuestionById($qid)['gid'];
+                $question = Question::model()->getQuestionById($qid);
+                $oldgid = $question['gid'];
                 if($oldgid != $gid) {
                         fixMovedQuestionConditions($qid,$oldgid,$gid,$iSurveyID);
                 }

--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -1025,18 +1025,19 @@ class SurveyAdmin extends Survey_Common_Action
             {
                 $qid = (int)substr($ID, 1);
                 $gid = (int)substr($parent, 1);
-                if (!isset($questionorder[$gid]))
-                    $questionorder[$gid] = 0;
-				$sBaseLanguage = Survey::model()->findByPk($iSurveyID)->language;
-				$question = Question::model()->findByPk(array("qid"=>$qid,'language'=>$sBaseLanguage));
-                $oldgid = $question['gid'];
-                if($oldgid != $gid) {
-                        fixMovedQuestionConditions($qid,$oldgid,$gid,$iSurveyID);
-                }
-                Question::model()->updateAll(array('question_order' => $questionorder[$gid], 'gid' => $gid), 'qid=:qid', array(':qid' => $qid));
-                Question::model()->updateAll(array('gid' => $gid), 'parent_qid=:parent_qid', array(':parent_qid' => $qid));
+                if (!isset($aQuestionOrder[$gid]))
+                    $aQuestionOrder[$gid] = 0;
 
-                $questionorder[$gid]++;
+				$sBaseLanguage = Survey::model()->findByPk($iSurveyID)->language;
+				$oQuestion = Question::model()->findByPk(array("qid"=>$qid,'language'=>$sBaseLanguage));
+                $oldGid = $oQuestion['gid'];
+
+                if($oldGid != $gid) {
+                        fixMovedQuestionConditions($qid,$oldGid,$gid,$iSurveyID);
+                }
+                Question::model()->updateAll(array('question_order' => $aQuestionOrder[$gid], 'gid' => $gid), 'qid=:qid', array(':qid' => $qid));
+                Question::model()->updateAll(array('gid' => $gid), 'parent_qid=:parent_qid', array(':parent_qid' => $qid));
+                $aQuestionOrder[$gid]++;
             }
         }
         LimeExpressionManager::SetDirtyFlag(); // so refreshes syntax highlighting

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1310,9 +1310,10 @@ function fixSortOrderGroups($surveyid) //Function rewrites the sortorder for gro
     QuestionGroup::model()->updateGroupOrder($surveyid,$baselang);
 }
 
-function fixMovedQuestionConditions($qid,$oldgid,$newgid) //Function rewrites the cfieldname for a question after group change
+function fixMovedQuestionConditions($qid,$oldgid,$newgid, $surveyid=NULL) //Function rewrites the cfieldname for a question after group change
 {
-    $surveyid = Yii::app()->getConfig('sid');
+    if(!isset($surveyid))
+        $surveyid = Yii::app()->getConfig('sid');
     $qid=sanitize_int($qid);
     $oldgid=sanitize_int($oldgid);
     $newgid=sanitize_int($newgid);

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1310,14 +1310,14 @@ function fixSortOrderGroups($surveyid) //Function rewrites the sortorder for gro
     QuestionGroup::model()->updateGroupOrder($surveyid,$baselang);
 }
 
-function fixMovedQuestionConditions($qid,$oldgid,$newgid, $surveyid=NULL) //Function rewrites the cfieldname for a question after group change
+function fixMovedQuestionConditions($qid,$oldgid,$newgid, $iSurveyID=NULL) //Function rewrites the cfieldname for a question after group change
 {
-    if(!isset($surveyid))
-        $surveyid = Yii::app()->getConfig('sid');
+    if(!isset($iSurveyID))
+        $iSurveyID = Yii::app()->getConfig('sid');
     $qid=sanitize_int($qid);
     $oldgid=sanitize_int($oldgid);
     $newgid=sanitize_int($newgid);
-    Condition::model()->updateCFieldName($surveyid,$qid,$oldgid,$newgid);
+    Condition::model()->updateCFieldName($iSurveyID,$qid,$oldgid,$newgid);
     // TMSW Condition->Relevance:  Call LEM->ConvertConditionsToRelevance() when done
 }
 

--- a/application/models/Condition.php
+++ b/application/models/Condition.php
@@ -106,15 +106,14 @@
             $oResults=$this->findAllByAttributes(array('cqid'=>$iQuestionID));
             foreach ($oResults as $oRow)
             {
-
                 $cfnregs='';
-                if (preg_match('/'.$surveyid."X".$iOldGroupID."X".$iQuestionID."(.*)/", $oRow->cfieldname, $cfnregs) > 0)
+                if (preg_match('/(\S*?)'.$iSurveyID."X".$iOldGroupID."X".$iQuestionID."(.*)/", $oRow->cfieldname, $cfnregs) > 0)
                 {
-                    $newcfn=$surveyid."X".$iNewGroupID."X".$iQuestionID.$cfnregs[1];
-                    $c2query="UPDATE ".db_table_name('conditions')
-                    ." SET cfieldname='{$newcfn}' WHERE cid={$oRow->cid}";
-
-                    Yii::app()->db->createCommand($c2query)->query();
+                    $newcfn=$cfnregs[1].$iSurveyID."X".$iNewGroupID."X".$iQuestionID.$cfnregs[2];
+                    $update = Yii::app()->db->createCommand()
+                        ->update($this->tableName(), array('cfieldname' => $newcfn),
+                        'cid=:cid',array(':cid'=>$oRow->cid));
+                    LimeExpressionManager::UpgradeConditionsToRelevance($iSurveyID,$oRow->qid);
                 }
             }
         }

--- a/application/models/Condition.php
+++ b/application/models/Condition.php
@@ -109,9 +109,9 @@
                 $cfnregs='';
                 if (preg_match('/(\S*?)'.$iSurveyID."X".$iOldGroupID."X".$iQuestionID."(.*)/", $oRow->cfieldname, $cfnregs) > 0)
                 {
-                    $newcfn=$cfnregs[1].$iSurveyID."X".$iNewGroupID."X".$iQuestionID.$cfnregs[2];
-                    $update = Yii::app()->db->createCommand()
-                        ->update($this->tableName(), array('cfieldname' => $newcfn),
+                    $sNewCfn=$cfnregs[1].$iSurveyID."X".$iNewGroupID."X".$iQuestionID.$cfnregs[2];
+                    Yii::app()->db->createCommand()
+                        ->update($this->tableName(), array('cfieldname' => $sNewCfn),
                         'cid=:cid',array(':cid'=>$oRow->cid));
                     LimeExpressionManager::UpgradeConditionsToRelevance($iSurveyID,$oRow->qid);
                 }

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -266,16 +266,6 @@
             return $aAttributeNames;
         }
 
-        function getQuestionById($qid)
-        {
-            return Yii::app()->db->createCommand()
-            ->select()
-            ->from(self::tableName())
-            ->where('qid=:qid')
-            ->bindParam(":qid", $qid, PDO::PARAM_INT)
-            ->queryRow();
-        }
-
         function getQuestions($sid, $gid, $language)
         {
             return Yii::app()->db->createCommand()

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -266,6 +266,16 @@
             return $aAttributeNames;
         }
 
+        function getQuestionById($qid)
+        {
+            return Yii::app()->db->createCommand()
+            ->select()
+            ->from(self::tableName())
+            ->where('qid=:qid')
+            ->bindParam(":qid", $qid, PDO::PARAM_INT)
+            ->queryRow();
+        }
+
         function getQuestions($sid, $gid, $language)
         {
             return Yii::app()->db->createCommand()


### PR DESCRIPTION
Hello,

Scenario : i have 2 questions and 2 groups. The question 2 depending on the options of the question 1. Originally and they are in the same group 1. If i move the question 1 to the group 2, the  "cfieldname" of the table lime_condition is not updated and the relevance of "lime_questions" is not also updated.

Patch: when user moves a question to another group, the code will detect if the old and new groups are different. If yes, limesurvey will try to update the lime_condition table and the "relevance" field in lime_questions table.

Truc