### PR TITLE
Fix #09776: Mail registered participants with RemoteControl API & Fix #09783: Use "adminname <adminemail>" as from-header in emailTokens

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -78,7 +78,7 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 
 		$fieldsarray["{ADMINNAME}"] = $oSurvey['admin'];
 		$fieldsarray["{ADMINEMAIL}"] = $oSurvey['adminemail'];
-		$from =  $fieldsarray["{ADMINEMAIL}"];
+		$from = $fieldsarray["{ADMINNAME}"] . ' <' . $fieldsarray["{ADMINEMAIL}"] . '>';
 		if($from ==  '')
 			$from = Yii::app()->getConfig('siteadminemail');
 

--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -17,7 +17,7 @@
 *
 * @param mixed $iSurveyID
 * @param array  $aResultTokens
-* @param string $sType type of notification invite|remind
+* @param string $sType type of notification invite|register|remind
 * @return array of results
 */
 function emailTokens($iSurveyID,$aResultTokens,$sType)
@@ -117,6 +117,11 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite_subj'];
 			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite'];
 		}
+		else if($sType == 'register')
+		{
+			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register_subj'];
+			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register'];
+		}
 		else
 		{
 			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind_subj'];
@@ -159,7 +164,7 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 													'email'=>$fieldsarray["{EMAIL}"],
 													'status'=>'OK');
 
-				if($sType == 'invite')
+				if($sType == 'invite' || $sType == 'register')
 					$oTokens->updateByPk($aTokenRow['tid'], array('sent' => dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i", Yii::app()->getConfig("timeadjust"))));
 
 				if($sType == 'remind')

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2023,7 +2023,7 @@ class remotecontrol_handle
      * @access public
      * @param string $sSessionKey Auth credentials
      * @param int $iSurveyID ID of the survey that participants belong
-     * @param array $overrideAllConditions replace the default consitions, like this:
+     * @param array $overrideAllConditions replace the default conditions, like this:
      *   $overrideAllConditions = Array();
      *   $overrideAllConditions[] = 'tid = 2';
      *   $response = $myJSONRPCClient->mail_registered_participants( $sessionKey, $survey_id, $overrideAllConditions );


### PR DESCRIPTION
PR for https://bugs.limesurvey.org/view.php?id=9776

mail_registered_participants is almost a direct copy of invite_participants, with one significant change: the default conditions can be overridden. Main use: do not mail all 'unsent' users, but select one.

For instance select one by tid:

    $overrideAllConditions = Array();
    $overrideAllConditions[] = 'tid = 12345';
    $response = $myJSONRPCClient->mail_registered_participants( $sessionKey, $survey_id, $overrideAllConditions );
