### PR TITLE
Fixed issue #08030: Prefilled values for obviously not relevant questions lost

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6665,6 +6665,11 @@
                         $_SESSION[$LEM->sessid][$sgqa]=$LEM->ProcessString($LEM->knownVars[$sgqa]['default'], $qInfo['qid'], NULL, false, 1, 1, false, false, true);// Fill the $_SESSION to don't do it again a second time
                         $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
                     }
+                    elseif(!isset($_SESSION[$LEM->sessid][$sgqa]) && isset($_SESSION[$LEM->sessid]['startingValues'][$sgqa]) )
+                    {
+                        $_SESSION[$LEM->sessid][$sgqa]=$_SESSION[$LEM->sessid]['startingValues'][$sgqa];
+                        $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
+                    }
                 }
             }
 
@@ -6688,6 +6693,10 @@
                     if(!is_null($LEM->knownVars[$sgqa]['default']))
                     {
                         $_SESSION[$LEM->sessid][$sgqa]=$LEM->ProcessString($LEM->knownVars[$sgqa]['default'],  $qInfo['qid'], NULL, false, 1, 1, false, false, true);
+                    }
+                    elseif(!isset($_SESSION[$LEM->sessid][$sgqa]) && isset($_SESSION[$LEM->sessid]['startingValues'][$sgqa]) )
+                    {
+                        $_SESSION[$LEM->sessid][$sgqa]=$_SESSION[$LEM->sessid]['startingValues'][$sgqa];
                     }
                     else
                     {


### PR DESCRIPTION
* use same system than default

I think all startingValues system mut be move to plugin, start in core for the 2 actual. But user can want to prefill by $_POST/$_SERVER or anything else.

Unsure we need actaul startingValues system in EM, adding 2 event in _validateQuestion make the fix, but i don't like 2 event in same function, one seem better .

Maybe one event in Question validation and one in updatedValues ? I think we need an event in updatedValues for Question plugin, and surely in question validation for Questions advanced settings too.
