### PR TITLE
Switch Hide Tip for Datetime default value to 0

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -1308,7 +1308,7 @@ function do_date($ia)
                 </script>";
         }
 
-        if (trim($aQuestionAttributes['hide_tip'])==1) {
+        if (trim($aQuestionAttributes['hide_tip'])==0) {
             $answer.="<p class=\"tip\">".sprintf(gT('Format: %s'),$dateformatdetails['dateformat'])."</p>";
         }
         //App()->getClientScript()->registerScript("doPopupDate{$ia[0]}","doPopupDate({$ia[0]})",CClientScript::POS_END);// Beter if just afetre answers part


### PR DESCRIPTION
Admin values for hide_tip are:
0=No
1=Yes

![screenshot from 2015-08-12 11-24-38](https://cloud.githubusercontent.com/assets/140433/9231338/fdd4194e-40e4-11e5-96a2-be3e04b9a030.png)

All others hide_tip are like:
if (count($values[1]) > 1 && $aQuestionAttributes['hide_tip']==0)
if (isset($aQuestionAttributes['hide_tip']) && $aQuestionAttributes['hide_tip']==0)