### PR TITLE
Handle cases where allow_url_fopen is set to off

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5213,12 +5213,14 @@ function getUpdateInfo()
             'ignore_errors' => true
         )
     );
-    $body = file_get_contents($url, false, stream_context_create($opts));
+    $body = @file_get_contents($url, false, stream_context_create($opts));
     if ($body != false && (null === $updateInfo = json_decode($body, true))) {
         $updateInfo = array(
             'errorhtml' => $body,
             'errorcode' => $http_response_header
         );
+    } else {
+        $updateInfo = null;
     }
     return $updateInfo;
 }


### PR DESCRIPTION
Continue silently when webserver configuration allow_url_fopen is set to off.
