### PR TITLE
Feature/new plugin event admin homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 .settings/org.eclipse.php.core.prefs
 .buildpath
 /application/config/config.php
+.idea
+.DS_Store

--- a/application/controllers/admin/index.php
+++ b/application/controllers/admin/index.php
@@ -35,7 +35,7 @@ class Index extends Survey_Common_Action
                     'message' => Yii::app()->session['loginsummary']
 
                 ));
-                $this->_renderWrappedTemplate('super', $aViewUrls);
+                $this->_renderWrappedTemplate('/admin/super', $aViewUrls);
             }
             unset(Yii::app()->session['just_logged_in'], Yii::app()->session['loginsummary']);
         }
@@ -46,7 +46,7 @@ class Index extends Survey_Common_Action
                 $this->_renderWrappedTemplate($event->get('viewUrl'), $event->get('viewName'));
 
             }else{
-                $this->_renderWrappedTemplate('super', 'firststeps');
+                $this->_renderWrappedTemplate('/admin/super', 'firststeps');
 
             }
 		}

--- a/application/controllers/admin/index.php
+++ b/application/controllers/admin/index.php
@@ -13,30 +13,46 @@
  */
 class Index extends Survey_Common_Action
 {
-
     public function run()
     {
-        
+
+        $event = new PluginEvent('modifyStartpage');
+
+        App()->getPluginManager()->dispatchEvent($event);
+
+        $event->set('viewName', $event->get('viewName'));
+        $event->set('viewUrl', $event->get('viewUrl'));
+
 
         if (Yii::app()->session['just_logged_in'])
         {
-            $aViewUrls = array('message' => array(
-                'title' => gT("Logged in"),
-                'message' => Yii::app()->session['loginsummary']
-            ));
-            unset(Yii::app()->session['just_logged_in'], Yii::app()->session['loginsummary']);
+            if(!is_null($event->get('viewName'))){
+                $this->_renderWrappedTemplate($event->get('viewUrl'), $event->get('viewName'));
 
-            $this->_renderWrappedTemplate('super', $aViewUrls);
+            }else{
+                $aViewUrls = array('message' => array(
+                    'title' => gT("Logged in"),
+                    'message' => Yii::app()->session['loginsummary']
+
+                ));
+                $this->_renderWrappedTemplate('super', $aViewUrls);
+            }
+            unset(Yii::app()->session['just_logged_in'], Yii::app()->session['loginsummary']);
         }
         elseif (count(getSurveyList(true)) == 0)
-		{
-            $this->_renderWrappedTemplate('super', 'firststeps');
-		}
+        {
+            if(!is_null($event->get('viewName')))
+            {
+                $this->_renderWrappedTemplate($event->get('viewUrl'), $event->get('viewName'));
+
+            }else{
+                $this->_renderWrappedTemplate('super', 'firststeps');
+
+            }
+        }
         else
         {
             $this->getController()->redirect(array('admin/survey/sa/index'));
         }
-
     }
-
 }

--- a/application/controllers/admin/index.php
+++ b/application/controllers/admin/index.php
@@ -40,7 +40,7 @@ class Index extends Survey_Common_Action
             unset(Yii::app()->session['just_logged_in'], Yii::app()->session['loginsummary']);
         }
         elseif (count(getSurveyList(true)) == 0)
-        {
+		{
             if(!is_null($event->get('viewName')))
             {
                 $this->_renderWrappedTemplate($event->get('viewUrl'), $event->get('viewName'));
@@ -49,7 +49,7 @@ class Index extends Survey_Common_Action
                 $this->_renderWrappedTemplate('super', 'firststeps');
 
             }
-        }
+		}
         else
         {
             $this->getController()->redirect(array('admin/survey/sa/index'));

--- a/application/core/Survey_Common_Action.php
+++ b/application/core/Survey_Common_Action.php
@@ -224,7 +224,7 @@ class Survey_Common_Action extends CAction
 
         $aData = $this->_addPseudoParams($aData);
         $aViewUrls = (array) $aViewUrls;
-        $sViewPath = '/admin/';
+        $sViewPath = '';
 
         if (!empty($sAction))
         {

--- a/plugins/EventTest/EventTest.php
+++ b/plugins/EventTest/EventTest.php
@@ -8,6 +8,9 @@ class EventTest extends PluginBase
 
     public function __construct(PluginManager $manager, $id)
     {
+
+        Yii::setPathOfAlias('EventTest', dirname(__FILE__));
+
         parent::__construct($manager, $id);
 
 
@@ -24,12 +27,7 @@ class EventTest extends PluginBase
     public function modifyStartpage()
     {
 
-        Yii::setPathOfAlias('EventTest', dirname(__FILE__));
-
-        $test = Yii::getPathOfAlias('EventTest');
-
-        var_dump($test);
-        $sViewPath = '/../../plugins/xolair/assets/views';
+        $sViewPath = '/../../plugins/EventTest/assets/views';
         $sViewName = 'myView';
 
         $event = $this->getEvent();

--- a/plugins/EventTest/EventTest.php
+++ b/plugins/EventTest/EventTest.php
@@ -1,0 +1,41 @@
+<?php
+class EventTest extends PluginBase
+{
+
+    protected $storage = 'DbStorage';
+    static protected $description = 'EventTest';
+
+
+    public function __construct(PluginManager $manager, $id)
+    {
+        parent::__construct($manager, $id);
+
+
+        /**
+         * Here you should handle subscribing to the events your plugin will handle
+         */
+        $this->subscribe('modifyStartpage');
+    }
+
+    /**
+     * change the view for admin homepage
+     */
+
+    public function modifyStartpage()
+    {
+
+        Yii::setPathOfAlias('EventTest', dirname(__FILE__));
+
+        $test = Yii::getPathOfAlias('EventTest');
+
+        var_dump($test);
+        $sViewPath = '/../../plugins/xolair/assets/views';
+        $sViewName = 'myView';
+
+        $event = $this->getEvent();
+        $event->set('viewName', $sViewName);
+        $event->set('viewUrl', $sViewPath);
+
+
+    }
+}

--- a/plugins/EventTest/assets/views/myView.php
+++ b/plugins/EventTest/assets/views/myView.php
@@ -1,0 +1,6 @@
+<div class='messagebox ui-corner-all'>
+    <div class='<?php echo '$class';?>'>
+        MY new view
+    </div>
+    <?php echo '$message';?>
+</div>


### PR DESCRIPTION
I inserted a new plugin event which allows us to insert a custom view on the admin homepage, for non admin users!

Write in a plugin this:

´´´
    public function modifyStartpage(){
      $sViewPath = '/../../plugins/myplugin';
      $sViewName = 'myviewname';
      $event = $this->getEvent();
      $event->set('viewName', $sViewName);
      $event->set('viewUrl', $sViewPath);
}
´´´
Any suggestions for naming the event?

I look forward to your feedback.

Cheers Kai 
