### PR TITLE
Google Analytics code not running: missing spaces

### DIFF
--- a/application/helpers/replacements_helper.php
+++ b/application/helpers/replacements_helper.php
@@ -463,8 +463,8 @@ function templatereplace($line, $replacements = array(), &$redata = array(), $de
                 // Default Google Tracking
                 $_googleAnalyticsJavaScript = <<<EOD
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+(function(i,s,o,g,r,a,m){ i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments) },i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 


### PR DESCRIPTION
The original code was missing spaces before and after the curly brackets.
This caused Lime to try and expand it.

https://manual.limesurvey.org/Workarounds:_Manipulating_a_survey_at_runtime_using_Javascript#How_to_use_Script_.28eg._JavaScript_etc..29_in_LimeSurvey.3F
```
Usage of brackets ({ and })

Important.pngCaution with bracket ( { and }) : Expression manager use bracket ( { and }) to enclose expression. Then if you have to use bracket in your javascript, you must add space or line feed after starting bracket ({) and before closing bracket (})

```