### PR TITLE
Fixed issue #9926: Can't save dropdown values in CPD

### DIFF
--- a/application/models/ParticipantAttributeName.php
+++ b/application/models/ParticipantAttributeName.php
@@ -409,7 +409,11 @@ class ParticipantAttributeName extends LSActiveRecord
         }
         if (!empty($insertnames))
         {
-            $oParticipantAttributeName=ParticipantAttributeName::model()->findByPk($data['attribute_id']);
+            $oParticipantAttributeName=ParticipantAttributeName::model()->findByPk(array (
+                    'attribute_id' => $data['attribute_id'],
+                    'attribute_type' => $data['attribute_type']
+                )
+            );
             foreach ($insertnames as $sFieldname=>$sValue)
             {
                $oParticipantAttributeName->$sFieldname=$sValue;


### PR DESCRIPTION
Error causes becasue the table has 2 primary key.

Now you can save options to a dropdown.