### PR TITLE
Fixed issue #10029: When sending AJAX calls from Firefox, RemoteControl doesn't respond

### DIFF
--- a/application/libraries/LSjsonRPCServer.php
+++ b/application/libraries/LSjsonRPCServer.php
@@ -14,7 +14,7 @@
 		if (
 			$_SERVER['REQUEST_METHOD'] != 'POST' ||
 			empty($_SERVER['CONTENT_TYPE']) ||
-			$_SERVER['CONTENT_TYPE'] != 'application/json'
+			strpos($_SERVER['CONTENT_TYPE'], "application/json") === FALSE
 			) {
 			// This is not a JSON-RPC request
 			return false;


### PR DESCRIPTION
FF appends "de-facto" the string "charset=UTF-8" to the content-type header
Remote Control  didn't recognize "application/json; charset=UTF-8" as valid header.
Now allows CONTENT_TYPE to be like "application/json; charset=UTF-8".