### PR TITLE
Fixed issue : enforce the mandatory token field + show warning if the import csv file contains ignored columns

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -2081,7 +2081,7 @@ class tokens extends Survey_Common_Action
                         }
                         $aFirstLine = str_getcsv($buffer, $sSeparator, '"');
                         $aFirstLine = array_map('trim', $aFirstLine);
-                        $aIgnoredColumns = array();
+                        $aIgnoredColumns = $invalideAttrFieldName = $missingAttrFieldName= array();
                         // Now check the first line for invalid fields
                         foreach ($aFirstLine as $index => $sFieldname)
                         {
@@ -2094,6 +2094,33 @@ class tokens extends Survey_Common_Action
                             if (array_key_exists($sFieldname, $aReplacedFields))
                             {
                                 $aFirstLine[$index] = $aReplacedFields[$sFieldname];
+                            }
+                            // Attribute not in list
+                            if (strpos($aFirstLine[$index], 'attribute_') !== false and !in_array($aFirstLine[$index], $aAttrFieldNames) and Yii::app()->request->getPost('showwarningtoken')) {
+                                $invalideAttrFieldName[] = $aFirstLine[$index];
+                            }
+                        }
+                        //compare attributes with source csv
+                        if(Yii::app()->request->getPost('showwarningtoken')){
+                            $missingAttrFieldName = array_diff($aAttrFieldNames, $aFirstLine);
+                            // get list of mandatory attributes
+                            $allAttrFieldNames = GetParticipantAttributes($iSurveyId);
+                            //if it isn't mandantory field we don't need to show in warning
+                            if(!empty($aAttrFieldNames)){
+                                if(!empty($missingAttrFieldName)){
+                                    foreach ($missingAttrFieldName as $index=>$AttrFieldName) {
+                                        if (isset($allAttrFieldNames[$AttrFieldName]) and strtolower($allAttrFieldNames[$AttrFieldName]["mandatory"])!= "y") {
+                                            unset($missingAttrFieldName[$index]);
+                                        }
+                                    }
+                                }
+                                if(isset($invalideAttrFieldName) and !empty($invalideAttrFieldName)){
+                                    foreach ($invalideAttrFieldName as $index=>$AttrFieldName) {
+                                        if (isset($allAttrFieldNames[$AttrFieldName]) and strtolower($allAttrFieldNames[$AttrFieldName]["mandatory"])!= "y") {
+                                            unset($invalideAttrFieldName[$index]);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -2235,6 +2262,8 @@ class tokens extends Survey_Common_Action
                 $aData['iInvalidEmailCount']=$iInvalidEmailCount;
                 $aData['thissurvey'] = getSurveyInfo($iSurveyId);
                 $aData['iSurveyId'] = $aData['surveyid'] = $iSurveyId;
+                $aData['invalideAttrFieldName'] = $invalideAttrFieldName;
+                $aData['missingAttrFieldName'] = $missingAttrFieldName;
 
                 $this->_renderWrappedTemplate('token', array('tokenbar', 'csvpost'), $aData);
                 Yii::app()->end();

--- a/application/views/admin/token/csvpost.php
+++ b/application/views/admin/token/csvpost.php
@@ -18,7 +18,7 @@
         <li><?php printf(gT("%s records imported"), $iRecordImported); ?></li>
     </ul>
 
-    <?php if (!empty($aDuplicateList) || !empty($aInvalidFormatList) || !empty($aInvalidEmailList) || !empty($aModelErrorList)) { ?>
+    <?php if (!empty($aDuplicateList) || !empty($aInvalidFormatList) || !empty($aInvalidEmailList) || !empty($aModelErrorList)|| !empty($invalideAttrFieldName) || !empty($missingAttrFieldName)) { ?>
 
         <div class='warningheader'><?php eT('Warnings'); ?></div>
 
@@ -76,6 +76,18 @@
                             <?php } ?>
                         </ul>
                     </div>
+                </li>
+            <?php } ?>
+
+            <?php if (isset($invalideAttrFieldName) and !empty($invalideAttrFieldName)) { ?>
+                <li>
+                    <?php echo '<b>'.implode(', ',$invalideAttrFieldName).'</b> '. gT("columns ignored") ?>
+                </li>
+            <?php } ?>
+
+            <?php if (isset($missingAttrFieldName) and !empty($missingAttrFieldName)) { ?>
+                <li>
+                    <?php echo '<b>'.implode(', ',$missingAttrFieldName).'</b> '. gT("columns missing") ?>
                 </li>
             <?php } ?>
 

--- a/application/views/admin/token/csvupload.php
+++ b/application/views/admin/token/csvupload.php
@@ -25,6 +25,12 @@
             <?php echo CHtml::checkBox('allowinvalidemail', false); ?>
         </li>
         <li>
+            <label for='showwarningtoken'><?php eT("Display warning attributes:"); ?></label>
+            <?php
+            echo CHtml::checkBox('showwarningtoken');
+            ?>
+        </li>
+        <li>
             <label for='filterduplicatetoken'><?php eT("Filter duplicate records:"); ?></label>
             <?php echo CHtml::checkBox('filterduplicatetoken', true); ?>
         </li>

--- a/locale/_template/limesurvey.pot
+++ b/locale/_template/limesurvey.pot
@@ -15182,9 +15182,13 @@ msgstr ""
 msgid "Allow invalid email addresses:"
 msgstr ""
 
-#: application/views/admin/token/csvupload.php:28
+#: application/views/admin/token/csvupload.php:34
 #: application/views/admin/token/ldapform.php:35
 msgid "Filter duplicate records:"
+msgstr ""
+
+#: application/views/admin/token/csvupload.php:28
+msgid "Display warning attributes:"
 msgstr ""
 
 #: application/views/admin/token/csvupload.php:32


### PR DESCRIPTION
@Shnoulle , as specified in the last our discussion in the request #315 , i have created the new patch   that fixes the problem and also proposes an attributes check to client, so that he can import with or without an extra step of verification (in this case, we named it as "display warning attributes".)  

I put a photo of my implementation  as the following figure : 

![displawarningattributes](https://cloud.githubusercontent.com/assets/486471/11585509/e1fd6f9a-9a6c-11e5-9a53-249a9b8dbde1.jpg)

Can you tell me if this solution is good and whether this functionality will be merged to the limesurvey ?
If you would like to add something more, please tell me.

Summary of the use cases : 
- an attribute is mandatory and it is missing in the import csv file, the  "display warning attributes" option is checked, a warning below will be shown to users, ex: `attribute_2 columns missing`
- an attribute is not declared but it is present in the import csv file, the  "display warning attributes" option is checked, a warning  below will be shown to users , ex : `attribute_4 columns ignored`
- If the  "display warning attributes" option is not checked by default, it works like before.