### PR TITLE
[Fixed issue] reuse the master field map in case of activating a survey

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -340,6 +340,9 @@ class SurveyAdmin extends Survey_Common_Action
 
                 $aData['tnewtable'] = $tnewtable;
                 $aData['toldtable'] = $toldtable;
+
+                // Reset the session of the survey when deactivating it
+                killSurveySession($iSurveyID);
             }
 
             //Remove any survey_links to the CPDB

--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -258,9 +258,6 @@ function activateSurvey($iSurveyID, $simulate = false)
     //Check for any additional fields for this survey and create necessary fields (token and datestamp)
     $prow = Survey::model()->findByAttributes(array('sid' => $iSurveyID));
 
-	//reset the session data of the survey if exist
-    unset(Yii::app()->session['survey_'.$iSurveyID]);
-
     //Get list of questions for the base language
     $fieldmap = createFieldMap($iSurveyID,'full',true,false,getBaseLanguageFromSurveyID($iSurveyID));
 

--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -258,6 +258,9 @@ function activateSurvey($iSurveyID, $simulate = false)
     //Check for any additional fields for this survey and create necessary fields (token and datestamp)
     $prow = Survey::model()->findByAttributes(array('sid' => $iSurveyID));
 
+	//reset the session data of the survey if exist
+    unset(Yii::app()->session['survey_'.$iSurveyID]);
+
     //Get list of questions for the base language
     $fieldmap = createFieldMap($iSurveyID,'full',true,false,getBaseLanguageFromSurveyID($iSurveyID));
 


### PR DESCRIPTION
BUG: 
 - Create a new survey with the "Save IP address" value to "No", create 5 tokens, do one or two  survey.
 - Deactivate that survey and reactive it with the "Save IP address" value to "Yes", restore the initial token table, and do one survey from that table. 
-----> Error: surveydynamic.ipaddr does not exist.
Check the table of that survey in the database, " describe lime_survey_[surveynumber]", this table does not have the field  "ipaddr".

Reason: 

 - Limesurvey reuses the master field map when activating the survey,  if master field map does not contain ipaddr , the created lime_survey_[surveynumber] table will not contain that field. 

- It is mentioned in the end of the function  createFieldMap of common_helper.php

`// If the fieldmap was randomized, the master will contain the proper order.  Copy that fieldmap with the new language settings`
           ` if (isset(Yii::app()->session['survey_'.$surveyid]['fieldmap-' . $surveyid . '-randMaster']))`

Patch: 

 * unset that session above everytime we activate a survey.

I have also noticed that the argument "$force_refresh" seems not be used in that function ???

Maybe you forget to use it to unset some session variable ? like the one that i did.


