### PR TITLE
Fixed issue : enforce the mandatory token field + show warning if the import csv file contains ignored columns

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -2092,6 +2092,7 @@ class tokens extends Survey_Common_Action
                     $aFilterDuplicateFields = Yii::app()->request->getPost('filterduplicatefields');
                 }
                 $sSeparator = Yii::app()->request->getPost('separator');
+                $aMissingAttrFieldName=$aInvalideAttrFieldName=array();
                 foreach ($aTokenListArray as $buffer)
                 {
                     $buffer = @mb_convert_encoding($buffer, "UTF-8", $sUploadCharset);
@@ -2136,6 +2137,33 @@ class tokens extends Survey_Common_Action
                             if (array_key_exists($sFieldname, $aReplacedFields))
                             {
                                 $aFirstLine[$index] = $aReplacedFields[$sFieldname];
+                            }
+                            // Attribute not in list
+                            if (strpos($aFirstLine[$index], 'attribute_') !== false and !in_array($aFirstLine[$index], $aAttrFieldNames) and Yii::app()->request->getPost('showwarningtoken')) {
+                                $aInvalideAttrFieldName[] = $aFirstLine[$index];
+                            }
+                        }
+                        //compare attributes with source csv
+                        if(Yii::app()->request->getPost('showwarningtoken')){
+                            $aMissingAttrFieldName = array_diff($aAttrFieldNames, $aFirstLine);
+                            // get list of mandatory attributes
+                            $allAttrFieldNames = GetParticipantAttributes($iSurveyId);
+                            //if it isn't mandantory field we don't need to show in warning
+                            if(!empty($aAttrFieldNames)){
+                                if(!empty($aMissingAttrFieldName)){
+                                    foreach ($aMissingAttrFieldName as $index=>$AttrFieldName) {
+                                        if (isset($allAttrFieldNames[$AttrFieldName]) and strtolower($allAttrFieldNames[$AttrFieldName]["mandatory"])!= "y") {
+                                            unset($aMissingAttrFieldName[$index]);
+                                        }
+                                    }
+                                }
+                                if(isset($aInvalideAttrFieldName) and !empty($aInvalideAttrFieldName)){
+                                    foreach ($aInvalideAttrFieldName as $index=>$AttrFieldName) {
+                                        if (isset($allAttrFieldNames[$AttrFieldName]) and strtolower($allAttrFieldNames[$AttrFieldName]["mandatory"])!= "y") {
+                                            unset($aInvalideAttrFieldName[$index]);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -2278,6 +2306,8 @@ class tokens extends Survey_Common_Action
                 $aData['iInvalidEmailCount']=$iInvalidEmailCount;
                 $aData['thissurvey'] = getSurveyInfo($iSurveyId);
                 $aData['iSurveyId'] = $aData['surveyid'] = $iSurveyId;
+                $aData['aInvalideAttrFieldName'] = $aInvalideAttrFieldName;
+                $aData['aMissingAttrFieldName'] = $aMissingAttrFieldName;
 
                 $this->_renderWrappedTemplate('token', array( 'csvpost'), $aData);
                 Yii::app()->end();

--- a/application/views/admin/token/csvpost.php
+++ b/application/views/admin/token/csvpost.php
@@ -40,8 +40,8 @@
                         </ul>
                     </p>
 
-                    <?php if (!empty($aDuplicateList) || !empty($aInvalidFormatList) || !empty($aInvalidEmailList) || !empty($aModelErrorList)) { ?>
-                    <h2 class='text-warning'><?php eT('Warnings'); ?></div>
+                    <?php if (!empty($aDuplicateList) || !empty($aInvalidFormatList) || !empty($aInvalidEmailList) || !empty($aModelErrorList) || !empty($aInvalideAttrFieldName) || !empty($aMissingAttrFieldName)) { ?>
+                    <h2 class='text-warning'><?php eT('Warnings'); ?></h2>
                     <p>
                         <ul class="list-unstyled">
                             <?php if (!empty($aDuplicateList)) { ?>
@@ -49,7 +49,7 @@
                                     <?php printf(gT("%s duplicate records removed"), count($aDuplicateList)); ?>
                                     [<a href='#' onclick='$("#duplicateslist").toggle();'><?php eT("List"); ?></a>]
                                     <div class='badtokenlist' id='duplicateslist' style='display: none;'>
-                                        <ul>
+                                        <ul class="list-unstyled">
                                             <?php foreach ($aDuplicateList as $sDuplicate) { ?>
                                                 <li><?php echo $sDuplicate; ?></li>
                                             <?php } ?>
@@ -63,7 +63,7 @@
                                     <?php printf(gT("%s lines had a mismatching number of fields."), count($invalidformatlist)); ?>
                                     [<a href='#' onclick='$("#invalidformatlist").toggle();'><?php eT("List"); ?></a>]
                                     <div class='badtokenlist' id='invalidformatlist' style='display: none;'>
-                                        <ul>
+                                        <ul class="list-unstyled">
                                             <?php foreach ($aInvalidFormatList as $sInvalidFormatList) { ?>
                                                 <li><?php echo $sInvalidFormatList; ?></li>
                                             <?php } ?>
@@ -77,7 +77,7 @@
                                     <?php printf(gT("%s records with invalid email address removed"), count($aInvalidEmailList)); ?>
                                     [<a href='#' onclick='$("#invalidemaillist").toggle();'><?php eT("List"); ?></a>]
                                     <div class='badtokenlist' id='invalidemaillist' style='display: none;'>
-                                        <ul>
+                                        <ul class="list-unstyled">
                                             <?php foreach ($aInvalidEmailList as $sInvalidEmail) { ?>
                                                 <li><?php echo $sInvalidEmail; ?></li>
                                             <?php } ?>
@@ -91,8 +91,36 @@
                                     <?php printf(gT("%s records with other invalid information"), count($aModelErrorList)); ?>
                                     [<a href='#' onclick='$("#invalidmodel").toggle();'><?php eT("List"); ?></a>]
                                     <div class='badtokenlist' id='invalidmodel' style='display: none;'>
-                                        <ul>
+                                        <ul class="list-unstyled">
                                             <?php foreach ($aModelErrorList as $sModelError) { ?>
+                                                <li><?php echo $sModelError; ?></li>
+                                            <?php } ?>
+                                        </ul>
+                                    </div>
+                                </li>
+                            <?php } ?>
+
+                            <?php if (!empty($aInvalideAttrFieldName)) { ?>
+                                <li>
+                                    <?php printf(gT("%s invalid attributes"), count($aInvalideAttrFieldName)); ?>
+                                    [<a href='#' onclick='$("#invalidattr").toggle();'><?php eT("columns ignored"); ?></a>]
+                                    <div class='badtokenlist' id='invalidattr' style='display: none;'>
+                                        <ul class="list-unstyled">
+                                            <?php foreach ($aInvalideAttrFieldName as $sModelError) { ?>
+                                                <li><?php echo $sModelError; ?></li>
+                                            <?php } ?>
+                                        </ul>
+                                    </div>
+                                </li>
+                            <?php } ?>
+
+                            <?php if (!empty($aMissingAttrFieldName)) { ?>
+                                <li>
+                                    <?php printf(gT("%s missing attributes"), count($aMissingAttrFieldName)); ?>
+                                    [<a href='#' onclick='$("#missingattr").toggle();'><?php eT("columns missing"); ?></a>]
+                                    <div class='badtokenlist' id='missingattr' style='display: none;'>
+                                        <ul class="list-unstyled">
+                                            <?php foreach ($aMissingAttrFieldName as $sModelError) { ?>
                                                 <li><?php echo $sModelError; ?></li>
                                             <?php } ?>
                                         </ul>
@@ -101,13 +129,13 @@
                             <?php } ?>
                 
                         </ul>
-                    </p> 
                     <?php } ?>
-
+                    </p>
                     <p>
                         <input class="btn btn-large btn-default" type='button' value='<?php eT("Display tokens"); ?>' onclick="window.open('<?php echo $this->createUrl("admin/tokens/sa/browse/surveyid/$surveyid"); ?>', '_top')" /><br />
                     </p>                                  
                 </div>                
             <?php endif;?>
+        </div>
     </div>
 </div>    

--- a/application/views/admin/token/csvupload.php
+++ b/application/views/admin/token/csvupload.php
@@ -23,7 +23,7 @@
                 <!-- "Character set of the file -->
                 <div class="form-group">
                     <label class="col-sm-2 control-label" for='csvcharset'><?php eT("Character set of the file:"); ?></label>
-                    <div class="col-lg-3">
+                    <div class="col-sm-5">
                         <?php echo CHtml::dropDownList('csvcharset', 'auto', $aEncodings, array('size' => '1', 'class'=>'form-control')); ?>
                     </div>
                 </div>
@@ -54,7 +54,15 @@
                         <?php echo CHtml::checkBox('allowinvalidemail', false); ?>
                     </div>
                 </div>
-                
+
+                <!-- show invalid attributes -->
+                <div class="form-group">
+                            <label class="col-sm-2 control-label" for='showwarningtoken'><?php eT("Display warning attributes:"); ?></label>
+                    <div class="col-sm-10">
+                           <?php echo CHtml::checkBox('showwarningtoken'); ?>
+                    </div>
+                </div>
+
                 <!-- Filter duplicate records -->
                 <div class="form-group">
                     <label class="col-sm-2 control-label" for='filterduplicatetoken'><?php eT("Filter duplicate records:"); ?></label>


### PR DESCRIPTION
> Quote here.
>
> -- <cite>@c-schmitz 
f you could create this patch for 2.5 this would be great.
I also note that your variable naming is not correct.
For explanations please have a look at https://manual.limesurvey.org/Coding_guidelines
and 
https://manual.limesurvey.org/Coding_guidelines#Localization
</cite>

I've developped another patch for the version 2.05 and fixed design a bit. Voila, here the result is : 
![lime_warning](https://cloud.githubusercontent.com/assets/486471/11720674/a5b153c8-9f60-11e5-8580-d0d536d48bf0.jpg)

Can you tell me if it will be accepted ? or any suggestion ?

