### PR TITLE
Fix initialize tokens error

### DIFF
--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -159,7 +159,7 @@
         public static function sanitizeToken($token)
         {
             // According to Yii doc : http://www.yiiframework.com/doc/api/1.1/CSecurityManager#generateRandomString-detail
-            return return preg_replace('/[^0-9a-zA-Z_~]/', '', $token);
+            return preg_replace('/[^0-9a-zA-Z_~]/', '', $token);
         }
         /**
          * Generates a token for all token objects in this survey.


### PR DESCRIPTION
Syntax error (consecutive return statements)

This causes a blank screen or PHP parse error message when initializing tokens, depending on your debug configurations.