### PR TITLE
Fixed issue #10208 render PDF, CVS, HTML in next situations:

### DIFF
--- a/application/controllers/PrintanswersController.php
+++ b/application/controllers/PrintanswersController.php
@@ -190,6 +190,7 @@
                 unset ($aFullResponseTable['startdate']);
                 foreach ($aFullResponseTable as $sFieldname=>$fname)
                 {
+                    $fname[2] = getExtendedAnswer($iSurveyID, $sFieldname, $fname[2], $sLanguage);
                     if (substr($sFieldname,0,4) == 'gid_')
                     {
                         $oPDF->addGidAnswer($fname[0], $fname[1]);

--- a/application/helpers/admin/export/Writer.php
+++ b/application/helpers/admin/export/Writer.php
@@ -321,6 +321,7 @@ abstract class Writer implements IWriter
                 $value = $response[$column];
                 if (isset($oSurvey->fieldMap[$column]) && $oSurvey->fieldMap[$column]['type']!='answer_time' && $oSurvey->fieldMap[$column]['type']!='page_time' && $oSurvey->fieldMap[$column]['type']!='interview_time')
                 {
+                    $value = getExtendedAnswer($oSurvey->id, $column, $value, $sLanguageCode);
                     switch ($oOptions->answerFormat) {
                         case 'long':
                             $elementArray[] = $this->getLongAnswer($oSurvey, $oOptions, $column,$value);

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1444,6 +1444,7 @@ function getExtendedAnswer($iSurveyID, $sFieldCode, $sValue, $sLanguage)
                 }
                 break;
             case 'N':
+            case 'K':
                 if (trim($sValue)!='')
                 {
                     if(strpos($sValue,".")!==false)
@@ -3170,7 +3171,7 @@ function questionAttributes($returnByName=false)
         //    "caption"=>gT('Value equals SGQA'));
 
         $qattributes["num_value_int_only"]=array(
-        "types"=>"N",
+        "types"=>"NK",
         'category'=>gT('Input'),
         'sortorder'=>100,
         'inputtype'=>'singleselect',

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3113,6 +3113,21 @@ function do_multiplenumeric($ia)
 
     $answer_main = '';
 
+    if (trim($aQuestionAttributes['num_value_int_only'])==1)
+    {
+        $acomma="";
+        $extraclass .=" integeronly";
+        $answertypeclass .= " integeronly";
+        $integeronly=1;
+    }
+    else
+    {
+        $acomma=getRadixPointData($thissurvey['surveyls_numberformat']);
+        $acomma = $acomma['separator'];
+        $integeronly=0;
+    }
+    
+    
     if ($anscount==0)
     {
         $inputnames=array();
@@ -3165,7 +3180,7 @@ function do_multiplenumeric($ia)
                     $answer_main .= $dispVal;
                 }
 
-                $answer_main .= '" onkeyup="'.$checkconditionFunction.'(this.value, this.name, this.type);" '." {$maxlength} />\n\t".$suffix."\n</span>{$sliderright}\n\t</li>\n";
+                $answer_main .= '" onkeyup="'.$checkconditionFunction.'(this.value, this.name, this.type, \'onchange\','.$integeronly.');" '." {$maxlength} />\n\t".$suffix."\n</span>{$sliderright}\n\t</li>\n";
 
             $fn++;
             $inputnames[]=$myfname;


### PR DESCRIPTION
Fixed issue #10208 render PDF, CVS, HTML in next situations:

- When render view of all survey answers
- When exported PDF, CVS, HTML, etc formats
- When is enabled print own answers and export them in a PDF etc [complement to pull request number #407]

Fixed issue #10208 when administrator exports a survey in PDF, CSV, HTML, etc format, numeric data is exported with 10 zeros, no matter if you selected only integer or not.
Dev: Added posibility to set integer or float values in multiple numeric questions in settings.
Dev: Added fixnum_checkconditions (Javascript) to multiple numeric answers to check if is allowed introduce decimal mark.