### PR TITLE
Fixed issue #09876: Different bogus with thousand seperator

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3000,6 +3000,7 @@ function do_multiplenumeric($ia)
 
 
     $extraclass ="";
+    $answertypeclass="";
     $checkconditionFunction = "fixnum_checkconditions";
     $aQuestionAttributes = getQuestionAttributeValues($ia[0]);
     $answer='';
@@ -3007,10 +3008,11 @@ function do_multiplenumeric($ia)
     $sSeparator = $sSeparator['separator'];
     //Must turn on the "numbers only javascript"
     $extraclass .=" numberonly";
+
     if ($aQuestionAttributes['thousands_separator'] == 1) {
         App()->clientScript->registerPackage('jquery-price-format');
         App()->clientScript->registerScriptFile(Yii::app()->getConfig('generalscripts').'numerical_input.js');
-        $extraclass .= " thousandsseparator";
+        $answertypeclass .= " thousandsseparator";
     }
 
     if (intval(trim($aQuestionAttributes['maximum_chars']))>0)
@@ -3046,13 +3048,10 @@ function do_multiplenumeric($ia)
     if ($thissurvey['nokeyboard']=='Y')
     {
         includeKeypad();
-        $kpclass = "num-keypad";
+        $answertypeclass = " num-keypad";
         $extraclass .=" keypad";
     }
-    else
-    {
-        $kpclass = "";
-    }
+
 
     $numbersonly_slider = ''; // DEPRECATED
 
@@ -3154,7 +3153,7 @@ function do_multiplenumeric($ia)
                 $sSeparator = getRadixPointData($thissurvey['surveyls_numberformat']);
                 $sSeparator = $sSeparator['separator'];
 
-                $answer_main .= "{$sliderleft}<span class=\"input\">\n\t".$prefix."\n\t<input class=\"text $kpclass\" type=\"text\" size=\"".$tiwidth."\" name=\"".$myfname."\" id=\"answer".$myfname."\" title=\"".gT('Only numbers may be entered in this field.')."\" value=\"";
+                $answer_main .= "{$sliderleft}<span class=\"input\">\n\t".$prefix."\n\t<input class=\"text $answertypeclass\" type=\"text\" size=\"".$tiwidth."\" name=\"".$myfname."\" id=\"answer".$myfname."\" title=\"".gT('Only numbers may be entered in this field.')."\" value=\"";
                 if (isset($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$myfname]))
                 {
                     $dispVal = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$myfname];
@@ -3243,7 +3242,6 @@ function do_multiplenumeric($ia)
     $sSeparator = getRadixPointData($thissurvey['surveyls_numberformat']);
     $sSeparator = $sSeparator['separator'];
 
-
     return array($answer, $inputnames);
 }
 
@@ -3273,7 +3271,7 @@ function do_numerical($ia)
     if ($aQuestionAttributes['thousands_separator'] == 1) {
         App()->clientScript->registerPackage('jquery-price-format');
         App()->clientScript->registerScriptFile(Yii::app()->getConfig('generalscripts').'numerical_input.js');
-        $extraclass .= " thousandsseparator";
+        $answertypeclass .= " thousandsseparator";
     }
     if (trim($aQuestionAttributes['suffix'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']])!='') {
         $suffix=$aQuestionAttributes['suffix'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']];
@@ -3334,10 +3332,7 @@ function do_numerical($ia)
         $extraclass .=" inputkeypad";
         $answertypeclass .= " num-keypad";
     }
-    else
-    {
-        $kpclass = "";
-    }
+
     // --> START NEW FEATURE - SAVE
     $answer = "<p class='question answer-item text-item numeric-item {$extraclass}'>"
     . " <label for='answer{$ia[1]}' class='hide label'>".gT('Your answer')."</label>\n$prefix\t"

--- a/scripts/numerical_input.js
+++ b/scripts/numerical_input.js
@@ -1,6 +1,15 @@
+$(document).on('submit','#limesurvey', function(){
+    $('.thousandsseparator').each(function(){
+            var re = new RegExp(escapeRegExp(thousandsSep()), 'g');
+           $(this).val($(this).val().replace(re, ''));
+    });
+});
+$(document).on('keyup','.thousandsseparator', function(){
+    ExprMgr_process_relevance_and_tailoring('onchange', $(this).attr('name'), $(this).attr('type'));
+});
+
 $(document).ready(function () {
     if (typeof LEMradix === 'undefined') { return; }
-
     if (LEMradix == ',')
     {
         var centsSep = ',';
@@ -11,44 +20,48 @@ $(document).ready(function () {
         var centsSep = '.';
         var thousandsSep = ',';
     }
-
-    var selector = '.thousandsseparator input.numeric, input.integeronly, .numberonly input[type=text]';
-    $(selector).unbind('keydown');
-    $('input.numeric, .numberonly input[type=text]').priceFormat({
-        'centsSeparator' : centsSep,
-        'thousandsSeparator' : thousandsSep,
-        'centsLimit' : 2,
-        'prefix' : '',
-        'allowNegative' : true
-    });
-    $('input.integeronly').priceFormat({
-        'centsSeparator' : centsSep,
-        'thousandsSeparator' : thousandsSep,
-        'centsLimit' : 0,
-        'prefix' : '',
-	'allowNegative' : true
-    });
-
-
-    $(selector).bind('keyup', custom_checkconditions);
-    // Initialize LEM tabs first.
-    LEMsetTabIndexes();
-
-    $(selector).removeAttr('onkeyup');
-    $('form#limesurvey').bind('submit', {'selector': selector}, ls_represent_all    );
-
+    // Replace the LEMval
     window.orgLEMval = window.LEMval;
     window.LEMval = function (alias) {
-
         var varName = LEMalias2varName[alias.split(".", 1)];
         var attr = LEMvarNameAttr[varName];
-        if (attr.onlynum == 1)
+        if (attr.onlynum == 1 && $('#' + attr.jsName_on).length && $('#' + attr.jsName_on).hasClass("thousandsseparator")) // Do it only if value is in page
         {
             return ls_represent($('#' + attr.jsName_on).val());
         }
         return orgLEMval(alias);
     };
+    $('.thousandsseparator').not('.integeronly').each(function(){
+        if($(this).val()!="")
+        {
+
+            var newVal=$(this).val();
+            console.log(newVal);
+            if(centsSep == ',')
+                newVal=newVal.split(',').join('.');
+            newVal=newVal*1;
+            newVal=Math.round(newVal * 100); // What for 0 .....
+            $(this).val(newVal);
+        }
+        $(this).unbind('keydown').removeAttr('onkeyup').priceFormat({
+            'centsSeparator' : centsSep,
+            'thousandsSeparator' : thousandsSep,
+            'centsLimit' : 2,
+            'prefix' : '',
+            'allowNegative' : true
+        }).trigger("keyup");
+    });
+    $('.thousandsseparator.integeronly').unbind('keydown').removeAttr('onkeyup').priceFormat({
+        'centsSeparator' : centsSep,
+        'thousandsSeparator' : thousandsSep,
+        'centsLimit' : 0,
+        'prefix' : '',
+        'allowNegative' : true
+    });
+    LEMsetTabIndexes();
+
 });
+
 
 /*
  This function is called on key down and checks the value when tab has been pressed.
@@ -62,25 +75,6 @@ function custom_tab(e)
     }
 }
 
-
-/*
- This function is called after priceformat has applied its layouting.
-*/
-function custom_checkconditions(evt_type)
-{
-    evt_type = typeof evt_type !== 'undefined' ? evt_type : 'onchange';
-
-    // We get the value.
-
-//    var val = $(this).attr('value');
-//    var pos = $(this).caret();
-//    $(this).attr('value', ls_represent(val));
-    ExprMgr_process_relevance_and_tailoring(evt_type, $(this).attr('name'), $(this).attr('type'));
-//    $(this).attr('value', val);
-//    $(this).caret(pos);
-
-}
-
 function centsSep()
 {
     return LEMradix;
@@ -88,7 +82,7 @@ function centsSep()
 
 function thousandsSep()
 {
-     if (LEMradix == ',')
+    if (LEMradix == ',')
     {
         return '.';
     }
@@ -99,7 +93,7 @@ function thousandsSep()
 }
 
 /*
-  Takes a value from a box and returns the representation limesurvey uses to save it.
+  Takes a value from a box and returns the representation for EM.
 */
 function ls_represent(value)
 {
@@ -118,17 +112,9 @@ function ls_represent(value)
     {
         return value;
     }
-
 }
 
 function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 
-function ls_represent_all(e)
-{
-    $(e.data.selector).each(function () {
-        $(this).attr('value', ls_represent($(this).attr('value')));
-
-    });
-}


### PR DESCRIPTION
Dev: set thousandsseparator directly to input: more easy to select in JS
Dev: fix number before set priceFormat ( , to . and *100)
Dev: remove thousand_separator before submit

Alternative to https://github.com/LimeSurvey/LimeSurvey/pull/412 with only JS
Fix the priceFormat system is , maybe, a better fix (https://github.com/LimeSurvey/LimeSurvey/pull/421)