### PR TITLE
Fixed issue #10252: old style (pre 2.0) URL mapping no longer working…

### DIFF
--- a/application/core/plugins/oldUrlCompat/oldUrlCompat.php
+++ b/application/core/plugins/oldUrlCompat/oldUrlCompat.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin to redirect old url system (index.php?sid=surveyid) to the new url
+ *
+ * @author Denis Chenu <denis@sondages.pro>
+ * @copyright 2016 LimeSurvey team <http://www.limesurvey.org>
+ * @license GPL v3
+ * @version 0.0.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+class oldUrlCompat extends PluginBase
+{
+    static protected $name = 'oldUrlCompat';
+    static protected $description = 'Old url (pre-2.0) compatible system';
+
+    /** init broke plugin management */
+    //~ public function init()
+    //~ {
+        //~ $this->subscribe('afterPluginLoad','oldUrlCompat');
+    //~ }
+    public function __construct(PluginManager $manager, $id)
+    {
+        parent::__construct($manager, $id);
+        $this->subscribe('afterPluginLoad','oldUrlCompat');
+    }
+    /**
+     * Forward survey controller if we are in default controller and a sid GET parameters is set
+     * @return void
+     */
+    public function oldUrlCompat()
+    {
+        $sControllerId=App()->getController()->getId();
+        $iSurveyId=App()->request->getQuery('sid');
+        if($sControllerId==="surveys" && $iSurveyId)
+        {
+            Yii::app()->getController()->forward('survey/index');
+        }
+    }
+}

--- a/application/core/plugins/oldUrlCompat/oldUrlCompat.php
+++ b/application/core/plugins/oldUrlCompat/oldUrlCompat.php
@@ -38,9 +38,7 @@ class oldUrlCompat extends PluginBase
      */
     public function oldUrlCompat()
     {
-        $sControllerId=App()->getController()->getId();
-        $iSurveyId=App()->request->getQuery('sid');
-        if($sControllerId==="surveys" && $iSurveyId)
+        if(App()->getController()->getId()==="surveys" && App()->request->getQuery('sid'))
         {
             Yii::app()->getController()->forward('survey/index');
         }


### PR DESCRIPTION
… in 2.06

Dev: forward to survey controller if controller is surveys and sid is in GET param
Dev: forward because redirect need query params reconstruction
Dev: use redirect can be an option (or new plugin)