### PR TITLE
Label Set and User Group gridview delete confirmation

### DIFF
--- a/application/views/admin/labels/labelsets_view.php
+++ b/application/views/admin/labels/labelsets_view.php
@@ -78,9 +78,7 @@ jQuery(function($) {
     //Delete button
     $(document).ready(function() {
         $('a[data-confirm]').click(function() {
-            if (!confirm($(this).attr('data-confirm'))) {
-              return false;
-            }
+            return confirm($(this).attr('data-confirm'));
         });
     });
 });

--- a/application/views/admin/labels/labelsets_view.php
+++ b/application/views/admin/labels/labelsets_view.php
@@ -69,11 +69,19 @@
 
 </div>
 
-<!-- To update rows per page via ajax -->
 <script type="text/javascript">
 jQuery(function($) {
-jQuery(document).on("change", '#pageSize', function(){
-    $.fn.yiiGridView.update('labelsets-grid',{ data:{ pageSize: $(this).val() }});
+    // To update rows per page via ajax
+    $(document).on("change", '#pageSize', function() {
+        $.fn.yiiGridView.update('labelsets-grid',{ data:{ pageSize: $(this).val() }});
+    });
+    //Delete button
+    $(document).ready(function() {
+        $('a[data-confirm]').click(function() {
+            if (!confirm($(this).attr('data-confirm'))) {
+              return false;
+            }
+        });
     });
 });
 </script>

--- a/application/views/admin/usergroup/usergroups_view.php
+++ b/application/views/admin/usergroup/usergroups_view.php
@@ -92,9 +92,7 @@ jQuery(function($) {
     //Delete button
     $(document).ready(function() {
         $('a[data-confirm]').click(function() {
-            if (!confirm($(this).attr('data-confirm'))) {
-              return false;
-            }
+            return confirm($(this).attr('data-confirm'));
         });
     });
 });

--- a/application/views/admin/usergroup/usergroups_view.php
+++ b/application/views/admin/usergroup/usergroups_view.php
@@ -83,11 +83,19 @@
 
 </div>
 
-<!-- To update rows per page via ajax -->
 <script type="text/javascript">
 jQuery(function($) {
-jQuery(document).on("change", '#pageSize', function(){
-    $.fn.yiiGridView.update('usergroups-grid',{ data:{ pageSize: $(this).val() }});
+    // To update rows per page via ajax
+    $(document).on("change", '#pageSize', function() {
+        $.fn.yiiGridView.update('usergroups-grid',{ data:{ pageSize: $(this).val() }});
+    });
+    //Delete button
+    $(document).ready(function() {
+        $('a[data-confirm]').click(function() {
+            if (!confirm($(this).attr('data-confirm'))) {
+              return false;
+            }
+        });
     });
 });
 </script>


### PR DESCRIPTION
@LouisGac 

I adopted the javascript approach that the other admin pages used to confirm deletion. This does not use bootstrap modals. I didn't want to make these 2 pages different from all the others. However, if you think modals would be better, I can work on changing all of the admin pages over to using modals for confirmations rather than the browser dialog.