### PR TITLE
Fixed issue: 'Unknown database driver' error during schema upgrade

### DIFF
--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -2485,6 +2485,7 @@ function dropPrimaryKey($sTablename)
             break;
         case 'pgsql':
         case 'sqlsrv':
+        case 'dblib':
         case 'mssql':
             $pkquery = "SELECT CONSTRAINT_NAME "
             ."FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS "


### PR DESCRIPTION
In a SQL Server-based setup using dblib driver, this issue breaks the schema upgrade process when a primary key has to be dropped.