### PR TITLE
Fixed issue: array declaration syntax incompatibility

### DIFF
--- a/application/models/QuestionGroup.php
+++ b/application/models/QuestionGroup.php
@@ -72,10 +72,10 @@ class QuestionGroup extends LSActiveRecord
 
     public function attributeLabels()
     {
-        return [
+        return array(
             'language' => gt('Language'),
             'group_name' => gt('Group name')
-        ];
+        );
     }
 
     /**


### PR DESCRIPTION
The short array syntax is not compatible with the minimum supported PHP version stated in the installation requirements.