### PR TITLE
Lenasterg patch pdf. Uses config parameters in order to define the styling of pdf 

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -384,10 +384,10 @@ $config['pdflogofile'] = 'logo_pdf.png';  // File name of logo for single answer
 $config['pdflogowidth'] = '50';           // Logo width
 $config['pdfheadertitle'] = '';           // Header title (bold font). If this config param is empty and header is enabled, site name is used
 $config['pdfheaderstring'] = '';          // Header string (under title). If this config param is empty and header is enabled, survey name is used
-$config['pdfquestionfill'] = '1';  	   // Background in questions should be painted (1) or transparent (0)	
-$config['pdfquestionbold'] = '0';		  // Questions in bold (1) or normal (0)
-$config['pdfquestionborder'] = '1'; 	  // Border in questions. Accepts 0:no border, 1:border
-$config['pdfresponseborder'] = '1';	  // Border in responses. Accepts 0:no border, 1:border
+$config['pdfQuestionFill'] = '1';  	   // Background in questions should be painted (1) or transparent (0)	
+$config['pdfQuestionBold'] = '0';		  // Questions in bold (1) or normal (0)
+$config['pdfQuestionBorder'] = '1'; 	  // Border in questions. Accepts 0:no border, 1:border
+$config['pdfResponseBorder'] = '1';	  // Border in responses. Accepts 0:no border, 1:border
 
 // QueXML-PDF: If set to true, the printable_help attribute will be visible on the exported PDF questionnaires
 // If used, the appearance (font size, justification, etc.) may be adjusted by editing td.questionHelpBefore and $helpBeforeBorderBottom of quexml.

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -384,6 +384,10 @@ $config['pdflogofile'] = 'logo_pdf.png';  // File name of logo for single answer
 $config['pdflogowidth'] = '50';           // Logo width
 $config['pdfheadertitle'] = '';           // Header title (bold font). If this config param is empty and header is enabled, site name is used
 $config['pdfheaderstring'] = '';          // Header string (under title). If this config param is empty and header is enabled, survey name is used
+$config['pdfquestionfill'] = '1';  	   // Background in questions should be painted (1) or transparent (0)	
+$config['pdfquestionbold'] = '0';		  // Questions in bold (1) or normal (0)
+$config['pdfquestionborder'] = '1'; 	  // Border in questions. Accepts 0:no border, 1:border
+$config['pdfresponseborder'] = '1';	  // Border in responses. Accepts 0:no border, 1:border
 
 // QueXML-PDF: If set to true, the printable_help attribute will be visible on the exported PDF questionnaires
 // If used, the appearance (font size, justification, etc.) may be adjusted by editing td.questionHelpBefore and $helpBeforeBorderBottom of quexml.

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -232,10 +232,10 @@ class GlobalSettings extends Survey_Common_Action
         setGlobalSetting('pdflogowidth', $iPDFLogoWidth);
         setGlobalSetting('pdfheadertitle', $_POST['pdfheadertitle']);
         setGlobalSetting('pdfheaderstring', $_POST['pdfheaderstring']);
-		setGlobalSetting('pdfQuestionFill', sanitize_int($_POST['pdfQuestionFill']));
-		setGlobalSetting('pdfQuestionBold', sanitize_int($_POST['pdfQuestionBold']));
-		setGlobalSetting('pdfQuestionBorder', sanitize_int($_POST['pdfQuestionBorder']));
-		setGlobalSetting('pdfResponseBorder', sanitize_int($_POST['pdfResponseBorder']));
+	setGlobalSetting('pdfQuestionFill', sanitize_int($_POST['pdfQuestionFill']));
+	setGlobalSetting('pdfQuestionBold', sanitize_int($_POST['pdfQuestionBold']));
+	setGlobalSetting('pdfQuestionBorder', sanitize_int($_POST['pdfQuestionBorder']));
+	setGlobalSetting('pdfResponseBorder', sanitize_int($_POST['pdfResponseBorder']));
         setGlobalSetting('googleMapsAPIKey', $_POST['googleMapsAPIKey']);
         setGlobalSetting('googleanalyticsapikey',$_POST['googleanalyticsapikey']);
         setGlobalSetting('googletranslateapikey',$_POST['googletranslateapikey']);

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -232,6 +232,10 @@ class GlobalSettings extends Survey_Common_Action
         setGlobalSetting('pdflogowidth', $iPDFLogoWidth);
         setGlobalSetting('pdfheadertitle', $_POST['pdfheadertitle']);
         setGlobalSetting('pdfheaderstring', $_POST['pdfheaderstring']);
+		setGlobalSetting('pdfQuestionFill', sanitize_int($_POST['pdfQuestionFill']));
+		setGlobalSetting('pdfQuestionBold', sanitize_int($_POST['pdfQuestionBold']));
+		setGlobalSetting('pdfQuestionBorder', sanitize_int($_POST['pdfQuestionBorder']));
+		setGlobalSetting('pdfResponseBorder', sanitize_int($_POST['pdfResponseBorder']));
         setGlobalSetting('googleMapsAPIKey', $_POST['googleMapsAPIKey']);
         setGlobalSetting('googleanalyticsapikey',$_POST['googleanalyticsapikey']);
         setGlobalSetting('googletranslateapikey',$_POST['googletranslateapikey']);

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -232,10 +232,10 @@ class GlobalSettings extends Survey_Common_Action
         setGlobalSetting('pdflogowidth', $iPDFLogoWidth);
         setGlobalSetting('pdfheadertitle', $_POST['pdfheadertitle']);
         setGlobalSetting('pdfheaderstring', $_POST['pdfheaderstring']);
-	setGlobalSetting('pdfQuestionFill', sanitize_int($_POST['pdfQuestionFill']));
-	setGlobalSetting('pdfQuestionBold', sanitize_int($_POST['pdfQuestionBold']));
-	setGlobalSetting('pdfQuestionBorder', sanitize_int($_POST['pdfQuestionBorder']));
-	setGlobalSetting('pdfResponseBorder', sanitize_int($_POST['pdfResponseBorder']));
+        setGlobalSetting('pdfQuestionFill', sanitize_int($_POST['pdfQuestionFill']));
+        setGlobalSetting('pdfQuestionBold', sanitize_int($_POST['pdfQuestionBold']));
+        setGlobalSetting('pdfQuestionBorder', sanitize_int($_POST['pdfQuestionBorder']));
+        setGlobalSetting('pdfResponseBorder', sanitize_int($_POST['pdfResponseBorder']));
         setGlobalSetting('googleMapsAPIKey', $_POST['googleMapsAPIKey']);
         setGlobalSetting('googleanalyticsapikey',$_POST['googleanalyticsapikey']);
         setGlobalSetting('googletranslateapikey',$_POST['googletranslateapikey']);

--- a/application/libraries/admin/pdf.php
+++ b/application/libraries/admin/pdf.php
@@ -767,6 +767,26 @@ class pdf extends TCPDF {
    */
   function addAnswer($sQuestion, $sResponse, $bReplaceExpressions=true, $bAllowBreakPage=false)
   {
+    $questionfill=1;
+	  $yiiquestionfill = Yii::app()->getConfig('pdfquestionfill');
+	  if ($yiiquestionfill==0) 
+	  {
+		    $questionfill=0;
+	  }
+  
+  	$questionborder=$responseborder=1;
+  	$yiiquestionborder = Yii::app()->getConfig('pdfquestionborder');
+  	if ($yiiquestionborder==0) 
+  	{
+  	    $questionborder=0;
+  	}
+	
+  	$yiiresponseborder = Yii::app()->getConfig('pdfresponseborder');
+  	if ($yiiquestionborder=='0') 
+  	{
+  	    $responseborder=0;
+  	}
+    
     $oPurifier = new CHtmlPurifier();
     $sQuestionHTML = str_replace('-oth-','',$sQuestion); // Copied from Writer::stripTagsFull. Really necessary?
     $sQuestionHTML = html_entity_decode(stripJavaScript($oPurifier->purify($sQuestionHTML)),ENT_COMPAT);
@@ -779,9 +799,24 @@ class pdf extends TCPDF {
 
     $startPage = $this->getPage();
     $this->startTransaction();
-    $this->SetFontSize($this->_ibaseAnswerFontSize);
-    $this->WriteHTMLCell(0, $this->_iCellHeight, $this->getX(), $this->getY(), $sQuestionHTML, 1, 1, true, true, 'L');
-    $this->MultiCell(0, $this->_iCellHeight, $sResponse, 1, 'L', 0, 1, '', '', true);
+    
+    $yiiquestionbold = Yii::app()->getConfig('pdfquestionbold');
+	  if ($yiiquestionbold=='1') 
+	  {
+		    $fontfamily = $this->getFontFamily;
+		    $this->SetFont($fontfamily,'B',$this->_ibaseAnswerFontSize);
+	  }
+	  else 
+	  {
+		    $this->SetFontSize($this->_ibaseAnswerFontSize);
+	  }
+   
+    $this->WriteHTMLCell(0, $this->_iCellHeight, $this->getX(), $this->getY(), $sQuestionHTML, $questionborder, 1, $questionfill, true, 'L');
+    if ($yiiquestionbold=='1') 
+    {
+		    $this->SetFont($fontfamily,'',$this->_ibaseAnswerFontSize);
+	  }
+    $this->MultiCell(0, $this->_iCellHeight, $sResponse, $responseborder, 'L', 0, 1, '', '', true);
     $this->ln(2);
     if ($this->getPage() != $startPage && !$bAllowBreakPage)
     {

--- a/application/libraries/admin/pdf.php
+++ b/application/libraries/admin/pdf.php
@@ -767,26 +767,23 @@ class pdf extends TCPDF {
    */
   function addAnswer($sQuestion, $sResponse, $bReplaceExpressions=true, $bAllowBreakPage=false)
   {
-    $questionfill=1;
-	  $yiiquestionfill = Yii::app()->getConfig('pdfquestionfill');
-	  if ($yiiquestionfill==0) 
-	  {
-		    $questionfill=0;
-	  }
-  
-  	$questionborder=$responseborder=1;
-  	$yiiquestionborder = Yii::app()->getConfig('pdfquestionborder');
-  	if ($yiiquestionborder==0) 
-  	{
-  	    $questionborder=0;
-  	}
+    $questionFill=$questionBorder=$responseBorder=1;
 	
-  	$yiiresponseborder = Yii::app()->getConfig('pdfresponseborder');
-  	if ($yiiquestionborder=='0') 
-  	{
-  	    $responseborder=0;
-  	}
+    $yiiQuestionFill = Yii::app()->getConfig('pdfQuestionFill');
+    if ($yiiQuestionFill==0) {
+    	$questionFill=0;
+    }
     
+    $yiiQuestionBorder = Yii::app()->getConfig('pdfQuestionBorder');
+    if ($yiiQuestionBorder==0) {
+        $questionBorder=0;
+	}
+	
+    $yiiResponseBorder = Yii::app()->getConfig('pdfResponseBorder');
+	if ($yiiResponseBorder=='0') {
+        $responseBorder=0;
+	}
+	
     $oPurifier = new CHtmlPurifier();
     $sQuestionHTML = str_replace('-oth-','',$sQuestion); // Copied from Writer::stripTagsFull. Really necessary?
     $sQuestionHTML = html_entity_decode(stripJavaScript($oPurifier->purify($sQuestionHTML)),ENT_COMPAT);
@@ -799,24 +796,20 @@ class pdf extends TCPDF {
 
     $startPage = $this->getPage();
     $this->startTransaction();
-    
-    $yiiquestionbold = Yii::app()->getConfig('pdfquestionbold');
-	  if ($yiiquestionbold=='1') 
-	  {
-		    $fontfamily = $this->getFontFamily;
-		    $this->SetFont($fontfamily,'B',$this->_ibaseAnswerFontSize);
-	  }
-	  else 
-	  {
-		    $this->SetFontSize($this->_ibaseAnswerFontSize);
-	  }
-   
-    $this->WriteHTMLCell(0, $this->_iCellHeight, $this->getX(), $this->getY(), $sQuestionHTML, $questionborder, 1, $questionfill, true, 'L');
-    if ($yiiquestionbold=='1') 
-    {
-		    $this->SetFont($fontfamily,'',$this->_ibaseAnswerFontSize);
-	  }
-    $this->MultiCell(0, $this->_iCellHeight, $sResponse, $responseborder, 'L', 0, 1, '', '', true);
+	
+    $yiiQuestionBold = Yii::app()->getConfig('pdfQuestionBold');
+    if ($yiiQuestionBold=='1') {
+        $fontFamily = $this->getFontFamily;
+        $this->SetFont($fontFamily,'B',$this->_ibaseAnswerFontSize);
+    }
+    else {
+        $this->SetFontSize($this->_ibaseAnswerFontSize);
+    }
+    $this->WriteHTMLCell(0, $this->_iCellHeight, $this->getX(), $this->getY(), $sQuestionHTML, $questionBorder, 1, $questionFill, true, 'L');
+    if ($yiiQuestionBold=='1') {
+        $this->SetFont($fontFamily,'',$this->_ibaseAnswerFontSize);
+    }
+    $this->MultiCell(0, $this->_iCellHeight, $sResponse, $responseBorder, 'L', 0, 1, '', '', true);
     $this->ln(2);
     if ($this->getPage() != $startPage && !$bAllowBreakPage)
     {

--- a/application/views/admin/global_settings/_presentation.php
+++ b/application/views/admin/global_settings/_presentation.php
@@ -150,6 +150,65 @@
         </div>
     </div>
 
+   <?php 
+    $pdfQuestionFill=getGlobalSetting('pdfQuestionFill');
+    $selPdfQuestionFill = array( 0 => '' , 1 => '');
+    $selPdfQuestionFill[$pdfQuestionFill] = ' selected="selected"'; 
+	?>
+    <div class="form-group">
+	    <label class="col-sm-6 control-label"  for='pdfQuestionFill'><?php eT("Add gray backgroung to PDF questions:"); ?></label>
+		   <div class="col-sm-6">
+               <select class="form-control"  id='pdfQuestionFill' name='pdfQuestionFill'>
+			       <option value="1" <?php echo $selPdfQuestionFill[1]; ?> ><?php eT('Yes'); ?></option>
+				   <option value="0" <?php echo $selPdfQuestionFill[0]; ?> ><?php eT('No'); ?></option>
+			  </select>
+		</div>
+    </div>
+	
+<?php 
+    $pdfQuestionBold=getGlobalSetting('pdfQuestionBold');
+    $selPdfQuestionBold = array( 0 => '' , 1 => '');
+    $selPdfQuestionBold[$pdfQuestionBold] = ' selected="selected"'; 
+	?>
+    <div class="form-group">
+		  <label class="col-sm-6 control-label"  for='pdfQuestionBold'><?php eT("PDF questions in bold:"); ?></label>
+		   <div class="col-sm-6">
+                <select class="form-control"  id='pdfQuestionBold' name='pdfQuestionBold'>
+				    <option value="1" <?php echo $selPdfQuestionBold[1]; ?> ><?php eT('Yes'); ?></option>
+					<option value="0" <?php echo $selPdfQuestionBold[0]; ?> ><?php eT('No'); ?></option>
+				</select>
+			</div>
+    </div>
+	
+<?php 
+    $pdfQuestionBorder=getGlobalSetting('pdfQuestionBorder');
+    $selPdfQuestionBorder = array( 0 => '' , 1 => '');
+    $selPdfQuestionBorder[$pdfQuestionBorder] = ' selected="selected"'; 
+	?>
+    <div class="form-group">
+		  <label class="col-sm-6 control-label"  for='pdfQuestionBorder'><?php eT("Borders around questions in PDF:"); ?></label>
+		   <div class="col-sm-6">
+                <select class="form-control"  id='pdfQuestionBorder' name='pdfQuestionBorder'>
+				    <option value="1" <?php echo $selPdfQuestionBorder[1]; ?> ><?php eT('Yes'); ?></option>
+					<option value="0" <?php echo $selPdfQuestionBorder[0]; ?> ><?php eT('No'); ?></option>
+				</select>
+			</div>
+    </div>
+	
+<?php 
+    $pdfResponseBorder=getGlobalSetting('pdfResponseBorder');
+    $selPdfResponseBorder = array( 0 => '' , 1 => '');
+    $selPdfResponseBorder[$pdfResponseBorder] = ' selected="selected"'; 
+	?>
+    <div class="form-group">
+	    <label class="col-sm-6 control-label"  for='pdfResponseBorder'><?php eT("Borders around responses in PDF:"); ?></label>
+		    <div class="col-sm-6">
+			    <select class="form-control"  id='pdfResponseBorder' name='pdfResponseBorder'>
+				    <option value="1" <?php echo $selPdfResponseBorder[1]; ?> ><?php eT('Yes'); ?></option>
+					<option value="0" <?php echo $selPdfResponseBorder[0]; ?> ><?php eT('No'); ?></option>
+				</select>
+			</div>
+    </div>
 
 <?php if (Yii::app()->getConfig("demoMode")==true):?>
     <p><?php eT("Note: Demo mode is activated. Marked (*) settings can't be changed."); ?></p>


### PR DESCRIPTION
This patch adds some flexibility to the administrator in formatting the output pdf for a participant's  responses.The patch introduces 4 new config parameters for the pdf export, which are used to format the questions and responses cells. 

- $config['pdfquestionfill']:  	defines if the background in questions should be painted (1) or transparent (0)	
 - $config['pdfquestionbold'] Questions in bold (1) or normal (0)
 - $config['pdfquestionborder']  Border in questions. Accepts 0:no border, 1:border
 - $config['pdfresponseborder']  Border in responses. Accepts 0:no border, 1:border