### PR TITLE
Fixed issue #10458: No save and close button for labelsets

### DIFF
--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -361,7 +361,9 @@ class labels extends Survey_Common_Action
                     $lid = 0;
                 }
             }
-            if ($lid)
+            if (isset($_POST['saveandclose']))
+                $this->getController()->redirect(array("admin/labels/sa/view"));
+            else if ($lid)
                 $this->getController()->redirect(array("admin/labels/sa/view/lid/" . $lid));
             else
                 $this->getController()->redirect(array("admin/labels/sa/view"));

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -352,7 +352,13 @@ class labels extends Survey_Common_Action
             if ($action == "insertlabelset" && Permission::model()->hasGlobalPermission('labelsets','create'))
                 $lid = insertlabelset();
             if (($action == "modlabelsetanswers" || ($action == "ajaxmodlabelsetanswers")) && Permission::model()->hasGlobalPermission('labelsets','update'))
+            {
                 modlabelsetanswers($lid);
+                if (isset($_POST['saveandclose']))
+                    $this->getController()->redirect(array("admin/labels/sa/view"));
+                else
+                    $this->getController()->redirect(array("admin/labels/sa/view/lid/" . $lid));
+            }
             if ($action == "deletelabelset" && Permission::model()->hasGlobalPermission('labelsets','delete'))
             {
                 if (deletelabelset($lid))
@@ -362,9 +368,9 @@ class labels extends Survey_Common_Action
                 }
             }
             if (isset($_POST['saveandclose']))
-                $this->getController()->redirect(array("admin/labels/sa/view"));
-            else if ($lid)
                 $this->getController()->redirect(array("admin/labels/sa/view/lid/" . $lid));
+            else if ($lid)
+                $this->getController()->redirect(array("admin/labels/sa/editlabelset/lid/" . $lid));
             else
                 $this->getController()->redirect(array("admin/labels/sa/view"));
     }

--- a/application/views/admin/labels/labelsetsbar_view.php
+++ b/application/views/admin/labels/labelsetsbar_view.php
@@ -99,8 +99,12 @@
             <?php if (isset($labelbar['buttons']['edition'])):?>
                 <a class="btn btn-success" href="#" role="button" id="save-form-button" data-form-id="<?php echo $labelbar['savebutton']['form']; ?>">
                     <span class="glyphicon glyphicon-ok"></span>
-
                     <?php echo $labelbar['savebutton']['text'];?>
+                </a>
+
+                <a class="btn btn-default" href="#" role="button" id="save-and-close-form-button" data-form-id="<?php echo $labelbar['savebutton']['form']; ?>">
+                    <span class="glyphicon glyphicon-saved"></span>
+                    <?php eT("Save and close");?>
                 </a>
             <?php endif;?>
 


### PR DESCRIPTION
This is in regards to bug #10458.  Adds a save and close button to the create label set page.  