### PR TITLE
Improvements to plugin manager admin page

### DIFF
--- a/application/controllers/admin/pluginmanager.php
+++ b/application/controllers/admin/pluginmanager.php
@@ -60,13 +60,7 @@ class PluginManager extends Survey_Common_Action
             }
         }
 
-        if(!is_null(Yii::app()->request->getParam('pageSize')))
-        {
-            $pageSize = intval(Yii::app()->request->getParam('pageSize'));
-            if(in_array($pageSize, Yii::app()->params['pageSizeOptions'])) {
-                Yii::app()->user->setState('pageSize', $pageSize);
-            }
-        }
+        $pageSize = intval(Yii::app()->request->getParam('pageSize', Yii::app()->params['defaultPageSize']));
 
         $aData['fullpagebar']['returnbutton']['url'] = 'index';
         $aData['fullpagebar']['returnbutton']['text'] = gT('Return to admin panel');

--- a/application/controllers/admin/pluginmanager.php
+++ b/application/controllers/admin/pluginmanager.php
@@ -60,7 +60,10 @@ class PluginManager extends Survey_Common_Action
             }
         }
 
-        $pageSize = intval(Yii::app()->request->getParam('pageSize', Yii::app()->params['defaultPageSize']));
+        if(isset($_GET['pageSize']))
+        {
+            Yii::app()->user->setState('pageSize',intval($_GET['pageSize']));
+        }
 
         $aData['fullpagebar']['returnbutton']['url'] = 'index';
         $aData['fullpagebar']['returnbutton']['text'] = gT('Return to admin panel');

--- a/application/controllers/admin/pluginmanager.php
+++ b/application/controllers/admin/pluginmanager.php
@@ -60,9 +60,8 @@ class PluginManager extends Survey_Common_Action
             }
         }
 
-        if(isset($_GET['pageSize']))
-        {
-            Yii::app()->user->setState('pageSize',intval($_GET['pageSize']));
+        if(Yii::app()->request->getParam('pageSize')) {
+            Yii::app()->user->setState('pageSize', intval(Yii::app()->request->getParam('pageSize')));
         }
 
         $aData['fullpagebar']['returnbutton']['url'] = 'index';

--- a/application/controllers/admin/pluginmanager.php
+++ b/application/controllers/admin/pluginmanager.php
@@ -60,8 +60,13 @@ class PluginManager extends Survey_Common_Action
             }
         }
 
+        if (isset($_GET['pageSize']))
+        {
+            Yii::app()->user->setState('pageSize',(int)$_GET['pageSize']);
+        }
+
         $aData['fullpagebar']['returnbutton']['url'] = 'index';
-        $aData['fullpagebar']['returnbutton']['text'] = gT('Close');
+        $aData['fullpagebar']['returnbutton']['text'] = gT('Return to admin panel');
         $aData['data'] = $data;
         $this->_renderWrappedTemplate('pluginmanager', 'index', $aData);
     }

--- a/application/controllers/admin/pluginmanager.php
+++ b/application/controllers/admin/pluginmanager.php
@@ -60,9 +60,12 @@ class PluginManager extends Survey_Common_Action
             }
         }
 
-        if (isset($_GET['pageSize']))
+        if(!is_null(Yii::app()->request->getParam('pageSize')))
         {
-            Yii::app()->user->setState('pageSize',(int)$_GET['pageSize']);
+            $pageSize = intval(Yii::app()->request->getParam('pageSize'));
+            if(in_array($pageSize, Yii::app()->params['pageSizeOptions'])) {
+                Yii::app()->user->setState('pageSize', $pageSize);
+            }
         }
 
         $aData['fullpagebar']['returnbutton']['url'] = 'index';

--- a/application/views/admin/pluginmanager/index.php
+++ b/application/views/admin/pluginmanager/index.php
@@ -48,7 +48,6 @@
 
     $gridColumns = array(
         array(// display the status
-            'class' => 'CDataColumn',
             'header' => gT('Status'),
             'type' => 'html',
             'name' => 'status',
@@ -65,9 +64,16 @@
                 }
             }
         ),
+        array(// display the 'name' attribute
+            'header' => gT('Plugin'),
+            'name' => 'name'
+        ),
+        array(// display the 'description' attribute
+            'header' => gT('Description'),
+            'name' => 'description'
+        ),
         array(// display the activation link
-            'class' => 'CDataColumn',
-            'type' => 'raw',
+            'type' => 'html',
             'header' => gT('Action'),
             'name' => 'action',
             'value' => function($data) {
@@ -83,16 +89,6 @@
                 }
                 return $output;
             }
-        ),
-        array(// display the 'name' attribute
-            'class' => 'CDataColumn',
-            'header' => gT('Plugin'),
-            'name' => 'name'
-        ),
-        array(// display the 'description' attribute
-            'class' => 'CDataColumn',
-            'header' => gT('Description'),
-            'name' => 'description'
         ),
     );
 
@@ -115,8 +111,7 @@
                 Yii::app()->params['pageSizeOptions'],
                 array('class'=>'changePageSize form-control', 'style'=>'display: inline; width: auto'))),
         'columns'=>$gridColumns,
-        'rowCssClassExpression'=> function ($data, $row) { return ($row % 2 ? 'even' : 'odd') . ' ' . ($data['new']==1 ? "new" : "old"); },
-        'itemsCssClass' => 'items table-condensed table-bordered'
+        'htmlOptions'=>array('style'=>'cursor: pointer;', 'class'=>'hoverAction'),
     ));
     ?>
 </div>

--- a/application/views/admin/pluginmanager/index.php
+++ b/application/views/admin/pluginmanager/index.php
@@ -8,7 +8,7 @@
 */
 
 ?>
-<?php $pageSize=Yii::app()->user->getState('pageSize',Yii::app()->params['defaultPageSize']);?>
+<?php $pageSize = intval(Yii::app()->user->getState('pageSize', Yii::app()->params['defaultPageSize'])); ?>
 
 <h3 class="pagetitle"><?php eT('Plugin manager'); ?></h3>
 <div style="width: 75%; margin: auto;">

--- a/application/views/admin/pluginmanager/index.php
+++ b/application/views/admin/pluginmanager/index.php
@@ -111,7 +111,6 @@
                 Yii::app()->params['pageSizeOptions'],
                 array('class'=>'changePageSize form-control', 'style'=>'display: inline; width: auto'))),
         'columns'=>$gridColumns,
-        'htmlOptions'=>array('style'=>'cursor: pointer;', 'class'=>'hoverAction'),
     ));
     ?>
 </div>

--- a/application/views/admin/pluginmanager/index.php
+++ b/application/views/admin/pluginmanager/index.php
@@ -16,13 +16,42 @@
     /* @var $this ConfigController */
     /* @var $dataProvider CActiveDataProvider */
 
-    $dataProvider = new CArrayDataProvider($data);
+    $sort = new CSort();
+    $sort->attributes = array(
+        'name'=>array(
+            'asc'=> 'name',
+            'desc'=> 'name desc',
+        ),
+        'description'=>array(
+            'asc'=> 'description',
+            'desc'=> 'description desc',
+        ),
+        'status'=>array(
+            'asc'=> 'active',
+            'desc'=> 'active desc',
+            'default'=> 'desc',
+        ),
+    );
+    $sort->defaultOrder = array(
+        'name'=>CSort::SORT_ASC,
+    );
+
+    $providerOptions = array(
+        'pagination'=>array(
+            'pageSize'=>$pageSize,
+        ),
+        'sort'=>$sort,
+        'caseSensitiveSort'=> false,
+    );
+
+    $dataProvider = new CArrayDataProvider($data, $providerOptions);
 
     $gridColumns = array(
         array(// display the status
             'class' => 'CDataColumn',
             'header' => gT('Status'),
             'type' => 'html',
+            'name' => 'status',
             //'value' => function($data) { return ($data['active'] == 1 ? CHtml::image(App()->getConfig('adminimageurl') . 'active.png', gT('Active'), array('width' => 32, 'height' => 32)) : CHtml::image(App()->getConfig('adminimageurl') . 'inactive.png', gT('Inactive'), array('width' => 32, 'height' => 32))); }
             'value' => function($data)
             {
@@ -40,6 +69,7 @@
             'class' => 'CDataColumn',
             'type' => 'raw',
             'header' => gT('Action'),
+            'name' => 'action',
             'value' => function($data) {
                 if ($data['active'] == 0)
                 {
@@ -77,6 +107,7 @@
 
     $this->widget('bootstrap.widgets.TbGridView', array(
         'dataProvider'=>$dataProvider,
+        'id' => 'plugins-grid',
         'summaryText'=>gT('Displaying {start}-{end} of {count} result(s).') .' '.sprintf(gT('%s rows per page'),
             CHtml::dropDownList(
                 'pageSize',
@@ -89,3 +120,12 @@
     ));
     ?>
 </div>
+
+<script type="text/javascript">
+jQuery(function($) {
+    // To update rows per page via ajax
+    $(document).on("change", '#pageSize', function() {
+        $.fn.yiiGridView.update('plugins-grid',{ data:{ pageSize: $(this).val() }});
+    });
+});
+</script>


### PR DESCRIPTION
- Changed the back button to say "Return to admin panel" instead of "Close" for consistency with other pages

- Hooked up the rows per page dropdown

- Added sorting to the grid view (default sort is by plugin name, can also sort by active status or description)

- Changed appearance to match the other admin gridviews

Note:
I really didn't think having to change the view for some of these things was a nice approach, but the only alternative was to rewrite the controller and the model
