### PR TITLE
Fix: token check should be case insensitive

### DIFF
--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -658,7 +658,7 @@ class index extends CAction {
 
     function _isClientTokenDifferentFromSessionToken($clientToken, $surveyid)
     {
-        return $clientToken != '' && isset($_SESSION['survey_'.$surveyid]['token']) && $clientToken != $_SESSION['survey_'.$surveyid]['token'];
+        return $clientToken != '' && isset($_SESSION['survey_'.$surveyid]['token']) && strtolower($clientToken) != strtolower($_SESSION['survey_'.$surveyid]['token']);
     }
 
     function _isSurveyFinished($surveyid)


### PR DESCRIPTION
While tokens should be case insensitive this check is still case sensitive, causing erratic behaviour when users enter a token in a different case than the one entered when the session was created.