### PR TITLE
Fixed issue #10806: A lot of white space lost in survey and question edit

### DIFF
--- a/application/helpers/admin/htmleditor_helper.php
+++ b/application/helpers/admin/htmleditor_helper.php
@@ -200,6 +200,7 @@
 
     function getInlineEditor($fieldtype,$fieldname,$fieldtext, $surveyID=null,$gID=null,$qID=null,$action=null)
     {
+        App()->getClientScript()->registerCssFile(Yii::app()->getConfig('styleurl')."htmleditor.css");
         $htmlcode = '';
         $imgopts = '';
         $toolbarname = 'inline';

--- a/application/views/admin/survey/Question/question_subviews/_tabs.php
+++ b/application/views/admin/survey/Question/question_subviews/_tabs.php
@@ -31,35 +31,33 @@
 
         <!-- Question Code -->
         <div class="form-group">
-            <div class="col-lg-offset-1">
-                <label class="col-sm-2 control-label"  for='title'><?php eT("Code:"); ?></label>
-                <div class="col-sm-5">
+                <label class="col-sm-3 control-label"  for='title'><?php eT("Code:"); ?></label>
+                <div class="col-sm-9">
                     <?php echo CHtml::textField("title",$eqrow['title'],array('class'=>'form-control','size'=>"20",'maxlength'=>'20','pattern'=>$sPattern,"autofocus"=>"autofocus",'id'=>"title")); ?>
                     <span class='text-warning'><?php  eT("Required"); ?> </span>
                 </div>
-            </div>
         </div>
 
         <!-- Question Text -->
         <div class="form-group">
-            <div class="col-lg-offset-1">
-                <label class="col-sm-2 control-label" for='question_<?php echo $eqrow['language']; ?>' class=""><?php eT("Question:"); ?></label>
-                <div class="htmleditor col-sm-6 input-group">
+                <label class="col-sm-3 control-label" for='question_<?php echo $eqrow['language']; ?>' class=""><?php eT("Question:"); ?></label>
+                <div class="col-sm-9">
+                <div class="htmleditor input-group">
                     <?php echo CHtml::textArea("question_{$eqrow['language']}",$eqrow['question'],array('class'=>'form-control','cols'=>'60','rows'=>'8','id'=>"question_{$eqrow['language']}")); ?>
                     <?php echo getEditor("question-text","question_".$eqrow['language'], "[".gT("Question:", "js")."](".$eqrow['language'].")",$surveyid,$gid,$qid,$action); ?>
                 </div>
-            </div>
+                </div>
         </div>
 
         <!-- Question Help -->
         <div class="form-group">
-            <div class="col-lg-offset-1">
-                <label class="col-sm-2 control-label" for='help_<?php echo $eqrow['language']; ?>'><?php eT("Help:"); ?></label>
-                <div class="htmleditor col-sm-6 input-group">
+                <label class="col-sm-3 control-label" for='help_<?php echo $eqrow['language']; ?>'><?php eT("Help:"); ?></label>
+                <div class="col-sm-9">
+                <div class="htmleditor input-group">
                     <?php echo CHtml::textArea("help_{$eqrow['language']}",$eqrow['help'],array('class'=>'form-control','cols'=>'60','rows'=>'4','id'=>"help_{$eqrow['language']}")); ?>
                     <?php echo getEditor("question-help","help_".$eqrow['language'], "[".gT("Help:", "js")."](".$eqrow['language'].")",$surveyid,$gid,$qid,$action); ?>
                 </div>
-            </div>
+                </div>
         </div>
     </div>
 
@@ -69,24 +67,24 @@
             <?php $aqrow = $aqrow->attributes;?>
                 <div id="<?php echo $aqrow['language']; ?>" class="tab-pane fade">
                     <div class="form-group">
-                        <div class="col-lg-offset-1">
-                            <label class="col-sm-2 control-label" for='question_<?php echo $aqrow['language']; ?>'><?php eT("Question:"); ?></label>
-                            <div class="htmleditor col-sm-6 input-group">
+                            <label class="col-sm-3 control-label" for='question_<?php echo $aqrow['language']; ?>'><?php eT("Question:"); ?></label>
+                            <div class="col-sm-9">
+                            <div class="htmleditor input-group">
                                 <?php echo CHtml::textArea("question_{$aqrow['language']}",$aqrow['question'],array('class'=>'form-control','cols'=>'60','rows'=>'8','id'=>"question_{$aqrow['language']}")); ?>
                                 <?php echo getEditor("question-text","question_".$aqrow['language'], "[".gT("Question:", "js")."](".$aqrow['language'].")",$surveyid,$gid,$qid,$action); ?>
                             </div>
-                        </div>
+                            </div>
                     </div>
 
                     <div class="form-group">
-                        <div class="col-lg-offset-1">
-                            <label class="col-sm-2 control-label" for='help_<?php echo $aqrow['language']; ?>'><?php eT("Help:"); ?></label>
-                            <div class="htmleditor col-sm-6 input-group">
+                            <label class="col-sm-3 control-label" for='help_<?php echo $aqrow['language']; ?>'><?php eT("Help:"); ?></label>
+                            <div class="col-sm-9">
+                            <div class="htmleditor input-group">
                                 <?php echo CHtml::textArea("help_{$aqrow['language']}",$aqrow['help'],array('class'=>'form-control','cols'=>'60','rows'=>'4','id'=>"help_{$aqrow['language']}")); ?>
                                 <?php echo getEditor("question-help","help_".$aqrow['language'], "[".gT("Help:", "js")."](".$aqrow['language'].")",$surveyid,$gid,$qid,$action); ?>
                             </div>
+                            </div>
                         </div>
-                    </div>
                 </div>
         <?php endforeach;?>
     <?php else:?>
@@ -95,23 +93,23 @@
             <div id="<?php echo $addlanguage; ?>"  class="tab-pane fade">
 
                 <div class="form-group">
-                    <div class="col-lg-offset-1">
-                        <label class="col-sm-2 control-label"  for='question_<?php echo $addlanguage; ?>'><?php eT("Question:");?></label>
-                        <div class="htmleditor col-sm-6 input-group">
+                        <label class="col-sm-3 control-label"  for='question_<?php echo $addlanguage; ?>'><?php eT("Question:");?></label>
+                        <div class="col-sm-9">
+                        <div class="htmleditor input-group">
                             <?php echo CHtml::textArea("question_{$addlanguage}","",array('class'=>'form-control','cols'=>'60','rows'=>'8','id'=>"question_{$addlanguage}")); ?>
                             <?php echo getEditor("question-text","question_".$addlanguage, "[".gT("Question:", "js")."](".$addlanguage.")",$surveyid,$gid,$qid,$action); ?>
                         </div>
-                    </div>
+                        </div>
                 </div>
 
                 <div class="form-group">
-                    <div class="col-lg-offset-1">
-                        <label class="col-sm-2 control-label" for='help_<?php echo $addlanguage; ?>'><?php eT("Help:"); ?></label>
-                        <div class="htmleditor col-sm-6 input-group">
+                        <label class="col-sm-3 control-label" for='help_<?php echo $addlanguage; ?>'><?php eT("Help:"); ?></label>
+                        <div class="col-sm-9">
+                        <div class="htmleditor input-group">
                             <?php echo CHtml::textArea("help_{$addlanguage}","",array('class'=>'form-control','cols'=>'60','rows'=>'4','id'=>"help_{$addlanguage}")); ?>
                             <?php echo getEditor("question-help","help_".$addlanguage, "[".gT("Help:", "js")."](".$addlanguage.")",$surveyid,$gid,$qid,$action); ?>
                         </div>
-                    </div>
+                        </div>
                 </div>
 
             </div>

--- a/application/views/admin/survey/editLocalSettings_view.php
+++ b/application/views/admin/survey/editLocalSettings_view.php
@@ -5,11 +5,11 @@
  */
 ?>
 
-<div id="edittxtele-<?php echo $i;?>" class="tab-pane fade in <?php if($i==0){echo "active";}?> col-lg-6 center-box">
+<div id="edittxtele-<?php echo $i;?>" class="tab-pane fade in <?php if($i==0){echo "active";}?> center-box">
 
     <!-- Survey title -->
     <div class="form-group">
-        <label class="col-sm-4 question-group-title" for="short_title<?php echo $esrow['surveyls_language']; ?>">
+        <label class="col-sm-4 question-group-title control-label" for="short_title<?php echo $esrow['surveyls_language']; ?>">
             <?php eT("Survey title"); ?>:
         </label>
         <div class="col-sm-8">
@@ -20,27 +20,33 @@
     <!-- Description -->
     <div class="form-group">
         <label class="col-sm-4 control-label"  for="description_<?php echo $esrow['surveyls_language']; ?>"><?php eT("Description:"); ?></label>
-        <div class="htmleditor col-sm-8">
+        <div class="col-sm-8">
+        <div class="htmleditor input-group">
             <?php echo CHtml::textArea("description_{$esrow['surveyls_language']}",$esrow['surveyls_description'],array('class'=>'form-control','cols'=>'80','rows'=>'15','id'=>"description_{$esrow['surveyls_language']}")); ?>
             <?php echo getEditor("survey-desc","description_".$esrow['surveyls_language'], "[".gT("Description:", "js")."](".$esrow['surveyls_language'].")",$surveyid,'','',$action); ?>
+        </div>
         </div>
     </div>
 
     <!-- Welcome message -->
     <div class="form-group">
         <label class="col-sm-4 control-label" for='welcome_<?php echo $esrow['surveyls_language']; ?>'><?php eT("Welcome message:"); ?></label>
-        <div class="htmleditor col-sm-8">
+        <div class="col-sm-8">
+        <div class="htmleditor input-group">
             <?php echo CHtml::textArea("welcome_{$esrow['surveyls_language']}",$esrow['surveyls_welcometext'],array('class'=>'form-control','cols'=>'80','rows'=>'15','id'=>"welcome_{$esrow['surveyls_language']}")); ?>
             <?php echo getEditor("survey-welc","welcome_".$esrow['surveyls_language'], "[".gT("Welcome:", "js")."](".$esrow['surveyls_language'].")",$surveyid,'','',$action); ?>
+        </div>
         </div>
     </div>
 
     <!-- End message -->
     <div class="form-group">
         <label class="col-sm-4 control-label" for='endtext_<?php echo $esrow['surveyls_language']; ?>'><?php eT("End message:"); ?></label>
-        <div class="htmleditor col-sm-8">
+        <div class="col-sm-8">
+        <div class="htmleditor input-group">
             <?php echo CHtml::textArea("endtext_{$esrow['surveyls_language']}",$esrow['surveyls_endtext'],array('class'=>'form-control','cols'=>'80','rows'=>'15','id'=>"endtext_{$esrow['surveyls_language']}")); ?>
             <?php echo getEditor("survey-endtext","endtext_".$esrow['surveyls_language'], "[".gT("End message:", "js")."](".$esrow['surveyls_language'].")",$surveyid,'','',$action); ?>
+        </div>
         </div>
     </div>
 

--- a/styles/htmleditor.css
+++ b/styles/htmleditor.css
@@ -1,0 +1,2 @@
+.htmleditor{width:100%;table-layout:fixed}
+.cke_skin_BootstrapCK-Skin{max-width:100%}


### PR DESCRIPTION
* Use always 12 columns, force html editor to max width of 100%
* add a css file for all admin theme
* use an input-group inside the col fix a lot of issue
* Why sometimes lable 4 and sometimes label 3 ?

![capture du 2016-03-21 16-34-23](https://cloud.githubusercontent.com/assets/1439428/13924010/f6afe218-ef82-11e5-8052-30a7872d6b11.png)
![capture du 2016-03-21 16-34-35](https://cloud.githubusercontent.com/assets/1439428/13924009/f6af77ba-ef82-11e5-8c7d-bef3ce51bb81.png)
![capture du 2016-03-21 16-35-02](https://cloud.githubusercontent.com/assets/1439428/13924012/f6bb4f2c-ef82-11e5-80a1-7bf0cfb51dd5.png)
![capture du 2016-03-21 16-35-14](https://cloud.githubusercontent.com/assets/1439428/13924011/f6b9da70-ef82-11e5-8583-d152c7c2912a.png)

Screenshot after the fix, for before fix : see bug report
