### PR TITLE
Update adminstyle.css

### DIFF
--- a/styles/blobblueish/adminstyle.css
+++ b/styles/blobblueish/adminstyle.css
@@ -99,7 +99,7 @@ legend {
     background: #C4C4C4;
     border-top: 2px solid #C9EF50;
     border-bottom: 2px solid #6a8b03;
-    background-image: url(bkgmaintitle.gif);
+    /*background-image: url(bkgmaintitle.gif);*/
     background-repeat: repeat-x;
     width:100%;
 }


### PR DESCRIPTION
Removed background image since it is not published to assets resulting in 404 errors. It serves no real visual purpose, so removing the line is easier than getting the image published.

This is probably no longer an issue in the 2.50 / master branch.