### PR TITLE
Fixed issue #10860 : Regular expression fail with specific value

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -270,17 +270,17 @@ class ExpressionManager {
             return false;
         }
 
-        $bNumericArg1 = (is_numeric($arg1[0]) || $arg1[0] == '');
-        $bNumericArg2 = (is_numeric($arg2[0]) || $arg2[0] == '');
+        $bNumericArg1 = !$arg1[0] || strval(floatval($arg1[0]))===strval($arg1[0]);
+        $bNumericArg2 = !$arg2[0] || strval(floatval($arg2[0]))===strval($arg2[0]);
 
-        $bStringArg1 = (!$bNumericArg1 || $arg1[0] == '');
-        $bStringArg2 = (!$bNumericArg2 || $arg2[0] == '');
+        $bStringArg1 = !$arg1[0] || !$bNumericArg1;
+        $bStringArg2 = !$arg1[0] || !$bNumericArg2;
 
         $bBothNumeric = ($bNumericArg1 && $bNumericArg2);
         $bBothString = ($bStringArg1 && $bStringArg2);
         $bMismatchType=(!$bBothNumeric && !$bBothString);
 
-        // Set bBothString if one is forced to be string, only if bith can be numeric. Mimic JS and PHO
+        // Set bBothString if one is forced to be string, only if both can be numeric. Mimic JS and PHP
         // Not sure if needed to test if [2] is set. : TODO review
         if($bBothNumeric){
             $aForceStringArray=array('DQ_STRING','DS_STRING','STRING');// Question can return NUMERIC or WORD : DQ and DS is string entered by user, STRING is a result of a String function

--- a/scripts/expressions/em_javascript.js
+++ b/scripts/expressions/em_javascript.js
@@ -736,10 +736,10 @@ function LEMval(alias)
                 return value;
             }
             else {
-                if (!LEMis_numeric(value) || (value.length > 0 && value[0]==0)) {// so keep 0 prefixes on numbers
-                    return value;
+                if (parseFloat(value)+""===value) {// return numeric only if it don't update string : see bugs #10860 + #08324 + #07805. Still issue with big number : difference in PHp/JS (Firefox) : 1234567890123456
+                    return parseFloat(value);
                 }
-                return +value;  // convert it to numeric
+                return value;
             }
         }
         case 'rowdivid':


### PR DESCRIPTION
- before 01 return a string and 1 a number
- now (if question is not numeric) return string : 
   - +1, 
   - 12345678901234567890
   -  01 
   - .0
- still issue with big number (but with big number : even when forcing to number : sum is broken).
   - 1234567890123456 is a number for JS , not for PHP
   - 1234567890123456789 is a string for JS and PHP