### PR TITLE
New feature #10571: beforeController event (for web)

### DIFF
--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -206,5 +206,26 @@ class LSYii_Application extends CWebApplication
         return $this->getComponent('pluginManager');
     }
 
+    /**
+     * The pre-filter for controller actions.
+     * This method is invoked before the currently requested controller action and all its filters
+     * are executed. You may override this method with logic that needs to be done
+     * before all controller actions.
+     * @param CController $controller the controller
+     * @param CAction $action the action
+     * @return boolean whether the action should be executed.
+     */
+    public function beforeControllerAction($controller,$action)
+    {
+        /**
+         * Plugin event done before all web controller action
+         * Can set run to false to deactivate action
+         */
+        $event = new PluginEvent('beforeControllerAction');
+        $event->set('controller',$controller->getId());
+        $event->set('action',$action->getId());
+        App()->getPluginManager()->dispatchEvent($event);
+        return $event->get("run",parent::beforeControllerAction($controller,$action));
+    }
 
 }


### PR DESCRIPTION
- use Yii beforeControllerAction function
- send controller+action, other params can be found via API
- Can set run to false to deactivate default action
- better system than afterPluginLoad of 2.05 hack plugin