### PR TITLE
Fixed issue #11088: Do not show all javascript in question overview

### DIFF
--- a/application/views/admin/survey/Question/listquestions.php
+++ b/application/views/admin/survey/Question/listquestions.php
@@ -76,7 +76,7 @@
                             array(
                                 'header' => gt('Question'),
                                 'name' => 'question',
-                                'value'=>'strip_tags($data->question)',
+                                'value'=>'viewHelper::flatEllipsizeText($data->question,true,0)',
                                 'htmlOptions' => array('class' => 'col-md-5'),
                             ),
                             array(
@@ -117,7 +117,6 @@
                                 $pageSize,
                                 Yii::app()->params['pageSizeOptions'],
                                 array('class'=>'changePageSize form-control', 'style'=>'display: inline; width: auto'))),
-
                                 'columns' => $columns,
                                 'ajaxUpdate' => true,
                             ));

--- a/application/views/admin/survey/QuestionGroups/listquestiongroups.php
+++ b/application/views/admin/survey/QuestionGroups/listquestiongroups.php
@@ -84,7 +84,7 @@
                                 'header'=>gT('Description'),
                                 'name'=>'description',
                                 'type'=>'raw',
-                                'value'=>'$data->description',
+                                'value'=>'viewHelper::flatEllipsizeText($data->description,true,0)',
                                 'htmlOptions' => array('class' => 'col-md-6'),
                             ),
 


### PR DESCRIPTION
- same for question group
- must add viewHelper cleanest function : whole flattenText must be review to really flatten text.
- move it to viewHelper ? If OK : i can rewrite it , whole in viewHelper maybe , same with santitize
- Think keepspan is not used actually