### PR TITLE
Labels with listradio answers where closed too early

### DIFF
--- a/application/views/survey/questions/listradio/rows/answer_row.php
+++ b/application/views/survey/questions/listradio/rows/answer_row.php
@@ -22,7 +22,7 @@
         onclick="if (document.getElementById('answer<?php echo $name; ?>othertext') != null) document.getElementById('answer<?php echo $name; ?>othertext').value='';checkconditions(this.value, this.name, this.type)"
         aria-labelledby="label-answer<?php echo $name.$code; ?>"
      />
-    <label for="answer<?php echo $name.$code; ?>" class="control-label radio-label"></label>
+    <label for="answer<?php echo $name.$code; ?>" class="control-label radio-label">
 
     <!--
          The label text is provided inside a div,
@@ -31,6 +31,6 @@
     -->
     <div class="label-text label-clickable" id="label-answer<?php echo $name.$code; ?>">
         <?php echo $answer; ?>
-    </div>
+    </div></label>
 </div>
 <!-- end of answer_row -->

--- a/application/views/survey/questions/listradio/rows/answer_row_noanswer.php
+++ b/application/views/survey/questions/listradio/rows/answer_row_noanswer.php
@@ -20,7 +20,7 @@
     onclick="if (document.getElementById('answer<?php echo $name;?>othertext') != null) document.getElementById('answer<?php echo $name; ?>othertext').value='';<?php echo $checkconditionFunction; ?>(this.value, this.name, this.type)"
     aria-labelledby="label-answer<?php echo $name; ?>NANS"
     />
-    <label for="answer<?php echo $name; ?>NANS" class="answertext control-label label-radio"></label>
+    <label for="answer<?php echo $name; ?>NANS" class="answertext control-label label-radio">
 
     <!--
          The label text is provided inside a div,
@@ -29,6 +29,6 @@
     -->
     <div class="label-text label-clickable" id="label-answer<?php echo $name; ?>NANS">
         <?php echo eT('No answer'); ?>
-    </div>
+    </div></label>
 </div>
 <!-- endof answer_row_noanswer -->

--- a/application/views/survey/questions/listradio/rows/answer_row_other.php
+++ b/application/views/survey/questions/listradio/rows/answer_row_other.php
@@ -31,7 +31,7 @@
         aria-labelledby="label-SOTH<?php echo $name; ?>"
         />
 
-        <label for="SOTH<?php echo $name; ?>" class="answertext control-label label-radio"></label>
+        <label for="SOTH<?php echo $name; ?>" class="answertext control-label label-radio">
 
         <!--
              The label text is provided inside a div,
@@ -40,7 +40,7 @@
         -->
         <div class="label-text label-clickable" id="label-SOTH<?php echo $name; ?>">
                 <?php echo $othertext; ?>&nbsp;
-        </div>
+        </div></label>
     </div>
 
     <!-- comment -->

--- a/application/views/survey/questions/multiplechoice/rows/answer_row.php
+++ b/application/views/survey/questions/multiplechoice/rows/answer_row.php
@@ -27,7 +27,7 @@
                 aria-labelledby="label-answer<?php echo $name.$title; ?>"
             />
 
-            <label for="answer<?php echo $name.$title; ?>" class="answertext"></label>
+            <label for="answer<?php echo $name.$title; ?>" class="answertext">
 
             <!--
                  The label text is provided inside a div,
@@ -36,7 +36,7 @@
             -->
             <div class="label-text label-clickable" id="label-answer<?php echo $name.$title; ?>">
                     <?php echo $question; ?>
-            </div>
+            </div></label>
 
             <input
                 type="hidden"

--- a/application/views/survey/questions/multiplechoice/rows/answer_row_other.php
+++ b/application/views/survey/questions/multiplechoice/rows/answer_row_other.php
@@ -34,7 +34,7 @@
              />
 
              <!-- label -->
-             <label for="<?php echo $myfname;?>cbox" class="answertext"></label>
+             <label for="<?php echo $myfname;?>cbox" class="answertext">
              <!--
                   The label text is provided inside a div,
                   so final user can add paragraph, div, or whatever he wants in the subquestion text
@@ -42,7 +42,7 @@
              -->
              <div class="label-text label-clickable" id="label-<?php echo $myfname;?>cbox">
                      <?php echo $othertext; ?>
-             </div>
+             </div></label>
         </div>
 
         <!-- comment -->


### PR DESCRIPTION
The LABEL tags for listradio answers where closed too soon, so the DIV tags with the answers fell outside and did not look right. This change fixes this.