### PR TITLE
New feature #09816: Using quotas to prevent new entries

### DIFF
--- a/application/controllers/admin/quotas.php
+++ b/application/controllers/admin/quotas.php
@@ -159,20 +159,26 @@ class quotas extends Survey_Common_Action
                     'subaction' => 'quota_delquota'
                 ));
 
+                $aResults2 = QuotaMember::model()->findAllByAttributes(array('quota_id' => $aQuotaListing['id']));
                 $aViewUrls['output'] .= $this->getController()->renderPartial("/admin/quotas/viewquotasrow_view", $aData, true);
                 $aData['output'] .= $this->getController()->renderPartial("/admin/quotas/viewquotasrow_view", $aData, true);
 
                 //check how many sub-elements exist for a certain quota
-                $aResults2 = QuotaMember::model()->findAllByAttributes(array('quota_id' => $aQuotaListing['id']));
-
-                //loop through all sub-parts
-                foreach ($aResults2 as $aQuotaQuestions)
+                if(count($aResults2))
                 {
-                    $aQuestionAnswers = self::getQuotaAnswers($aQuotaQuestions['qid'], $iSurveyId, $aQuotaListing['id']);
-                    $aData['question_answers'] = $aQuestionAnswers;
-                    $aData['quota_questions'] = $aQuotaQuestions;
-                    $aViewUrls['output'] .= $this->getController()->renderPartial('/admin/quotas/viewquotasrowsub_view', $aData, true);
-                    //$aData['output'] .= $this->getController()->renderPartial('/admin/quotas/viewquotasrowsub_view', $aData, true);
+                    //loop through all sub-parts
+                    foreach ($aResults2 as $aQuotaQuestions)
+                    {
+                        $aQuestionAnswers = self::getQuotaAnswers($aQuotaQuestions['qid'], $iSurveyId, $aQuotaListing['id']);
+                        $aData['question_answers'] = $aQuestionAnswers;
+                        $aData['quota_questions'] = $aQuotaQuestions;
+                        $aViewUrls['output'] .= $this->getController()->renderPartial('/admin/quotas/viewquotasrowsub_view', $aData, true);
+                        //$aData['output'] .= $this->getController()->renderPartial('/admin/quotas/viewquotasrowsub_view', $aData, true);
+                    }
+                }
+                elseif($aQuotaListing['active'])
+                {
+                    $aViewUrls['output'] .= $this->getController()->renderPartial('/admin/quotas/viewemptyquotasrowsub_view', $aData, true);
                 }
 
             }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5590,8 +5590,7 @@ function getQuotaCompletedCount($iSurveyId, $quotaid)
     $aColumnName=SurveyDynamic::model($iSurveyId)->getTableSchema()->getColumnNames();
     $aQuotas = getQuotaInformation($iSurveyId, Survey::model()->findByPk($iSurveyId)->language, $quotaid);
     $aQuota = $aQuotas[0];
-    if (Yii::app()->db->schema->getTable('{{survey_' . $iSurveyId . '}}') &&
-    count($aQuota['members']) > 0)
+    if (Yii::app()->db->schema->getTable('{{survey_' . $iSurveyId . '}}'))
     {
         // Keep a list of fields for easy reference
         $aQuotaColumns = array();

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1984,8 +1984,8 @@ function checkCompletedQuota($surveyid,$return=false)
         {
             if(!$aQuotaInfo['active'])
                 continue;
-            if(count($aQuotaInfo['members'])===0)
-                continue;
+            if(count($aQuotaInfo['members'])===0 && ((int)getQuotaCompletedCount($surveyid, $aQuotaInfo['id']) >= (int)$aQuotaInfo['qlimit'])) // Feature #09816: Using quotas to prevent new entries
+                $aMatchedQuotas[]=$aQuotaInfo;
             $iMatchedAnswers=0;
             $bPostedField=false;
             // Array of field with quota array value

--- a/application/views/admin/quotas/viewemptyquotasrowsub_view.php
+++ b/application/views/admin/quotas/viewemptyquotasrowsub_view.php
@@ -1,0 +1,5 @@
+<tr class="bg-danger">
+	<td colspan=6>
+		<?php echo gt("You didn't add any questions to this quota. Thus, the system will just compare all completed responses with the max value you have set"); ?>
+	</td>
+</tr>


### PR DESCRIPTION
Dev: readd the system like done in 2.06 less than 150831
Dev: little issue : don't happen at survey welcome page (plugin can do the job more easily)

- Since we have "active/unactiv" have this solution is more better than before
- But : a plugin can do the job really better : break BEFORE welcome page with less php file