### PR TITLE
Fixed issue #10323: Rollback AuthLDAP to a version that supports user creation

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -6,14 +6,6 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
     static protected $description = 'Core: LDAP authentication';
     static protected $name = 'LDAP';
 
-    /**
-     * Can we autocreate users? For the moment this is disabled, will be moved
-     * to a setting when we have more robust user creation system.
-     *
-     * @var boolean
-     */
-    protected $autoCreate = false;
-
     protected $settings = array(
         'server' => array(
             'type' => 'string',
@@ -148,8 +140,7 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
     /**
      * Create a LDAP user
      *
-     * @param string $new_user
-     * @return null|string New user ID
+     * @return int New user ID
      */
     private function _createNewUser($new_user)
     {
@@ -503,27 +494,6 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
             $this->setAuthFailure(100, ldap_error($ldapconn));
             ldap_close($ldapconn); // all done? close connection
             return;
-        }
-
-        // Authentication was successful, now see if we have a user or that we should create one
-        if (is_null($user)) {
-            if ($this->autoCreate === true)  {
-                /*
-                 * Dispatch the newUserLogin event, and hope that after this we can find the user
-                 * this allows users to create their own plugin for handling the user creation
-                 * we will need more methods to pass username, rdn and ldap connection.
-                 */
-                $this->pluginManager->dispatchEvent(new PluginEvent('newUserLogin', $this));
-
-                // Check ourselves, we do not want fake responses from a plugin
-                $user = $this->api->getUserByName($username);
-            }
-
-            if (is_null($user)) {
-                $this->setAuthFailure(self::ERROR_USERNAME_INVALID);
-                ldap_close($ldapconn); // all done? close connection
-                return;
-            }
         }
 
         ldap_close($ldapconn); // all done? close connection


### PR DESCRIPTION
I backported the version from commit f630da9943340178d67edfbb55ae732f352af21b, which fixes the problem seen in the bug report.
