### PR TITLE
better compare of EM value

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -270,8 +270,8 @@ class ExpressionManager {
             return false;
         }
 
-        $bNumericArg1 = !$arg1[0] || strval(floatval($arg1[0]))===strval($arg1[0]);
-        $bNumericArg2 = !$arg2[0] || strval(floatval($arg2[0]))===strval($arg2[0]);
+        $bNumericArg1 = $arg1[0]==='' || (isset($arg1[2]) && $arg1[2]=="NUMBER") || strval(floatval($arg1[0]))===$arg1[0];
+        $bNumericArg2 = $arg2[0]==='' || (isset($arg2[2]) && $arg2[2]=="NUMBER") || strval(floatval($arg2[0]))===$arg2[0];
 
         $bStringArg1 = !$arg1[0] || !$bNumericArg1;
         $bStringArg2 = !$arg1[0] || !$bNumericArg2;


### PR DESCRIPTION
- don't find real issue in it but
- before true =>$bNumericArg=false, and before this fix strval(floatval(true))===strval(true)
- if arg type is NUMBER : always set to bNumericArg
- @olleharstedt  Maybe linked to bug https://bugs.limesurvey.org/view.php?id=11163 for 2.06 lts (i make a test, manually revert this part)