### PR TITLE
Fixed issue #09828: Ranking question : update allowed can broke Surve…

### DIFF
--- a/application/controllers/admin/database.php
+++ b/application/controllers/admin/database.php
@@ -149,12 +149,24 @@ class database extends Survey_Common_Action
             $sQuestionType = $arQuestion['type'];    // Checked)
             $aQuestionTypeList=getQuestionTypeList('','array');
             $iScaleCount=$aQuestionTypeList[$sQuestionType]['answerscales'];
-
-            // This is needed for ranking question. See issue #09828
-            $__max_db_answers = QuestionAttribute::model()->findByAttributes(array(
-                'qid' => $iQuestionID,
-                'attribute' => '__max_db_answers'
-            ));
+            /* for already activated survey and rank question type : fix the maxDbAnswer before deleting answers */
+            /* @todo : add it to upgrage DB system, and see for the lsa */
+            if($sQuestionType=="R" && Survey::model()->findByPk($iSurveyID)->active=="Y")
+            {
+                $oQuestionAttributeMaxDBanswers = QuestionAttribute::model()->find(
+                    "qid = :qid AND attribute = 'maxDBanswers'",
+                    array(':qid' => $iQuestionID)
+                );
+                if (empty($oQuestionAttribute))
+                {
+                    $answerCount=Answer::model()->countByAttributes(array('qid' => $iQuestionID,'language'=>Survey::model()->findByPk($iSurveyID)->language));
+                    $oQuestionAttribute = new QuestionAttribute();
+                    $oQuestionAttribute->qid = $iQuestionID;
+                    $oQuestionAttribute->attribute = 'maxDBanswers';
+                    $oQuestionAttribute->value = $answerCount;
+                    $oQuestionAttribute->save();
+                }
+            }
 
             //First delete all answers
             Answer::model()->deleteAllByAttributes(array('qid'=>$iQuestionID));
@@ -162,17 +174,6 @@ class database extends Survey_Common_Action
             for ($iScaleID=0;$iScaleID<$iScaleCount;$iScaleID++)
             {
                 $iMaxCount=(int) Yii::app()->request->getPost('answercount_'.$iScaleID);
-
-                // This is needed for ranking question. See issue #09828
-                if (!empty($__max_db_answers))
-                {
-                    if ($iMaxCount > $__max_db_answers->value + 1)
-                    {
-                        Yii::app()->setFlashMessage(gT("You cannot add more answer options while the survey is active."), 'error');
-                    }
-                    $iMaxCount = min($iMaxCount, $__max_db_answers->value + 1);
-                }
-
                 for ($iSortOrderID=1;$iSortOrderID<$iMaxCount;$iSortOrderID++)
                 {
                     $sCode=sanitize_paranoid_string(Yii::app()->request->getPost('code_'.$iSortOrderID.'_'.$iScaleID));

--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -360,20 +360,16 @@ function activateSurvey($iSurveyID, $simulate = false)
             case 'R':
 
                 /**
-                 * Patch for bug #09828: Ranking question : update allowed can broke Survey DB
-                 *
-                 * Solution is to store number of answers as max answers (hidden attribute),
-                 * then check this attribute when answer options is saved.
-                 *
-                 * The longterm solution is to make answer options subquestions instead.
+                 * See bug #09828: Ranking question : update allowed can broke Survey DB
+                 * If maxDBanswers is not set or is invalid : set it to actual answers numbers
                  */
 
                 $nrOfAnswers = Answer::model()->countByAttributes(
-                    array('qid' => $arow['qid'])
+                    array('qid' => $arow['qid'],'language'=>Survey::model()->findByPk($iSurveyID)->language;)
                 );
 
                 $oQuestionAttribute = QuestionAttribute::model()->find(
-                    "qid = :qid AND attribute = '__max_db_answers'",
+                    "qid = :qid AND attribute = 'maxDBanswers'",
                     array(':qid' => $arow['qid'])
                 );
 
@@ -381,12 +377,11 @@ function activateSurvey($iSurveyID, $simulate = false)
                 {
                     $oQuestionAttribute = new QuestionAttribute();
                     $oQuestionAttribute->qid = $arow['qid'];
-                    $oQuestionAttribute->attribute = '__max_db_answers';
+                    $oQuestionAttribute->attribute = 'maxDBanswers';
                     $oQuestionAttribute->value = $nrOfAnswers;
-                    $oQuestionAttribute->language = Survey::model()->findByPk($iSurveyID)->language;
                     $oQuestionAttribute->save();
                 }
-                else
+                elseif(int_val($oQuestionAttribute->value)<1)) // Fix it if invalid : disallow 0, but need a sub question minimum for EM
                 {
                     $oQuestionAttribute->value = $nrOfAnswers;
                     $oQuestionAttribute->save();

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2151,11 +2151,11 @@ function createFieldMap($surveyid, $style='short', $force_refresh=false, $questi
 
         elseif ($arow['type'] == "R")
         {
-            //MULTI ENTRY
-            $data = Answer::model()->findAllByAttributes(array('qid' => $arow['qid'], 'language' => $sLanguage));
-            $data = count($data);
-            $slots=$data;
-            for ($i=1; $i<=$slots; $i++)
+            // Sub question by answer number OR attribute
+            $answersCount = intval(Answer::model()->countByAttributes(array('qid' => $arow['qid'], 'language' => $sLanguage)));
+            $maxDbAnswer=QuestionAttribute::model()->find("qid = :qid AND attribute = 'maxDBanswers'",array(':qid' => $arow['qid']));
+            $columnsCount=(!$maxDbAnswer || intval($maxDbAnswer->value)<1) ? $answersCount : intval($maxDbAnswer->value);
+            for ($i=1; $i<=$columnsCount; $i++)
             {
                 $fieldname="{$arow['sid']}X{$arow['gid']}X{$arow['qid']}$i";
                 if (isset($fieldmap[$fieldname])) $aDuplicateQIDs[$arow['qid']]=array('fieldname'=>$fieldname,'question'=>$arow['question'],'gid'=>$arow['gid']);
@@ -3124,6 +3124,16 @@ function questionAttributes($returnByName=false)
         //    'inputtype'=>'text',
         //    "help"=>gT('Enter the SGQA identifier to use the total of a previous question as the maximum for this question'),
         //    "caption"=>gT('Max value from SGQA'));
+
+        /* Ranking specific : max DB answer */
+        $qattributes["maxDBanswers"]=array(
+        "types"=>"R",
+        'readonly_when_active'=>true,
+        'category'=>gT('Logic'),
+        'sortorder'=>12,
+        'inputtype'=>'integer',
+        "help"=>gT('Limit the number of possible answers fixed by number of columns in DB'),
+        "caption"=>gT('Maximum DB answers'));
 
         $qattributes["maximum_chars"]=array(
         "types"=>"STUNQK:;",

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -2144,7 +2144,11 @@
                 {
                     $max_answers='';
                 }
+                /* @todo : Specific with Ranking question : $max_answers is not set but $maxDBanswers < $answerCount OR $maxDBanswers < max_answres (maybe) */
+                if (isset($qattr['maxDBanswers']) && trim($qattr['maxDBanswers']) != '')
+                {
 
+                }
                 // Fix min_num_value_n and max_num_value_n for multinumeric with slider: see bug #7798
                 if($type=="K" && isset($qattr['slider_min']) && ( !isset($qattr['min_num_value_n']) || trim($qattr['min_num_value_n'])==''))
                     $qattr['min_num_value_n']=$qattr['slider_min'];

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -1861,23 +1861,23 @@ function do_ranking($ia)
 
     $ansresult = Yii::app()->db->createCommand($ansquery)->query()->readAll();
     $anscount  = count($ansresult);
-
+    $maxDbAnswer = intval($aQuestionAttributes['maxDBanswers']) > 0 ? intval($aQuestionAttributes['maxDBanswers']) : $anscount;
     if (trim($aQuestionAttributes["max_answers"])!='')
     {
         $max_answers = trim($aQuestionAttributes["max_answers"]);
     }
     else
     {
-        $max_answers = $anscount;
+        $max_answers = $maxDbAnswer;
     }
     // Get the max number of line needed
-    if(ctype_digit($max_answers) && intval($max_answers)<$anscount)
+    if(ctype_digit($max_answers) && intval($max_answers)<$maxDbAnswer)
     {
         $iMaxLine = $max_answers;
     }
     else
     {
-        $iMaxLine = $anscount;
+        $iMaxLine = $maxDbAnswer;
     }
     if (trim($aQuestionAttributes["min_answers"])!='')
     {


### PR DESCRIPTION
…y DB

- add a new QuestionAttribute maxDBanswers, not updatable if survey is activated
- fix max_answers according to this attribute
- Have only maxDBanswers in survey runtime, then other are not set
- Sub question by answer number OR attribute in createFieldMap
- todo : some fix specific to EM, but maybe just in qanda and JS 
- todo: set maxDBanswers when update and when import LSA