### PR TITLE
Allow the get_participation_properties and set_participation_properties to query using any token field

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1626,7 +1626,7 @@ class remotecontrol_handle
     * @access public
     * @param string $sSessionKey Auth credentials
     * @param int $iSurveyID Id of the Survey to get token properties
-    * @param array|struct|int Array of participant properties used to query the participant, or the token id as an integer 
+    * @param array|struct|int Array $aTokenQueryProperties of participant properties used to query the participant, or the token id as an integer 
     * @param array $aTokenProperties The properties to get
     * @return array The requested values
     */

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1685,11 +1685,11 @@ class remotecontrol_handle
     * @access public
     * @param string $sSessionKey Auth credentials
     * @param int $iSurveyID Id of the survey that participants belong
-    * @param int $iTokenID Id of the participant to alter
+    * @param array|struct|int Array $aTokenQueryProperties of participant properties used to query the participant, or the token id as an integer
     * @param array|struct $aTokenData Data to change
     * @return array Result of the change action
     */
-    public function set_participant_properties($sSessionKey, $iSurveyID, $iTokenID, $aTokenData)
+    public function set_participant_properties($sSessionKey, $iSurveyID, $aTokenQueryProperties, $aTokenData)
     {
         if ($this->_checkSessionKey($sSessionKey))
         {
@@ -1702,7 +1702,19 @@ class remotecontrol_handle
                 if(!tableExists("{{tokens_$iSurveyID}}"))
                     return array('status' => 'Error: No token table');
 
-                $oToken = Token::model($iSurveyID)->findByPk($iTokenID);
+                if(is_array($aTokenQueryProperties)){
+					$tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
+					if(count($tokens) == 0){
+						return array('status' => 'Error: No results were found based on your attributes.');
+					}else if(count($tokens) > 1){
+						return array('status' => 'Error: More than 1 result was found based on your attributes.');
+					}
+					$oToken = $tokens[0];
+				}else{
+                    // If aTokenQueryProperties is not an array, it's an integer
+                    $iTokenID = $aTokenQueryProperties;
+					$oToken = Token::model($iSurveyID)->findByPk($iTokenID);
+				}
                 if (!isset($oToken))
                     return array('status' => 'Error: Invalid tokenid');
 

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1626,11 +1626,11 @@ class remotecontrol_handle
     * @access public
     * @param string $sSessionKey Auth credentials
     * @param int $iSurveyID Id of the Survey to get token properties
-    * @param int $iTokenID Id of the participant to check
+    * @param array|struct|int Array of participant properties used to query the participant, or the token id as an integer 
     * @param array $aTokenProperties The properties to get
     * @return array The requested values
     */
-    public function get_participant_properties($sSessionKey, $iSurveyID, $iTokenID, $aTokenProperties)
+    public function get_participant_properties($sSessionKey, $iSurveyID, $aTokenQueryProperties, $aTokenProperties)
     {
         if ($this->_checkSessionKey($sSessionKey))
         {
@@ -1643,7 +1643,19 @@ class remotecontrol_handle
                 if(!tableExists("{{tokens_$iSurveyID}}"))
                     return array('status' => 'Error: No token table');
 
-                $token = Token::model($iSurveyID)->findByPk($iTokenID);
+                if(is_array($aTokenQueryProperties)){
+					$tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
+					if(count($tokens) == 0){
+						return array('status' => 'Error: No results were found based on your attributes.');
+					}else if(count($tokens) > 1){
+						return array('status' => 'Error: More than 1 result was found based on your attributes.');
+					}
+					$token = $tokens[0];
+				}else{
+                    // If aTokenQueryProperties is not an array, it's an integer
+                    $iTokenID = $aTokenQueryProperties;
+					$token = Token::model($iSurveyID)->findByPk($iTokenID);
+				}
                 if (!isset($token))
                     return array('status' => 'Error: Invalid tokenid');
 

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1644,18 +1644,18 @@ class remotecontrol_handle
                     return array('status' => 'Error: No token table');
 
                 if(is_array($aTokenQueryProperties)){
-					$tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
-					if(count($tokens) == 0){
-						return array('status' => 'Error: No results were found based on your attributes.');
-					}else if(count($tokens) > 1){
-						return array('status' => 'Error: More than 1 result was found based on your attributes.');
-					}
-					$token = $tokens[0];
-				}else{
+		    $tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
+		    if(count($tokens) == 0){
+			return array('status' => 'Error: No results were found based on your attributes.');
+		    }else if(count($tokens) > 1){
+			return array('status' => 'Error: More than 1 result was found based on your attributes.');
+		    }
+		    $token = $tokens[0];
+		}else{
                     // If aTokenQueryProperties is not an array, it's an integer
                     $iTokenID = $aTokenQueryProperties;
-					$token = Token::model($iSurveyID)->findByPk($iTokenID);
-				}
+		    $token = Token::model($iSurveyID)->findByPk($iTokenID);
+		}
                 if (!isset($token))
                     return array('status' => 'Error: Invalid tokenid');
 
@@ -1703,18 +1703,18 @@ class remotecontrol_handle
                     return array('status' => 'Error: No token table');
 
                 if(is_array($aTokenQueryProperties)){
-					$tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
-					if(count($tokens) == 0){
-						return array('status' => 'Error: No results were found based on your attributes.');
-					}else if(count($tokens) > 1){
-						return array('status' => 'Error: More than 1 result was found based on your attributes.');
-					}
-					$oToken = $tokens[0];
-				}else{
+		    $tokens = Token::model($iSurveyID)->findAllByAttributes($aTokenQueryProperties);
+		    if(count($tokens) == 0){
+			return array('status' => 'Error: No results were found based on your attributes.');
+		    }else if(count($tokens) > 1){
+			return array('status' => 'Error: More than 1 result was found based on your attributes.');
+		    }
+		    $oToken = $tokens[0];
+		}else{
                     // If aTokenQueryProperties is not an array, it's an integer
                     $iTokenID = $aTokenQueryProperties;
-					$oToken = Token::model($iSurveyID)->findByPk($iTokenID);
-				}
+	  	    $oToken = Token::model($iSurveyID)->findByPk($iTokenID);
+		}
                 if (!isset($oToken))
                     return array('status' => 'Error: Invalid tokenid');
 


### PR DESCRIPTION
This PR allows the RPC participation methods to be used with more then only the iTokenID as the field to query for the token.

Now the get_participant_properties and set_participant_properties can accept an integer or an array

integer: the token id (same as before the PR)
array|struct: an array containing key-value objects which will be used to query the token: new array("token" => "TSTTOKEN")