### PR TITLE
Fixed issue: RemoteControl 2 API (mail_registered_participants) sending 'reminder' instead of 'register' emails

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -113,28 +113,25 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 		global $maildebug;
 
 		//choose appriopriate email message
-		if($sType == 'invite')
-		{
-			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite_subj'];
-			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite'];
-		}
-		elseif ($sType == 'remind')
-		{
-			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind_subj'];
-			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind'];
-		}
-		elseif ($sType == 'register')
-		{
-			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register_subj'];
-			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register'];
-		}
-		elseif ($sType == 'confirm')
-		{
-			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm_subj'];
-			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm'];
-		}
-		else {
-			throw new Exception('Invalid template name');
+		switch ($sType) {
+			case 'invite':
+				$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite_subj'];
+				$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite'];
+				break;
+			case 'remind':
+				$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind_subj'];
+				$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind'];
+				break;
+			case 'register':
+				$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register_subj'];
+				$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register'];
+				break;
+			case 'confirm':
+				$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm_subj'];
+				$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm'];
+				break;
+			default:
+				throw new Exception('Invalid template name');
 		}
 
 		$modsubject = Replacefields($sSubject, $fieldsarray);

--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -13,11 +13,11 @@
 */
 
 /**
-* Sends email to tokens - invitation and reminders
+* Sends email to tokens - invitations, reminders, registers, and confirmations
 *
 * @param mixed $iSurveyID
 * @param array  $aResultTokens
-* @param string $sType type of notification invite|register|remind
+* @param string $sType type of notification invite|register|remind|confirm
 * @return array of results
 */
 function emailTokens($iSurveyID,$aResultTokens,$sType)
@@ -118,10 +118,23 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite_subj'];
 			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_invite'];
 		}
-		else
+		elseif ($sType == 'remind')
 		{
 			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind_subj'];
 			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind'];
+		}
+		elseif ($sType == 'register')
+		{
+			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register_subj'];
+			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_register'];
+		}
+		elseif ($sType == 'confirm')
+		{
+			$sSubject = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm_subj'];
+			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_confirm'];
+		}
+		else {
+			throw new Exception('Invalid template name');
 		}
 
 		$modsubject = Replacefields($sSubject, $fieldsarray);


### PR DESCRIPTION
Dev The issue was in token_helper:emailTokens(), where the documentation stated that 'register'
Dev was an acceptable value for the parameter 'sType', while this value was not tested.