### PR TITLE
Fixed issue: RemoteControl 2 JSON-API: parameters could have their values exchanged

### DIFF
--- a/application/libraries/LSjsonRPCServer.php
+++ b/application/libraries/LSjsonRPCServer.php
@@ -32,7 +32,20 @@
                                 );
         } else {
             try {
-                $result = @call_user_func_array(array($object,$request['method']),$request['params']);
+                $oMethod = new ReflectionMethod($object, $request['method']);
+                $aArguments = array();
+                foreach($oMethod->getParameters() as $oParam){
+                    $sParamName = $oParam->getName();
+                    $iParamPos = $oParam->getPosition();
+                    if(array_key_exists($sParamName, $request['params'])) {
+                        $aArguments[$iParamPos] = $request['params'][$sParamName];
+                    } elseif ($oParam->isOptional()) {
+                        $aArguments[$iParamPos] = $oParam->getDefaultValue();
+                    } else {
+                        throw new Exception('missing non-optional parameter '.$sParamName);
+                    }
+                }
+                $result = @call_user_func_array(array($object,$request['method']),$aArguments);
                 if ($result!==false) {
                     $response = array (
                                         'id' => $request['id'],


### PR DESCRIPTION
Dev In JSON, collections of name/value pairs are _unordered_ (cf. http://json.org/):
Dev when the LSjsonRPCServer::handle() method receives the request, it should
Dev therefore sort the arguments before calling the requested method in remotecontrol_handle.php.

Dev Note that this bug has already been reported by some else in the forum:
Dev https://www.limesurvey.org/forum/development/99577-lsrc2-add_participants-failing-with-invalidsessionkey