### PR TITLE
Fixed #11405: for php compatibility-reasons use xpath() instead of '-…

### DIFF
--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -137,8 +137,7 @@ class TemplateConfiguration extends CFormModel
         $this->overwrite_question_views    = (isset($this->config->engine->overwrite_question_views))? ( $this->config->engine->overwrite_question_views=='true' || $this->config->engine->overwrite_question_views=='yes' ) : false;
 
         $this->cssFramework = $this->config->engine->cssframework;
-        $oPackages      =  $this->config->engine->packages->package;
-        $this->packages =  (array) $oPackages;
+        $this->packages     = $this->config->xpath('engine/packages/package');
         $this->otherFiles   = $this->setOtherFiles();
         $this->depends      = $this->packages;
         //$this->depends[]    = (string) $this->cssFramework;                   // Bootstrap CSS is no more needed for Bootstrap templates (their custom css like "flat_and_modern.css" is a custom version of bootstrap.css )
@@ -185,19 +184,15 @@ class TemplateConfiguration extends CFormModel
         Yii::setPathOfAlias('survey.template.path', $this->path);                                   // The package creation/publication need an alias
         Yii::setPathOfAlias('survey.template.viewpath', $this->viewPath);
 
-        $oCssFiles   = $this->config->files->css->filename;                                 // The CSS files of this template
-        $oJsFiles    = $this->config->files->js->filename;                                  // The JS files of this template
+        $aCssFiles   = $this->config->xpath('files/css/filename');                                  // The CSS files of this template
+        $aJsFiles    = $this->config->xpath('files/js/filename');                                   // The JS files of this template
 
 
         if (getLanguageRTL(App()->language))
         {
-            $oCssFiles = $this->config->files->rtl->css->filename; // In RTL mode, original CSS files should not be loaded, else padding-left could be added to padding-right.)
-            $oJsFiles  = $this->config->files->rtl->js->filename;   // In RTL mode,
+            $aCssFiles = $this->config->xpath('files/rtl/css/filename'); // In RTL mode, original CSS files should not be loaded, else padding-left could be added to padding-right.)
+            $aJsFiles  = $this->config->xpath('files/rtl/js/filename');  // In RTL mode,
         }
-
-        $aCssFiles = (array) $oCssFiles;
-        $aJsFiles  = (array) $oJsFiles;
-
 
         // The package "survey-template" will be available from anywhere in the app now.
         // To publish it : Yii::app()->clientScript->registerPackage( 'survey-template' );


### PR DESCRIPTION
…>' to retrieve array of settings from config.xml

Seems to be a better fix than commit 1b26318658b43e767ae41e7e8bc9e2530cac50cc 