### PR TITLE
New feature : allow adding new question attribute in Plugin

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3998,6 +3998,26 @@ function questionAttributes($returnByName=false)
         'default'=>0,
         "help"=>gT('Use button group or radio list'),
         "caption"=>gT('Display type'));
+        /* Find all plugin with questionAttributes */
+        $aPlugins = App()->getPluginManager()->getInstalledPlugins();
+        foreach ($aPlugins as $oPlugin)
+        {
+            $aPluginQuestionAttributes = App()->getPluginManager()->loadPlugin($oPlugin->name, $oPlugin->id)->getQuestionAttributes();
+            foreach($aPluginQuestionAttributes as &$aPluginQuestionAttribute)
+            {
+                $aPluginQuestionAttribute['category']=gT($aPluginQuestionAttribute['category']);
+                $aPluginQuestionAttribute['caption']=gT($aPluginQuestionAttribute['caption']);
+                $aPluginQuestionAttribute['help']=gT($aPluginQuestionAttribute['help']);
+                if(isset($aPluginQuestionAttribute['options']))
+                {
+                    foreach($aPluginQuestionAttribute['options'] as $option=>$text)
+                    {
+                        $aPluginQuestionAttribute['options'][$option]=gT($text);
+                    }
+                }
+            }
+            $qattributes=array_merge($qattributes,$aPluginQuestionAttributes); // We allow to replace core question attribute : must fix some part
+        }
 
     }
     //This builds a more useful array (don't modify)

--- a/application/libraries/PluginManager/PluginBase.php
+++ b/application/libraries/PluginManager/PluginBase.php
@@ -9,24 +9,37 @@ namespace ls\pluginmanager;
          * @var LimesurveyApi
          */
         protected $api = null;
-        
+
         /**
          *
          * @var PluginEvent
          */
         protected $event = null;
-        
+
         protected $id = null;
         protected $storage = 'DummyStorage';
-        
+
         static protected $description = 'Base plugin object';
         static protected $name = 'PluginBase';
         private $store = null;
         protected $settings = array();
-        
+        /**
+         * New question attribute (settings) by plugin
+         * Must be array with [attributeName]=>
+         *      'types' : Aply to this question type
+         *      'category' : Where to put it
+         *      'sortorder' : Qort order in this category
+         *      'inputtype' : type of input
+         *      'options' : optionnal options if input type need it*
+         *      'default' : the defaumt value
+         *      'caption' : the label
+         *      'help' : an help
+         */
+        protected $questionAttributes = array();
+
         /**
          * This holds the pluginmanager that instantiated the plugin
-         * 
+         *
          * @var PluginManager
          */
         protected $pluginManager;
@@ -43,12 +56,12 @@ namespace ls\pluginmanager;
             $this->id = $id;
             $this->api = $manager->getAPI();
         }
-        
+
         /**
          * This function retrieves plugin data. Do not cache this data; the plugin storage
-         * engine will handling caching. After the first call to this function, subsequent 
-         * calls will only consist of a few function calls and array lookups. 
-         * 
+         * engine will handling caching. After the first call to this function, subsequent
+         * calls will only consist of a few function calls and array lookups.
+         *
          * @param string $key
          * @param string $model
          * @param int $id
@@ -59,7 +72,7 @@ namespace ls\pluginmanager;
         {
             return $this->getStore()->get($this, $key, $model, $id, $default);
         }
-        
+
         /**
          * Return the description for this plugin
          */
@@ -67,37 +80,37 @@ namespace ls\pluginmanager;
         {
             return static::$description;
         }
-        
+
         /**
          * Get the current event this plugin is responding to
-         * 
+         *
          * @return PluginEvent
          */
         public function getEvent()
         {
             return $this->event;
         }
-        
+
         /**
          * Returns the id of the plugin
-         * 
+         *
          * Used by storage model to find settings specific to this plugin
-         * 
+         *
          * @return int
          */
         public function getId()
         {
             return $this->id;
         }
-        
+
         /**
          * Provides meta data on the plugin settings that are available for this plugin.
          * This does not include enable / disable; a disabled plugin is never loaded.
-         * 
+         *
          */
         public function getPluginSettings($getValues = true)
         {
-            
+
             $settings = $this->settings;
             foreach ($settings as $name => &$setting)
             {
@@ -113,6 +126,15 @@ namespace ls\pluginmanager;
             return $settings;
         }
 
+        /**
+         * Provides the question atributes by plugins
+         *
+         */
+        public function getQuestionAttributes()
+        {
+            return $this->questionAttributes;
+        }
+
         public static function getName()
         {
             return static::$name;
@@ -120,7 +142,7 @@ namespace ls\pluginmanager;
         /**
          * Returns the plugin storage and takes care of
          * instantiating it
-         * 
+         *
          * @return iPluginStorage
          */
         public function getStore()
@@ -128,11 +150,11 @@ namespace ls\pluginmanager;
             if (is_null($this->store)) {
                 $this->store = $this->pluginManager->getStore($this->storage);
             }
-            
+
             return $this->store;
         }
-        
-        /** 
+
+        /**
          * Publishes plugin assets.
          */
         public function publish($fileName)
@@ -144,7 +166,7 @@ namespace ls\pluginmanager;
                 if (strpos('/', $fileName) === 0)
                 {
                     $url = \Yii::getPathOfAlias('webroot') . $fileName;
-                    
+
                 }
                 else // This is a plugin relative path.
                 {
@@ -162,10 +184,10 @@ namespace ls\pluginmanager;
             }
             return $url;
         }
-        
+
         /**
-         * 
-         * @param string $name Name of the setting.         
+         *
+         * @param string $name Name of the setting.
          * The type of the setting is either a basic type or choice.
          * The choice type is either a single or a multiple choice setting.
          * @param array $options
@@ -182,9 +204,9 @@ namespace ls\pluginmanager;
         {
             $this->settings[$name] = $options;
         }
-        
+
         /**
-         * 
+         *
          * @param type $settings
          */
         public function saveSettings($settings)
@@ -194,11 +216,11 @@ namespace ls\pluginmanager;
                 $this->set($name, $setting);
             }
         }
-        
-        
+
+
         /**
          * This function stores plugin data.
-         * 
+         *
          * @param string $key
          * @param mixed $data
          * @param string $model
@@ -209,11 +231,11 @@ namespace ls\pluginmanager;
         {
             return $this->getStore()->set($this, $key, $data, $model, $id);
         }
-        
+
         /**
          * Set the event to the plugin, this method is executed by the PluginManager
          * just before dispatching the event.
-         * 
+         *
          * @param PluginEvent $event
          * @return PluginBase
          */
@@ -222,26 +244,26 @@ namespace ls\pluginmanager;
             $this->event = $event;
             return $this;
         }
-    
+
         /**
          * Here you should handle subscribing to the events your plugin will handle
          */
         //abstract public function registerEvents();
-        
+
         /**
          * This function subscribes the plugin to receive an event.
-         * 
+         *
          * @param string $event
          */
         protected function subscribe($event, $function = null)
         {
             return $this->pluginManager->subscribe($this, $event, $function);
         }
-        
+
         /**
          * This function unsubscribes the plugin from an event.
          * @param string $event
-         */        
+         */
         protected function unsubscribe($event)
         {
             return $this->pluginManager->unsubscribe($this, $event);


### PR DESCRIPTION
- 1st solution : easy way for plugin : just need to put the array in protected $questionAttributes array
- translation is done by LS core after
- no event added.
- Think the second one is better
- Actually i use "Survey settings" to add specific attribute OR use cssclass ...
- Have a cleanest way seems really needed