### PR TITLE
Fix and improve beforeTokenEmail

### DIFF
--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -40,7 +40,7 @@ class RegisterController extends LSYii_Controller {
     {
         return array(
             'captcha' => array(
-                'class' => 'CCaptchaAction', 
+                'class' => 'CCaptchaAction',
                 'backColor'=>0xf6f6f6
             )
         );
@@ -141,7 +141,7 @@ class RegisterController extends LSYii_Controller {
             $sLoadsecurity=Yii::app()->request->getPost('loadsecurity','');
             $captcha=Yii::app()->getController()->createAction("captcha");
             $captchaCorrect = $captcha->validate( $sLoadsecurity, false);
-            
+
             if (!$captchaCorrect)
             {
                 $this->aRegisterErrors[] = gT("Your answer to the security question was not correct - please try again.");
@@ -204,7 +204,7 @@ class RegisterController extends LSYii_Controller {
         {
             $sRegisterError='';
         }
-        
+
         $aReplacement['REGISTERERROR'] = $sRegisterError;
         $aReplacement['REGISTERMESSAGE1'] = gT("You must be registered to complete this survey");
         if($sStartDate=$this->getStartDate($iSurveyId))
@@ -265,7 +265,9 @@ class RegisterController extends LSYii_Controller {
         $sitename =  Yii::app()->getConfig('sitename');
         // Plugin event for email handling (Same than admin token but with register type)
         $event = new PluginEvent('beforeTokenEmail');
+        $event->set('survey', $iSurveyId);
         $event->set('type', 'register');
+        $event->set('model', 'register');
         $event->set('subject', $aMail['subject']);
         $event->set('to', $sTo);
         $event->set('body', $aMail['message']);
@@ -485,7 +487,7 @@ class RegisterController extends LSYii_Controller {
             Yii::app()->clientScript->registerPackage( 'survey-template' );
             App()->getClientScript()->registerPackage('jqueryui');
             App()->getClientScript()->registerPackage('jquery-touch-punch');
-            App()->getClientScript()->registerScriptFile(Yii::app()->getConfig('generalscripts')."survey_runtime.js");            
+            App()->getClientScript()->registerScriptFile(Yii::app()->getConfig('generalscripts')."survey_runtime.js");
             useFirebug();
             $this->render('/register/display',$aViewData);
         }else{

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1645,7 +1645,9 @@ class tokens extends Survey_Common_Action
                          * token        r       Raw token data.
                          */
                         $event = new PluginEvent('beforeTokenEmail');
+                        $event->set('survey', $iSurveyId);
                         $event->set('type', $sTemplate);
+                        $event->set('model', $sSubAction);
                         $event->set('subject', $modsubject);
                         $event->set('to', $to);
                         $event->set('body', $modmessage);

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -591,7 +591,24 @@ function submittokens($quotaexit=false)
                         }
                     }
                 }
-                SendEmailMessage($message, $subject, $sToAddress, $from, $sitename, $ishtml, null, $aRelevantAttachments);
+                $event = new PluginEvent('beforeTokenEmail');
+                $event->set('type', 'confirm');
+                $event->set('subject', $subject);
+                $event->set('to', $sToAddress);
+                $event->set('body', $message);
+                $event->set('from', $from);
+                $event->set('bounce', getBounceEmail($surveyid));
+                $event->set('token', $token->attributes);
+                App()->getPluginManager()->dispatchEvent($event);
+                $subject = $event->get('subject');
+                $message = $event->get('body');
+                $to = $event->get('to');
+                $from = $event->get('from');
+                $bounce = $event->get('bounce');
+                if ($event->get('send', true) != false)
+                {
+                    SendEmailMessage($message, $subject, $to, $from, Yii::app()->getConfig("sitename"), $ishtml, $bounce, $aRelevantAttachments);
+                }
             }
      //   } else {
                 // Leave it to send optional confirmation at closed token
@@ -879,7 +896,7 @@ function buildsurveysession($surveyid,$preview=false)
     }
 
     $thissurvey = getSurveyInfo($surveyid,$sLangCode);
-    
+
     if ($thissurvey['nokeyboard']=='Y')
     {
         includeKeypad();
@@ -902,7 +919,7 @@ function buildsurveysession($surveyid,$preview=false)
 
     /**
     * This method has multiple outcomes that virtually do the same thing
-    * Possible scenarios/subscenarios are => 
+    * Possible scenarios/subscenarios are =>
     *   - No token required & no captcha required
     *   - No token required & captcha required
     *       > captcha may be wrong
@@ -916,7 +933,7 @@ function buildsurveysession($surveyid,$preview=false)
         "captchaRequired" => (isCaptchaEnabled('surveyaccessscreen',$thissurvey['usecaptcha']) && !isset($_SESSION['survey_'.$surveyid]['captcha_surveyaccessscreen']))
     );
 
-    /** 
+    /**
     *   Set subscenarios depending on scenario outcome
     */
     $subscenarios = array(
@@ -935,7 +952,7 @@ function buildsurveysession($surveyid,$preview=false)
 
         $subscenarios['tokenValid'] = isset($oTokenEntry);
     }
-    else 
+    else
     {
         $subscenarios['tokenValid'] = true;
     }
@@ -948,7 +965,7 @@ function buildsurveysession($surveyid,$preview=false)
         $captcha = Yii::app()->getController()->createAction('captcha');
         $subscenarios['captchaCorrect'] = $captcha->validate($loadsecurity, false);
     }
-    else 
+    else
     {
         $subscenarios['captchaCorrect'] = true;
         $loadsecurity = false;
@@ -2334,7 +2351,7 @@ function SetSurveyLanguage($surveyid, $sLanguage)
         $default_survey_language= Survey::model()->findByPk($surveyid)->language;
         $additional_survey_languages = Survey::model()->findByPk($surveyid)->getAdditionalLanguages();
         if (
-            empty($sLanguage)                                       //check if there 
+            empty($sLanguage)                                       //check if there
             || (!in_array($sLanguage, $additional_survey_languages))  //Is the language in the survey-language array
             || ($default_survey_language == $sLanguage)              //Is the $default_language the chosen language?
          )

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -592,7 +592,9 @@ function submittokens($quotaexit=false)
                     }
                 }
                 $event = new PluginEvent('beforeTokenEmail');
+                $event->set('survey', $surveyid);
                 $event->set('type', 'confirm');
+                $event->set('model', 'confirm');
                 $event->set('subject', $subject);
                 $event->set('to', $sToAddress);
                 $event->set('body', $message);


### PR DESCRIPTION
- This fix the issue : beforeTokenEMail don't happen for confirm (this MUST be, between a bug and a feature)
- Adding survey id (as survey) in the event. Really more easy
- Adding model : it's for db attribute. Not sure the best name. But without : plugin must rename $type for invitation and reminder.