### PR TITLE
Better i18n management for QuestionAttribute

### DIFF
--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -269,6 +269,7 @@ class questionHelper
         "types"=>":;ABCDEFKMNOPQRSTU",
         'category'=>gT('Logic'),
         'sortorder'=>210,
+        'i18n'=>true,
         'inputtype'=>'textarea',
         "help"=>gT('This is a hint text that will be shown to the participant describing the question validation equation.'),
         "caption"=>gT('Question validation tip'));
@@ -285,6 +286,7 @@ class questionHelper
         "types"=>";:KQSTUN",
         'category'=>gT('Logic'),
         'sortorder'=>230,
+        'i18n'=>true,
         'inputtype'=>'textarea',
         "help"=>gT('This is a tip shown to the participant describing the sub-question validation equation.'),
         "caption"=>gT('Sub-question validation tip'));

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -228,10 +228,14 @@ class Question extends LSActiveRecord
             $aAttributeValues=array();
             foreach($oAttributeValues as $oAttributeValue)
             {
+                if(!isset($aAttributeValues[$oAttributeValue->attribute]))
+                {
+                    $aAttributeValues[$oAttributeValue->attribute]=array();
+                }
                 if($oAttributeValue->language){
                     $aAttributeValues[$oAttributeValue->attribute][$oAttributeValue->language]=$oAttributeValue->value;
                 }else{
-                    $aAttributeValues[$oAttributeValue->attribute]=$oAttributeValue->value;
+                    $aAttributeValues[$oAttributeValue->attribute]['nolanguage']=$oAttributeValue->value;
                 }
             }
         }
@@ -241,9 +245,9 @@ class Question extends LSActiveRecord
         {
             if ($aAttribute['i18n'] == false)
             {
-                if (isset($aAttributeValues[$aAttribute['name']]))
+                if (isset($aAttributeValues[$aAttribute['name']]['nolanguage']))
                 {
-                    $aAttributeNames[$iKey]['value'] = $aAttributeValues[$aAttribute['name']];
+                    $aAttributeNames[$iKey]['value'] = $aAttributeValues[$aAttribute['name']]['nolanguage'];
                 }
                 else
                 {
@@ -257,6 +261,10 @@ class Question extends LSActiveRecord
                     if (isset($aAttributeValues[$aAttribute['name']][$sLanguage]))
                     {
                         $aAttributeNames[$iKey][$sLanguage]['value'] = $aAttributeValues[$aAttribute['name']][$sLanguage];
+                    }
+                    elseif(isset($aAttributeValues[$aAttribute['name']]['nolanguage']))
+                    {
+                        $aAttributeNames[$iKey][$sLanguage]['value'] = $aAttributeValues[$aAttribute['name']]['nolanguage'];
                     }
                     else
                     {

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -200,7 +200,7 @@ class QuestionAttribute extends LSActiveRecord
                 if($oAttributeValue->language){
                     $aAttributeValues[$oAttributeValue->attribute][$oAttributeValue->language]=$oAttributeValue->value;
                 }else{
-                    $aAttributeValues[$oAttributeValue->attribute]=$oAttributeValue->value;
+                    $aAttributeValues[$oAttributeValue->attribute]['nolanguage']=$oAttributeValue->value;
                 }
             }
 
@@ -210,9 +210,9 @@ class QuestionAttribute extends LSActiveRecord
             {
                 if ($aAttribute['i18n'] == false)
                 {
-                    if(isset($aAttributeValues[$aAttribute['name']]))
+                    if(isset($aAttributeValues[$aAttribute['name']]['nolanguage']))
                     {
-                        $aQuestionAttributes[$aAttribute['name']]=$aAttributeValues[$aAttribute['name']];
+                        $aQuestionAttributes[$aAttribute['name']]=$aAttributeValues[$aAttribute['name']]['nolanguage'];
                     }
                     else
                     {
@@ -227,6 +227,10 @@ class QuestionAttribute extends LSActiveRecord
                         {
                             $aQuestionAttributes[$aAttribute['name']][$sLanguage] = $aAttributeValues[$aAttribute['name']][$sLanguage];
                         }
+                        elseif(isset($aAttributeValues[$aAttribute['name']]['nolanguage']))
+                        {
+                            $aQuestionAttributes[$aAttribute['name']][$sLanguage] = $aAttributeValues[$aAttribute['name']]['nolanguage'];
+                        }
                         else
                         {
                             $aQuestionAttributes[$aAttribute['name']][$sLanguage] = $aAttribute['default'];
@@ -234,13 +238,13 @@ class QuestionAttribute extends LSActiveRecord
                     }
                 }
             }
+            $aQuestionAttributesStatic[$iQuestionID]=$aQuestionAttributes;
+            return $aQuestionAttributes;
         }
         else
         {
-            return false; // return false but don't set $aQuestionAttributesStatic[$iQuestionID]
+            return false;
         }
-        $aQuestionAttributesStatic[$iQuestionID]=$aQuestionAttributes;
-        return $aQuestionAttributes;
     }
 
     public static function insertRecords($data)


### PR DESCRIPTION
Actually : it's hard to move some attribute to i18n if it's not true before : we lost all existing part, and this can broke admin part with debug=>1.

- [x] Fixed issue #11682 : Possible illegal string offset with some attribute
- [x] New feature #11683: EM validations tip must be i18n
- [ ] Only one way to search value (Question::model()->getAdvancedSettingsWithValues must use QuestionAttribute::model()->getQuestionAttributes
