### PR TITLE
Add afterQuestionTypesBuilt event

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -644,6 +644,12 @@ class Question extends LSActiveRecord
          */
         asort($questionTypes);
 
+        // allow plugins to alter the Question Type list
+        $event = new PluginEvent('afterQuestionTypesBuilt');
+        $event->set('questionTypes', $questionTypes);
+        App()->getPluginManager()->dispatchEvent($event);
+        $questionTypes = $event->get('questionTypes');
+
         return $questionTypes;
     }
 


### PR DESCRIPTION
Event allows plugins to alter the possible question types.

Use-case involves removing question types deemed not necessary.
