### PR TITLE
Extend AuthLDAP with optional group-membership restriction

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -99,6 +99,16 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
         'automaticsurveycreation' => array(
                 'type' => 'checkbox',
                 'label' => 'Grant survey creation permission to automatically created users'
+        	),
+        'groupsearchbase' => array(
+                'type' => 'string',
+                'label' => 'Optional base DN for group restriction',
+                'help' => 'E.g., ou=Groups,dc=example,dc=com'
+                ),
+        'groupsearchfilter' => array(
+                'type' => 'string',
+                'label' => 'Optional filter for group restriction',
+                'help' => 'Required if group search base set. E.g. (&(cn=limesurvey)(memberUid=$username))'
                 )
     );
 
@@ -434,6 +444,8 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
         $usersearchbase		= $this->get('usersearchbase');
         $binddn     		= $this->get('binddn');
         $bindpwd     		= $this->get('bindpwd');
+        $groupsearchbase        = $this->get('groupsearchbase');
+        $groupsearchfilter      = $this->get('groupsearchfilter');
 
         // Try to connect
         $ldapconn = $this->createConnection();
@@ -492,6 +504,21 @@ class AuthLDAP extends ls\pluginmanager\AuthPluginBase
                 $this->setAuthFailure(self::ERROR_USERNAME_INVALID);
                 ldap_close($ldapconn); // all done? close connection
                 return;
+            }
+
+            // If specifed, check group membership
+            if ($groupsearchbase != '' && $groupsearchfilter != '')
+            {
+                $filter = str_replace('$username', $username, $groupsearchfilter);
+                $groupsearchres = ldap_search($ldapconn, $groupsearchbase, $filter);
+                $grouprescount = ldap_count_entries($ldapconn, $groupsearchres);
+                if ($grouprescount < 1)
+                {
+                    $this->setAuthFailure(self::ERROR_USERNAME_INVALID,
+                    gT('Valid username but not authorized by group restriction'));
+                    ldap_close($ldapconn); // all done? close connection
+                    return;
+                }
             }
 
             // binding to ldap server with the userDN and privided credentials


### PR DESCRIPTION
This adds an optional restriction to LDAP authentication intended for checking that the user is a member of a particular group in LDAP. It adds two new setting parameters -- a base DN and a filter -- and if set searches those and rejects the authentication attempt if there is no match.
