### PR TITLE
Fixed issue #10025: Quotas : Terminate survey with warning allow submit

### DIFF
--- a/application/controllers/admin/quotas.php
+++ b/application/controllers/admin/quotas.php
@@ -82,6 +82,11 @@ class quotas extends Survey_Common_Action
         }
     }
 
+    /**
+     *
+     * @param integer $iSurveyId the survey id
+     * @param boolean $quickreport : quick export a csv with actual quotas
+     */
     function index($iSurveyId, $quickreport = false)
     {
         $iSurveyId = sanitize_int($iSurveyId);
@@ -198,10 +203,8 @@ class quotas extends Survey_Common_Action
         }
         else
         {
-
-            //// WHY ???????
-
-            header("Content-Disposition: attachment; filename=results-survey" . $iSurveyId . ".csv");
+            /* Export a quickly done csv file */
+            header("Content-Disposition: attachment; filename=quotas-survey" . $iSurveyId . ".csv");
             header("Content-type: text/comma-separated-values; charset=UTF-8");
             header("Pragma: public");
             echo gT("Quota name") . "," . gT("Limit") . "," . gT("Completed") . "," . gT("Remaining") . "\r\n";
@@ -209,7 +212,7 @@ class quotas extends Survey_Common_Action
             {
                 echo $line;
             }
-            die;
+            App()->end();
         }
     }
 

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -182,6 +182,11 @@ class SurveyRuntimeHelper {
                 $_SESSION[$LEMsessid]['prevstep']=$_SESSION[$LEMsessid]['step']-1;   // this only happens on re-load
             }
 
+            /* quota submitted */
+            if(isset($move) && $move=='confirmquota'){
+                checkCompletedQuota($surveyid);
+            }
+
             if (isset($_SESSION[$LEMsessid]['LEMtokenResume']))
             {
                 LimeExpressionManager::StartSurvey($thissurvey['sid'], $surveyMode, $surveyOptions, false,$LEMdebugLevel);

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8596,6 +8596,7 @@ EOD;
                 $relevant=false;
                 $qid = $qinfo['info']['qid'];
                 $gseq = $qinfo['info']['gseq'];
+                /* Never use posted value : must be fixed and find real actual relevance */
                 $relevant = (isset($_POST['relevance' . $qid]) ? ($_POST['relevance' . $qid] == 1) : false);
                 $grelevant = (isset($_POST['relevanceG' . $gseq]) ? ($_POST['relevanceG' . $gseq] == 1) : false);
                 $_SESSION[$LEM->sessid]['relevanceStatus'][$qid] = $relevant;

--- a/application/views/admin/quotas/editquota_view.php
+++ b/application/views/admin/quotas/editquota_view.php
@@ -24,9 +24,10 @@
                     <div class='col-sm-9'>
                         <select name="quota_action" id="quota_action" class="form-control">
                             <option value ="1" <?php if($quotainfo['action'] == 1) echo "selected='selected'"; ?>><?php eT("Terminate survey");?></option>
-                            <option value ="2" <?php if($quotainfo['action'] == 2) echo "selected='selected'"; ?>><?php eT("Terminate survey with warning");?></option>
+                            <option value ="2" <?php if($quotainfo['action'] == 2) echo "selected='selected'"; ?>><?php eT("Allow user to update last answers before submit and terminate survey.");?></option>
                         </select>
                     </div>
+                    <div class="col-sm-9 col-sm-offset-3 help-block"><?php eT("To allow update : one of the question tested must be viewed in the last page before quota.The end url action is done only after confirm survey.");?></div>
                 </div>
                 <div class='form-group'>
                     <label class='control-label col-sm-3' for='autoload_url'><?php eT("Autoload URL:");?></label>

--- a/application/views/admin/quotas/newquota_view.php
+++ b/application/views/admin/quotas/newquota_view.php
@@ -29,9 +29,10 @@
                     <div class="col-sm-5">
                         <select id="quota_action" name="quota_action" class="form-control">
                             <option value ="1"><?php eT("Terminate survey");?></option>
-                            <option value ="2"><?php eT("Terminate survey with warning");?></option>
+                            <option value ="2"><?php eT("Allow user to update last answers before submit and terminate survey.");?></option>
                         </select>
                     </div>
+                    <div class="col-sm-5 col-sm-offset-2 help-block"><?php eT("To allow update : one of the question tested must be viewed in the last page before quota.The end url action is done only after confirm survey.");?></div>
                 </div>
 
                 <!-- -->
@@ -41,7 +42,7 @@
                         <?php $this->widget('yiiwheels.widgets.switch.WhSwitch', array(
                             'name' => 'autoload_url',
                             'id'=>'autoload_url',
-                            'value' => 1,
+                            'value' => 0,
                             'onLabel'=>gT('Yes'),
                             'offLabel' => gT('No')));
                         ?>

--- a/application/views/admin/quotas/viewquotasrow_view.php
+++ b/application/views/admin/quotas/viewquotasrow_view.php
@@ -17,7 +17,7 @@
         <?php if ($quotalisting['action'] == 1) {
                 eT("Terminate survey");
             } elseif ($quotalisting['action'] == 2) {
-                eT("Terminate survey with warning");
+                eT("Allow user to update answers before submit.");
         } ?>
     </td>
     <td <?php echo $highlight;?>><?php echo is_null($completed) ? gT("N/A"): $completed ;?></td>


### PR DESCRIPTION
- fix the issueDev: same message is shown twice, deactivate url the 1st time
- i like to use directly movenext and send only 'quota' input to EM : but broken (see comment)
- then update move button value to confirmquota, and redirect in SurveyRuntimeHelper