### PR TITLE
ga('send', 'pageview') is generated 2 times

### DIFF
--- a/application/helpers/replacements_helper.php
+++ b/application/helpers/replacements_helper.php
@@ -624,7 +624,6 @@ EOD;
  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 ga('create', '$_googleAnalyticsAPIKey', 'auto');
-ga('send', 'pageview');
 ga('send', 'pageview', '$_trackURL');
 
 </script>


### PR DESCRIPTION
ga('send', 'pageview') is generated 2 times in the Google Analytics tracking code when "Survey-SID/Group" is selected as GA style in the survey settings.