### PR TITLE
Better 404 management

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -58,5 +58,25 @@
              */
             App()->end();
         }
+        /**
+         * System error : only 404 error are managed here (2016-11-29)
+         * SurveysController is the default controller set in internal
+         * @see http://www.yiiframework.com/doc/guide/1.1/en/topics.error#handling-errors-using-an-action
+         */
+        public function actionError()
+        {
+            $oTemplate = Template::model()->getInstance(Yii::app()->getConfig("defaulttemplate"));
+
+            $this->sTemplate = $oTemplate->name;
+
+            $error = Yii::app()->errorHandler->error;
+            if ($error){
+                App()->setConfig('sitename',"Not found");
+                $this->render('/system/error'.$error['code'], array('error'=>$error,'admin'=>encodeEmail(Yii::app()->getConfig("siteadminemail"))));
+            }else{
+                throw new CHttpException(404, 'Page not found.');
+            }
+        }
+
     }
 ?>

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -283,4 +283,20 @@ class LSYii_Application extends CWebApplication
     {
         return $this->plugin;
     }
+
+    /**
+     * @see http://www.yiiframework.com/doc/api/1.1/CApplication#onException-detail
+     * Set surveys/error for 404 error
+     * @param CExceptionEvent $event
+     * @return : void
+     */
+    public function onException($event){
+        if(Yii::app() instanceof CWebApplication){
+            if($event->exception->statusCode=='404'){
+                Yii::app()->setComponent('errorHandler',array(
+                    'errorAction'=>'surveys/error',
+                ));
+            }
+        }
+    }
 }

--- a/application/views/system/error404.php
+++ b/application/views/system/error404.php
@@ -1,18 +1,11 @@
-<html>
-    <head>
-        <title>Not Found</title>
-    </head>
-    <body>
-        <h1>404 Not found.</h1>
-        <?php
-            echo CHtml::tag('h2', array(), nl2br(CHtml::encode($data['message'])));
-        ?>
-        <p>
-        The requested URL was not found on this server.
-        If you entered the URL manually please check your spelling and try again.
-        </p>
-        <p>
-        If you think this is a server error, please contact <?php echo $data['admin']; ?>.
-        </p>
-    </body>
-</html>
+<h1>404 Not found.</h1>
+<?php
+    echo CHtml::tag('h2', array(), nl2br(CHtml::encode($error['message'])));
+?>
+<p>
+    The requested URL was not found on this server.
+    If you entered the URL manually please check your spelling and try again.
+</p>
+<p>
+    If you think this is a server error, please contact <?php echo $admin; ?>.
+</p>


### PR DESCRIPTION
See : https://bugs.limesurvey.org/view.php?id=11963
- Currently : not translated : did error page must be translated ? Easy step
- Can use near same solution for 401 : but think 401/admin can show 'loggin' if user are not loggued. This can be done

holch (from LS forum) have a complete different think abot survey list :  [holch about surveys list](https://www.limesurvey.org/community-services/forums/can-i-do-this-with-limesurvey/107708-different-endpage-pstpl-for-the-survey-and-another-one-for-the-list-of-surveys#145128 )

Else : 
Before 
![404-debug0](https://cloud.githubusercontent.com/assets/1439428/20715452/8a3beb88-b64f-11e6-8925-e1ae3ce646a3.png)
Or
![404-debug1](https://cloud.githubusercontent.com/assets/1439428/20715458/9172a3ec-b64f-11e6-892f-12df7e7efa34.png)

After
![404-fixed](https://cloud.githubusercontent.com/assets/1439428/20715501/af0ac31c-b64f-11e6-8306-c4154182458c.png)

