### PR TITLE
develop : separe settings in survey and question

### DIFF
--- a/application/views/admin/survey/Question/advanced_settings_view.php
+++ b/application/views/admin/survey/Question/advanced_settings_view.php
@@ -3,23 +3,37 @@
  * This view generate the advanced question attributes
  */
 $currentfieldset='';
+$categoryNum=0;
 ?>
 <!-- Advanced Settings -->
 <?php foreach ($attributedata as $index=>$aAttribute):?>
 
     <!-- Fieldsets -->
     <?php if ($currentfieldset!=$aAttribute['category']): ?>
+        <?php $categoryNum++; ?>
         <?php if ($currentfieldset!=''): ?>
-            </fieldset>
+            </div></div></div></div>
+        </div>
         <?php endif; ?>
+        <div class="panel panel-default panel-advancedquestionsettings">
+            <div class="panel-heading" role="tab">
+                <h4 class="panel-title">
+                    <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion">
+                        <span class="glyphicon glyphicon-chevron-left"></span>
+                    </a>
+                    <a id="button-collapse<?php echo $categoryNum ?>" class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-cat<?php echo $categoryNum ?>" aria-expanded="false" aria-controls="collapse-cat<?php echo $categoryNum ?>">
+                        <?php echo $aAttribute['category']; ?>
+                    </a>
+                </h4>
+            </div>
+            <div id="collapse-cat<?php echo $categoryNum ?>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="button-collapse<?php echo $categoryNum ?>">
+                <div class="panel-body">
+                    <div>
+
         <?php $currentfieldset=$aAttribute['category']; ?>
-        <fieldset>
-        <legend><?php echo $aAttribute['category'];?></legend>
     <?php endif; ?>
-
-    <!-- Form Group -->
     <div class="form-group">
-
+    <!-- Form Group -->
         <!-- Label -->
         <label class="col-sm-4 control-label" for='<?php echo $aAttribute['name'];?>' title='<?php echo $aAttribute['help'];?>'>
             <?php
@@ -121,12 +135,13 @@ $currentfieldset='';
                 }?>
             </div>
         </div>
-<?php endforeach;
-foreach (Yii::app()->clientScript->scripts as $index=>$script)
-{
-    echo CHtml::script(implode("\n",$script));
-}
-Yii::app()->clientScript->reset();
+<?php endforeach;?>
+ </div></div></div></div>
+<?php
+//~ foreach (Yii::app()->clientScript->scripts as $index=>$script)
+//~ {
+    //~ echo CHtml::script(implode("\n",$script));
+//~ }
+//~ Yii::app()->clientScript->reset();
 ?>
-</fieldset>
 <!-- end of Advanced Settings -->

--- a/application/views/admin/survey/Question/editQuestion_view.php
+++ b/application/views/admin/survey/Question/editQuestion_view.php
@@ -85,17 +85,17 @@
                     <!-- Copy options -->
                     <?php if ($copying): ?>
                         <div class="panel panel-default">
-                            <div class="panel-heading" role="tab" id="headingZero">
+                            <div class="panel-heading" role="tab" id="heading-copy">
                                 <h4 class="panel-title">
                                     <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion">
                                         <span class="glyphicon glyphicon-chevron-left"></span>
                                     </a>
-                                    <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseZero" aria-expanded="false" aria-controls="collapseZero">
+                                    <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-copy" aria-expanded="false" aria-controls="collapse-copy">
                                         <?php eT("Copy options"); ?>
                                     </a>
                                 </h4>
                             </div>
-                            <div id="collapseZero" class="panel-collapse collapse  in" role="tabpanel" aria-labelledby="headingTwo">
+                            <div id="collapse-copy" class="panel-collapse collapse  in" role="tabpanel" aria-labelledby="heading-copy">
                                 <div class="panel-body">
                                     <div  class="form-group">
                                         <label class="col-sm-4 control-label" for='copysubquestions'><?php eT("Copy subquestions?"); ?></label>
@@ -147,16 +147,16 @@
                                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion">
                                     <span class="glyphicon glyphicon-chevron-left"></span>
                                 </a>
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-question" aria-expanded="true" aria-controls="collapse-question">
                                     <?php eT("General options");?>
                                 </a>
                             </h4>
                         </div>
 
-                        <div id="collapseOne" class="panel-collapse collapse <?php if (!$copying){echo ' in '; } ?>" role="tabpanel" aria-labelledby="headingOne">
+                        <div id="collapse-question" class="panel-collapse collapse <?php if (!$copying){echo ' in '; } ?>" role="tabpanel" aria-labelledby="headingOne">
                             <div class="panel-body">
                                 <div>
-                                    <div  class="form-group">
+                                    <div class="form-group">
                                         <label class="col-sm-4 control-label" for="question_type_button">
                                             <?php
                                             eT("Question type:");
@@ -302,37 +302,11 @@
                         </div>
                     </div>
                     <?php if (!$copying): ?>
+                    <div class="loader-advancedquestionsettings text-center">
+                        <span class="glyphicon glyphicon-refresh" style="font-size:3em;" aria-hidden='true'></span>
+                    </div>
                         <!-- Advanced settings -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading" role="tab" id="headingTwo">
-                                <h4 class="panel-title">
-                                    <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion">
-                                        <span class="glyphicon glyphicon-chevron-left"></span>
-                                    </a>
-                                    <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                                        <?php eT("Advanced settings"); ?>
-                                    </a>
-                                </h4>
-                            </div>
-
-                            <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
-                                <div class="panel-body">
-                                    <div id="advancedquestionsettingswrapper" >
-                                        <div class="loader">
-                                            <?php eT("Loading..."); ?>
-                                        </div>
-
-                                        <div id="advancedquestionsettings">
-                                            <!-- Content append via ajax -->
-                                        </div>
-                                    </div>
-
-                                    <br />
-                                    <br/>
-                                </div>
-                            </div>
-                        </div>
-                        <?php endif; ?>
+                    <?php endif; ?>
 
                 </div>
             </div>

--- a/application/views/admin/survey/subview/accordion/_accordion_container.php
+++ b/application/views/admin/survey/subview/accordion/_accordion_container.php
@@ -10,17 +10,17 @@
 
     <!-- General Option -->
     <div class="panel panel-default" id="generaloptionsContainer">
-        <div class="panel-heading" role="tab" id="headingOne">
+        <div class="panel-heading" role="tab" id="heading-generaloptions">
             <h4 class="panel-title">
                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </a>
-                <a role="button" data-toggle="collapse" href="#generaloptions" aria-expanded="true" aria-controls="generaloptions">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#generaloptions" aria-expanded="true" aria-controls="generaloptions">
                     <?php eT("General options");?>
                 </a>
             </h4>
         </div>
-        <div id="generaloptions" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+        <div id="generaloptions" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading-generaloptions">
             <div class="panel-body">
                 <?php $this->renderPartial('/admin/survey/subview/accordion/_generaloptions_panel', $data); ?>
             </div>
@@ -30,17 +30,17 @@
 
     <!-- Presentation & navigation  -->
     <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="headingTwo">
+        <div class="panel-heading" role="tab" id="heading-presentationoptions">
             <h4 class="panel-title">
                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </a>
-                <a class="collapsed" role="button" data-toggle="collapse" href="#presentationoptions" aria-expanded="false" aria-controls="presentationoptions">
+                <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#presentationoptions" aria-expanded="false" aria-controls="presentationoptions">
                     <?php  eT("Presentation & navigation"); ?>
                 </a>
             </h4>
         </div>
-        <div id="presentationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="presentationoptions">
+        <div id="presentationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-presentationoptions">
             <div class="panel-body">
                 <?php $this->renderPartial('/admin/survey/subview/accordion/_presentation_panel', $data); ?>
             </div>
@@ -49,17 +49,17 @@
 
     <!-- Publication & access control -->
     <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="headingThree">
+        <div class="panel-heading" role="tab" id="heading-publicationoptions">
             <h4 class="panel-title">
                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </a>
-                <a class="collapsed" role="button" data-toggle="collapse" href="#publicationoptions" aria-expanded="false" aria-controls="publicationoptions">
+                <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#publicationoptions" aria-expanded="false" aria-controls="publicationoptions">
                     <?php  eT("Publication & access control"); ?>
                 </a>
             </h4>
         </div>
-        <div id="publicationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="publicationoptions">
+        <div id="publicationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-publicationoptions">
             <div class="panel-body">
                 <?php $this->renderPartial('/admin/survey/subview/accordion/_publication_panel', $data); ?>
             </div>
@@ -68,17 +68,17 @@
 
     <!-- Notification & data management -->
     <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="headingFour">
+        <div class="panel-heading" role="tab" id="heading-notificationoptions">
             <h4 class="panel-title">
                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </a>
-                <a class="collapsed" role="button" data-toggle="collapse" href="#notificationoptions" aria-expanded="false" aria-controls="notificationoptions">
+                <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#notificationoptions" aria-expanded="false" aria-controls="notificationoptions">
                     <?php  eT("Notification & data management"); ?>
                 </a>
             </h4>
         </div>
-        <div id="notificationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="notificationoptions">
+        <div id="notificationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-notificationoptions">
             <div class="panel-body">
                 <?php $this->renderPartial('/admin/survey/subview/accordion/_notification_panel', $data); ?>
             </div>
@@ -87,17 +87,17 @@
 
     <!-- Tokens -->
     <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="headingFive">
+        <div class="panel-heading" role="tab" id="heading-tokensoptions">
             <h4 class="panel-title">
                 <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </a>
-                <a class="collapsed" role="button" data-toggle="collapse" href="#tokensoptions" aria-expanded="false" aria-controls="tokensoptions">
+                <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#tokensoptions" aria-expanded="false" aria-controls="tokensoptions">
                     <?php  eT("Tokens"); ?>
                 </a>
             </h4>
         </div>
-        <div id="tokensoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="tokensoptions">
+        <div id="tokensoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-tokensoptions">
             <div class="panel-body">
                 <?php $this->renderPartial('/admin/survey/subview/accordion/_tokens_panel', $data); ?>
             </div>
@@ -108,17 +108,17 @@
     <?php if($data['action']=='editsurveysettings'):?>
         <!-- Panel integration -->
         <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="headingSix">
+            <div class="panel-heading" role="tab" id="heading-integrationoptions">
                 <h4 class="panel-title">
                     <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                         <span class="glyphicon glyphicon-chevron-left"></span>
                     </a>
-                    <a class="collapsed" role="button" data-toggle="collapse" href="#integrationoptions" aria-expanded="false" aria-controls="integrationoptions">
+                    <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#integrationoptions" aria-expanded="false" aria-controls="integrationoptions">
                         <?php  eT("Panel integration"); ?>
                     </a>
                 </h4>
             </div>
-            <div id="integrationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="integrationoptions">
+            <div id="integrationoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-integrationoptions">
                 <div class="panel-body">
                     <?php $this->renderPartial('/admin/survey/subview/accordion/_integration_panel', $data); ?>
                 </div>
@@ -130,17 +130,17 @@
 
         <!-- Resources -->
         <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="headingSeven">
+            <div class="panel-heading" role="tab" id="heading-resourcesoptions">
                 <h4 class="panel-title">
                     <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                         <span class="glyphicon glyphicon-chevron-left"></span>
                     </a>
-                    <a class="collapsed" role="button" data-toggle="collapse" href="#resourcesoptions" aria-expanded="false" aria-controls="resourcesoptions">
+                    <a class="collapsed" role="button" data-parent="#accordion" data-toggle="collapse" href="#resourcesoptions" aria-expanded="false" aria-controls="resourcesoptions">
                         <?php  eT("Resources"); ?>
                     </a>
                 </h4>
             </div>
-            <div id="resourcesoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="resourcesoptions">
+            <div id="resourcesoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-resourcesoptions">
                 <div class="panel-body">
                     <?php $this->renderPartial('/admin/survey/subview/accordion/_resources_panel', $data); ?>
                 </div>

--- a/application/views/admin/survey/subview/accordion/_accordion_container.php
+++ b/application/views/admin/survey/subview/accordion/_accordion_container.php
@@ -106,7 +106,6 @@
 
     <!-- Edition Mode -->
     <?php if($data['action']=='editsurveysettings'):?>
-
         <!-- Panel integration -->
         <div class="panel panel-default">
             <div class="panel-heading" role="tab" id="headingSix">
@@ -127,23 +126,7 @@
         </div>
 
         <!-- PLugin settings -->
-        <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="headingEight">
-                <h4 class="panel-title">
-                    <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
-                        <span class="glyphicon glyphicon-chevron-left"></span>
-                    </a>
-                    <a class="collapsed" role="button" data-toggle="collapse" href="#pluginsoptions" aria-expanded="false" aria-controls="pluginsoptions">
-                        <?php  eT("Plugins"); ?>
-                    </a>
-                </h4>
-            </div>
-            <div id="pluginsoptions" class="panel-collapse collapse" role="tabpanel" aria-labelledby="pluginoptions">
-                <div class="panel-body">
-                    <?php $this->renderPartial('/admin/survey/subview/accordion/_plugins_panel', $data); ?>
-                </div>
-            </div>
-        </div>
+        <?php $this->renderPartial('/admin/survey/subview/accordion/_plugins_panel', $data); ?>
 
         <!-- Resources -->
         <div class="panel panel-default">

--- a/application/views/admin/survey/subview/accordion/_plugin_panel.php
+++ b/application/views/admin/survey/subview/accordion/_plugin_panel.php
@@ -10,7 +10,7 @@
                     <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
                         <span class="glyphicon glyphicon-chevron-left"></span>
                     </a>
-                    <a id="button-plugin<?php echo $id; ?>" class="collapsed" role="button" data-toggle="collapse" href="#plugin<?php echo $id; ?>" aria-expanded="false" aria-controls="plugin<?php echo $id; ?>">
+                    <a id="button-plugin<?php echo $id; ?>" class="collapsed" data-parent="#accordion" role="button" data-toggle="collapse" href="#plugin<?php echo $id; ?>" aria-expanded="false" aria-controls="plugin<?php echo $id; ?>">
                         <?php printf(gT("Settings for plugin %s"), $plugin['name']); ?>
                     </a>
                 </h4>

--- a/application/views/admin/survey/subview/accordion/_plugin_panel.php
+++ b/application/views/admin/survey/subview/accordion/_plugin_panel.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin options panel
+ */
+?>
+<?php if (!empty($plugin['settings'])): ?>
+        <div class="panel panel-default">
+            <div class="panel-heading" role="tab" id="heading-plugin<?php echo $id; ?>">
+                <h4 class="panel-title">
+                    <a class="btn btn-default btn-xs hide-button hidden-xs opened handleAccordion hidden-sm">
+                        <span class="glyphicon glyphicon-chevron-left"></span>
+                    </a>
+                    <a id="button-plugin<?php echo $id; ?>" class="collapsed" role="button" data-toggle="collapse" href="#plugin<?php echo $id; ?>" aria-expanded="false" aria-controls="plugin<?php echo $id; ?>">
+                        <?php printf(gT("Settings for plugin %s"), $plugin['name']); ?>
+                    </a>
+                </h4>
+            </div>
+            <div id="plugin<?php echo $id; ?>" class="panel-collapse collapse" role="tabpanel">
+                <div class="panel-body">
+                <?php
+                $this->widget('ext.SettingsWidget.SettingsWidget', array(
+                    'settings' => $plugin['settings'],
+                    'form' => false,
+                    'title' => null,
+                    'prefix' => "plugin[{$plugin['name']}]",
+                    'formHtmlOptions' =>array(
+                        'aria-labelledby'=>"button-plugin{$id}"
+                    )
+                ));
+                ?>
+                </div>
+            </div>
+        </div>
+<?php endif; ?>

--- a/application/views/admin/survey/subview/accordion/_plugins_panel.php
+++ b/application/views/admin/survey/subview/accordion/_plugins_panel.php
@@ -1,21 +1,11 @@
 <?php
 /**
- * Plugin options panel
+ * Optionnal plugins options panels
  */
 ?>
-<?php if (isset($pluginSettings)): ?>
-    <div id='plugin' class="tab-pane fade in">
-        <?php
+<?php if (isset($pluginSettings)):
         foreach ($pluginSettings as $id => $plugin)
         {
-            $this->widget('ext.SettingsWidget.SettingsWidget', array(
-                'settings' => $plugin['settings'],
-                'form' => false,
-                'title' => sprintf(gT("Settings for plugin %s"), $plugin['name']),
-                'prefix' => "plugin[{$plugin['name']}]"
-
-            ));
+            $this->renderPartial('/admin/survey/subview/accordion/_plugin_panel', array('id'=>$id,'plugin'=>$plugin));
         }
-        ?>
-    </div>
-<?php endif; ?>
+endif; ?>

--- a/scripts/admin/admin_core.js
+++ b/scripts/admin/admin_core.js
@@ -115,23 +115,6 @@ $(document).ready(function(){
 
     });
 
-    $('#hideadvancedattributes').click(function(){
-        $('#showadvancedattributes').show();
-        $('#hideadvancedattributes').hide();
-        $('#advancedquestionsettingswrapper').animate({
-            "height": "toggle", "opacity": "toggle"
-        });
-
-    });
-    $('#question_type').change(updatequestionattributes);
-
-    $('#question_type_button  li a').click(function(){
-        $(".btn:first-child .buttontext").text($(this).text());
-        $('#question_type').val($(this).data('value'));
-
-        updatequestionattributes();
-       });
-
     $('#MinimizeGroupWindow').click(function(){
         $('#groupdetails').hide();
     });
@@ -329,41 +312,6 @@ function getToolTip(type){
 
 //We have form validation and other stuff..
 
-function updatequestionattributes()
-{
-    var type = $('#question_type').val();
-    OtherSelection(type);
-
-    $('.loader').show();
-    $('#advancedquestionsettings').html('');
-    var selected_value = qDescToCode[''+$("#question_type_child .selected").text()];
-    if (selected_value==undefined) selected_value = $("#question_type").val();
-    $('#advancedquestionsettings').load(attr_url,{qid:$('#qid').val(),
-        question_type:selected_value,
-        sid:$('#sid').val()
-    }, function(){
-        // Loads the tooltips for the toolbars
-
-        // Loads the tooltips for the toolbars
-        $('.loader').hide();
-        $('label[title]').qtip({
-            style: {name: 'cream',
-                tip: true,
-                color:'#111111',
-                border: {
-                    width: 1,
-                    radius: 5,
-                    color: '#EADF95'}
-            },
-            position: {adjust: {
-                    screen: true, scroll:true},
-                corner: {
-                    target: 'bottomRight'}
-            },
-            show: {effect: {length:50}}
-        });}
-    );
-}
 
 function validatefilename (form, strmessage )
 {
@@ -850,20 +798,20 @@ function onlyUnique(value, index, self) {
 
 /**
  * A method to use the implemented notifier, via ajax or javascript
- * 
+ *
  * @param text string  | The text to be displayed
  * @param classes string | The classes that will be put onto the inner container
  * @param styles object | An object of css-attributes that will be put onto the inner container
- * @param customOptions | possible options are: 
+ * @param customOptions | possible options are:
  *                         useHtml (boolean) -> use the @text as html
- *                         timeout (int) -> the timeout in milliseconds until the notifier will fade/slide out 
+ *                         timeout (int) -> the timeout in milliseconds until the notifier will fade/slide out
  *                         inAnimation (string) -> The jQuery animation to call for the notifier [fadeIn||slideDown]
  *                         outAnimation (string) -> The jQuery animation to remove the notifier [fadeOut||slideUp]
- *                         animationTime (int) -> The time in milliseconds the animation will last             
+ *                         animationTime (int) -> The time in milliseconds the animation will last
  */
 function NotifyFader(){
     var count = 0;
-    
+
     var increment = function(){count = count+1;},
         decrement = function(){count = count-1;},
         getCount = function(){return count;};
@@ -877,8 +825,8 @@ function NotifyFader(){
         var options = {
             useHtml : customOptions.useHtml || true,
             timeout : customOptions.timeout || 3500,
-            inAnimation : customOptions.inAnimation || "slideDown", 
-            outAnimation : customOptions.outAnimation || "slideUp", 
+            inAnimation : customOptions.inAnimation || "slideDown",
+            outAnimation : customOptions.outAnimation || "slideUp",
             animationTime : customOptions.animationTime || 450
         };
         var container = $("<div> </div>");
@@ -898,7 +846,7 @@ function NotifyFader(){
                 position: 'fixed',
                 left : "15%",
                 width : "70%",
-                'z-index':3500 
+                'z-index':3500
             })
             .appendTo($('#notif-container').parent())
             .html(container);

--- a/scripts/admin/admin_core.js
+++ b/scripts/admin/admin_core.js
@@ -22,13 +22,15 @@ var LS = LS || {};
  */
 hasFormValidation= typeof document.createElement( 'input' ).checkValidity == 'function';
 
+/* See function */
+fixAccordionPosition();
+
 $(document).ready(function(){
 
     initializeAjaxProgress();
     tableCellAdapters();
     linksInDialog();
     doToolTip();
-
     $('button,input[type=submit],input[type=button],input[type=reset],.button').button();
     $('button,input[type=submit],input[type=button],input[type=reset],.button').addClass("limebutton");
 
@@ -958,4 +960,19 @@ LS.ajax = function(options) {
     $('#ls-loading').show();
 
     return $.ajax(options);
+}
+/* When using accordion : sometimes the start of accordion is uot of range (in question and survey settings)
+ * Then move to id just after opened it
+ * Attach to document due to ajax call in question
+ */
+function fixAccordionPosition(){
+    $(document).on('shown.bs.collapse',"#accordion", function () {
+        var collapsed = $(this).find('.collapse.in').prev('.panel-heading');
+        /* test if is up to surveybarid bottom, if yes : scrollTo */
+        if($(collapsed).offset().top-$(window).scrollTop() < $(".navbar-fixed-top").first().outerHeight(true)){
+            $('html, body').animate({
+                scrollTop: $(collapsed).offset().top-$(".navbar-fixed-top").first().outerHeight(true)
+            }, 500);
+        }
+    });
 }

--- a/scripts/admin/questions.js
+++ b/scripts/admin/questions.js
@@ -1,8 +1,8 @@
 /*
 * LimeSurvey (tm)
-* Copyright (C) 2012 The LimeSurvey Project Team / Carsten Schmitz
+* Copyright (C) 2012-2016 The LimeSurvey Project Team / Carsten Schmitz
 * All rights reserved.
-* License: GNU/GPL License v2 or later, see LICENSE.php
+* License: GNU/GPL License v3 or later, see LICENSE.php
 * LimeSurvey is free software. This version may have been modified pursuant
 * to the GNU General Public License, and as distributed it includes or
 * is derivative of works licensed under the GNU General Public License or
@@ -20,6 +20,18 @@ $(document).ready(function(){
     $('#collapseOne').on('hide.bs.collapse', function () {
         $('#questionTypeContainer').css("overflow","hidden");
     });
+
+    if($('.loader-advancedquestionsettings').length){
+        updatequestionattributes();
+    }
+    $('#question_type').change(updatequestionattributes);
+
+    $('#question_type_button  li a').click(function(){
+        $(".btn:first-child .buttontext").text($(this).text());
+        $('#question_type').val($(this).data('value'));
+
+        updatequestionattributes();
+   });
 });
 /**
 * Validate question object on blur on title element
@@ -99,4 +111,38 @@ function validateQuestion(jqObject){
             },
         dataType="json"
     );
+}
+function updatequestionattributes()
+{
+    var type = $('#question_type').val();
+    OtherSelection(type);
+
+    $('.loader-advancedquestionsettings').removeClass("hidden");
+    $('.panel-advancedquestionsettings').remove();
+    var selected_value = qDescToCode[''+$("#question_type_child .selected").text()];
+    if (selected_value==undefined) selected_value = $("#question_type").val();
+    $.post(attr_url,{
+            'qid':$('#qid').val(),
+            'question_type':selected_value,
+            'sid':$('#sid').val()
+        }, function(data) {
+        $('.loader-advancedquestionsettings').before(data);
+        $('.loader-advancedquestionsettings').addClass("hidden");
+        $('label[title]').qtip({
+            style: {name: 'cream',
+                tip: true,
+                color:'#111111',
+                border: {
+                    width: 1,
+                    radius: 5,
+                    color: '#EADF95'}
+            },
+            position: {adjust: {
+                    screen: true, scroll:true},
+                corner: {
+                    target: 'bottomRight'}
+            },
+            show: {effect: {length:50}}
+        });
+    });
 }


### PR DESCRIPTION
# More accordion #
Seems REALLY better and needed for questions advanced settings

## survey settings: ##
![separate_survey_plugins_settings](https://cloud.githubusercontent.com/assets/1439428/21132834/4fa07418-c116-11e6-99fe-b549115088e4.png)

## question settings: ##
![question_settings](https://cloud.githubusercontent.com/assets/1439428/21132847/6517bd1a-c116-11e6-8409-3f4b2e17e6ec.png)
**and**
![question_settings2](https://cloud.githubusercontent.com/assets/1439428/21132856/6adcdc26-c116-11e6-8180-0a3d0f71b01e.png)

Real accordion in questions settings (show one hide other) 