### PR TITLE
#12034 : add minimum id of answer for the export page

### DIFF
--- a/application/controllers/admin/export.php
+++ b/application/controllers/admin/export.php
@@ -209,8 +209,11 @@ class export extends Survey_Common_Action {
             $data['aFieldsOptions'] = $aFieldsOptions;
             //get max number of datasets
             $iMaximum = SurveyDynamic::model($iSurveyID)->getMaxId();
+            //get min number of datasets
+            $iMinimum = SurveyDynamic::model($iSurveyID)->getMinId();
 
             $data['max_datasets'] = $iMaximum;
+            $data['min_datasets'] = $iMinimum;
             $data['surveyid'] = $iSurveyID;
             $data['imageurl'] = Yii::app()->getConfig('imageurl');
             $data['thissurvey'] = $thissurvey;

--- a/application/views/admin/export/exportresults_view.php
+++ b/application/views/admin/export/exportresults_view.php
@@ -67,11 +67,11 @@
                                     </label>
                                     <div class="col-sm-2">
                                         <input
-                                            min="1"
+                                            min="<?php echo $min_datasets; ?>"
                                             max="<?php echo $max_datasets; ?>"
                                             step="1"
                                             type="number"
-                                            value="1"
+                                            value="<?php echo $min_datasets; ?>"
                                             name="export_from"
                                             id="export_from"
                                             class="form-control"
@@ -84,7 +84,7 @@
                                     </label>
                                     <div class="col-sm-2">
                                         <input
-                                            min="1"
+                                            min="<?php echo $min_datasets; ?>"
                                             max="<?php echo $max_datasets; ?>"
                                             step="1"
                                             type="number"


### PR DESCRIPTION
Hello,
I've made this in regard of the bug #12034. Like explained in the note ~42635 the interest is not to have an empty lines or file for the export of the answer when the min id is greater than 1
bests