### PR TITLE
Fixed issue #12041 : expire date of a survey deactivated manually is …

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -79,7 +79,7 @@ class Survey extends LSActiveRecord
     public function expire($surveyId = null)
     {
         $dateTime = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", Yii::app()->getConfig('timeadjust'));
-        $dateTime = dateShift($dateTime, "Y-m-d H:i:s", '-1 day');
+        $dateTime = dateShift($dateTime, "Y-m-d H:i:s", '-1 minute');
 
         if (!isset($surveyId))
         {


### PR DESCRIPTION
…one day before the date of the day