### PR TITLE
Hide IFrame embedding security option when XSS protection is active.

### DIFF
--- a/application/views/admin/global_settings/_security.php
+++ b/application/views/admin/global_settings/_security.php
@@ -48,23 +48,25 @@
     </div>
 </div>
 
-<div class="form-group">
-    <label class="col-sm-5 control-label"  for="force_ssl">
-    <?php if (Yii::app()->getConfig("demoMode")==true){ ?>
-    <span class="text-danger asterisk"></span>
-    <?php }; ?>
-     <?php eT('IFrame embedding allowed:'); echo ((Yii::app()->getConfig("demoMode")==true)?'*':'');?></label>
-    <div class="col-sm-6">
-        <?php $this->widget('yiiwheels.widgets.buttongroup.WhButtonGroup', array(
-            'name' => 'x_frame_options',
-            'value'=> getGlobalSetting('x_frame_options'),
-            'selectOptions'=>array(
-                "allow"=>gT("Allow",'unescaped'),
-                "sameorigin"=>gT("Same origin",'unescaped')
-            )
-        ));?>
+<?php if (Yii::app()->getConfig("filterxsshtml")==false){ ?>
+    <div class="form-group">
+        <label class="col-sm-5 control-label"  for="force_ssl">
+        <?php if (Yii::app()->getConfig("demoMode")==true){ ?>
+        <span class="text-danger asterisk"></span>
+        <?php }; ?>
+         <?php eT('IFrame embedding allowed:'); echo ((Yii::app()->getConfig("demoMode")==true)?'*':'');?></label>
+        <div class="col-sm-6">
+            <?php $this->widget('yiiwheels.widgets.buttongroup.WhButtonGroup', array(
+                'name' => 'x_frame_options',
+                'value'=> getGlobalSetting('x_frame_options'),
+                'selectOptions'=>array(
+                    "allow"=>gT("Allow",'unescaped'),
+                    "sameorigin"=>gT("Same origin",'unescaped')
+                )
+            ));?>
+        </div>
     </div>
-</div>
+<?php }; ?>
 
 <div class="form-group">
     <label class="col-sm-5 control-label"  for="force_ssl"><?php eT('Force HTTPS:'); ?></label>


### PR DESCRIPTION
IFrames [seems to be filtered](https://www.limesurvey.org/forum/can-i-do-this-with-limesurvey/108110-embedding-youtube-via-iframe-with-active-xss-protection) when XSS protection is active. Showing the »IFrame embedding allowed« option is suggesting it is valid to use iFrames with active XSS protection. This PR hides the »IFrame embedding allowed« option when XSS protection is active.