### PR TITLE
Fixed issue: Replacing `@@SURVEYURL@@` incorrectly in RPC

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -129,17 +129,14 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			$sMessage = $aSurveyLocaleData[$sTokenLanguage]['surveyls_email_remind'];
 		}
 
-		$modsubject = Replacefields($sSubject, $fieldsarray);
-		$modmessage = Replacefields($sMessage, $fieldsarray);
-
 		if (isset($barebone_link))
 		{
 			$modsubject = str_replace("@@SURVEYURL@@", $barebone_link, $modsubject);
 			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $modmessage);
 		}
-
-
-
+		
+		$modsubject = Replacefields($sSubject, $fieldsarray);
+		$modmessage = Replacefields($sMessage, $fieldsarray);
 
 		if (isset($aTokenRow['validfrom']) && trim($aTokenRow['validfrom']) != '' && convertDateTimeFormat($aTokenRow['validfrom'], 'Y-m-d H:i:s', 'U') * 1 > date('U') * 1)
 		{


### PR DESCRIPTION
When using the value `@@SURVEYURL@@` in an email, `SURVEYURL` will be replaced by calling `ReplaceFields` as it's a part of the `$fieldsarray`.
This way, the barebone_link is never replaced correctly.

To fix this, we need to replace the barebone_link before caling `ReplaceFields`.

To reproduce:

- Add `@@SURVEYURL@@` to an email template (invite or remind in my case)
- Send a mail using the RPC.