### PR TITLE
Fixed issue: Replacing `@@SURVEYURL@@` incorrectly in RPC

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -136,12 +136,12 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 
 		if (isset($barebone_link))
 		{
-			$modsubject = str_replace("@@SURVEYURL@@", $barebone_link, $modsubject);
-			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $modmessage);
+			$modsubject = str_replace("@@SURVEYURL@@", $barebone_link, $sSubject);
+			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $sMessage);
 		}
-		
-		$modsubject = Replacefields($sSubject, $fieldsarray);
-		$modmessage = Replacefields($sMessage, $fieldsarray);
+
+		$modsubject = Replacefields($modsubject, $fieldsarray);
+		$modmessage = Replacefields($modmessage, $fieldsarray);
 
 		if (isset($aTokenRow['validfrom']) && trim($aTokenRow['validfrom']) != '' && convertDateTimeFormat($aTokenRow['validfrom'], 'Y-m-d H:i:s', 'U') * 1 > date('U') * 1)
 		{


### PR DESCRIPTION
Don't use `$sSubject` and `$sMessage` after it has been modified.
Don't use `$modsubject` and `$modmessage` before it has been modified.

Fix issue introduced in PR https://github.com/LimeSurvey/LimeSurvey/pull/625