### PR TITLE
Fixed issue #12113 : fix invalid QubQUetsions when activate

### DIFF
--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -267,9 +267,10 @@ function activateSurvey($iSurveyID, $simulate = false)
         $sCollation=" COLLATE SQL_Latin1_General_CP1_CS_AS";
     }
     //Check for any additional fields for this survey and create necessary fields (token and datestamp)
-    $arSurvey = Survey::model()->findByAttributes(array('sid' => $iSurveyID));
+    $oSurvey = Survey::model()->findByPk($iSurveyID);
+    $oSurvey->fixInvalidQuestions();
     //Get list of questions for the base language
-    $sFieldMap = createFieldMap($iSurveyID,'full',true,false,$arSurvey->language);
+    $sFieldMap = createFieldMap($iSurveyID,'full',true,false,$oSurvey->language);
     //For each question, create the appropriate field(s)
     foreach ($sFieldMap as $j=>$aRow)
     {
@@ -342,11 +343,11 @@ function activateSurvey($iSurveyID, $simulate = false)
                     $aTableDefinition[$aRow['fieldname']] = "text";
                 break;
             case "ipaddress":
-                if ($arSurvey->ipaddr == "Y")
+                if ($oSurvey->ipaddr == "Y")
                     $aTableDefinition[$aRow['fieldname']] = "text";
                 break;
             case "url":
-                if ($arSurvey->refurl == "Y")
+                if ($oSurvey->refurl == "Y")
                     $aTableDefinition[$aRow['fieldname']] = "text";
                 break;
             case "token":
@@ -386,7 +387,7 @@ function activateSurvey($iSurveyID, $simulate = false)
             default:
                 $aTableDefinition[$aRow['fieldname']] = "string(5)";
         }
-        if ($arSurvey->anonymized == 'N' && !array_key_exists('token',$aTableDefinition)){
+        if ($oSurvey->anonymized == 'N' && !array_key_exists('token',$aTableDefinition)){
             $aTableDefinition['token'] = 'string(35)'.$sCollation;
         }
         if ($simulate){
@@ -463,7 +464,7 @@ function activateSurvey($iSurveyID, $simulate = false)
         }
     }
 
-    if ($arSurvey->savetimings == "Y")
+    if ($oSurvey->savetimings == "Y")
     {
         $timingsfieldmap = createTimingsFieldMap($iSurveyID,"full",false,false,getBaseLanguageFromSurveyID($iSurveyID));
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4981,7 +4981,8 @@ function fixLanguageConsistency($sid, $availlangs='')
             reset($langs);
         }
     }
-
+    /* Remove invalid question : can break survey */
+    Survey::model()->findByPk($sid)->fixInvalidQuestions();
 
     $query = "SELECT * FROM {{assessments}} WHERE sid='{$sid}' AND language='{$baselang}'";
     $result = Yii::app()->db->createCommand($query)->query();
@@ -5661,7 +5662,7 @@ function getPrintableHeader()
     return $headelements;
 }
 
-/** 
+/**
  * This function returns the Footer as result string
  * If you want to echo the Footer use doFooter()!
  * @return string

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -1008,13 +1008,13 @@ class Question extends LSActiveRecord
 
         /* Delete invalid subquestions (not in primary language */
         $validSubQuestion = Question::model()->findAll(array(
-            'select'=>'qid',
+            'select'=>'title',
             'condition'=>'parent_qid=:parent_qid AND language=:language',
             'params'=>array('parent_qid' => $this->qid,'language' => $oSurvey->language)
         ));
         $criteria = new CDbCriteria;
         $criteria->compare('parent_qid',$this->qid);
-        $criteria->addNotInCondition('qid', CHtml::listData($validSubQuestion,'qid','qid'));
+        $criteria->addNotInCondition('title', CHtml::listData($validSubQuestion,'title','title'));
         Question::model()->deleteAll($criteria);// Must log count of deleted ?
     }
 


### PR DESCRIPTION
- add a Questions in Survey model fixer for all other language
- use qid for question and title for subquestion : this broke Survey SQL
- we must have same qid+title then we can directly delete whole qid (no test on parent_qid)
- did we must log it ? In log("X questions are deleted",'info',application.survey.???) for example