### PR TITLE
New feature: add Plugin event afterFindSurvey

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -251,10 +251,10 @@ class Survey extends LSActiveRecord
 
         $event = new PluginEvent('afterFindSurvey');
         App()->getPluginManager()->dispatchEvent($event);
+        // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
             'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
             'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
-        // set the attributes we won't allow to fix
         foreach ($allowedAttributes as $attribute){
             if (!is_null($event->get($attribute)))
             {

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -248,15 +248,14 @@ class Survey extends LSActiveRecord
     public function fixSurveyAttribute($event)
     {
         $event = new PluginEvent('afterFindSurvey');
-        $event->set('surveyid',$this->sid) ;
+        $event->set('surveyid',$this->sid);
         App()->getPluginManager()->dispatchEvent($event);
         // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
             'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
             'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
-        foreach ($allowedAttributes as $attribute){
-            if (!is_null($event->get($attribute)))
-            {
+        foreach ($allowedAttributes as $attribute) {
+            if (!is_null($event->get($attribute))) {
                 $this->{$attribute} = $event->get($attribute);
             }
         }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -247,9 +247,8 @@ class Survey extends LSActiveRecord
     */
     public function fixSurveyAttribute($event)
     {
-        $this->template=Template::templateNameFilter($this->template);
-
         $event = new PluginEvent('afterFindSurvey');
+        $event->set('surveyid',$this->sid) ;
         App()->getPluginManager()->dispatchEvent($event);
         // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
@@ -261,6 +260,7 @@ class Survey extends LSActiveRecord
                 $this->{$attribute} = $event->get($attribute);
             }
         }
+        $this->template=Template::templateNameFilter($this->template);
     }
 
     /**

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -248,6 +248,19 @@ class Survey extends LSActiveRecord
     public function fixSurveyAttribute($event)
     {
         $this->template=Template::templateNameFilter($this->template);
+
+        $event = new PluginEvent('afterFindSurvey');
+        App()->getPluginManager()->dispatchEvent($event);
+        $allowedAttributes = array( 'template','usecookie', 'allowprev',
+            'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
+            'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
+        // set the attributes we won't allow to fix
+        foreach ($allowedAttributes as $attribute){
+            if (!is_null($event->get($attribute)))
+            {
+                $this->{$attribute} = $event->get($attribute);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This is a further development of a PR started here #632:

The initial idea was to allow template to be changed to participants via plugin events. Existing events did not work to effectively change the template. 

