### PR TITLE
dev: add getTemplateList to LimeSurveyApi

### DIFF
--- a/application/libraries/PluginManager/LimesurveyApi.php
+++ b/application/libraries/PluginManager/LimesurveyApi.php
@@ -4,6 +4,8 @@ use Yii;
 use User;
 use PluginDynamic;
 use SurveyDynamic;
+use Template;
+
     /**
     * Class exposing a Limesurvey API to plugins.
     * This class is instantiated by the plugin manager,
@@ -168,11 +170,19 @@ use SurveyDynamic;
         /**
          * Get the current request object
          *
-         * @return LSHttpRequest
+         * @return \LSHttpRequest
          */
         public function getRequest()
         {
             return App()->getRequest();
+        }
+
+        /**
+         * Returns an array of all available template names - does a basic check if the template might be valid
+         * @return array
+         */
+        public function getTemplateList(){
+            return Template::getTemplateList();
         }
 
         /**

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -251,10 +251,10 @@ class Survey extends LSActiveRecord
 
         $event = new PluginEvent('afterFindSurvey');
         App()->getPluginManager()->dispatchEvent($event);
+        // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
             'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
             'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
-        // set the attributes we won't allow to fix
         foreach ($allowedAttributes as $attribute){
             if (!is_null($event->get($attribute)))
             {

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -248,15 +248,14 @@ class Survey extends LSActiveRecord
     public function fixSurveyAttribute($event)
     {
         $event = new PluginEvent('afterFindSurvey');
-        $event->set('surveyid',$this->sid) ;
+        $event->set('surveyid',$this->sid);
         App()->getPluginManager()->dispatchEvent($event);
         // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
             'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
             'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
-        foreach ($allowedAttributes as $attribute){
-            if (!is_null($event->get($attribute)))
-            {
+        foreach ($allowedAttributes as $attribute) {
+            if (!is_null($event->get($attribute))) {
                 $this->{$attribute} = $event->get($attribute);
             }
         }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -247,9 +247,8 @@ class Survey extends LSActiveRecord
     */
     public function fixSurveyAttribute($event)
     {
-        $this->template=Template::templateNameFilter($this->template);
-
         $event = new PluginEvent('afterFindSurvey');
+        $event->set('surveyid',$this->sid) ;
         App()->getPluginManager()->dispatchEvent($event);
         // set the attributes we allow to be fixed
         $allowedAttributes = array( 'template','usecookie', 'allowprev',
@@ -261,6 +260,7 @@ class Survey extends LSActiveRecord
                 $this->{$attribute} = $event->get($attribute);
             }
         }
+        $this->template=Template::templateNameFilter($this->template);
     }
 
     /**

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -248,6 +248,19 @@ class Survey extends LSActiveRecord
     public function fixSurveyAttribute($event)
     {
         $this->template=Template::templateNameFilter($this->template);
+
+        $event = new PluginEvent('afterFindSurvey');
+        App()->getPluginManager()->dispatchEvent($event);
+        $allowedAttributes = array( 'template','usecookie', 'allowprev',
+            'showxquestions', 'shownoanswer', 'showprogress', 'questionindex',
+            'usecaptcha', 'showgroupinfo', 'showqnumcode', 'navigationdelay');
+        // set the attributes we won't allow to fix
+        foreach ($allowedAttributes as $attribute){
+            if (!is_null($event->get($attribute)))
+            {
+                $this->{$attribute} = $event->get($attribute);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Add getTemplateList to LimeSurveyApi to enable getting template list to plugins via API. 

This is to enable working of this plugin:
https://github.com/TonisOrmisson/limesurvey-url-templates
Which is a result of having #634