### PR TITLE
 Fixed issue #12132: Survey List Status Filter 'Active and running' does not list expiring surveys

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1113,8 +1113,9 @@ class Survey extends LSActiveRecord
                     $subCriteria1 = new CDbCriteria;
                     $subCriteria2 = new CDbCriteria;
                     $subCriteria1->addCondition($now.' > t.startdate', 'OR');
-                    $subCriteria2->addCondition($now.' < t.expires', 'OR');
                     $subCriteria1->addCondition('t.expires IS NULL', "OR");
+                    $subCriteria1->addCondition($now.' < t.expires', 'OR');
+                    $subCriteria2->addCondition($now.' < t.expires', 'OR');
                     $subCriteria2->addCondition('t.startdate IS NULL', "OR");
                     $criteria->mergeWith($subCriteria1);
                     $criteria->mergeWith($subCriteria2);


### PR DESCRIPTION
 Fixed issue #12132: Survey List Status Filter 'Active and running' does not list expiring surveys