### PR TITLE
Fixed issue #12146: Edit answer options: New answer option UI error

### DIFF
--- a/scripts/admin/answers.js
+++ b/scripts/admin/answers.js
@@ -171,18 +171,17 @@ function addinput()
     $codes = JSON.stringify(codes);
 
     //We build the datas for the request
-    datas                  = 'surveyid='+$elDatas.data('surveyid');
-    datas                 += '&gid='+$elDatas.data('gid');
-    datas                 += '&qid='+$elDatas.data('qid');
-    datas                 += '&codes='+$codes;
-    datas                 += '&scale_id='+$(this).data('scale-id');
-    datas                 += '&type=answer';
-    datas                 += '&position='+$(this).data('position');
-    datas                 += '&languages='+$languages;
-    console.log($elDatas.data('assessmentvisible'));
-    if( $elDatas.data('assessmentvisible') == 1 ){
-      datas += '&assessmentvisible=true';
-    }
+    datas = {
+        'surveyid':             $elDatas.data('surveyid'),
+        'gid':                  $elDatas.data('gid'),
+        'qid':                  $elDatas.data('qid'),
+        'codes':                $codes,
+        'scale_id':             $(this).data('scale-id'),
+        'type':                 'answer',
+        'position':             $(this).data('position'),
+        'languages':            $languages,
+        'assessmentvisible':    $elDatas.data('assessmentvisible') == 1,
+    };
 
     $scaleId  = $(this).data('scale-id')
     $position = $(this).data('position')


### PR DESCRIPTION
https://bugs.limesurvey.org/view.php?id=12146

In the case of assementvisible being false, it would not be appended to the ajax request string. The function that handles this request has the default value of this argument as an empty string. Then on the check on assessmentvisible for creating the html, it is only checked against the string value false. Therefore omitting it will always result in a true so these assessment fields are shown. Simple fix is to send false when false and true when true.