### PR TITLE
Fixed issue #12187: invitation mails are not being sent using json-rpc

### DIFF
--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -133,11 +133,14 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			default:
 				throw new Exception('Invalid template name');
 		}
-
+		
+		$modsubject = $sSubject;
+		$modmessage = $sMessage;
+		
 		if (isset($barebone_link))
 		{
-			$modsubject = str_replace("@@SURVEYURL@@", $barebone_link, $sSubject);
-			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $sMessage);
+			$modsubject = str_replace("@@SURVEYURL@@", $barebone_link, $modsubject);
+			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $modmessage);
 		}
 
 		$modsubject = Replacefields($modsubject, $fieldsarray);

--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -143,8 +143,8 @@ function emailTokens($iSurveyID,$aResultTokens,$sType)
 			$modmessage = str_replace("@@SURVEYURL@@", $barebone_link, $modmessage);
 		}
 
-		$modsubject = Replacefields($modsubject, $fieldsarray);
-		$modmessage = Replacefields($modmessage, $fieldsarray);
+		$modsubject = ReplaceFields($modsubject, $fieldsarray);
+		$modmessage = ReplaceFields($modmessage, $fieldsarray);
 
 		if (isset($aTokenRow['validfrom']) && trim($aTokenRow['validfrom']) != '' && convertDateTimeFormat($aTokenRow['validfrom'], 'Y-m-d H:i:s', 'U') * 1 > date('U') * 1)
 		{


### PR DESCRIPTION
- avoiding uninitialized variables clearing the mail subject and body
- camelcasing function call ReplaceFields