### PR TITLE
Fixed issue #12198: Date/Time question timeformat A seems invalid

### DIFF
--- a/application/helpers/surveytranslator_helper.php
+++ b/application/helpers/surveytranslator_helper.php
@@ -36,18 +36,18 @@
         // Bootstrap DateTimePicker uses capital letters, but
         // we still need small jsdate letters for dropdown client side.
         $aDateFormats= array(
-        1=> array ('phpdate' => 'd.m.Y', 'jsdate' => 'DD.MM.YYYY', 'jsdate_original' => 'dd.mm.yyyy', 'dateformat' => gT('dd.mm.yyyy')),
-        2=> array ('phpdate' => 'd-m-Y', 'jsdate' => 'DD-MM-YYYY', 'jsdate_original' => 'dd-mm-yyyy', 'dateformat' => gT('dd-mm-yyyy')),
-        3=> array ('phpdate' => 'Y.m.d', 'jsdate' => 'YYYY.MM.DD', 'jsdate_original' => 'yyyy.mm.dd', 'dateformat' => gT('yyyy.mm.dd')),
-        4=> array ('phpdate' => 'j.n.Y', 'jsdate' => 'D.M.YYYY',   'jsdate_original' => 'd.m.yyyy',   'dateformat' => gT('d.m.yyyy')),
-        5=> array ('phpdate' => 'd/m/Y', 'jsdate' => 'DD/MM/YYYY', 'jsdate_original' => 'dd/mm/yyyy', 'dateformat' => gT('dd/mm/yyyy')),
-        6=> array ('phpdate' => 'Y-m-d', 'jsdate' => 'YYYY-MM-DD', 'jsdate_original' => 'yyyy-mm-dd', 'dateformat' => gT('yyyy-mm-dd')),
-        7=> array ('phpdate' => 'Y/m/d', 'jsdate' => 'YYYY/MM/DD', 'jsdate_original' => 'yyyy/mm/dd', 'dateformat' => gT('yyyy/mm/dd')),
-        8=> array ('phpdate' => 'j/n/Y', 'jsdate' => 'D/M/YYYY',   'jsdate_original' => 'd/m/yyyy',   'dateformat' => gT('d/m/yyyy')),
-        9=> array ('phpdate' => 'm-d-Y', 'jsdate' => 'MM-DD-YYYY', 'jsdate_original' => 'mm-dd-yyyy', 'dateformat' => gT('mm-dd-yyyy')),
-        10=>array ('phpdate' => 'm.d.Y', 'jsdate' => 'MM.DD.YYYY', 'jsdate_original' => 'mm.dd.yyyy', 'dateformat' => gT('mm.dd.yyyy')),
-        11=>array ('phpdate' => 'm/d/Y', 'jsdate' => 'MM/DD/YYYY', 'jsdate_original' => 'mm/dd/yyyy', 'dateformat' => gT('mm/dd/yyyy')),
-        12=>array ('phpdate' => 'j-n-Y', 'jsdate' => 'D-M-YYYY',   'jsdate_original' => 'd-m-yyyy',   'dateformat' => gT('d-m-yyyy'))
+            1=> array ('phpdate' => 'd.m.Y', 'jsdate' => 'DD.MM.YYYY', 'jsdate_original' => 'dd.mm.yyyy', 'dateformat' => gT('dd.mm.yyyy')),
+            2=> array ('phpdate' => 'd-m-Y', 'jsdate' => 'DD-MM-YYYY', 'jsdate_original' => 'dd-mm-yyyy', 'dateformat' => gT('dd-mm-yyyy')),
+            3=> array ('phpdate' => 'Y.m.d', 'jsdate' => 'YYYY.MM.DD', 'jsdate_original' => 'yyyy.mm.dd', 'dateformat' => gT('yyyy.mm.dd')),
+            4=> array ('phpdate' => 'j.n.Y', 'jsdate' => 'D.M.YYYY',   'jsdate_original' => 'd.m.yyyy',   'dateformat' => gT('d.m.yyyy')),
+            5=> array ('phpdate' => 'd/m/Y', 'jsdate' => 'DD/MM/YYYY', 'jsdate_original' => 'dd/mm/yyyy', 'dateformat' => gT('dd/mm/yyyy')),
+            6=> array ('phpdate' => 'Y-m-d', 'jsdate' => 'YYYY-MM-DD', 'jsdate_original' => 'yyyy-mm-dd', 'dateformat' => gT('yyyy-mm-dd')),
+            7=> array ('phpdate' => 'Y/m/d', 'jsdate' => 'YYYY/MM/DD', 'jsdate_original' => 'yyyy/mm/dd', 'dateformat' => gT('yyyy/mm/dd')),
+            8=> array ('phpdate' => 'j/n/Y', 'jsdate' => 'D/M/YYYY',   'jsdate_original' => 'd/m/yyyy',   'dateformat' => gT('d/m/yyyy')),
+            9=> array ('phpdate' => 'm-d-Y', 'jsdate' => 'MM-DD-YYYY', 'jsdate_original' => 'mm-dd-yyyy', 'dateformat' => gT('mm-dd-yyyy')),
+            10=>array ('phpdate' => 'm.d.Y', 'jsdate' => 'MM.DD.YYYY', 'jsdate_original' => 'mm.dd.yyyy', 'dateformat' => gT('mm.dd.yyyy')),
+            11=>array ('phpdate' => 'm/d/Y', 'jsdate' => 'MM/DD/YYYY', 'jsdate_original' => 'mm/dd/yyyy', 'dateformat' => gT('mm/dd/yyyy')),
+            12=>array ('phpdate' => 'j-n-Y', 'jsdate' => 'D-M-YYYY',   'jsdate_original' => 'd-m-yyyy',   'dateformat' => gT('d-m-yyyy'))
         );
 
         if ($iDateFormat > 12 || $iDateFormat<0) {
@@ -407,7 +407,7 @@
         $supportedLanguages['ky']['dateformat'] = 1;
         $supportedLanguages['ky']['radixpoint'] = 1;
 
-        // Luxembourgish 
+        // Luxembourgish
         $supportedLanguages['lb']['description'] = gT('Luxembourgish');
         $supportedLanguages['lb']['nativedescription'] = 'L&#235;tzebuergesch';
         $supportedLanguages['lb']['rtl'] = false;
@@ -750,18 +750,22 @@
     {
         // Note that order is relevant (longer strings first)
         $aFmts = array(
-        // With leading zero
-        "dd"   => "d",
-        "mm"   => "m",
-        "yyyy" => "Y",
-        "HH"   => "H",
-        "MM"   => "i",
-        // Without leading zero
-        "d"    => "j",
-        "m"    => "n",
-        "yy"   => "y",
-        "H"    => "G",
-        "M"    => "i");
+            // With leading zero
+            "dd"   => "d",
+            "mm"   => "m",
+            "yyyy" => "Y",
+            "HH"   => "H",
+            "MM"   => "i",
+            // Without leading zero
+            "d"    => "j",
+            "m"    => "n",
+            "yy"   => "y",
+            "H"    => "G",
+            "M"    => "i",
+            // AP/PM
+            "A"    => "A",
+            "a"    => "a",
+        );
 
         // Extra allowed characters
         $aAllowed = array('-', '.', '/', ':', ' ');
@@ -807,9 +811,21 @@
      */
     function getJSDateFromDateFormat($sDateformat)
     {
-        // Reverse case, trick from here: http://stackoverflow.com/a/6612519/2138090
-        $newDateFormat = strtolower($sDateformat) ^ strtoupper($sDateformat) ^ $sDateformat;
-        $newDateFormat = str_replace("hh", "HH", $newDateFormat);  // HH (hours) need still be in upper-case for 00-23 representation (not AM/PM)
+        $newDateFormat = str_replace(
+            array(
+                "d",   // day
+                "m",   // month
+                "y",   // year
+                "M",   // minutes
+            ),
+            array(
+                "D",   // day
+                "M",   // month
+                "Y",   // year
+                "m",   // minutes
+            ),
+            $sDateformat
+        );
         return $newDateFormat;
     }
 

--- a/application/libraries/Date_Time_Converter.php
+++ b/application/libraries/Date_Time_Converter.php
@@ -344,7 +344,9 @@ class Date_Time_Converter
             }
         }
 
-        if (strtolower($this->ampm) == "pm") {$this->hours = $this->hours + 12;}			//if its pm, add 12 hours
+        if (strtolower($this->ampm) == "pm" && $this->hours < 12) { //if its pm, add 12 hours
+            $this->hours = $this->hours + 12;
+        }
 
         $make_stamp = adodb_mktime( (int)ltrim($this->hours, "0"), (int)ltrim($this->minutes, "0"),
         (int)ltrim($this->seconds, "0"), (int)ltrim($this->months, "0"),


### PR DESCRIPTION
- looking at help : d/m/y for date H:M for time, adding A a
- js use momentjs : http://momentjs.com/docs/#/displaying/format/
- but hard to use momentjs with php date
- see http://locutus.io/php/datetime/date/ too

Here, fixing only format using d, m, y for date and H M for time. Currently + new M for 'minutes without leading 0 broke : seems OK in js, but not in PHP.