### PR TITLE
Move doc from remote control to phpDoc

### DIFF
--- a/application/controllers/admin/remotecontrol.php
+++ b/application/controllers/admin/remotecontrol.php
@@ -66,10 +66,9 @@ class remotecontrol extends Survey_Common_Action
                 }
                 LSjsonRPCServer::handle($oHandler);
             }
-			foreach (App()->log->routes as $route)
-			{
-				$route->enabled = $route->enabled && !($route instanceOf CWebLogRoute);
-			}
+            foreach (App()->log->routes as $route) {
+                $route->enabled = $route->enabled && !($route instanceOf CWebLogRoute);
+            }
 
             exit;
         } else {
@@ -80,15 +79,14 @@ class remotecontrol extends Survey_Common_Action
                     /* @var $method ReflectionMethod */
                     if (substr($method->getName(),0,1) !== '_') {
                         $list[$method->getName()] = array(
-                            'description' => str_replace(array("\r", "\r\n", "\n"), "<br/>", $method->getDocComment()),
-                            'parameters'  => $method->getParameters()
+                            'description' => $method->getDocComment(),
+                            'parameters'  => $method->getParameters(),
                         );
                     }
                 }
                 ksort($list);
                 $aData['method'] = $RPCType;
                 $aData['list'] = $list;
-                $aData['display']['menu_bars'] = false; // Hide normal menu bar
                 $this->_renderWrappedTemplate('remotecontrol', array('index_view'), $aData);
             }
         }

--- a/application/views/admin/remotecontrol/index_view.php
+++ b/application/views/admin/remotecontrol/index_view.php
@@ -1,11 +1,27 @@
 <div id='remotecontrol' class="row">
     <div class="col-xs-12">
-    <h3 class="pagetitle"><?php echo sprintf(gT('RemoteControl is available using %s for transport and exposes the following functionality:'),$method); ?></h3>
+    <div class="pagetitle h3"><?php echo sprintf(gT('RemoteControl is available using %s for transport and exposes the following functionality:'),$method); ?></div>
     <dl>
     <?php
     foreach ($list as $method => $info) {
-        echo \CHtml::tag("dt",array('class'=>"h4"),$method);
-        echo \CHtml::tag("dd",array(),\CHtml::tag("pre",array(),\CHtml::encode($info['description'])));
+        echo \CHtml::tag(
+            "dt",
+            array('class'=>"h4"),
+            \CHtml::link($method,"#definition-{$method}",array(
+                "role" => "button",
+                "data-toggle" => "collapse",
+                "aria-expanded" => "false",
+                "aria-controls" => "definition-{$method}",
+            ))
+        );
+        echo \CHtml::tag(
+            "dd",
+            array(
+                "class" => "collapse",
+                "id" => "definition-{$method}"
+            ),
+            \CHtml::tag("pre",array(),\CHtml::encode($info['description']))
+        );
     }
     ?>
     </dl>

--- a/application/views/admin/remotecontrol/index_view.php
+++ b/application/views/admin/remotecontrol/index_view.php
@@ -1,9 +1,13 @@
-<div id='remotecontrol'>
-    <?php echo sprintf(gT('RemoteControl is available using %s for transport and exposes the following functionality:'),$method); ?>
-    <br/><br/>
+<div id='remotecontrol' class="row">
+    <div class="col-xs-12">
+    <h3 class="pagetitle"><?php echo sprintf(gT('RemoteControl is available using %s for transport and exposes the following functionality:'),$method); ?></h3>
+    <dl>
     <?php
     foreach ($list as $method => $info) {
-        echo sprintf('<b>%s</b><br/>%s<br/>',$method, $info['description']);
+        echo \CHtml::tag("dt",array('class'=>"h4"),$method);
+        echo \CHtml::tag("dd",array(),\CHtml::tag("pre",array(),\CHtml::encode($info['description'])));
     }
     ?>
+    </dl>
+    </div>
 </div>


### PR DESCRIPTION
Fixed issue #12368: Remote control: properties that are available are not shown

* starting, but really long ..... think i move to only needed part for starting
* [phpDoc manual](https://www.phpdoc.org/docs/latest/references/phpdoc/basic-syntax.html) allow markdown then use it, must control if api.limesurvey.org show it better. 
* Fix principal doc needed (about properties) : only good way `@see` because already in model and come from models
* Add a solution to get whole attribute 
