### PR TITLE
FIX: Installation duplicate column hash for prefix_notifications

### DIFF
--- a/installer/sql/create-mssql.sql
+++ b/installer/sql/create-mssql.sql
@@ -605,7 +605,6 @@ CREATE TABLE prefix_notifications (
     [hash] nvarchar(64) DEFAULT NULL,
     [created] datetime NOT NULL,
     [first_read] datetime DEFAULT NULL,
-    [hash] nvarchar(64) DEFAULT '',
     PRIMARY KEY ([id])
 );
 CREATE INDEX [notif_index] ON [prefix_notifications] ([entity_id],[entity],[status]);

--- a/installer/sql/create-mysql.sql
+++ b/installer/sql/create-mysql.sql
@@ -611,7 +611,6 @@ CREATE TABLE IF NOT EXISTS `prefix_notifications` (
     `hash` VARCHAR(64) DEFAULT NULL COMMENT 'Hash of title, message and entity to avoid duplication',
     `created` DATETIME NOT NULL,
     `first_read` DATETIME DEFAULT NULL,
-    `hash` VARCHAR(64) DEFAULT '',
     PRIMARY KEY (`id`),
     INDEX(`entity`, `entity_id`, `status`),
     INDEX(`hash`)

--- a/installer/sql/create-pgsql.sql
+++ b/installer/sql/create-pgsql.sql
@@ -614,7 +614,6 @@ CREATE TABLE prefix_notifications (
     "hash" character varying(64) DEFAULT NULL,
     "created" timestamp NOT NULL,
     "first_read" timestamp DEFAULT NULL,
-    "hash" character varying(64) DEFAULT '',
     CONSTRAINT prefix_notifications_pkey PRIMARY KEY (id)
 );
 CREATE INDEX prefix_index ON prefix_notifications USING btree (entity, entity_id, status);


### PR DESCRIPTION
What is should be by default NULL or '' ??