### PR TITLE
DEV: kill SurveyObj: remove unused things

### DIFF
--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -6,7 +6,6 @@ class SurveyObj
     */
     public $id;
 
-
     /**
     * Answer, codes, and full text to the questions.
     * This is used in conjunction with the fieldMap to produce
@@ -65,9 +64,6 @@ class SurveyObj
     * @var array[int][string]mixed
     */
     public $languageSettings;
-
-
-
 
 
 

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -6,11 +6,6 @@ class SurveyObj
     */
     public $id;
 
-    /**
-    * Whether the survey is anonymous or not.
-    * @var boolean
-    */
-    public $anonymous;
 
     /**
     * Answer, codes, and full text to the questions.
@@ -77,28 +72,6 @@ class SurveyObj
     */
     public $languageSettings;
 
-    /**
-    * Returns question arrays ONLY for questions that are part of the
-    * indicated group and are top level (i.e. no subquestions will be
-    * returned).   If there are no then an empty array will be returned.
-    * If $groupId is not set then all top level questions will be
-    * returned regardless of the group they are a part of.
-    */
-    public function getQuestions($groupId = null)
-    {
-        $qs = array();
-        foreach($this->questions as $q)
-        {
-            if ($q['parent_qid'] == 0)
-            {
-                if(empty($groupId) || $q['gid'] == $groupId)
-                {
-                    $qs[] = $q;
-                }
-            }
-        }
-        return $qs;
-    }
 
 
 

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -100,23 +100,7 @@ class SurveyObj
         return $qs;
     }
 
-    /**
-    * Returns the question code/title for the question that matches the $fieldName.
-    * False is returned if no matching question is found.
-    * @param string $fieldName
-    * @return string (or false)
-    */
-    public function getQuestionCode($fieldName)
-    {
-        if (isset($this->fieldMap[$fieldName]['title']))
-        {
-            return $this->fieldMap[$fieldName]['title'];
-        }
-        else
-        {
-            return false;
-        }
-    }
+
 
     public function getQuestionText($fieldName)
     {

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -44,12 +44,6 @@ class SurveyObj
     */
     public $questions;
 
-    /**
-    * The tokens in the survey.
-    *
-    * @var array[int][string]mixed
-    */
-    public $tokens;
 
     /**
      * When relevant holds the available fields from the token table

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -104,28 +104,6 @@ class SurveyObj
 
 
 
-
-    /**
-    * Returns an array containing all child question rows for the given parent
-    * question ID.  If no children are found then an empty array is
-    * returned.
-    *
-    * @param int $parentQuestionId
-    * @return array[int]array[string]mixed
-    */
-    public function getSubQuestionArrays($parentQuestionId)
-    {
-        $results = array();
-        foreach ($this->questions as $question)
-        {
-            if ($question['parent_qid'] == $parentQuestionId)
-            {
-                $results[$question['qid']] = $question;
-            }
-        }
-        return $results;
-    }
-
     /**
     * Returns the full answer for the question that matches $fieldName
     * and the answer that matches the $answerCode.  If a match cannot

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -102,18 +102,7 @@ class SurveyObj
 
 
 
-    public function getQuestionText($fieldName)
-    {
-        $question = $this->fieldMap[$fieldName];
-        if ($question)
-        {
-            return $question['question'];
-        }
-        else
-        {
-            return false;
-        }
-    }
+
 
 
     /**

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -106,28 +106,6 @@ class SurveyObj
 
 
     /**
-    * Returns all token records that have a token value that matches
-    * the one given.  An empty array is returned if there are no
-    * matching token records.
-    *
-    * @param mixed $token
-    */
-    public function getTokens($token)
-    {
-        $matchingTokens = array();
-
-        foreach($this->tokens as $t)
-        {
-            if ($t['token'] == $token)
-            {
-                $matchingTokens[] = $t;
-            }
-        }
-
-        return $matchingTokens;
-    }
-
-    /**
     * Returns an array containing all child question rows for the given parent
     * question ID.  If no children are found then an empty array is
     * returned.


### PR DESCRIPTION
I really do not undertstand why there is SurveyObj and why Survey is not used instead. It is really confusing and in many places also the phpDoc is mixed up. 

I'll try to kill it. 
Here's the first part removing unused stuff