### PR TITLE
Fixed issue #12504: Tidy not available - Blocking quick translate

### DIFF
--- a/application/controllers/InstallerController.php
+++ b/application/controllers/InstallerController.php
@@ -1392,7 +1392,8 @@ class InstallerController extends CController {
             'filter',
             'ctype',
             'session',
-            'hash'
+            'hash',
+            'tidy'
         );
 
         foreach ($extensions as $extension) {


### PR DESCRIPTION
Limesurvey depends on the PHP extension 'tidy' for the quick translate functionality. I've added this as a requirement in the installer.