### PR TITLE
Fixed issue: malformed pagination query in SQL Server

### DIFF
--- a/application/models/Participant.php
+++ b/application/models/Participant.php
@@ -496,9 +496,11 @@ class Participant extends LSActiveRecord
         $sqlCountActiveSurveys = "(SELECT COUNT(*) FROM ".$DBCountActiveSurveys." cas WHERE cas.participant_id = t.participant_id )";
 
         $criteria->select = array(
-            '*',
+            't.*',
+            'shares.share_uid',
+            'shares.date_added',
+            'shares.can_edit',
             $sqlCountActiveSurveys . ' AS countActiveSurveys',
-            't.participant_id',
             't.participant_id AS id',   // This is need to avoid confusion between t.participant_id and shares.participant_id
         );
         if($this->extraCondition) {


### PR DESCRIPTION
Due to a weak implementation of the `CMssqlCommandBuilder::applyLimit()` method in Yii SQL Server driver the pagination query at the "Central participant database" page fails because "The column 'participant_id' was specified multiple times" (error 8156).

I could provide also a patch for the driver but since the Yii framework has reached its EOL (currently they accept only security fixes) one may easily avoid this error by qualifying the column names to be selected without duplicates that may arise (for example) from a * selection on joined tables.