### PR TITLE
Set expire permission to "activate"

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -1448,7 +1448,7 @@ class SurveyAdmin extends Survey_Common_Action
     function expire($iSurveyID)
     {
         $iSurveyID = (int) $iSurveyID;
-        if (!Permission::model()->hasSurveyPermission($iSurveyID, 'surveysettings', 'update'))
+        if (!Permission::model()->hasSurveyPermission($iSurveyID, 'surveyactivation', 'update'))
         {
             Yii::app()->setFlashMessage(gT("You do not have permission to access this page."),'error');
             $this->getController()->redirect(array('admin/survey','sa'=>'view','surveyid'=>$iSurveyID));


### PR DESCRIPTION
Hello,
In the survey view, when you click on "Stop this survey", you see this view:
![capture du 2017-09-04 10-48-23](https://user-images.githubusercontent.com/6367936/30101095-5b353d70-92eb-11e7-9b0b-6f0f051b9efa.png)

Like you can see, in the UI, you can choose between `Expire survey` and `Deactivate survey`. To deactivate the survey you need the `surveyactivation` permission but to expire the survey you need the `surveysettings` permission.

This patch fixes this inconsistency by setting the `surveyactivation` to expire. The `surveysettings` permission gives too much permission if you just want to allow the admin to expire the survey. Moreover, the UI is clear: it should be the same permission for both buttons.

Sincerely,
Jean-Sébastien 