### PR TITLE
issue #12652: AuditLog plugin reset langage to default

### DIFF
--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -101,24 +101,21 @@ class AdminController extends LSYii_Controller
     {
         // From personal settings
         if (Yii::app()->request->getPost('action') == 'savepersonalsettings') {
-            if (Yii::app()->request->getPost('lang')=='auto')
-            {
+            if (Yii::app()->request->getPost('lang')=='auto') {
                 $sLanguage= getBrowserLanguage();
-            }
-            else
-            {
+            } else {
                 $sLanguage=sanitize_languagecode(Yii::app()->request->getPost('lang'));
             }
             Yii::app()->session['adminlang'] = $sLanguage;
         }
-
-        if (empty(Yii::app()->session['adminlang']))
+        if (empty(Yii::app()->session['adminlang'])) {
             Yii::app()->session["adminlang"] = Yii::app()->getConfig("defaultlang");
-
+        }
         Yii::app()->setLanguage(Yii::app()->session["adminlang"]);
 
-        if (!empty($this->user_id))
+        if (!empty($this->user_id)) {
             $this->_GetSessionUserRights($this->user_id);
+        }
     }
 
     /**
@@ -274,8 +271,9 @@ class AdminController extends LSYii_Controller
     */
     public function _getAdminHeader($meta = false, $return = false)
     {
-        if (empty(Yii::app()->session['adminlang']))
+        if (empty(Yii::app()->session['adminlang'])) {
             Yii::app()->session["adminlang"] = Yii::app()->getConfig("defaultlang");
+        }
 
         $aData = array();
         $aData['adminlang'] = Yii::app()->language;

--- a/application/controllers/admin/authentication.php
+++ b/application/controllers/admin/authentication.php
@@ -35,6 +35,11 @@ class Authentication extends Survey_Common_Action
      */
     public function index()
     {
+        /* Set adminlang to the one set in dropdown */
+        if(Yii::app()->request->getPost('loginlang','default')!='default') {
+            Yii::app()->session['adminlang'] = Yii::app()->request->getPost('loginlang','default');
+            Yii::app()->setLanguage(Yii::app()->session["adminlang"]);
+        }
         // The page should be shown only for non logged in users
         $this->_redirectIfLoggedIn();
 
@@ -223,12 +228,9 @@ class Authentication extends Survey_Common_Action
     {
         $this->_redirectIfLoggedIn();
 
-        if (!Yii::app()->request->getPost('action'))
-        {
+        if (!Yii::app()->request->getPost('action')) {
             $this->_renderWrappedTemplate('authentication', 'forgotpassword');
-        }
-        else
-        {
+        } else {
             $sUserName = Yii::app()->request->getPost('user');
             $sEmailAddr = Yii::app()->request->getPost('email');
 
@@ -237,13 +239,10 @@ class Authentication extends Survey_Common_Action
             // Preventing attacker from easily knowing whether the user and email address are valid or not (and slowing down brute force attacks)
             usleep(rand(Yii::app()->getConfig("minforgottenpasswordemaildelay"),Yii::app()->getConfig("maxforgottenpasswordemaildelay")));
 
-            if (count($aFields) < 1 || ($aFields[0]['uid'] != 1 && !Permission::model()->hasGlobalPermission('auth_db','read',$aFields[0]['uid'])))
-            {
+            if (count($aFields) < 1 || ($aFields[0]['uid'] != 1 && !Permission::model()->hasGlobalPermission('auth_db','read',$aFields[0]['uid']))) {
                 // Wrong or unknown username and/or email. For security reasons, we don't show a fail message
                 $aData['message'] = '<br>'.gT('If username and email are valid and you are allowed to use internal database authentication a new password has been sent to you').'<br>';
-            }
-            else
-            {
+            } else {
                 $aData['message'] = '<br>'.$this->_sendPasswordEmail($sEmailAddr, $aFields).'</br>';
             }
             $this->_renderWrappedTemplate('authentication', 'message', $aData);
@@ -373,6 +372,7 @@ class Authentication extends Survey_Common_Action
     protected function _renderWrappedTemplate($sAction = 'authentication', $aViewUrls = array(), $aData = array())
     {
         $aData['display']['menu_bars'] = false;
+        $aData['language'] = Yii::app()->getLanguage() != Yii::app()->getConfig("defaultlang") ? Yii::app()->getLanguage() : 'default';
         parent::_renderWrappedTemplate($sAction, $aViewUrls, $aData);
     }
 

--- a/application/core/LSWebUser.php
+++ b/application/core/LSWebUser.php
@@ -6,17 +6,8 @@
         protected $sessionVariable = 'LSWebUser';
 
 
-        public function __construct()
-        {
+        public function __construct() {
             $this->loginUrl = Yii::app()->createUrl('admin/authentication', array('sa' => 'login'));
-
-            // Try to fix missing language in plugin controller
-            if (empty(Yii::app()->session['adminlang']))
-            {
-                 Yii::app()->session["adminlang"] = Yii::app()->getConfig("defaultlang");
-            }
-
-            Yii::app()->setLanguage(Yii::app()->session['adminlang']);
         }
 
         public function checkAccess($operation, $params = array(), $allowCaching = true)

--- a/application/core/LSYii_Controller.php
+++ b/application/core/LSYii_Controller.php
@@ -139,9 +139,8 @@ abstract class LSYii_Controller extends CController
         {
             Yii::app()->setConfig("timeadjust",$timeadjust.' hours');
         }
-
-        //Yii::app()->setConfig('adminimageurl', Yii::app()->getConfig('styleurl').Yii::app()->getConfig('admintheme').'/images/');
-        //Yii::app()->setConfig('adminstyleurl', Yii::app()->getConfig('styleurl').Yii::app()->getConfig('admintheme').'/');
+        /* Set the default language, other controller can update if wanted */
+        Yii::app()->setLanguage(Yii::app()->getConfig("defaultlang"));
     }
 
     /**

--- a/application/views/admin/authentication/login.php
+++ b/application/views/admin/authentication/login.php
@@ -98,19 +98,17 @@
 
 
                                 echo CHtml::label(gT('Language'), 'loginlang');
-
+                                
                                 $this->widget('yiiwheels.widgets.select2.WhSelect2', array(
                                     'name' => 'loginlang',
                                     'data' => $languageData,
+                                    'value' => $language,
                                     'pluginOptions' => array(
-                                    'options' => array(
-                                        'value' => 'default'
-                                    ),
-                                    'htmlOptions' => array(
-                                        'id' => 'loginlang'
-                                    ),
-
-                                )));
+                                        'htmlOptions' => array(
+                                            'id' => 'loginlang'
+                                        ),
+                                    )
+                                ));
                                 ?>
 
                                 <?php   if (Yii::app()->getConfig("demoMode") === true && Yii::app()->getConfig("demoModePrefill") === true)


### PR DESCRIPTION
- [12652: AuditLog plugin reset langage to default when register](https://bugs.limesurvey.org/view.php?id=12652)
- fix LSWebUser : no reason to set language here.
- really unsure original issue about language in plugin manager is fixed but i don't find a way to reproduce
- but pluginmanager extend admincontroller : then one can set lang
- admin part get adminlang
- other controller must check the language, but the default is set
- login form language are not updated after error.