### PR TITLE
Dev: allow to use Yii log system for tracevar even with debug=>0

### DIFF
--- a/application/helpers/globals.php
+++ b/application/helpers/globals.php
@@ -15,7 +15,6 @@
         return Yii::app();
     }
 
-
     /**
      * If debug = 2 in application/config.php this will produce output in the console / firebug
      * similar to var_dump. It will also include the filename and line that called this method.
@@ -27,11 +26,8 @@
         $msg = CVarDumper::dumpAsString($variable, $depth, false);
         $fullTrace = debug_backtrace();
         $trace=array_shift($fullTrace);
-        if(isset($trace['file'],$trace['line']) && strpos($trace['file'],YII_PATH)!==0)
-        {
+        if(isset($trace['file'],$trace['line']) && strpos($trace['file'],YII_PATH)!==0) {
             $msg = $trace['file'].' ('.$trace['line']."):\n" . $msg;
         }
-        Yii::trace($msg, 'vardump');
+        Yii::log($msg, 'trace', 'vardump');
     }
-    
-?>


### PR DESCRIPTION
- with debug=>0 : log is not done (http://www.yiiframework.com/doc/api/1.1/YiiBase#trace-detail)
- with log : we allow user to have their way to log
- Just a shortcut, but quickest way to trace ;)
- No change with default config, then easy merge.