### PR TITLE
enable video in spite of active xss filtering #112560

### DIFF
--- a/application/core/LSYii_Validators.php
+++ b/application/core/LSYii_Validators.php
@@ -54,14 +54,14 @@ class LSYii_Validators extends CValidator {
             $object->$attribute=$this->xssFilter($object->$attribute);
             if($this->isUrl)
             {
-                $object->$attribute=str_replace('javascript:','',html_entity_decode($object->$attribute, ENT_QUOTES, "UTF-8")); 
+                $object->$attribute=str_replace('javascript:','',html_entity_decode($object->$attribute, ENT_QUOTES, "UTF-8"));
             }
         }
         // Note that URL checking only checks basic URL properties. As a URL can contain EM expression there needs to be a lot of freedom.
         if($this->isUrl)
         {
             if ($object->$attribute== 'http://' || $object->$attribute=='https://') {$object->$attribute="";}
-            $object->$attribute=html_entity_decode($object->$attribute, ENT_QUOTES, "UTF-8"); 
+            $object->$attribute=html_entity_decode($object->$attribute, ENT_QUOTES, "UTF-8");
         }
         if($this->isLanguage)
         {
@@ -127,6 +127,45 @@ class LSYii_Validators extends CValidator {
                 )
         );
         // To allow script BUT purify : HTML.Trusted=true (plugin idea for admin or without XSS filtering ?)
+
+        // to enable video or something else we must use the config object of HTML-Purifier
+        $config = $filter->getPurifier()->config;
+
+        // enable video
+        $config->set('HTML.DefinitionID', 'html5-definitions');
+
+        $def = $config->maybeGetRawHTMLDefinition();
+        $max = $config->get('HTML.MaxImgLength');
+        if ($def) {
+          $def->addElement(
+        		'video',   // name
+        		'Inline',  // content set
+        		'Flow', // allowed children
+        		'Common', // attribute collection
+        		array( // attributes
+        			'src' => 'URI',
+              'id' => 'Text',
+            	'poster' => 'Text',
+        			'width' => 'Pixels#' . $max,
+        			'height' => 'Pixels#' . $max,
+        			'controls' => 'Bool#controls',
+        			'autobuffer' => 'Bool#autobuffer',
+        			'autoplay' => 'Bool#autoplay',
+        			'loop' => 'Bool#loop',
+        			'muted' => 'Bool#muted'
+        		)
+        	);
+        	$def->addElement(
+        		'source',   // name
+        		'Inline',  // content set
+        		'Empty', // allowed children
+        		null, // attribute collection
+        		array( // attributes
+        			'src*' => 'URI',
+        			'type' => 'Enum#video/mp4,video/webm',
+        		)
+        	);
+        }
 
         /** Start to get complete filtered value with  url decode {QCODE} (bug #09300). This allow only question number in url, seems OK with XSS protection **/
         $sFiltered=preg_replace('#%7B([a-zA-Z0-9\.]*)%7D#','{$1}',$filter->purify($value));

--- a/framework/web/widgets/CHtmlPurifier.php
+++ b/framework/web/widgets/CHtmlPurifier.php
@@ -59,7 +59,7 @@ class CHtmlPurifier extends COutputProcessor
 	 * @see http://htmlpurifier.org/live/configdoc/plain.html
 	 */
 	private $_options=null;
-	
+
 	/**
 	 * Processes the captured output.
 	 * This method purifies the output using {@link http://htmlpurifier.org HTML Purifier}.
@@ -70,11 +70,11 @@ class CHtmlPurifier extends COutputProcessor
 		$output=$this->purify($output);
 		parent::processOutput($output);
 	}
-	
+
 	/**
 	 * Purifies the HTML content by removing malicious code.
 	 * @param mixed $content the content to be purified.
-	 * @return mixed the purified content 
+	 * @return mixed the purified content
 	 */
 	public function purify($content)
 	{
@@ -84,7 +84,7 @@ class CHtmlPurifier extends COutputProcessor
 			$content=$this->getPurifier()->purify($content);
 		return $content;
 	}
-	
+
 	/**
 	 * Set the options for HTML Purifier and create a new HTML Purifier instance based on these options.
 	 * @param mixed $options the options for HTML Purifier
@@ -96,7 +96,7 @@ class CHtmlPurifier extends COutputProcessor
 		$this->createNewHtmlPurifierInstance();
 		return $this;
 	}
-	
+
 	/**
 	 * Get the options for the HTML Purifier instance.
 	 * @return mixed the HTML Purifier instance options
@@ -105,18 +105,18 @@ class CHtmlPurifier extends COutputProcessor
 	{
 		return $this->_options;
 	}
-	
+
 	/**
 	 * Get the HTML Purifier instance or create a new one if it doesn't exist.
 	 * @return HTMLPurifier
 	 */
-	protected function getPurifier()
+	public function getPurifier()
 	{
 		if($this->_purifier!==null)
 			return $this->_purifier;
 		return $this->createNewHtmlPurifierInstance();
 	}
-	
+
 	/**
 	 * Create a new HTML Purifier instance.
 	 * @return HTMLPurifier


### PR DESCRIPTION
New feature # : 12560
Link : https://bugs.limesurvey.org/view.php?id=12560
Desc :

Dear LS-Developer,

xss filtering is mandatory for us, but videos (self uploaded - YouTube is a no-go) in questions and help texts is the most requested feature at our organization.

LimeSurvey uses HtmlPurifier for xss filtering via yii-framework and the wrapper class CHhtmlPurifier.php. Unfortunately the wrapper class uses the old way to configure HtmlPurifier via an array. To enable video tag (HTML5) we must use the config-object of HtmlPurifier. The trick is:

1. change function getPurifier of CHtmlPurifier.php (line 113 - framework/web/widget) from proteced to public - so we can get to the configuration of the internal _purifier.
2. add some code to LSYii_Validators.php (130ff - application/core) - see file

My approach was to change classes from the yii-framework only minimal and add the maximum changes to the core code of LimeSurvey.

Hope, you can think about und maybe integrate it in LimeSurvey.

Best wishes .. Iver