### PR TITLE
Dev: TODOS: participant_attribute_names ->participant_attribute_name

### DIFF
--- a/application/models/ParticipantAttribute.php
+++ b/application/models/ParticipantAttribute.php
@@ -22,7 +22,7 @@
  * @property string $value
  *
  * @property Participant $participant
- * @property ParticipantAttributeName $participant_attribute_names //todo this should be singular not plural
+ * @property ParticipantAttributeName $participant_attribute_name
  */
 class ParticipantAttribute extends LSActiveRecord
 {
@@ -55,7 +55,7 @@ class ParticipantAttribute extends LSActiveRecord
         // class name for the relations automatically generated below.
         return array(
             'participant' => array(self::HAS_ONE, 'Participant', 'participant_id'),
-            'participant_attribute_names'=>array(self::BELONGS_TO, 'ParticipantAttributeName', 'attribute_id')
+            'participant_attribute_name'=>array(self::BELONGS_TO, 'ParticipantAttributeName', 'attribute_id')
         );
     }
 

--- a/application/models/ParticipantAttributeNameLang.php
+++ b/application/models/ParticipantAttributeNameLang.php
@@ -19,7 +19,7 @@
  * @property string $attribute_name
  * @property string $lang
  *
- * @property ParticipantAttributeName $participant_attribute_names //TODO should be singular
+ * @property ParticipantAttributeName $participant_attribute_name
  */
 class ParticipantAttributeNameLang extends LSActiveRecord
 {
@@ -63,7 +63,7 @@ class ParticipantAttributeNameLang extends LSActiveRecord
 		// NOTE: you may need to adjust the relation name and the related
 		// class name for the relations automatically generated below.
 		return array(
-            'participant_attribute_names'=>array(self::BELONGS_TO, 'ParticipantAttributeName', 'attribute_id')
+            'participant_attribute_name'=>array(self::BELONGS_TO, 'ParticipantAttributeName', 'attribute_id')
 		);
 	}
 


### PR DESCRIPTION
The participant_attribute_name seems to be unused, cold not find any usage.
Probably generated by automatically by Gii due to table name in plural

https://www.teamten.com/lawrence/programming/use-singular-nouns-for-database-table-names.html
http://www.yiiframework.com/doc/guide/1.1/en/basics.convention#database

> For table names, you may use either singular or plural names, but not both. For simplicity, we recommend using singular names.