### PR TITLE
removed API restriction to prevent survey ownership transfer

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -299,7 +299,6 @@ class remotecontrol_handle
     * Properties available are restricted
     * * Always
     *     * sid
-    *     * owner_id
     *     * active
     *     * language
     *     * additional_languages
@@ -333,7 +332,7 @@ class remotecontrol_handle
             {
                 // Remove fields that may not be modified
                 unset($aSurveyData['sid']);
-                unset($aSurveyData['owner_id']);
+                //unset($aSurveyData['owner_id']);
                 unset($aSurveyData['active']);
                 unset($aSurveyData['language']);
                 unset($aSurveyData['additional_languages']);


### PR DESCRIPTION
Just thought this would be useful as we are working with a superuser anyway and there is no separate function for this.

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 