### PR TITLE
New feature: set_quota_properties via RemoteControl API

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2039,14 +2039,15 @@ class remotecontrol_handle
     }
 
     /**
-     * Toggle the status of the quota to enable/disable quota
+     * Set Quota Attributes
+     * Retuns an array containing the boolean 'success' and 'message' with either errors or Quota attributes (on success)
      * @access public
      * @param string $sSessionKey Auth credentials
      * @param integer $iQuotaId Quota ID
-     * @param boolean $enabled Whether quota is to be enabled (true) or disabled (false). Default=true
+     * @param array $aQuotaData Quota attributes as array eg ['active'=>1,'limit'=>100]
      * @return array ['success'=>bool, 'message'=>string]
      */
-    public function toggle_quota($sSessionKey, $iQuotaId, $enabled = true)
+    public function set_quota_properties($sSessionKey, $iQuotaId, $aQuotaData)
     {
         if ($this->_checkSessionKey($sSessionKey)) {
             /** @var Quota $oQuota */
@@ -2059,11 +2060,20 @@ class remotecontrol_handle
             }
             $oSurvey = $oQuota->survey;
             if (Permission::model()->hasSurveyPermission($oSurvey->sid, 'quotas', 'update')) {
-                $oQuota->active = (int) $enabled;
+
+                // don't accept id & sid
+                isset($aQuotaData['id']) ? unset($aQuotaData['id']):null;
+                isset($aQuotaData['sid']) ? unset($aQuotaData['sid']):null;
+
+                // accept boolean input also
+                isset($aQuotaData['active']) ? $aQuotaData['active'] = (int) $aQuotaData['active']:null;
+                isset($aQuotaData['autoload_url']) ? $aQuotaData['autoload_url'] = (int) $aQuotaData['autoload_url']:null;
+
+                $oQuota->attributes = $aQuotaData;
                 if(!$oQuota->save()){
                     return ['success' => false, 'message' => $oQuota->errors];
                 } else {
-                    return ['success' => true,'message'=>$oQuota->active];
+                    return ['success' => true,'message'=>$oQuota->attributes];
                 }
             } else {
                 return ['success' => false, 'message' =>'Denied!'];

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2063,7 +2063,7 @@ class remotecontrol_handle
                 if(!$oQuota->save()){
                     return ['success' => false, 'message' => $oQuota->errors];
                 } else {
-                    return ['success' => true,'active'=>$oQuota->active];
+                    return ['success' => true,'message'=>$oQuota->active];
                 }
             } else {
                 return ['success' => false, 'message' =>'Denied!'];

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2039,6 +2039,41 @@ class remotecontrol_handle
     }
 
     /**
+     * Toggle the status of the quota to enable/disable quota
+     * @access public
+     * @param string $sSessionKey Auth credentials
+     * @param integer $iQuotaId Quota ID
+     * @param boolean $enabled Whether quota is to be enabled (true) or disabled (false). Default=true
+     * @return array ['success'=>bool, 'message'=>string]
+     */
+    public function toggle_quota($sSessionKey, $iQuotaId, $enabled = true)
+    {
+        if ($this->_checkSessionKey($sSessionKey)) {
+            /** @var Quota $oQuota */
+            $oQuota = Quota::model()->findByPk($iQuotaId);
+            if (!$oQuota){
+                return [
+                    'success' => false,
+                    'message' => 'Error: Invalid quota ID'
+                ];
+            }
+            $oSurvey = $oQuota->survey;
+            if (Permission::model()->hasSurveyPermission($oSurvey->sid, 'quotas', 'update')) {
+                $oQuota->active = (int) $enabled;
+                if(!$oQuota->save()){
+                    return ['success' => false, 'message' => $oQuota->errors];
+                } else {
+                    return ['success' => true];
+                }
+            } else {
+                return ['success' => false, 'message' =>'Denied!'];
+            }
+        } else {
+            return ['success' => false, 'message' =>'Invalid session key'];
+        }
+    }
+
+    /**
     * List the survey belonging to a user
     *
     * If user is admin he can get surveys of every user (parameter sUser) or all surveys (sUser=null)

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2063,7 +2063,7 @@ class remotecontrol_handle
                 if(!$oQuota->save()){
                     return ['success' => false, 'message' => $oQuota->errors];
                 } else {
-                    return ['success' => true];
+                    return ['success' => true,'active'=>$oQuota->active];
                 }
             } else {
                 return ['success' => false, 'message' =>'Denied!'];


### PR DESCRIPTION
tested, works

Why? 
Eg: I have a external sample managing system using LS as data-collector interface for CATI. And quotas need to be "released" & reassigned sometimes from the external system. 