### PR TITLE
WIP : Fixed issue #09567: no salt used for password hashing.

### DIFF
--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -163,11 +163,15 @@ class Authdb extends AuthPluginBase
             $this->setAuthSuccess($user);
             return;
         }
-
-        if ($sStoredPassword !== hash('sha256', $password))
-        {
-            $this->setAuthFailure(self::ERROR_PASSWORD_INVALID);
-            return;
+        if(!password_verify($password,$sStoredPassword)) {
+            // It can be an old password
+            if ($sStoredPassword !== hash('sha256', $password))
+            {
+                $this->setAuthFailure(self::ERROR_PASSWORD_INVALID);
+                return;
+            }
+            // Then fix it (update)
+            $user->updatePassword($user->uid,$password);
         }
 
         $this->setAuthSuccess($user);

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -177,7 +177,7 @@ class User extends LSActiveRecord
     {
         $oUser = new self;
         $oUser->users_name = $new_user;
-        $oUser->password = hash('sha256', $new_pass);
+        $oUser->password =  password_hash($new_pass,PASSWORD_DEFAULT);
         $oUser->full_name = $new_full_name;
         $oUser->parent_id = $parent_user;
         $oUser->lang = 'auto';
@@ -192,7 +192,8 @@ class User extends LSActiveRecord
     /** @inheritdoc */
     public function beforeSave()
     {
-         // Postgres delivers bytea fields as streams :-o - if this is not done it looks like Postgres saves something unexpected
+        // Postgres delivers bytea fields as streams :-o - if this is not done it looks like Postgres saves something unexpected
+        /* Deprecated ? To confirm */
         if (gettype($this->password)=='resource') {
             $this->password=stream_get_contents($this->password,-1,0);
         }
@@ -238,7 +239,8 @@ class User extends LSActiveRecord
     public function updatePassword($iUserID, $sPassword)
     {
         // TODO should be $oUser->updatePassword($password)
-        return $this->updateByPk($iUserID, array('password' => hash('sha256', $sPassword)));
+        // Answer : no : other user can update …
+        return $this->updateByPk($iUserID, array('password' =>  password_hash($sPassword,PASSWORD_DEFAULT)));
     }
 
     /**


### PR DESCRIPTION
Dev: password_hash didn't need salt
Dev: PHP 5 >= 5.5.0, PHP 7 function
Dev: have an issue in admin/user/sa/index, must fix it before

But need to [fix User management](https://bugs.limesurvey.org/view.php?id=12814) and remove deprecated code for pgsql