### PR TITLE
Bug Fix on change password into useraction.php

### DIFF
--- a/application/controllers/admin/useraction.php
+++ b/application/controllers/admin/useraction.php
@@ -673,7 +673,7 @@ class UserAction extends Survey_Common_Action
                     Yii::app()->setFlashMessage(gT("Your new password was not saved because the passwords did not match."),'error');
 
                 //Now check if the old password matches the old password saved
-                } else if($oUserModel->password !== $oldPasswordHash){
+                } else if( (((gettype($oUserModel->password)=='resource'))?stream_get_contents($oUserModel->password,-1,0):$oUserModel->password) !== $oldPasswordHash){
                     Yii::app()->setFlashMessage(gT("Your new password was not saved because the old password was wrong."),'error');
                 
                 //At last if everything worked set the new password


### PR DESCRIPTION
When the RDBMS used is PostgreSQL, if user try to change password the action fail, because the password is a bytea fields delivered as stream.
The fix proposed is same that is used into AuthDb core plugin.

Below the references to the version where the bug was found:

Version 2.72.3+171020

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 