### PR TITLE
Fixed issue #13001: Expression Manager evaluates answers to free text…

### DIFF
--- a/application/views/survey/questions/shortfreetext/text/item.php
+++ b/application/views/survey/questions/shortfreetext/text/item.php
@@ -36,7 +36,7 @@
                 size="<?php echo $tiwidth; ?>"
                 name="<?php echo $name; ?>"
                 id="answer<?php echo $name;?>"
-                value="<?php echo $dispVal; ?>"
+                value="<?php echo str_replace(array("{","}"),array("&#123;","&#125;"),$dispVal); ?>"
                 <?php echo $maxlength; ?>
                 onkeyup="<?php echo $checkconditionFunction; ?>"
             />

--- a/application/views/survey/questions/shortfreetext/textarea/item.php
+++ b/application/views/survey/questions/shortfreetext/textarea/item.php
@@ -30,7 +30,7 @@
             cols="<?php echo $tiwidth; ?>"
             <?php echo $maxlength; ?>
             onkeyup="<?php echo $checkconditionFunction; ?>"
-        ><?php echo $dispVal; ?></textarea>
+        ><?php echo str_replace(array("{","}"),array("&#123;","&#125;"),$dispVal); ?></textarea>
 
     </div>
 </div>


### PR DESCRIPTION
Fixed issue #13001: Expression Manager evaluates answers to free text questions enclosed by "{" and "}"
- This fix this issue for short free text
- Other free text can use same system
- This don't broke EM in default value
- Using only views and don't touch to EM seems the best solution
- for develop or  master+develop (issue since 1.92 surely)