### PR TITLE
DEV: change renderinf of .ls-questionhelp icon similar to ls-question-message

### DIFF
--- a/themes/survey/bootswatch/css/theme.css
+++ b/themes/survey/bootswatch/css/theme.css
@@ -169,18 +169,8 @@ padding-top:1em;padding-bottom:1em;margin-bottom:2em;
 }
 /* little icon near the question-help */
 .ls-questionhelp{position: relative;}
-.dir-ltr .ls-questionhelp{margin-left:1.2em;}
 .dir-rtl .ls-questionhelp{margin-right:1.2em;}
 
-.ls-questionhelp:before{content:"\f059"}
-.ls-questionhelp:before {
-    display: block;
-    position:absolute;
-    font-family: FontAwesome;
-    font-size: inherit;
-    line-height: inherit;
-    height:100%;
-}
 
 /* If you want to center the icon */
 /*

--- a/themes/survey/fruity/css/theme.css
+++ b/themes/survey/fruity/css/theme.css
@@ -179,18 +179,7 @@ element.style {
 }
 /* little icon near the question-help */
 .ls-questionhelp{position: relative;}
-.dir-ltr .ls-questionhelp{margin-left:1.2em;}
 .dir-rtl .ls-questionhelp{margin-right:1.2em;}
-
-.ls-questionhelp:before{content:"\f059"}
-.ls-questionhelp:before {
-    display: block;
-    position:absolute;
-    font-family: FontAwesome;
-    font-size: inherit;
-    line-height: inherit;
-    height:100%;
-}
 
 /* If you want to center the icon */
 /*
@@ -199,12 +188,6 @@ element.style {
     margin-top:-0.7em;
 }
 */
-.dir-ltr .ls-questionhelp:before {
-    left:-1.1em;
-}
-.dir-rtl .ls-questionhelp:before {
-    right:-1.1em;
-}
 
 /**
  * Unsure part

--- a/themes/survey/vanilla/css/theme.css
+++ b/themes/survey/vanilla/css/theme.css
@@ -157,18 +157,7 @@ body {
 
 /* little icon near the question-help */
 .ls-questionhelp{position: relative;}
-.dir-ltr .ls-questionhelp{margin-left:1.2em;}
 .dir-rtl .ls-questionhelp{margin-right:1.2em;}
-
-.ls-questionhelp:before{content:"\f059"}
-.ls-questionhelp:before {
-    display: block;
-    position:absolute;
-    font-family: FontAwesome;
-    font-size: inherit;
-    line-height: inherit;
-    height:100%;
-}
 
 /* If you want to center the icon */
 /*

--- a/themes/survey/vanilla/views/subviews/survey/question_subviews/survey_question_help.twig
+++ b/themes/survey/vanilla/views/subviews/survey/question_subviews/survey_question_help.twig
@@ -21,6 +21,7 @@
 <div class="{{ aSurveyInfo.class.helpcontainer }}  text-info col-xs-12 " {{ aSurveyInfo.attr.helpcontainer }}>
     {% if aQuestion.help.show %}
         <div class="{{ aSurveyInfo.class.lsquestionhelp }}">
+            <span class="fa fa-question-circle" aria-hidden="true"></span>
             {{ aQuestion.help.text | raw }}
         </div>
     {% endif %}


### PR DESCRIPTION
The .ls-questionhelp is very similar to  .ls-question-message in essence. They look the same basically. And I like to use them both in the same place. But. one of the icons is currently rendered via html, another via CSS. which makes it difficult to use them together. 

I swithced both to html.