### PR TITLE
DEV: fix question-container.row align offset

### DIFF
--- a/themes/survey/vanilla/css/theme.css
+++ b/themes/survey/vanilla/css/theme.css
@@ -124,6 +124,10 @@ body {
   margin-bottom: 2em ;
   padding-bottom: 2em ;
 }
+.question-container.row {
+    margin-right: 0;
+    margin-left: 0;
+}
 
 .question-title-container {
   padding-top: 1em;

--- a/themes/survey/vanilla/views/subviews/navigation/ajax_indicator.twig
+++ b/themes/survey/vanilla/views/subviews/navigation/ajax_indicator.twig
@@ -1,17 +1,13 @@
-{#
-    LimeSurvey
-    Copyright (C) 2007-2017 The LimeSurvey Project Team / Louis Gac
-    All rights reserved.
-    License: GNU/GPL License v2 or later, see LICENSE.php
-    LimeSurvey is free software. This version may have been modified pursuant
-    to the GNU General Public License, and as distributed it includes or
-    is derivative of works licensed under the GNU General Public License or
-    other free or open source software licenses.
-    See COPYRIGHT.php for copyright notices and details.
-
-    (¯`·._.·(¯`·._.· Clear all links: Shows the exit button ·._.·´¯)·._.·´¯)
-
-    This file render the ajax indicator
-
-    In vanilla, this file is empty, we keep it to have a common layout between all core themes
-#}
+<script>
+    $.ajaxSetup({
+        beforeSend:function(){
+            // show gif here, eg:
+            $("#ajax-loading").show();
+        },
+        complete:function(){
+            // hide gif here, eg:
+            $("#ajax-loading").hide();
+        }
+    });
+</script>
+<div id="ajax-loading" hidden></div>


### PR DESCRIPTION
Fix the question row container going 15px offset left & right, see image:
by default the bootstrap .row has:

```
.row {
    margin-right: -15px;
    margin-left: -15px;
}
```
but for the questions it just goes out of align

![image](https://user-images.githubusercontent.com/6357451/34563684-3f8ac412-f15c-11e7-9671-529cf316f911.png)
