### PR TITLE
removed survey language switching prevention in the API (only additional languages)

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -355,7 +355,7 @@ class remotecontrol_handle
      * * Always
      *     * sid
      *     * active
-     *     * additional_languages
+     *     * language
      * * If survey is active
      *     * anonymized
      *     * datestamp
@@ -385,7 +385,7 @@ class remotecontrol_handle
                 // Remove fields that may not be modified
                 unset($aSurveyData['sid']);
                 unset($aSurveyData['active']);
-                unset($aSurveyData['additional_languages']);
+                unset($aSurveyData['language']);
                 // Remove invalid fields
                 $aDestinationFields = array_flip(Survey::model()->tableSchema->columnNames);
                 $aSurveyData = array_intersect_key($aSurveyData, $aDestinationFields);

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -355,7 +355,6 @@ class remotecontrol_handle
      * * Always
      *     * sid
      *     * active
-     *     * language
      *     * additional_languages
      * * If survey is active
      *     * anonymized
@@ -385,9 +384,7 @@ class remotecontrol_handle
             if (Permission::model()->hasSurveyPermission($iSurveyID, 'surveysettings', 'update')) {
                 // Remove fields that may not be modified
                 unset($aSurveyData['sid']);
-                //unset($aSurveyData['owner_id']);
                 unset($aSurveyData['active']);
-                unset($aSurveyData['language']);
                 unset($aSurveyData['additional_languages']);
                 // Remove invalid fields
                 $aDestinationFields = array_flip(Survey::model()->tableSchema->columnNames);


### PR DESCRIPTION
It is not necessary to block language switching as a survey owner could do this by the webinterface, too.