### PR TITLE
removed restriction regarding survey enabling/disabling via rpc-api

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -384,6 +384,7 @@ class remotecontrol_handle
             if (Permission::model()->hasSurveyPermission($iSurveyID, 'surveysettings', 'update')) {
                 // Remove fields that may not be modified
                 unset($aSurveyData['sid']);
+                if (@$aSurveyData['active'] == 'Y') unset($aSurveyData['active']);
                 unset($aSurveyData['language']);
                 unset($aSurveyData['additional_languages']);
                 // Remove invalid fields

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -354,7 +354,6 @@ class remotecontrol_handle
      * Properties available are restricted
      * * Always
      *     * sid
-     *     * active
      *     * language
      *     * additional_languages
      * * If survey is active
@@ -385,8 +384,6 @@ class remotecontrol_handle
             if (Permission::model()->hasSurveyPermission($iSurveyID, 'surveysettings', 'update')) {
                 // Remove fields that may not be modified
                 unset($aSurveyData['sid']);
-                //unset($aSurveyData['owner_id']);
-                unset($aSurveyData['active']);
                 unset($aSurveyData['language']);
                 unset($aSurveyData['additional_languages']);
                 // Remove invalid fields


### PR DESCRIPTION
This should not cause any integrity failure when disabling an active survey, but could someone more experienced with Limesurvey's structure take a look at it?
Enabling a survey could cause trouble indeed since the survey's own table does not get created this way, but when used only for disabling it should be fine, right? For that case we could change the restriction to only allow disabling, but not enabling.