### PR TITLE
DEV: fix failing tests (missing upload/themes/survey folder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ third_party/composer/installed\.json
 !.eslintignore
 !.eslint.json
 !.eslintrc.json
+!.travis.yml
 
 ## ignore Vagrantfile
 Vagrantfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_script:
       #- rm -r third_party
     - composer install
       #- composer install
+    - mkdir upload/themes
+    - mkdir upload/themes/survey
     - chmod -R 777 tmp
     - chmod -R 777 upload
     - chmod -R 777 themes  # Need 777 so both console and web server can cd into the folder.


### PR DESCRIPTION
removing the index.html files from upload/themes & upload/themes/survey caused the global settings to not open with no upload/themes/survey folder