### PR TITLE
DEV: remove duplications from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,19 @@
 # ignore CAssetManager for debugging
 /framework/web/CAssetManager.php
 
+## Ignore any hidden folder/files (except explicitly defined)
+## such as various IDE folders .idea .netbeans .vscode
+## or development environment things like .vagrant etc
+.*
+!.htaccess
+!.scrutinizer.yml
+!.bowerrc
+!.gitignore
+!.gitattributes
+!.editorconfig
+!.travis.yml
+
+
 # upload directory : whole except the index.html and readme.txt
 /upload/*
 !/upload/index.html
@@ -37,8 +50,6 @@
 /styles/
 
 #ignore most of the js-build stuff
-.eslintrc
-.eslintignore
 node_modules/
 third_party/**/docs/
 third_party/**/scripts/
@@ -59,32 +70,15 @@ chromedriver
 
 # Some global "temporary files" (see
 *~
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
 ehthumbs.db
 Thumbs.db
 
-# IDE specific
-.settings
-.project
 
 # miscellaneous
 /application/controllers/admin/updater.php
 /nbproject
-.svn
-.settings/org.eclipse.php.core.prefs
-.buildpath
 *.un~
 launch.json
-# ignore plugins directory by default except LS plugin
-# if you want to add a new distributed plugin : add the directory here
-/plugins/*
-!/plugins/index.html
-!/plugins/Demo/
-!/plugins/AuditLog/
 enabletests
 
 ## Ignore test tmp files
@@ -96,20 +90,6 @@ third_party/facebook/**/*
 third_party/symfony/**/*
 third_party/composer/installed\.json
 
-## Ignore any hidden folder/files (except explicitly defined)
-## such as various IDE folders .idea .netbeans .vscode
-## or development environment things like .vagrant etc
-.*
-!.htaccess
-!.scrutinizer.yml
-!.bowerrc
-!.gitignore
-!.gitattributes
-!.editorconfig
-!.eslintignore
-!.eslint.json
-!.eslintrc.json
-!.travis.yml
 
 ## ignore Vagrantfile
 Vagrantfile


### PR DESCRIPTION
removed the duplicate plugins section
and removed all `.` files covered by general `.*` (moved to top)