### PR TITLE
DEV: remove the model->insertRecords() methods 1

### DIFF
--- a/application/controllers/admin/database.php
+++ b/application/controllers/admin/database.php
@@ -1321,15 +1321,12 @@ class database extends Survey_Common_Action
                         $r1 = Answer::model()->getAnswers((int) returnGlobal('oldqid'));
                         $aAnswerOptions = $r1->readAll();
                         foreach ($aAnswerOptions as $qr1) {
-                            Answer::model()->insertRecords(array(
-                                'qid' => $this->iQuestionID,
-                                'code' => $qr1['code'],
-                                'answer' => $qr1['answer'],
-                                'assessment_value' => $qr1['assessment_value'],
-                                'sortorder' => $qr1['sortorder'],
-                                'language' => $qr1['language'],
-                                'scale_id' => $qr1['scale_id']
-                            ));
+                            $newAnswer = new Answer();
+                            $newAnswer->attributes = $qr1;
+                            $newAnswer->qid = $this->iQuestionID;
+                            if(!$newAnswer->save()){
+                                Yii::log(\CVarDumper::dumpAsString($newAnswer->getErrors()), 'warning', __METHOD__);
+                            }
                         }
                     }
 

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -2853,8 +2853,10 @@ function TSVImportSurvey($sFullFilePath)
                 $insertdata['language'] = (isset($row['language']) ? $row['language'] : $baselang);
                 $insertdata['assessment_value'] = (int) (isset($row['relevance']) ? $row['relevance'] : '');
                 $insertdata['sortorder'] = ++$aseq;
-                $result = Answer::model()->insertRecords($insertdata); // or safeDie("Error: Failed to insert answer<br />");
-                if (!$result) {
+                $answer = new Answer();
+                $answer->attributes = $insertdata;
+
+                if (!$answer->save()) {
                     $results['error'][] = gT("Error")." : ".gT("Could not insert answer").". ".gT("Text file row number ").$rownumber;
                 }
                 $results['answers']++;

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1711,11 +1711,19 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
                     if ($insertdata) {
                         XSSFilterArray($insertdata);
                     }
+                    $questionAttribute = new QuestionAttribute();
+                    $questionAttribute->attributes = $insertdata;
+                    if(!$questionAttribute->save()){
+                        safeDie(gT("Error").": Failed to insert data[7]<br />");
+                    }
 
-                    $result = QuestionAttribute::model()->insertRecords($insertdata) or safeDie(gT("Error").": Failed to insert data[7]<br />");
                 }
             } else {
-                $result = QuestionAttribute::model()->insertRecords($insertdata) or safeDie(gT("Error").": Failed to insert data[8]<br />");
+                $questionAttribute = new QuestionAttribute();
+                $questionAttribute->attributes = $insertdata;
+                if(!$questionAttribute->save()){
+                    safeDie(gT("Error").": Failed to insert data[8]<br />");
+                }
             }
 
             $results['question_attributes']++;
@@ -2727,19 +2735,17 @@ function TSVImportSurvey($sFullFilePath)
                             break;
                         default:
                             if ($key != '' && $val != '') {
-                                $insertdata = array();
-                                $insertdata['qid'] = $qid;
+                                $questionAttribute = new QuestionAttribute();
+                                $questionAttribute->qid = $qid;
                                 // check if attribute is a i18n attribute. If yes, set language, else set language to null in attribute table
                                 $aAttributeList[$qtype] = questionHelper::getQuestionAttributesSettings($qtype);
                                 if ($aAttributeList[$qtype][$key]['i18n']) {
-                                    $insertdata['language'] = (isset($row['language']) ? $row['language'] : $baselang);
-                                } else {
-                                    $insertdata['language'] = null;
+                                    $questionAttribute->language = (isset($row['language']) ? $row['language'] : $baselang);
                                 }
-                                $insertdata['attribute'] = $key;
-                                $insertdata['value'] = $val;
-                                $result = QuestionAttribute::model()->insertRecords($insertdata); //
-                                if (!$result) {
+                                $questionAttribute->attribute = $key;
+                                $questionAttribute->value = $val;
+
+                                if (!$questionAttribute->save()) {
                                     $results['importwarnings'][] = gT("Warning")." : ".gT("Failed to insert question attribute").". ".gT("Text file row number ").$rownumber." ({$key})";
                                     break;
                                 }

--- a/application/helpers/admin/label_helper.php
+++ b/application/helpers/admin/label_helper.php
@@ -85,19 +85,20 @@ debugbreak();
     $labelset->save();
 }
 
+/**
+ * @return LabelSet
+ */
 function insertlabelset()
 {
     $postlabel_name = flattenText(Yii::app()->getRequest()->getPost('label_name'), false, true, 'UTF-8', true);
+    $labelSet = new LabelSet();
 
-    $data = array(
-        'label_name' => $postlabel_name,
-        'languages' => sanitize_languagecodeS(implode(' ', Yii::app()->getRequest()->getPost('languageids', array('en'))))
-    );
-    $result = LabelSet::model()->insertRecords($data);
-    if (!$result) {
+    $labelSet->label_name = $postlabel_name;
+    $labelSet->languages = sanitize_languagecodeS(implode(' ', Yii::app()->getRequest()->getPost('languageids', array('en'))));
+    if (!$labelSet->save()) {
         Yii::app()->session['flashmessage'] = gT("Inserting the label set failed.");
     } else {
-        return $result;
+        return $labelSet;
     }
 }
 

--- a/application/models/Answer.php
+++ b/application/models/Answer.php
@@ -168,6 +168,8 @@ class Answer extends LSActiveRecord
     /**
      * @param array $data
      * @return boolean|null
+     * @deprecated at 2018-01-29 use $model->attributes = $data && $model->save()
+     *
      */
     public function insertRecords($data)
     {

--- a/application/models/Assessment.php
+++ b/application/models/Assessment.php
@@ -30,6 +30,15 @@
  */
 class Assessment extends LSActiveRecord
 {
+    public function init()
+    {
+        parent::init();
+        if($this->isNewRecord){
+            // default values
+            if(empty($this->scope)) $this->scope = '0';
+        }
+    }
+
     /**
      * @inheritdoc
      * @return Assessment
@@ -173,6 +182,7 @@ class Assessment extends LSActiveRecord
     /**
      * @param array $data
      * @return Assessment
+     * @deprecated use model->attributes = $data && $model->save()
      */
     public static function insertRecords($data)
     {

--- a/application/models/LabelSet.php
+++ b/application/models/LabelSet.php
@@ -99,6 +99,11 @@ class LabelSet extends LSActiveRecord
         return true;
     }
 
+    /**
+     * @param $data
+     * @return bool|int
+     * @deprecated at 2018-01-29 use $model->attributes = $data && $model->save()
+     */
     public function insertRecords($data)
     {
         $lblset = new self;

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -256,6 +256,11 @@ class QuestionAttribute extends LSActiveRecord
         return $aQuestionAttributes;
     }
 
+    /**
+     * @param $data
+     * @return bool
+     * @deprecated at 2018-01-29 use $model->attributes = $data && $model->save()
+     */
     public static function insertRecords($data)
     {
         $attrib = new self;

--- a/application/models/Quota.php
+++ b/application/models/Quota.php
@@ -104,6 +104,11 @@ class Quota extends LSActiveRecord
         );
     }
 
+    /**
+     * @param $data
+     * @return bool|int
+     * @deprecated at 2018-01-29 use $model->attributes = $data && $model->save()
+     */
     function insertRecords($data)
     {
         $quota = new self;


### PR DESCRIPTION
does not make sense
```
      foreach ($data as $k => $v) {
                    $model->$k = $v;
        }
```
there is the `$model->attributes = $array`
I'll add the `@deprecated` with a date and refactor all current usages i find