### PR TITLE
Feature: Survey default configs

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -94,6 +94,12 @@ $config['showpopups']         = 1; // Show popup messages if mandatory or condit
 
 $config['maxemails']          = 50; // The maximum number of emails to send in one go (this is to prevent your mail server or script from timeouting when sending mass mail)
 
+// Survey default settings
+$config['survey_allowprev'] = 'N';
+$config['survey_showxquestions'] = 'Y';
+$config['survey_tokenanswerspersistence'] = 'N';
+$config['survey_sendconfirmation'] = 'Y';
+
 // Experimental parameters, only change if you know what you're doing
 //
 // filterout_incomplete_answers

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -100,6 +100,9 @@ $config['survey_showxquestions'] = 'Y';
 $config['survey_tokenanswerspersistence'] = 'N';
 $config['survey_sendconfirmation'] = 'Y';
 
+// Question default settings
+$config['question_mandatory'] = 'N';
+
 // Experimental parameters, only change if you know what you're doing
 //
 // filterout_incomplete_answers

--- a/application/controllers/admin/questions.php
+++ b/application/controllers/admin/questions.php
@@ -1039,7 +1039,7 @@ class questions extends Survey_Common_Action
         $eqrow['lid1'] = 0;
         $eqrow['gid'] = null;
         $eqrow['other'] = 'N';
-        $eqrow['mandatory'] = 'N';
+        $eqrow['mandatory'] = getGlobalSetting('question_mandatory');
         $eqrow['preg'] = '';
         $eqrow['relevance'] = 1;
         $eqrow['group_name'] = '';

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -182,6 +182,10 @@ class Survey extends LSActiveRecord
             $this->googleanalyticsapikeysetting = "G";
         }
 
+        $this->allowprev = getGlobalSetting('survey_allowprev');
+        $this->showxquestions = getGlobalSetting('survey_showxquestions');
+        $this->tokenanswerspersistence = getGlobalSetting('survey_tokenanswerspersistence');
+        $this->sendconfirmation = getGlobalSetting('survey_sendconfirmation');
 
         $this->template = Template::templateNameFilter(getGlobalSetting('defaulttheme'));
         $validator = new LSYii_Validators;


### PR DESCRIPTION
Let you set some default configs for new surveys, so you don't have to change them every time you create a new survey. Also contains a default for "mandatory" setting in new questions, so you can make new questions always as mandatory if you like. 
The config file in this push still has the old defaults values.