### PR TITLE
Statistics PDF download instead of opening in current tab

### DIFF
--- a/application/controllers/admin/statistics.php
+++ b/application/controllers/admin/statistics.php
@@ -468,7 +468,7 @@ class statistics extends Survey_Common_Action
                     $statisticsoutput .= $helper->generate_html_chartjs_statistics($surveyid, $summary, $summary, $usegraph, $outputType, 'DD', $statlang);
                     break;
                 case 'pdf':
-                    $helper->generate_statistics($surveyid, $summary, $summary, $usegraph, $outputType, 'I', $statlang);
+                    $helper->generate_statistics($surveyid, $summary, $summary, $usegraph, $outputType, 'D', $statlang);
                     exit;
                     break;
                 case 'xls':


### PR DESCRIPTION
While the statistics Excel export creates a download, the PDF opens in the current tab. The backend page is not visible/accessible anymore.