### PR TITLE
Fixed issue #13001: Expression Manager evaluates answers to free text…

### DIFF
--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3264,9 +3264,9 @@ function do_shortfreetext($ia)
         $answer = doRender('/survey/questions/answer/shortfreetext/location_mapservice/item_100', $itemDatas, true);
     } else {
         //no question attribute set, use common input text field
-        $value = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
+        $dispVal = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
         if ($aQuestionAttributes['numbers_only']) {
-            $value = str_replace('.', $sSeparator, $dispVal);
+            $dispVal = str_replace('.', $sSeparator, $dispVal);
         }
         $itemDatas = array(
             'value' => $value,
@@ -3277,7 +3277,7 @@ function do_shortfreetext($ia)
             'prefix'=>$prefix,
             'suffix'=>$suffix,
             'kpclass'=>$kpclass,
-            'dispVal'=>$_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]],
+            'dispVal'=>$dispVal,
             'maxlength'=>$maxlength,
             'inputsize'              => $inputsize,
             'withColumn'             => $withColumn

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3095,12 +3095,10 @@ function do_shortfreetext($ia)
         $dispVal = "";
 
         if ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) {
-            $dispVal = str_replace("\\", "", $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]);
-
+            $dispVal = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
             if ($aQuestionAttributes['numbers_only'] == 1) {
                 $dispVal = str_replace('.', $sSeparator, $dispVal);
             }
-            $dispVal = htmlspecialchars($dispVal);
         }
 
         $answer .= doRender('/survey/questions/answer/shortfreetext/textarea/item', array(
@@ -3266,21 +3264,20 @@ function do_shortfreetext($ia)
         $answer = doRender('/survey/questions/answer/shortfreetext/location_mapservice/item_100', $itemDatas, true);
     } else {
         //no question attribute set, use common input text field
-        $dispVal = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
-        if ($aQuestionAttributes['numbers_only'] == 1) {
-            $dispVal = str_replace('.', $sSeparator, $dispVal);
+        $value = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
+        if ($aQuestionAttributes['numbers_only']) {
+            $value = str_replace('.', $sSeparator, $dispVal);
         }
-        $dispVal = htmlspecialchars($dispVal, ENT_QUOTES, 'UTF-8');
-
         $itemDatas = array(
+            'value' => $value,
+            'name'=>$ia[1],
             'extraclass'=>$extraclass,
             'coreClass'=> $coreClass,
-            'name'=>$ia[1],
             'basename'               => $ia[1],
             'prefix'=>$prefix,
             'suffix'=>$suffix,
             'kpclass'=>$kpclass,
-            'dispVal'=>$dispVal,
+            'dispVal'=>$_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]],
             'maxlength'=>$maxlength,
             'inputsize'              => $inputsize,
             'withColumn'             => $withColumn
@@ -3364,7 +3361,7 @@ function do_longfreetext($ia)
         $inputsize = null;
     }
 
-    $dispVal = ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) ?htmlspecialchars($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) : '';
+    $dispVal = ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) ? $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]] : '';
 
     $answer = doRender('/survey/questions/answer/longfreetext/answer', array(
         'extraclass'             => $extraclass,
@@ -3437,7 +3434,7 @@ function do_hugefreetext($ia)
 
     $dispVal = "";
     if ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) {
-        $dispVal = htmlspecialchars($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]);
+        $dispVal = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
     }
 
     $itemDatas = array(

--- a/application/helpers/viewHelper.php
+++ b/application/helpers/viewHelper.php
@@ -309,4 +309,14 @@ class viewHelper
         {
             return sprintf('<x-test id="action::%s"></x-test>', $name);
         }
+        /**
+         * Fix value to be shown using echo (not CHtml)
+         * @param string $value the value
+         * @return string
+         */
+        public static function getPublicDisplayTextValue($value) {
+            $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+            $value = str_replace(array("{","}"),array("&#123;","&#125;"),$value);
+            return $value;
+        }
 }

--- a/application/views/survey/questions/answer/longfreetext/answer.php
+++ b/application/views/survey/questions/answer/longfreetext/answer.php
@@ -28,7 +28,7 @@
         <?php echo ($inputsize ? 'cols="'.$inputsize.'"': '') ; ?>
         <?php echo ($maxlength ? 'maxlength='.$maxlength: ''); ?>
         aria-labelledby="ls-question-text-<?php echo $basename; ?>"
-    ><?php echo $dispVal;?></textarea>
+    ><?php echo viewHelper::getPublicDisplayTextValue($dispVal);?></textarea>
 <?php if($withColumn): ?>
     </div>
 </div>

--- a/application/views/survey/questions/answer/shortfreetext/text/item.php
+++ b/application/views/survey/questions/answer/shortfreetext/text/item.php
@@ -34,7 +34,7 @@
             type="text"
             name="<?php echo $name; ?>"
             id="answer<?php echo $name;?>"
-            value="<?php echo $dispVal; ?>"
+            value="<?php echo viewHelper::getPublicDisplayTextValue($value); ?>"
             <?php echo ($inputsize ? 'size="'.$inputsize.'"': '') ; ?>
             <?php echo ($maxlength ? 'maxlength='.$maxlength: ''); ?>
             aria-labelledby="ls-question-text-<?php echo $basename; ?>"

--- a/application/views/survey/questions/answer/shortfreetext/textarea/item.php
+++ b/application/views/survey/questions/answer/shortfreetext/textarea/item.php
@@ -36,7 +36,7 @@
                 <?php echo ($inputsize ? 'cols="'.$inputsize.'"': '') ; ?>
                 <?php echo ($maxlength ? 'maxlength='.$maxlength: ''); ?>
                 aria-labelledby="ls-question-text-<?php echo $basename; ?>"
-            ><?php echo $dispVal; ?></textarea>
+            ><?php echo viewHelper::getPublicDisplayTextValue($dispVal); ?></textarea>
 
             <!-- Suffix -->
             <?php if ($suffix !== ''): ?>


### PR DESCRIPTION
… questions enclosed by "{" and "}"
Dev: replace with encoded value : then EM don't update it
Dev: but HTML show it good (in source, shown encoded)
