### PR TITLE
Fix issue: Disable sorting in left box of ranking question.

### DIFF
--- a/assets/packages/questions/ranking/scripts/ranking.js
+++ b/assets/packages/questions/ranking/scripts/ranking.js
@@ -31,6 +31,7 @@ var RankingQuestion = function (options) {
         $('#sortable-choice-' + questionId).sortable({
             group: "sortable-" + questionId,
             ghostClass: "ls-rank-placeholder",
+            sort: false
         });
 
         $('#sortable-rank-' + questionId).sortable({


### PR DESCRIPTION
DEV: Some users where confused by this. They sorted the left box and did not understand why the required question is not accepted.
This disables sorting in the left box. Sorting into the right box still works. Also you can still remove items from the right box back into the left.