### PR TITLE
New Feature: Additional mail header for bounce mails

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -666,6 +666,7 @@ $config['bounceaccounthost'] = '';
 $config['bounceaccounttype'] = 'off';
 $config['bounceencryption'] = 'off';
 $config['bounceaccountuser'] = '';
+$config['bouncemailheader'] = '';
 
 // Question selector
 $config['defaultquestionselectormode'] = 'default';

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -250,6 +250,7 @@ class GlobalSettings extends Survey_Common_Action
         setGlobalSetting('bounceaccounttype', Yii::app()->request->getPost('bounceaccounttype', 'off'));
         setGlobalSetting('bounceencryption', Yii::app()->request->getPost('bounceencryption', 'off'));
         setGlobalSetting('bounceaccountuser', strip_tags(returnGlobal('bounceaccountuser')));
+        setGlobalSetting('bouncemailheader', strip_tags(returnGlobal('bouncemailheader')));
 
         if (returnGlobal('bounceaccountpass') != 'enteredpassword') {
             setGlobalSetting('bounceaccountpass', strip_tags(returnGlobal('bounceaccountpass')));

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1373,8 +1373,14 @@ class tokens extends Survey_Common_Action
                                                         ->createAbsoluteUrl("/survey/index", array("sid"=>$iSurveyId, "token"=>$emrow['token'], "lang"=>trim($emrow['language'])));
                     // Add some var for expression : actually only EXPIRY because : it's used in limereplacement field and have good reason to have it.
                     $fieldsarray["{EXPIRY}"] = $aData['thissurvey']["expires"];
-                    $customheaders = array('1' => "X-surveyid: ".$iSurveyId,
-                    '2' => "X-tokenid: ".$fieldsarray["{TOKEN}"]);
+                    $customheaders = array(
+                        '1' => "X-surveyid: ".$iSurveyId,
+                        '2' => "X-tokenid: ".$fieldsarray["{TOKEN}"]
+                    );
+                    if (getGlobalSetting('bouncemailheader'))
+                    {
+                        $customheaders['3'] = getGlobalSetting('bouncemailheader');
+                    }
                     global $maildebug;
                     $modsubject = $sSubject[$emrow['language']];
                     $modmessage = $sMessage[$emrow['language']];

--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -102,6 +102,10 @@ function emailTokens($iSurveyID, $aResultTokens, $sType)
 
         //mail headers
         $customheaders = array('1' => "X-surveyid: ".$iSurveyID, '2' => "X-tokenid: ".$fieldsarray["{TOKEN}"]);
+        if (getGlobalSetting('bouncemailheader'))
+        {
+            $customheaders['3'] = getGlobalSetting('bouncemailheader');
+        }
 
         global $maildebug;
 

--- a/application/views/admin/global_settings/_bounce.php
+++ b/application/views/admin/global_settings/_bounce.php
@@ -67,6 +67,12 @@
     </div>
 </div>
 
+<div class="form-group">
+    <label class=" control-label" for='bouncemailheader'><?php eT("Additional mail header:"); ?></label>
+    <div class="">
+        <input class="form-control" type='text' size='50' id='bouncemailheader' name='bouncemailheader' value="<?php echo htmlspecialchars(getGlobalSetting('bouncemailheader')); ?>" />
+    </div>
+</div>
 
 <?php if (Yii::app()->getConfig("demoMode")==true):?>
     <p><?php eT("Note: Demo mode is activated. Marked (*) settings can't be changed."); ?></p>


### PR DESCRIPTION
The email bounces we get do not contain the original header. Because of this the survey related headers (X-surveyid, X-tokenid) are missing and the bounces can not be processed. We arranged with t-systems that they include the full header if we send an additional email header.
This pull requests allows to add a custom header email header from globale settings, which fixes the issue for us. Might be useful for others too.