### PR TITLE
Fix:  JQuery in pre-defined labels Answers!

### DIFF
--- a/assets/scripts/admin/answers.js
+++ b/assets/scripts/admin/answers.js
@@ -414,10 +414,10 @@ function lsbrowser(e)
 
     $.getJSON(lspickurl,{sid:surveyid, match:1},function(json){
         var x=0;
-        // $("#labelsets").removeOption(/.*/);
+        $('#labelsets').find('option').remove();
         for (x in json)
             {
-            $('#labelsets').addOption(json[x][0],json[x][1]);
+            $("#labelsets").append($("<option></option>").attr("value", json[x][0]).text(json[x][1]));
             if (x==0){
                 remind=json[x][0];
             }


### PR DESCRIPTION
Hello , the function .addoptions not found in jquery.

In console javascript this error is send:
TypeError: $(...).selectOptions is not a function

I alter function for append function and add remove options in script.

Att.
Marcio Junior Vieira
http://www.ambientelivre.com.br

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 