### PR TITLE
Fix AuthLDAP: make multiple search bases work again.

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -260,7 +260,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
         $userentry = false;
         // try each semicolon-separated search base in order
         foreach (explode(";", $usersearchbase) as $usb) {
-            $dnsearchres = ldap_search($ldapconn, $usersearchbase, $usersearchfilter, array($mailattribute, $fullnameattribute));
+            $dnsearchres = ldap_search($ldapconn, $usb, $usersearchfilter, array($mailattribute, $fullnameattribute));
             $rescount = ldap_count_entries($ldapconn, $dnsearchres);
             if ($rescount == 1) {
                 $userentry = ldap_get_entries($ldapconn, $dnsearchres);
@@ -504,12 +504,15 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
                 $usersearchfilter = "($searchuserattribute=$username)";
             }
             // Search for the user
-            $dnsearchres = ldap_search($ldapconn, $usersearchbase, $usersearchfilter, array($searchuserattribute));
-            $rescount = ldap_count_entries($ldapconn, $dnsearchres);
-            if ($rescount == 1) {
-                $userentry = ldap_get_entries($ldapconn, $dnsearchres);
-                $userdn = $userentry[0]["dn"];
-            } else {
+            foreach (explode(";", $usersearchbase) as $usb) {
+                $dnsearchres = ldap_search($ldapconn, $usb, $usersearchfilter, array($searchuserattribute));
+                $rescount = ldap_count_entries($ldapconn, $dnsearchres);
+                if ($rescount == 1) {
+                    $userentry = ldap_get_entries($ldapconn, $dnsearchres);
+                    $userdn = $userentry[0]["dn"];
+                }
+            }
+            if(!$userentry) {
                 // if no entry or more than one entry returned
                 // then deny authentication
                 $this->setAuthFailure(self::ERROR_USERNAME_INVALID);


### PR DESCRIPTION
Currently AuthLDAP does *not* work with multiple search bases.

This commit fixes the typo on account creation and searches through all
base DNs for login.

We use multiple base DNs, I'm looking into upgrading to a current version, but somewhere in between the one we use and current head this broke.
