### PR TITLE
Deactivate, deactivedebugging.js

### DIFF
--- a/assets/scripts/deactivatedebug.js
+++ b/assets/scripts/deactivatedebug.js
@@ -1,6 +1,0 @@
-var dummyConsole = {
-    log : function(){},
-    error : function(){}
-};
-console = dummyConsole;
-window.console = dummyConsole;


### PR DESCRIPTION
Not sure why this is. This is horrible and not even the correct way to disable debugging. Other scripts would not work for example the Facebook tracking pixel. It tries to bind on an undefined function for example. 

Dev: @xvilo