### PR TITLE
Reflect all available console functions in deactivatedebug.js

### DIFF
--- a/assets/scripts/deactivatedebug.js
+++ b/assets/scripts/deactivatedebug.js
@@ -1,6 +1,8 @@
-var dummyConsole = {
-    log : function(){},
-    error : function(){}
-};
+var dummyConsole = {};
+var realConsole = console || window.console
+for (var consoleFunction in realConsole) {
+    dummyConsole[consoleFunction] = function(){};
+}
+
 console = dummyConsole;
 window.console = dummyConsole;


### PR DESCRIPTION
Some scripts make use of other console functions than ` log` and `error`. These scripts kinda depend on those other functions to exist (like `console.warn` in the Facebook tracking pixel script) and therefor these other scripts will break if those functions don't exist.

Since the idea is to completely disable the `console` when debugging is disabled, the entire console should me mocked.