### PR TITLE
Usage of Expression in theme [All done]

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -227,6 +227,7 @@ $internalConfig = array(
                 'unregisterScriptForAjax' => 'LS_Twig_Extension::unregisterScriptForAjax',
                 'listCoreScripts'         => 'LS_Twig_Extension::listCoreScripts',
                 'listScriptFiles'         => 'LS_Twig_Extension::listScriptFiles',
+                'processString'           => 'LS_Twig_Extension::processString',
                 'getAllQuestionClasses'   => 'LS_Twig_Extension::getAllQuestionClasses',
                 'intval'                  => 'intval',
                 'empty'                   => 'empty',
@@ -271,7 +272,7 @@ $internalConfig = array(
                     'Question' => array('qid', 'parent_qid', 'sid', 'gid', 'type', 'title', 'question', 'help', 'other', 'mandatory', 'language', 'scale_qid'),
                     'QuestionGroups' => array('gid', 'sid', 'group_name', 'group_order', 'description', 'language', 'randomization_group', 'grelevance')
                 ),
-                'functions' => array('include', 'dump', 'flatEllipsizeText', 'getLanguageData', 'array_flip', 'array_intersect_key', 'registerPublicCssFile', 'registerTemplateCssFile', 'registerGeneralScript', 'registerTemplateScript', 'registerScript', 'registerPackage', 'unregisterPackage', 'registerCssFile', 'registerScriptFile', 'unregisterScriptFile', 'unregisterScriptForAjax', 'listCoreScripts', 'listScriptFiles', 'getAllQuestionClasses', 'intval', 'count', 'empty', 'reset', 'renderCaptcha', 'getPost', 'getParam', 'getQuery', 'isset', 'str_replace', 'assetPublish', 'image', 'imageSrc', 'sprintf', 'gT', 'ngT', 'createUrl', 'json_decode', 'json_encode'),
+                'functions' => array('include', 'dump', 'flatEllipsizeText', 'getLanguageData', 'array_flip', 'array_intersect_key', 'registerPublicCssFile', 'registerTemplateCssFile', 'registerGeneralScript', 'registerTemplateScript', 'registerScript', 'registerPackage', 'unregisterPackage', 'registerCssFile', 'registerScriptFile', 'unregisterScriptFile', 'unregisterScriptForAjax', 'listCoreScripts', 'listScriptFiles', 'processString', 'getAllQuestionClasses', 'intval', 'count', 'empty', 'reset', 'renderCaptcha', 'getPost', 'getParam', 'getQuery', 'isset', 'str_replace', 'assetPublish', 'image', 'imageSrc', 'sprintf', 'gT', 'ngT', 'createUrl', 'json_decode', 'json_encode'),
             ),
 
         ),

--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -40,11 +40,10 @@ class LSETwigViewRenderer extends ETwigViewRenderer
             if ($oLayoutTemplate) {
                 $line       = file_get_contents($oLayoutTemplate->viewPath.$sLayout);
                 $sHtml      = $this->convertTwigToHtml($line, $aDatas, $oTemplate);
-                if(isset($aDatas['step'])) {
-                    /* If step is set : we need EM javascript added */
+                if(LimeExpressionManager::isInitialized()) {
+                    /* If LimeExpressionManager is Initialized : we need EM javascript added */
                     /* And this js must be added after all html read to allow usage of EM in template */
-                    $step = $aDatas['step'];
-                    $LEMskipReprocessing = $aDatas['LEMskipReprocessing'];
+                    $LEMskipReprocessing = isset($aDatas['LEMskipReprocessing']) ? $aDatas['LEMskipReprocessing'] : false;
                     LimeExpressionManager::FinishProcessingGroup($LEMskipReprocessing);
                     $aScriptsAndHiddenInputs = LimeExpressionManager::GetRelevanceAndTailoringJavaScript(true);
                     $sScripts = implode('', $aScriptsAndHiddenInputs['scripts']);

--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -40,21 +40,9 @@ class LSETwigViewRenderer extends ETwigViewRenderer
             if ($oLayoutTemplate) {
                 $line       = file_get_contents($oLayoutTemplate->viewPath.$sLayout);
                 $sHtml      = $this->convertTwigToHtml($line, $aDatas, $oTemplate);
-                if(LimeExpressionManager::isInitialized()) {
-                    /* If LimeExpressionManager is Initialized : we need EM javascript added */
-                    /* And this js must be added after all html read to allow usage of EM in template */
-                    $LEMskipReprocessing = isset($aDatas['LEMskipReprocessing']) ? $aDatas['LEMskipReprocessing'] : false;
-                    LimeExpressionManager::FinishProcessingGroup($LEMskipReprocessing);
-                    $aScriptsAndHiddenInputs = LimeExpressionManager::GetRelevanceAndTailoringJavaScript(true);
-                    $sScripts = implode('', $aScriptsAndHiddenInputs['scripts']);
-                    Yii::app()->clientScript->registerScript('lemscripts', $sScripts, CClientScript::POS_BEGIN);
-                    $sHiddenInputs = implode('', $aScriptsAndHiddenInputs['inputs']);
-                    $sHtml = str_replace("<!-- emScriptsAndHiddenInputs -->","<!-- emScriptsAndHiddenInputs updated -->\n".$sHiddenInputs,$sHtml);
-                    /* @TODO : remove usage of "<!-- emScriptsAndHiddenInputs -->" : directly add even if template don't have aSurveyInfo.EM.ScriptsAndHiddenInputs */
-                    /* Add it at end of form ( replace </form>) ? */
-                    Yii::app()->clientScript->registerScript('triggerEmRelevance', "triggerEmRelevance();", CClientScript::POS_END);
-                    Yii::app()->clientScript->registerScript('updateMandatoryErrorClass', "updateMandatoryErrorClass();", CClientScript::POS_END); /* Maybe only if we have mandatory error ?*/
-                    LimeExpressionManager::FinishProcessingPage();
+                $sEmHiddenInputs = LimeExpressionManager::FinishProcessPublicPage();
+                if($sEmHiddenInputs) {
+                    $sHtml = str_replace("<!-- emScriptsAndHiddenInputs -->","<!-- emScriptsAndHiddenInputs updated -->\n".$sEmHiddenInputs,$sHtml);
                 }
                 if ($bReturn) {
                     return $sHtml;

--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -50,8 +50,9 @@ class LSETwigViewRenderer extends ETwigViewRenderer
                     $sScripts = implode('', $aScriptsAndHiddenInputs['scripts']);
                     Yii::app()->clientScript->registerScript('lemscripts', $sScripts, CClientScript::POS_BEGIN);
                     $sHiddenInputs = implode('', $aScriptsAndHiddenInputs['inputs']);
-                    /* Maybe using some str_replace("<!-- EM Hidden Inputs -->",$sHiddenInputs,$sHtml); Unsure of usage without javascript ?*/
-                    Yii::app()->clientScript->registerScript('lemHiddenInputs','$("#limesurvey").append('.json_encode($sHiddenInputs).');',CClientScript::POS_BEGIN);
+                    $sHtml = str_replace("<!-- emScriptsAndHiddenInputs -->","<!-- emScriptsAndHiddenInputs updated -->\n".$sHiddenInputs,$sHtml);
+                    /* @TODO : remove usage of "<!-- emScriptsAndHiddenInputs -->" : directly add even if template don't have aSurveyInfo.EM.ScriptsAndHiddenInputs */
+                    /* Add it at end of form ( replace </form>) ? */
                     Yii::app()->clientScript->registerScript('triggerEmRelevance', "triggerEmRelevance();", CClientScript::POS_END);
                     Yii::app()->clientScript->registerScript('updateMandatoryErrorClass', "updateMandatoryErrorClass();", CClientScript::POS_END); /* Maybe only if we have mandatory error ?*/
                     LimeExpressionManager::FinishProcessingPage();

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -396,4 +396,16 @@ class LS_Twig_Extension extends Twig_Extension
         }
     }
 
+    /**
+     * Process any string with current page
+     * @param string to be processed
+     * @param boolean $static return static string (or not)
+     * @param integer $numRecursionLevels recursion (max) level to do
+     * @param array $aReplacement replacement out of EM
+     * @return string
+     */
+    public static function processString($string,$static=false,$numRecursionLevels=3,$aReplacement = array())
+    {
+        return LimeExpressionManager::ProcessStepString($string, $aReplacement,$numRecursionLevels, $static);
+    }
 }

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -406,6 +406,13 @@ class LS_Twig_Extension extends Twig_Extension
      */
     public static function processString($string,$static=false,$numRecursionLevels=3,$aReplacement = array())
     {
+        if(!is_string($string)) {
+            /* Add some errors in template editor , see #13532 too */
+            if(Yii::app()->getController()->getId() == 'admin' && Yii::app()->getController()->getAction()->getId() == 'themes') {
+                Yii::app()->setFlashMessage(gT("Usage of processString without a string in your template"),'error');
+            }
+            return;
+        }
         return LimeExpressionManager::ProcessStepString($string, $aReplacement,$numRecursionLevels, $static);
     }
 }

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -121,8 +121,6 @@ class SurveyRuntimeHelper
 
         $this->fixMaxStep();
 
-        /* Update Survey text after move : get current (static) value (TODO : find the solution to get javascripted EM) */
-        $this->processSurveyText();
         //******************************************************************************************************
         //PRESENT SURVEY
         //******************************************************************************************************
@@ -131,7 +129,7 @@ class SurveyRuntimeHelper
 
         Yii::app()->loadHelper('qanda');
         setNoAnswerMode($this->aSurveyInfo);
-
+        
         //Iterate through the questions about to be displayed:
         $inputnames = array();
         $vpopup     = $fpopup = false;
@@ -260,7 +258,6 @@ class SurveyRuntimeHelper
         }
 
         sendCacheHeaders();
-
         Yii::app()->loadHelper('surveytranslator');
 
         $this->aSurveyInfo['upload_file'] = $upload_file;
@@ -307,9 +304,9 @@ class SurveyRuntimeHelper
             $aGroup           = array();
             $groupname        = $gl['group_name'];
             // TODO: Add standard replacement fields to group name and description?
-            $groupname        = LimeExpressionManager::ProcessString($groupname, null, null, 3, 1, false, true, false);
+            $groupname        = $this->processString($groupname);
             $groupdescription = $gl['description'];
-            $groupdescription = LimeExpressionManager::ProcessString($groupdescription, null, null, 3, 1, false, true, false);
+            $groupdescription = $this->processString($groupdescription);
 
             if ($this->sSurveyMode != 'survey') {
                 $onlyThisGID = $this->aStepInfo['gid'];
@@ -328,7 +325,7 @@ class SurveyRuntimeHelper
                 $aGroup['class'] = ' ls-hidden';
             }
 
-            $aGroup['name']        = LimeExpressionManager::ProcessString($gl['group_name'], null, null, 3, 1, false, true, false);
+            $aGroup['name']        = $this->ProcessString($gl['group_name']);
             $aGroup['gseq']        = $_gseq;
             $showgroupinfo_global_ = getGlobalSetting('showgroupinfo');
             $aSurveyinfo           = getSurveyInfo($this->iSurveyid, App()->getLanguage());
@@ -343,9 +340,8 @@ class SurveyRuntimeHelper
             $showgroupdesc_ = $showgroupinfo_ == 'B' /* both */ || $showgroupinfo_ == 'D'; /* (group-) description */
 
             $aGroup['showgroupinfo'] = $showgroupinfo_;
-            $aGroup['showdescription']  = (!$this->previewquestion && trim($redata['groupdescription']) != "" && $showgroupdesc_);
-            $aGroup['description']      = $redata['groupdescription'];
-
+            $aGroup['description']      = $this->processString($gl['description']);
+            $aGroup['showdescription']  = (!$this->previewquestion && trim($aGroup['description']) != "" && $showgroupdesc_);
             // one entry per QID
             foreach ($qanda as $qa) {
 
@@ -420,11 +416,12 @@ class SurveyRuntimeHelper
                 $this->aSurveyInfo['aGroups'][$gid] = $aGroup;
             }
         }
-
         /**
          *  Expression Manager Scrips and inputs
          */
         $step = isset($_SESSION[$this->LEMsessid]['step']) ? $_SESSION[$this->LEMsessid]['step'] : '';
+        /* Update Survey text after move : get current value */
+        $this->processSurveyText();
         LimeExpressionManager::FinishProcessingGroup($this->LEMskipReprocessing);
         $aScriptsAndHiddenInputs = LimeExpressionManager::GetRelevanceAndTailoringJavaScript(true);
         $sScripts = implode('', $aScriptsAndHiddenInputs['scripts']);
@@ -537,10 +534,10 @@ class SurveyRuntimeHelper
      */
     private function initMove()
     {
+        $this->processSurveyText(); // Basic replacement, needed for all page
         $this->initFirstStep(); // If it's the first time user load this survey, will init session and LEM
         $this->initTotalAndMaxSteps();
         $this->checkIfUseBrowserNav(); // Check if user used browser navigation, or relaoded page
-        $this->processSurveyText(); // Basic replacement (can be need to be updated)
         if ($this->sMove != 'clearcancel' && $this->sMove != 'confirmquota') {
             $this->checkPrevStep(); // Check if prev step is set, else set it
             $this->setMoveResult();
@@ -557,9 +554,8 @@ class SurveyRuntimeHelper
             if ($_SESSION[$this->LEMsessid]['step'] == 0) {
                 $this->bShowEmptyGroup = true;
             }
-
         }
-
+        
     }
 
 
@@ -966,13 +962,13 @@ class SurveyRuntimeHelper
      */
     private function processSurveyText()
     {
-            $this->aSurveyInfo['name']                      = $this->processString($this->aSurveyInfo['name']);
-            $this->aSurveyInfo['description']               = $this->processString($this->aSurveyInfo['description']);
-            $this->aSurveyInfo['welcome']                   = $this->processString($this->aSurveyInfo['welcome']) ;
-            $this->aSurveyInfo['datasecurity_notice']       = $this->processString($this->aSurveyInfo['datasecurity_notice']) ;
-            $this->aSurveyInfo['datasecurity_error']        = $this->processString($this->aSurveyInfo['datasecurity_error']) ;
-            $this->aSurveyInfo['datasecurity_notice_label'] = Survey::replacePolicyLink($this->aSurveyInfo['datasecurity_notice_label'],$this->aSurveyInfo['sid']);
-            $this->aSurveyInfo['datasecurity_notice_label'] = $this->processString($this->aSurveyInfo['datasecurity_notice_label']) ;
+        $this->aSurveyInfo['name']                      = $this->processString($this->aSurveyInfo['surveyls_title']);
+        $this->aSurveyInfo['description']               = $this->processString($this->aSurveyInfo['surveyls_description']);
+        $this->aSurveyInfo['welcome']                   = $this->processString($this->aSurveyInfo['surveyls_welcometext']) ;
+        $this->aSurveyInfo['datasecurity_notice']       = $this->processString($this->aSurveyInfo['surveyls_policy_notice']) ;
+        $this->aSurveyInfo['datasecurity_error']        = $this->processString($this->aSurveyInfo['surveyls_policy_error']) ;
+        $this->aSurveyInfo['datasecurity_notice_label'] = Survey::replacePolicyLink($this->aSurveyInfo['surveyls_policy_notice_label'],$this->aSurveyInfo['sid']);
+        $this->aSurveyInfo['datasecurity_notice_label'] = $this->processString($this->aSurveyInfo['datasecurity_notice_label']) ;
     }
 
     private function checkForDataSecurityAccepted(){
@@ -1246,7 +1242,7 @@ class SurveyRuntimeHelper
         if((strpos($sProcessedString, "{") !== false)){
             // process string anyway so that it can be pretty-printed
             $aStandardsReplacementFields = getStandardsReplacementFields($this->aSurveyInfo);
-            $sProcessedString = LimeExpressionManager::ProcessString( $sString, null, $aStandardsReplacementFields, $iRecursionLevel);
+            $sProcessedString = LimeExpressionManager::ProcessStepString( $sString, $aStandardsReplacementFields, $iRecursionLevel);
         }
         return $sProcessedString;
     }

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -416,6 +416,7 @@ class SurveyRuntimeHelper
          *  Expression Manager Scrips and inputs
          */
         $step = isset($_SESSION[$this->LEMsessid]['step']) ? $_SESSION[$this->LEMsessid]['step'] : '';
+        $this->aSurveyInfo['EM']['ScriptsAndHiddenInputs'] = "<!-- emScriptsAndHiddenInputs -->";
         /**
          * Navigator
          */

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -7213,7 +7213,6 @@
         */
         public static function GetRelevanceAndTailoringJavaScript($bReturnArray=false)
         {
-            tracevar('GetRelevanceAndTailoringJavaScript');
             $aQuestionsWithDependencies = array();
             $now = microtime(true);
             $LEM =& LimeExpressionManager::singleton();

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -7215,6 +7215,28 @@
             $_SESSION['LEMsingleton']=serialize($LEM);
         }
 
+        /**
+         * End public HTML
+         * @return string|null : hidden inputs needed for relevance
+         * @todo : add directly hidden input in page without return it.
+         */
+        public static function FinishProcessPublicPage()
+        {
+            if(self::isInitialized()) {
+                $LEM =& LimeExpressionManager::singleton();
+                /* Replace FinishProcessingGroup directly : always needed (in all in one too, and needed at end only (after all html are processed for Expression)) */
+                $LEM->pageTailorInfo[] = $LEM->em->GetCurrentSubstitutionInfo();
+                $LEM->pageRelevanceInfo[] = $LEM->groupRelevanceInfo;
+                $aScriptsAndHiddenInputs = self::GetRelevanceAndTailoringJavaScript(true);
+                $sScripts = implode('', $aScriptsAndHiddenInputs['scripts']);
+                Yii::app()->clientScript->registerScript('lemscripts', $sScripts, CClientScript::POS_BEGIN);
+                $sHiddenInputs = implode('', $aScriptsAndHiddenInputs['inputs']);
+                Yii::app()->clientScript->registerScript('triggerEmRelevance', "triggerEmRelevance();", CClientScript::POS_END);
+                Yii::app()->clientScript->registerScript('updateMandatoryErrorClass', "updateMandatoryErrorClass();", CClientScript::POS_END); /* Maybe only if we have mandatory error ?*/
+                $LEM->FinishProcessingPage();
+                return $sHiddenInputs;
+            }
+        }
         /*
         * Generate JavaScript needed to do dynamic relevance and tailoring
         * Also create list of variables that need to be declared

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -7178,6 +7178,15 @@
         }
 
         /**
+         * Did LEM is currently initialized
+         * @return boolean
+         */
+        public static function isInitialized ()
+        {
+            $LEM =& LimeExpressionManager::singleton();
+            return $LEM->initialized;
+        }
+        /**
         * Should be called at end of each page
         * @return void
         */

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4484,7 +4484,6 @@
             }
             $stringToParse = $string;   // decode called later htmlspecialchars_decode($string,ENT_QUOTES);
             $qnum = is_null($questionNum) ? 0 : $questionNum;
-
             $result = $LEM->em->sProcessStringContainingExpressions($stringToParse,$qnum, $numRecursionLevels, $whichPrettyPrintIteration, $groupSeq, $questionSeq, $staticReplacement);
 
             if ($timeit) {
@@ -4497,13 +4496,16 @@
         /**
         * Translate all Expressions, Macros, registered variables, etc. in $string for current step
         * @param string $string - the string to be replaced
-        * @param array|null $replacementFields - optional replacement values
+        * @param array $replacementFields - optional replacement values
         * @param integer $numRecursionLevels - the number of times to recursively subtitute values in this string
-        * @param integer $whichPrettyPrintIteration - if want to pretty-print the source string, which recursion  level should be pretty-printed ( I don't know the usage (Shnoulle 2018-03-23))
+        * @param boolean $static - return static string (without any javascript)
         * @return string - the original $string with all replacements done.
         */
-        static function ProcessStepString($string, $replacementFields=array(), $numRecursionLevels=1, $whichPrettyPrintIteration=1)
+        public static function ProcessStepString($string, $replacementFields=array(), $numRecursionLevels=3, $static=false)
         {
+            if((strpos($string, "{") === false)){
+                return $string;
+            }
             $LEM =& LimeExpressionManager::singleton();
 
             // Fill tempVars if needed
@@ -4535,9 +4537,10 @@
                 }
             }
             // Replace in string
-            $string = $LEM->em->sProcessStringContainingExpressions($string,$qid, $numRecursionLevels, $whichPrettyPrintIteration, $groupSeq, $questionSeq);
+            $string = $LEM->em->sProcessStringContainingExpressions($string,$qid, $numRecursionLevels, 1, $groupSeq, $questionSeq,$static);
             return $string;
         }
+
         /**
         * Compute Relevance, processing $eqn to get a boolean value.  If there are syntax errors, return false.
         * @param string $eqn - the relevance equation
@@ -7210,6 +7213,7 @@
         */
         public static function GetRelevanceAndTailoringJavaScript($bReturnArray=false)
         {
+            tracevar('GetRelevanceAndTailoringJavaScript');
             $aQuestionsWithDependencies = array();
             $now = microtime(true);
             $LEM =& LimeExpressionManager::singleton();

--- a/themes/survey/vanilla/views/subviews/header/head.twig
+++ b/themes/survey/vanilla/views/subviews/header/head.twig
@@ -30,7 +30,7 @@
     {{ aSurveyInfo.metas }}
 
     <title>
-        {{ aSurveyInfo.surveyls_title }}
+        {{ processString(aSurveyInfo.surveyls_title,1) }}
     </title>
 
     <link rel="shortcut icon" href="{{ aSurveyInfo.oTemplate.sTemplateurl }}files/favicon.ico" />

--- a/themes/survey/vanilla/views/subviews/messages/welcome.twig
+++ b/themes/survey/vanilla/views/subviews/messages/welcome.twig
@@ -26,17 +26,17 @@
 
     <!-- Survey Name -->
     <h1 class="{{ aSurveyInfo.class.surveyname }} text-center" {{ aSurveyInfo.attr.surveyname }} >
-        {{ aSurveyInfo.name }}
+        {{ processString(aSurveyInfo.name,1) }}
     </h1>
 
     <!-- Survey description -->
     <div class="{{ aSurveyInfo.class.description }} text-info text-center" {{ aSurveyInfo.attr.description }}>
-        {{ aSurveyInfo.description }}
+        {{ processString(aSurveyInfo.description,1) }}
     </div>
 
     <!-- Welcome text -->
     <div class="{{ aSurveyInfo.class.welcome }} h4 text-primary" {{ aSurveyInfo.attr.welcome }}>
-        {{ aSurveyInfo.welcome }}
+        {{ processString(aSurveyInfo.welcome,1) }}
     </div>
 
     <!-- Question count -->

--- a/themes/survey/vanilla/views/subviews/survey/group_subviews/group_desc.twig
+++ b/themes/survey/vanilla/views/subviews/survey/group_subviews/group_desc.twig
@@ -22,7 +22,7 @@
     {% if aGroup.description != '' %}
         <!-- Group description -->
         <div class="{{ aSurveyInfo.class.groupdesc }} row well space-col" {{ aSurveyInfo.attr.groupdesc }}>
-            {{ aGroup.description }}
+            {{ processString(aGroup.description) }}
         </div>
     {% endif %}
 {% endif %}

--- a/themes/survey/vanilla/views/subviews/survey/group_subviews/group_name.twig
+++ b/themes/survey/vanilla/views/subviews/survey/group_subviews/group_name.twig
@@ -21,6 +21,6 @@
 <!-- Group Name -->
 {% if aGroup.showgroupinfo == 'N' or aGroup.showgroupinfo == 'B' %}
     <div class="{{ aSurveyInfo.class.grouptitle }} text-center h3 space-col" {{ aSurveyInfo.attr.grouptitle }}>
-        {{ aGroup.name }}
+        {{ processString(aGroup.name) }}
     </div>
 {% endif %}


### PR DESCRIPTION
Fixed issue #13533 : Unable to use Expression Manager inside template 
Fixed issue #13529 : Survey/Group text with exppression are not updated via javascript

This leave choice for Theme developper, currently seems group descriptin must be added but can remove Survey title : less used.

Theme developer can use Expression like this `{{ processString(Expresssion) }}` expression can come from existing object 
exemples 

- `processString(aSurveyInfo.surveyls_title)` 
- `processString('{strip_tags(TOKEN:ATTRIBUTE_1)}')`

Purpose is to replace existing system and workaround already existing in template.


- [x] Move function to EM
- [x] Test group by group
- [x] Test question by question
- [x] Test all in one
- [x] Test other page (save, clearall)