### PR TITLE
Fixed issue #13540: Panel integration add url parameter doesn't show any target question

### DIFF
--- a/application/views/admin/survey/subview/accordion/_integration_panel.php
+++ b/application/views/admin/survey/subview/accordion/_integration_panel.php
@@ -54,6 +54,6 @@ echo viewHelper::getViewTestTag('surveyPanelIntegration');
     var sAddParam = '".gT('Add URL parameter','js')."';  
     var sEditParam = '".gT('Edit URL parameter','js')."';  
     var iSurveyId = '".$surveyid."';  
-    var questionArray = JSON.parse('".json_encode($questions)."');  
+    var questionArray = JSON.parse('".str_replace('\"',"\\\\\"",json_encode($questions))."');  
     ", LSYii_ClientScript::POS_BEGIN ); 
 ?> 


### PR DESCRIPTION
https://bugs.limesurvey.org/view.php?id=13540

Problem was with questions using relevance that had \"Y\" inside. The \" needs to be further escaped