### PR TITLE
Rollback #812

### DIFF
--- a/application/helpers/globals.php
+++ b/application/helpers/globals.php
@@ -29,5 +29,5 @@
         if(isset($trace['file'],$trace['line']) && strpos($trace['file'],YII_PATH)!==0) {
             $msg = $trace['file'].' ('.$trace['line']."):\n" . $msg;
         }
-        Yii::log($msg, 'trace', 'vardump');
+        Yii::trace($msg, 'vardump');
     }


### PR DESCRIPTION
As mention in the PR https://github.com/LimeSurvey/LimeSurvey/pull/812#issuecomment-380826565, this introduce a regression and always display trace even if `debug = 0`.

I think we should tag a new 2.X version for this.

Thanks again guys.

