### PR TITLE
Fixed issue #13599:  Table user_in_groups not cleaned

### DIFF
--- a/application/controllers/admin/checkintegrity.php
+++ b/application/controllers/admin/checkintegrity.php
@@ -134,6 +134,10 @@ class CheckIntegrity extends Survey_Common_Action
                 $aData = $this->_deleteGroups($aDelete['groups'], $aData);
             }
 
+            if (isset($aDelete['user_in_groups'])) {
+                $aData = $this->_deleteUserInGroups($aDelete['user_in_groups'], $aData);
+            }
+
             if (isset($aDelete['orphansurveytables'])) {
                 $aData = $this->_dropOrphanSurveyTables($aDelete['orphansurveytables'], $aData);
             }
@@ -179,6 +183,23 @@ class CheckIntegrity extends Survey_Common_Action
         }
         $aData['messages'][] = sprintf(gT('Deleting groups: %u groups deleted'), count($groups));
 
+        return $aData;
+    }
+
+    private function _deleteUserInGroups(array $userInGroups, array $aData)
+    {
+        $gids = array();
+        foreach ($userInGroups as $group) {
+            $gids[] = $group['ugid'];
+        }
+
+        $criteria = new CDbCriteria;
+        $criteria->addInCondition('ugid', $gids);
+        $model = UserInGroup::model();
+        $deletedRows = UserInGroup::model()->deleteAll($criteria);
+        if ($deletedRows === count($userInGroups)) {
+            $aData['messages'][] = sprintf(gT('Deleting groups: %u groups deleted'), count($userInGroups));
+        }
         return $aData;
     }
 
@@ -357,7 +378,7 @@ class CheckIntegrity extends Survey_Common_Action
     /**
      * This function checks the LimeSurvey database for logical consistency and returns an according array
      * containing all issues in the particular tables.
-     * @returns Array with all found issues.
+     * @returns array Array with all found issues.
      */
     protected function _checkintegrity()
     {
@@ -667,6 +688,18 @@ class CheckIntegrity extends Survey_Common_Action
         /** @var QuestionGroup $group */
         foreach ($groups as $group) {
             $aDelete['groups'][] = array('gid' => $group['gid'], 'reason' => gT('There is no matching survey.').' SID:'.$group['sid']);
+        }
+
+        /**********************************************************************/
+        /*     Check orphan user_in_groups                                    */
+        /**********************************************************************/
+        $oCriteria = new CDbCriteria;
+        $oCriteria->join = 'LEFT JOIN {{user_groups}} ug ON t.ugid=ug.ugid';
+        $oCriteria->condition = '(ug.ugid IS NULL)';
+        $userInGroups = UserInGroup::model()->findAll($oCriteria);
+        /** @var UserInGroup[] $userInGroups */
+        foreach ($userInGroups as $userInGroup) {
+            $aDelete['user_in_groups'][] = array('ugid' => $userInGroup->ugid, 'reason' => gT('There is no matching user group.').' ID:'.$userInGroup->ugid);
         }
 
         /**********************************************************************/

--- a/application/controllers/admin/checkintegrity.php
+++ b/application/controllers/admin/checkintegrity.php
@@ -188,14 +188,13 @@ class CheckIntegrity extends Survey_Common_Action
 
     private function _deleteUserInGroups(array $userInGroups, array $aData)
     {
-        $gids = array();
+        $ugids = array();
         foreach ($userInGroups as $group) {
-            $gids[] = $group['ugid'];
+            $ugids[] = $group['ugid'];
         }
 
         $criteria = new CDbCriteria;
-        $criteria->addInCondition('ugid', $gids);
-        $model = UserInGroup::model();
+        $criteria->addInCondition('ugid', $ugids);
         $deletedRows = UserInGroup::model()->deleteAll($criteria);
         if ($deletedRows === count($userInGroups)) {
             $aData['messages'][] = sprintf(gT('Deleting groups: %u groups deleted'), count($userInGroups));

--- a/application/controllers/admin/checkintegrity.php
+++ b/application/controllers/admin/checkintegrity.php
@@ -698,7 +698,7 @@ class CheckIntegrity extends Survey_Common_Action
         $userInGroups = UserInGroup::model()->findAll($oCriteria);
         /** @var UserInGroup[] $userInGroups */
         foreach ($userInGroups as $userInGroup) {
-            $aDelete['user_in_groups'][] = array('ugid' => $userInGroup->ugid, 'reason' => gT('There is no matching user group.').' ID:'.$userInGroup->ugid);
+            $aDelete['user_in_groups'][] = array('ugid' => $userInGroup->ugid,'uid' => $userInGroup->uid, 'reason' => sprintf(gT('There is no matching user %s in group %s.'),$userInGroup->uid,$userInGroup->ugid));
         }
 
         /**********************************************************************/

--- a/application/controllers/admin/checkintegrity.php
+++ b/application/controllers/admin/checkintegrity.php
@@ -197,7 +197,7 @@ class CheckIntegrity extends Survey_Common_Action
         $criteria->addInCondition('ugid', $ugids);
         $deletedRows = UserInGroup::model()->deleteAll($criteria);
         if ($deletedRows === count($userInGroups)) {
-            $aData['messages'][] = sprintf(gT('Deleting groups: %u groups deleted'), count($userInGroups));
+            $aData['messages'][] = sprintf(gT('Deleting orphaned user group assignments: %u assignments deleted'), count($userInGroups));
         }
         return $aData;
     }

--- a/application/controllers/admin/checkintegrity.php
+++ b/application/controllers/admin/checkintegrity.php
@@ -178,6 +178,7 @@ class CheckIntegrity extends Survey_Common_Action
         $criteria = new CDbCriteria;
         $criteria->addInCondition('gid', $gids);
         QuestionGroup::model()->deleteAll($criteria);
+        // TODO all this type of checks is meaningless since the code above will a) not put errors in model and b) its not the same model instance anyway
         if (QuestionGroup::model()->hasErrors()) {
             safeDie(join('<br>', QuestionGroup::model()->getErrors()));
         }

--- a/application/controllers/admin/usergroups.php
+++ b/application/controllers/admin/usergroups.php
@@ -121,10 +121,9 @@ class Usergroups extends Survey_Common_Action
         if (Permission::model()->hasGlobalPermission('usergroups', 'delete')) {
             $ugid = Yii::app()->request->getPost("ugid");
             if (!empty($ugid) && ($ugid > -1)) {
-                $result = UserGroup::model()->requestEditGroup($ugid, Yii::app()->session["loginID"]);
-                if ($result->count() > 0) {
-                    $delquery_result = UserGroup::model()->deleteGroup($ugid, Yii::app()->session["loginID"]);
-                    if ($delquery_result) {
+                $userGroup = UserGroup::model()->requestEditGroup($ugid, Yii::app()->session["loginID"]);
+                if (!empty($userGroup)) {
+                    if ($userGroup->delete()) {
                         Yii::app()->user->setFlash("success", gT("Successfully deleted user group."));
                     } else {
                         Yii::app()->user->setFlash("notice", gT("Could not delete user group."));

--- a/application/models/UserGroup.php
+++ b/application/models/UserGroup.php
@@ -252,6 +252,15 @@ class UserGroup extends LSActiveRecord
         }
     }
 
+    public function delete()
+    {
+        if (parent::delete()) {
+            UserInGroup::model()->deleteAllByAttributes(['ugid'=>$this->primaryKey]);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @return int
      */

--- a/application/models/UserGroup.php
+++ b/application/models/UserGroup.php
@@ -253,6 +253,10 @@ class UserGroup extends LSActiveRecord
         }
     }
 
+
+    /**
+     * {@inheritdoc}
+     */
     public function delete()
     {
         if (parent::delete()) {

--- a/application/models/UserGroup.php
+++ b/application/models/UserGroup.php
@@ -231,6 +231,7 @@ class UserGroup extends LSActiveRecord
      * @param integer $ugId
      * @param integer $ownerId
      * @return bool
+     * @deprecated since 2018-04-21 use $this->delete and do the permissions check in controller!!
      */
     public function deleteGroup($ugId, $ownerId)
     {
@@ -246,9 +247,9 @@ class UserGroup extends LSActiveRecord
         $group->delete();
 
         if ($group->getErrors()) {
-                    return false;
+            return false;
         } else {
-                    return true;
+            return true;
         }
     }
 

--- a/application/views/admin/checkintegrity/check_view.php
+++ b/application/views/admin/checkintegrity/check_view.php
@@ -210,7 +210,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled" >
                             <?php
                             foreach ($user_in_groups as $user_in_group) {?>
-                                <li>UGID:<?php echo $user_in_group['ugid'];?> <?php eT("Reason:");?> <?php echo $user_in_group['reason'];?></li><?php
+                                <li>UID:<?php echo $user_in_group['uid'];?> UGID:<?php echo $user_in_group['ugid'];?> <?php eT("Reason:");?> <?php echo $user_in_group['reason'];?></li><?php
                             }?>
                         </ul>
                     </li>

--- a/application/views/admin/checkintegrity/check_view.php
+++ b/application/views/admin/checkintegrity/check_view.php
@@ -203,6 +203,24 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                     <li><?php eT("All groups meet consistency standards."); ?></li><?php
                 } ?>
 
+                <?php
+                if (isset($user_in_groups))
+                {?>
+                    <li><?php eT("The following user group assignments should be deleted:"); ?>
+                        <ul class="list-unstyled" >
+                            <?php
+                            foreach ($user_in_groups as $user_in_group) {?>
+                                <li>UGID:<?php echo $user_in_group['ugid'];?> <?php eT("Reason:");?> <?php echo $user_in_group['reason'];?></li><?php
+                            }?>
+                        </ul>
+                    </li>
+                    <?php
+                }
+                else
+                { ?>
+                    <li><?php eT("All groups meet consistency standards."); ?></li><?php
+                } ?>
+
                 <?php if (isset($groupOrderDuplicates) && !empty($groupOrderDuplicates)): ?>
                     <li><?php eT("The following surveys have an errorneous question group order. Please go to each survey respectively, check the group order and save it."); ?>
                         <ul>


### PR DESCRIPTION
https://bugs.limesurvey.org/view.php?id=13599

1) new deletions of groups will delete also user-group assignments

2) old undeleted assignments will be cleaned via the integrity checking tool (which looks awful btw)