### PR TITLE
[WIP] Fix Expression Manager in answer text

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -487,7 +487,7 @@ class SurveyRuntimeHelper
                     $aGroup['aQuestions'][$qid]['valid_message']        = $qa[0]['valid_message'];
                     $aGroup['aQuestions'][$qid]['file_valid_message']   = $qa[0]['file_valid_message'];
                     $aGroup['aQuestions'][$qid]['man_message']          = $qa[0]['man_message'];
-                    $aGroup['aQuestions'][$qid]['answer']               = LimeExpressionManager::ProcessString($qa[1], $qa[4], null, 3, 1, false, true, false);
+                    $aGroup['aQuestions'][$qid]['answer']               = $qa[1];
                     $aGroup['aQuestions'][$qid]['help']['show']         = (flattenText($lemQuestionInfo['info']['help'], true, true) != '');
                     $aGroup['aQuestions'][$qid]['help']['text']         = LimeExpressionManager::ProcessString($lemQuestionInfo['info']['help'], $qa[4], null, 3, 1, false, true, false);
                     $aGroup['aQuestions'][$qid] = $this->doBeforeQuestionRenderEvent($aGroup['aQuestions'][$qid]);

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -1291,7 +1291,7 @@ function do_list_dropdown($ia)
                     'name'=> $ia[1],
                     'value'=>$optionarray['code'],
                     'opt_select'=>$opt_select,
-                    'answer'=>flattenText($optionarray['answer'])
+                    'answer'=>$optionarray['answer']
                     ), true);
             }
 
@@ -1313,7 +1313,7 @@ function do_list_dropdown($ia)
                 'name'=> $ia[1],
                 'value'=>$optionarray['code'],
                 'opt_select'=>$opt_select,
-                'answer'=>flattenText($optionarray['answer'])
+                'answer'=>$optionarray['answer']
                 ), true);
         }
     }
@@ -1333,7 +1333,7 @@ function do_list_dropdown($ia)
             'classes'=>'other-item',
             'value'=>'-oth-',
             'opt_select'=>$opt_select,
-            'answer'=>flattenText($_prefix.$othertext)
+            'answer'=>$_prefix.$othertext
             ), true);
     }
 

--- a/application/views/survey/questions/answer/list_dropdown/rows/optgroup.php
+++ b/application/views/survey/questions/answer/list_dropdown/rows/optgroup.php
@@ -11,7 +11,7 @@
 <optgroup class="dropdowncategory" label="<?php echo $categoryname;?>">
     <?php
         // rows/option.php
-        echo $sOptGroupOptions;
+        echo LimeExpressionManager::ProcessStepString($sOptGroupOptions,array(),3,true);
     ?>
 </optgroup>
 <!-- end of optgroup -->

--- a/application/views/survey/questions/answer/list_dropdown/rows/option.php
+++ b/application/views/survey/questions/answer/list_dropdown/rows/option.php
@@ -10,6 +10,6 @@
 
 <!-- option -->
 <option value='<?php echo $value?>' <?php echo $opt_select;?> <?php if(isset($classes)):?> class="<?php echo $classes;?>" <?php endif;?> >
-    <?php echo $answer;?>
+    <?php echo flattenText(LimeExpressionManager::ProcessStepString($answer,array(),3,true)); // Using static and flat ?>
 </option>
 <!-- end of option -->

--- a/application/views/survey/questions/answer/list_dropdown/rows/othertext.php
+++ b/application/views/survey/questions/answer/list_dropdown/rows/othertext.php
@@ -9,7 +9,7 @@
  */
 ?>
 <label for="othertext<?php echo $name; ?>" class="sr-only">
-    <?php echo $label; ?>
+    <?php echo LimeExpressionManager::ProcessStepString($label); ?>
 </label>
 <div class="form-group text-item other-text-item">
 <?php

--- a/application/views/survey/questions/answer/listradio/rows/answer_row.php
+++ b/application/views/survey/questions/answer/listradio/rows/answer_row.php
@@ -21,7 +21,7 @@
         onclick="if (document.getElementById('answer<?php echo $name; ?>othertext') != null) document.getElementById('answer<?php echo $name; ?>othertext').value='';checkconditions(this.value, this.name, this.type)"
      />
     <label for="answer<?php echo $name.$code; ?>" class="control-label radio-label">
-        <?php echo $answer; ?>
+        <?php echo LimeExpressionManager::ProcessStepString($answer); ?>
     </label>
 </li>
 <!-- end of answer_row -->

--- a/application/views/survey/questions/answer/listradio/rows/answer_row_other.php
+++ b/application/views/survey/questions/answer/listradio/rows/answer_row_other.php
@@ -29,7 +29,7 @@
         onclick="<?php echo $checkconditionFunction; ?>(this.value, this.name, this.type)"
         />
 
-        <label for="SOTH<?php echo $name; ?>" class="control-label label-radio" id="label-id-<?php echo $name; ?>"><?php echo $othertext; ?></label>
+        <label for="SOTH<?php echo $name; ?>" class="control-label label-radio" id="label-id-<?php echo $name; ?>"><?php echo LimeExpressionManager::ProcessStepString($othertext); ?></label>
     </div>
 
     <!-- comment -->


### PR DESCRIPTION
- The real fix is [this commit](https://github.com/LimeSurvey/LimeSurvey/pull/1054/commits/b84d6c0658f380689f459367fe89cb7a65fdf4fc)
- After need to move Expression Manager for sub question and answer text
- here move whole to view (then twig file)

Alternative : move it to qanda BUT : here for example , a Question template can allow Exprerssion in dropdown using [select2](https://select2.org/) (or another system).

I'm for updating all view and twig.