### PR TITLE
Fix "There are X questions in this survey." always displays

### DIFF
--- a/themes/survey/vanilla/views/subviews/messages/welcome.twig
+++ b/themes/survey/vanilla/views/subviews/messages/welcome.twig
@@ -44,7 +44,7 @@
         <div class='{{ aSurveyInfo.class.questioncounttext }}' {{ aSurveyInfo.attr.questioncounttext }}>
 
             {# If survey creator set "show x questions" in survey setting  #}
-            {% if aSurveyInfo.bShowxquestions == true %}
+            {% if aSurveyInfo.showxquestions == 'Y' %}
                 {% if aSurveyInfo.iTotalquestions < 1 %}
                     {{ gT("There are no question in this survey.") }}
                 {% elseif aSurveyInfo.iTotalquestions == 1  %}


### PR DESCRIPTION
Even if the setting in Presentations "Display 'There are X questions in this suvery" is set to No (parameter value 'N'), the number of questions is still displayed in the Welcome message.

I'm not sure if this is the right place to fix the issue, but there is a mismatch in parameter name and a mismatch in the value tested. This fixes it, but feel free to reject this fix and propose a better one. Thanks !
