### PR TITLE
Fix Statistics Response filter for "Array Dual Scale" type

### DIFF
--- a/application/views/admin/export/statistics_subviews/_question.php
+++ b/application/views/admin/export/statistics_subviews/_question.php
@@ -756,7 +756,7 @@
                     echo "<!-- $myfield2 - ";
                     if (isset($_POST[$myfield2]))
                     {
-                        echo htmlspecialchars($_POST[$myfield2]);
+                        echo htmlspecialchars(implode(',',$_POST[$myfield2]));
                     }
                     echo " -->\n";
 
@@ -803,7 +803,7 @@
                     $fresult = Answer::model()->getQuestionsForStatistics('*', "qid='$flt[0]' AND language = '{$language}' AND scale_id = 0", 'sortorder, code');
 
                     //this is for debugging only
-                    echo "\t<select name='{$surveyid}X{$flt[1]}X{$flt[0]}{$row[0]}#{0}[]' multiple='multiple' class='form-control'>\n";
+                    echo "\t<select name='{$surveyid}X{$flt[1]}X{$flt[0]}{$row[0]}#0[]' multiple='multiple' class='form-control'>\n";
 
                     //list answers
                     foreach($fresult as $frow)
@@ -828,7 +828,7 @@
                     echo "<!-- $myfield2 - ";
                     if (isset($_POST[$myfield2]))
                     {
-                        echo htmlspecialchars($_POST[$myfield2]);
+                        echo htmlspecialchars(implode(',',$_POST[$myfield2]));
                     }
 
                     echo " -->\n";
@@ -865,7 +865,7 @@
                     $fresult = Answer::model()->getQuestionsForStatistics('*', "qid='$flt[0]' AND language = '$language' AND scale_id = 1", 'sortorder, code');
 
                     //this is for debugging only
-                    echo "\t<select name='{$surveyid}X{$flt[1]}X{$flt[0]}{$row[0]}#{1}[]' multiple='multiple' class='form-control'>\n";
+                    echo "\t<select name='{$surveyid}X{$flt[1]}X{$flt[0]}{$row[0]}#1[]' multiple='multiple' class='form-control'>\n";
 
                     //list answers
                     foreach($fresult as $frow)


### PR DESCRIPTION
In Statistics, Filtering on responses for questions of type Array Dual Scale was not working at all: Results were not respecting those filters, and the selections in those selectors were lost on the results page.

**Testing instructions:**
To reproduce: Just create a one-question survey with a dual array dual scale question and their sub-questions. Or use an example from the man page https://manual.limesurvey.org/Question_type_-_Array_dual_scale . Then fill-in one survey, and go to admin results statistics. In Response Filters select one of the dual-scale answers that was NOT selected in that test survey.

Expected result: 0 out of 1 shown and selection in Response Filter still selected.
Actual result: 1 out of 1 shown and Response Filter selection lost.
After applying PR: Result becomes as expected.

**Analysis and fixes:**
Those filters' multi-selects were ignored in the filtering because their select names were wrong: E.g.:
Actual wrong: `select name="956915X67X519SQ001#{0}[]"` and `select name="956915X67X519SQ001#{1}[]"`
Expected correct: `select name="956915X67X519SQ001#0[]"` and `select name="956915X67X519SQ001#1[]"`

Additionally, once fixed, an html comment above was generating a warning because they supposed strings and got arrays of strings. This PR fixes both of them.
