### PR TITLE
Dev: move default QuestionAttribute to model and use it

### DIFF
--- a/application/controllers/admin/database.php
+++ b/application/controllers/admin/database.php
@@ -569,7 +569,7 @@ class database extends Survey_Common_Action
         $aLanguages = array_merge(array(Survey::model()->findByPk($iSurveyID)->language), Survey::model()->findByPk($iSurveyID)->additionalLanguages);
         foreach ($validAttributes as $validAttribute) {
             /* Readonly attribute : disable save */
-            if((isset($validAttribute['readonly']) && !empty($validAttribute['readonly'])) || (isset($validAttribute['readonly_when_active']) && !empty($validAttribute['readonly_when_active']) && Survey::model()->findByPk($iSurveyID)->getIsActive()) ) {
+            if( $validAttribute['readonly'] || $validAttribute['readonly_when_active'] && Survey::model()->findByPk($iSurveyID)->getIsActive() ) {
                 continue;
             }
             if ($validAttribute['i18n']) {

--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -1607,30 +1607,17 @@ class questionHelper
             self::$questionAttributesSettings[$sType] = array();
             self::getAttributesDefinitions(); /* we need to have self::$attributes */
             /* Filter to get this question type setting */
-            $aQuestionTypeAttribute = array_filter(self::$attributes, function($attribute) use ($sType)
-            {
+            $aQuestionTypeAttribute = array_filter(self::$attributes, function($attribute) use ($sType) {
                 return stripos($attribute['types'], $sType) !== false;
             });
 
-            $default = array(
-                "caption"=>'',
-                "inputtype"=>"text",
-                "options"=>'',
-                "category"=>gT("Plugins"),
-                "default"=>'',
-                "help"=>'',
-                "sortorder"=>1000,
-                "i18n"=>false,
-                "readonly"=>false,
-                "readonly_when_active"=>false,
-                "expression"=>null,
-            );
             foreach ($aQuestionTypeAttribute as $attribute=>$settings) {
-                self::$questionAttributesSettings[$sType][$attribute] = array_merge(
-                    $default,
-                    $settings,
-                    array("name"=>$attribute)
-                );
+                  self::$questionAttributesSettings[$sType][$attribute] = array_merge(
+                      QuestionAttribute::getDefaultSettings(),
+                      array("category"=>gT("Plugins")),
+                      $aCustomAttribute,
+                      array("name"=>$attribute)
+                  );
             }
         }
         return self::$questionAttributesSettings[$sType];

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -288,18 +288,13 @@ class Question extends LSActiveRecord
                 if ($oQuestionTemplate->bHasCustomAttributes) {
                     // Add the custom attributes to the list
                     foreach ($oQuestionTemplate->oConfig->custom_attributes->attribute as $oCustomAttribute) {
-
                         $sAttributeName = (string) $oCustomAttribute->name;
                         $aCustomAttribute = json_decode(json_encode((array) $oCustomAttribute), 1);
-
-                        if (!isset($aCustomAttribute['i18n'])) {
-                            $aCustomAttribute['i18n'] = false;
-                        }
-
-                        if (!isset($aCustomAttribute['readonly'])) {
-                            $aCustomAttribute['readonly'] = false;
-                        }
-
+                        $aCustomAttribute = array_merge(
+                            QuestionAttribute::getDefaultSettings(),
+                            array("category"=>gT("Template")),
+                            $aCustomAttribute
+                        );
                         $aAttributeNames[$sAttributeName] = $aCustomAttribute;
                     }
                 }

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -297,4 +297,26 @@ class QuestionAttribute extends LSActiveRecord
     {
         return $this->question->survey;
     }
+
+    /**
+     * Get default settings for an attribut
+     * @return array
+     */
+    public static function getDefaultSettings()
+    {
+        return array(
+            "name" => null,
+            "caption" => '',
+            "inputtype" => "text",
+            "options" => null,
+            "category" => gT("Attribute"),
+            "default" => '',
+            "help" => '',
+            "sortorder" => 1000,
+            "i18n"=> false,
+            "readonly" => false,
+            "readonly_when_active" => false,
+            "expression"=> null,
+        );
+    }
 }

--- a/application/views/admin/survey/Question/advanced_settings_view.php
+++ b/application/views/admin/survey/Question/advanced_settings_view.php
@@ -46,7 +46,7 @@ $categoryNum=0;
         <!-- Input -->
         <div class="">
             <?php
-                $readonly = $aAttribute['readonly'] || (isset($aAttribute['readonly_when_active']) && $aAttribute['readonly_when_active'] && $bIsActive);
+                $readonly = ( $aAttribute['readonly'] || ($aAttribute['readonly_when_active'] && $bIsActive) );
                 switch ($aAttribute['inputtype'])
                 {
                     // Switch


### PR DESCRIPTION
See https://github.com/LimeSurvey/LimeSurvey/commit/3b152c658c15613de5e64da2d83e1d74e996041b (and some other)

Question Attribute settings need some default always set, then set it always.