### PR TITLE
Deny access to hidden files and directories

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,6 +7,13 @@
 
     # otherwise forward it to index.php
     RewriteRule . index.php
+
+    # deny access to hidden files and directories
+    RewriteRule ^(.*/)?\.+ - [F]
 </IfModule>
+
+# deny access to hidden files and directories without mod_rewrite
+RedirectMatch 403 ^(.*/)?\.+
+
 # General setting to properly handle LimeSurvey paths
 # AcceptPathInfo on


### PR DESCRIPTION
Files like .editorconfig and .gitignore are accessible via HTTP. The best practice is to deny access to hidden files in the source tree.