### PR TITLE
Add an empty footer to the vanilla theme.

### DIFF
--- a/themes/survey/vanilla/config.xml
+++ b/themes/survey/vanilla/config.xml
@@ -88,6 +88,7 @@
             <screens>
                 <question>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="content">./subviews/content/main.twig</file>
                     <file type="view" role="subview">./subviews/survey/group.twig</file>
                     <file type="view" role="subview">./subviews/survey/group_subviews/group_container.twig</file>
@@ -108,6 +109,7 @@
 
                 <surveylist>
                     <file type="view" role="layout">layout_survey_list.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="css">./css/theme.css</file>
@@ -118,6 +120,7 @@
 
                 <welcome>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/firstpage.twig</file>
@@ -138,6 +141,7 @@
 
                 <completed>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/submit.twig</file>
@@ -149,6 +153,7 @@
 
                 <assessments>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/submit.twig</file>
@@ -161,10 +166,12 @@
 
                 <error>
                     <file type="view" role="layout">layout_errors.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                 </error>
 
                 <clearall>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/clearall.twig</file>
@@ -176,6 +183,7 @@
 
                 <load>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/load.twig</file>
@@ -187,6 +195,7 @@
 
                 <save>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="subview">./subviews/content/mainrow.twig</file>
                     <file type="view" role="subview">./subviews/content/outerframe.twig</file>
                     <file type="view" role="content">./subviews/content/save.twig</file>
@@ -198,6 +207,7 @@
 
                 <register>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="content">./subviews/content/register.twig</file>
                     <file type="view" role="subview">./subviews/registration/register_error.twig</file>
                     <file type="view" role="subview">./subviews/registration/register_head.twig</file>
@@ -220,6 +230,7 @@
 
                 <navigation>
                     <file type="view" role="layout">layout_global.twig</file>
+                    <file type="view" role="subview">./subviews/footer/footer.twig</file>
                     <file type="view" role="content">./subviews/content/main.twig</file>
                     <file type="view" role="subview">./subviews/navigation/ajax_indicator.twig</file>
                     <file type="view" role="subview">./subviews/navigation/clearall_links.twig</file>

--- a/themes/survey/vanilla/views/layout_errors.twig
+++ b/themes/survey/vanilla/views/layout_errors.twig
@@ -48,7 +48,7 @@
     </head>
 
     <body  class="{{ aSurveyInfo.class.body }} lang-{{surveylanguage}} {{surveyformat}}" marginwidth="0" marginheight="0" {{ aSurveyInfo.attr.body }}>
-        <div id="block_error">
+        <article id="block_error">
             <div>
                 <h2>{{ aError.title }}</h2>
                 <p>
@@ -59,6 +59,9 @@
                     <a href='mailto:{{ aSurveyInfo.adminemail }}'>{{ aSurveyInfo.adminemail }}</a>
                 </p>
             </div>
-        </div>
+        </article>
+        {% block footer %}
+            {{ include('./subviews/footer/footer.twig') }}
+        {% endblock %}
     </body>
 </html>

--- a/themes/survey/vanilla/views/layout_global.twig
+++ b/themes/survey/vanilla/views/layout_global.twig
@@ -130,7 +130,9 @@
             </div>
 
         </article>
-
+        {% block footer %}
+            {{ include('./subviews/footer/footer.twig') }}
+        {% endblock %}
         {% block pjaxend %}
             <div id="bottomScripts" class="script-container">
                 <###end###>

--- a/themes/survey/vanilla/views/layout_survey_list.twig
+++ b/themes/survey/vanilla/views/layout_survey_list.twig
@@ -190,6 +190,9 @@
             {% endblock %}
             </div>
         </article>
+        {% block footer %}
+            {{ include('./subviews/footer/footer.twig') }}
+        {% endblock %}
         <div id="bottomScripts">
             <###end###>
         </div>

--- a/themes/survey/vanilla/views/subviews/footer/footer.twig
+++ b/themes/survey/vanilla/views/subviews/footer/footer.twig
@@ -1,0 +1,19 @@
+{#
+Add your footer in this file.
+
+You will need to add custom CSS to make this work, for example, the following
+should work for a bottom-aligned footer in all browsers that properly support
+flex:
+
+body {
+     padding-bottom: 0; /* no bottom padding, footer should be bottom aligned */
+     padding-top: 60px;/* now is redefine in JS to fit any title length */
+     flex-direction: column; /* article, then footer */
+     display: flex; /* flex, to extend the content to full size */
+     min-height: 100vh; /* full height, to bottom-align footer */
+}
+body > article {
+    flex: 1; /* the main article should use as much space as possible */
+}
+
+#}


### PR DESCRIPTION
This commit adds a file footer.twig, includes it in the relevant layout_*.twig, and includes a few lines of CSS to bottom-align the footer with css.

The CSS can be dropped, it could be added by the user, but the twig file cannot easily be added to extended themes (especially not to config.xml) :-/

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 