### PR TITLE
FIX: endless redirections in theme setting menu

### DIFF
--- a/application/controllers/admin/themeoptions.php
+++ b/application/controllers/admin/themeoptions.php
@@ -117,7 +117,7 @@ class themeoptions  extends Survey_Common_Action
             $this->_updateCommon($model, $sid);
         } else {
             Yii::app()->setFlashMessage(gT("We are sorry but you don't have permissions to do this."), 'error');
-            $this->getController()->redirect(Yii::app()->getController()->createUrl("/admin/themeoptions/sa/updatesurvey", ['surveyid'=>$sid, 'sid'=>$sid]));
+            $this->getController()->redirect(array('admin/survey/sa/view/surveyid/'.$sid));
         }
     }
 


### PR DESCRIPTION
If users view the theme settings they will face endless redirections to the same page. I've pointed the redirection back to the survey overview page.