### PR TITLE
Updated feature: Added token_screenout to returned fields of API's get_summary() method

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -639,6 +639,7 @@ class remotecontrol_handle
      *     * token_sent
      *     * token_opted_out
      *     * token_completed
+     *     * token_screenout
      * All available status can be sent using `all`
      *
      * Failure status : No available data, No such property, Invalid session key, No permission
@@ -659,7 +660,8 @@ class remotecontrol_handle
                 'token_invalid',
                 'token_sent',
                 'token_opted_out',
-                'token_completed'
+                'token_completed',
+                'token_screenout'
             );
             $aPermittedSurveyStats = array(
                 'completed_responses',
@@ -691,6 +693,7 @@ class remotecontrol_handle
                             $aSummary['token_sent'] = $aTokenSummary['sent'];
                             $aSummary['token_opted_out'] = $aTokenSummary['optout'];
                             $aSummary['token_completed'] = $aTokenSummary['completed'];
+                            $aSummary['token_screenout'] = $aTokenSummary['screenout'];
                         }
                     } elseif ($sStatName != 'all') {
                         return array('status' => 'No available data');


### PR DESCRIPTION
Fixed issue # : 
New feature # :
Changed feature # : 13737
Dev: Trivial change, as the new field token_screenout was fetched by the API method already using Token->summary(). It was just not returned - I guess because the screenout was added to Token->summary() after the implementation of API's get_summary() and no one updated it.

Report is at https://bugs.limesurvey.org/view.php?id=13737 

This is my first PR, I tried to follow your contribution guideline and hope it's ok.