### PR TITLE
Fixed issue #13821: When importing a survey I receive a "Failed to In…

### DIFF
--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -20,16 +20,22 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 {
 	/**
 	 * Returns last inserted ID value.
-	 * SQLSRV driver supports PDO::lastInsertId() with one peculiarity: when $sequence's value is null or empty
-	 * string it returns empty string. But when parameter is not specified at all it's working as expected
-	 * and returns actual last inserted ID (like other PDO drivers).
+	 * Before version 5.0, the SQLSRV driver supports PDO::lastInsertId() with one peculiarity: when $sequence's 
+	 * value is null or empty string it returns empty string. But when parameter is not specified at all it's working as 
+	 * expected and returns actual last inserted ID (like other PDO drivers).
+	 * Version 5.0 of the Microsoft PHP Drivers for SQL Server changes the behaviour of PDO::lastInsertID to be 
+	 * consistent with the behaviour outlined in the PDO documentation. It returns the ID of the 
+	 * last inserted sequence or row.
 	 *
-	 * @param string|null $sequence the sequence name. Defaults to null.
+	 * @param string|null $sequence the sequence/table name. Defaults to null.
 	 * @return integer last inserted ID value.
 	 */
 	public function lastInsertId($sequence=null)
 	{
-		if(!$sequence)
+		$parts = explode('.', phpversion('pdo_sqlsrv'));
+		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($parts)) : 0;
+
+		if(!$sequence || $sqlsrvVer >= 5)
 			return parent::lastInsertId();
 		return parent::lastInsertId($sequence);
 	}


### PR DESCRIPTION
…sert [3]" error message

This issue is caused by a change in the sql pdo driver, without this fix, new ids aren't returned from tables with identity columns in mssql. This affects any objects that use Identity columns, such as questions, assessments. This has the effect in the application to prevent questions from saving correctly either by creating new ones or via survey import.

This fix is copied from the yii 1.19-dev label, here: https://github.com/yiisoft/yii/commit/7b768c304289ede574768de68939224d1180e2b1

Consideration should be given to updating the whole framework.