### PR TITLE
Fixed issue #13702: beforeCloseHtml event removed

### DIFF
--- a/application/core/LSYii_ClientScript.php
+++ b/application/core/LSYii_ClientScript.php
@@ -562,7 +562,6 @@ class LSYii_ClientScript extends CClientScript
             $html .= $this->renderScriptBatch($scripts);
         }
 
-
         if ($fullPage) {
             $output = preg_replace('/<###end###>/', $html, $output, 1);
         } else {
@@ -579,14 +578,26 @@ class LSYii_ClientScript extends CClientScript
      */
     public function render(&$output)
     {
+        /* beforeCloseHtml event @see https://manual.limesurvey.org/BeforeCloseHtml */
+        /* Set it before all other action allow registerScript by plugin */
+        if(Yii::app()->getController()->getId() != "admin" && strpos($output, '</body>')) {
+            $event = new PluginEvent('beforeCloseHtml');
+            $surveyId = Yii::app()->getRequest()->getParam('surveyid',Yii::app()->getRequest()->getParam('sid',Yii::app()->getConfig('surveyid')));
+            $event->set('surveyId', $surveyId); // Set to null if not set by param
+            App()->getPluginManager()->dispatchEvent($event);
+            $pluginHtml = $event->get('html');
+            if (!empty($pluginHtml) && is_string($pluginHtml)) {
+                $output = preg_replace('/(<\\/body\s*>)/is', "{$pluginHtml}$1", $output, 1);
+            }
+        }
         if (!$this->hasScripts) {
-                    return;
+            return;
         }
 
         $this->renderCoreScripts();
 
         if (!empty($this->scriptMap)) {
-                    $this->remapScripts();
+            $this->remapScripts();
         }
 
         $this->unifyScripts();

--- a/application/core/LSYii_ClientScript.php
+++ b/application/core/LSYii_ClientScript.php
@@ -578,9 +578,13 @@ class LSYii_ClientScript extends CClientScript
      */
     public function render(&$output)
     {
-        /* beforeCloseHtml event @see https://manual.limesurvey.org/BeforeCloseHtml */
-        /* Set it before all other action allow registerScript by plugin */
-        if(Yii::app()->getController()->getId() != "admin" && strpos($output, '</body>')) {
+        /**
+         * beforeCloseHtml event @see https://manual.limesurvey.org/BeforeCloseHtml
+         * Set it before all other action allow registerScript by plugin
+         * Whitelisting available controller (public plugin not happen for PluginsController using actionDirect, actionUnsecure event)
+         */
+        $publicControllers = array('option','optout','printanswers','register','statistics_user','survey','surveys','uploader');
+        if(Yii::app()->getController() && in_array(Yii::app()->getController()->getId(),$publicControllers) && strpos($output, '</body>')) {
             $event = new PluginEvent('beforeCloseHtml');
             $surveyId = Yii::app()->getRequest()->getParam('surveyid',Yii::app()->getRequest()->getParam('sid',Yii::app()->getConfig('surveyid')));
             $event->set('surveyId', $surveyId); // Set to null if not set by param


### PR DESCRIPTION
Dev: Readded in render, limit to none admin controller (like before)

see https://bugs.limesurvey.org/view.php?id=13702 and https://manual.limesurvey.org/BeforeCloseHtml