### PR TITLE
Fixed issue #13910: Unable to use saveall button (an other button)

### DIFF
--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -414,3 +414,9 @@ function alertSurveyDialog(text,title)
 {
     alert(text);
 }
+$(document).on('click', '#limesurvey [type=submit]:not([data-confirmedby])', function (e) {
+    $('#limesurvey').append('<input id="onsubmitbuttoninput" name=\'' + $(this).attr('name') + '\' value=\'' + $(this).attr('value') + '\' type=\'hidden\' />');
+});
+$(document).on('submit', '#limesurvey', function (e) {
+    $('#limesurvey [type=submit]').prop("disabled",true);
+});

--- a/themes/survey/vanilla/scripts/ajaxify.js
+++ b/themes/survey/vanilla/scripts/ajaxify.js
@@ -111,7 +111,7 @@ var AjaxSubmitObject = function () {
         // Restrict to [type=submit]:not([data-confirmedby])
         // - :submit is the default if button don't have type (reset button on slider for example),
         // - confirmedby have their own javascript system
-        $(document).on('click', '#ls-button-submit, #ls-button-previous', function (e) {
+        $(document).on('click', '#limesurvey [type=submit]:not([data-confirmedby])', function (e) {
             $('#limesurvey').append('<input id="onsubmitbuttoninput" name=\'' + $(this).attr('name') + '\' value=\'' + $(this).attr('value') + '\' type=\'hidden\' />');
             if (isIE10 || /Edge\/\d+\.\d+/.test(navigator.userAgent)) {
                 e.preventDefault();
@@ -123,6 +123,7 @@ var AjaxSubmitObject = function () {
         // If the user try to submit the form
         // Always bind to document to not need to bind again
         $(document).on('submit', '#limesurvey', function (e) {
+            console.log(activeSubmit);
             // Prevent multiposting
             //Check if there is an active submit
             //If there is -> return immediately
@@ -130,7 +131,7 @@ var AjaxSubmitObject = function () {
             //block further submissions
             activeSubmit = true;
             if ($('#onsubmitbuttoninput').length == 0) {
-                $('#limesurvey').append('<input id="onsubmitbuttoninput" name=\'' + $('#limesurvey [type=submit]:not([data-confirmedby])').attr('name') + '\' value=\'' + $('#limesurvey [type=submit]:not([data-confirmedby])').attr('value') + '\' type=\'hidden\' />');
+                $('#limesurvey').append('<input id="onsubmitbuttoninput" name="move" value="default">');
             }
             //start the loading animation
             startLoadingBar();

--- a/themes/survey/vanilla/scripts/ajaxify.js
+++ b/themes/survey/vanilla/scripts/ajaxify.js
@@ -111,7 +111,7 @@ var AjaxSubmitObject = function () {
         // Restrict to [type=submit]:not([data-confirmedby])
         // - :submit is the default if button don't have type (reset button on slider for example),
         // - confirmedby have their own javascript system
-        $(document).on('click', '#limesurvey [type=submit]:not([data-confirmedby])', function (e) {
+        $(document).on('click', '#limesurvey [type=submit]:not([data-confirmedby]:not(disabled))', function (e) {
             $('#limesurvey').append('<input id="onsubmitbuttoninput" name=\'' + $(this).attr('name') + '\' value=\'' + $(this).attr('value') + '\' type=\'hidden\' />');
             if (isIE10 || /Edge\/\d+\.\d+/.test(navigator.userAgent)) {
                 e.preventDefault();
@@ -123,7 +123,7 @@ var AjaxSubmitObject = function () {
         // If the user try to submit the form
         // Always bind to document to not need to bind again
         $(document).on('submit', '#limesurvey', function (e) {
-            console.log(activeSubmit);
+            $('#limesurvey [type=submit]').prop("disabled",true);
             // Prevent multiposting
             //Check if there is an active submit
             //If there is -> return immediately
@@ -131,7 +131,8 @@ var AjaxSubmitObject = function () {
             //block further submissions
             activeSubmit = true;
             if ($('#onsubmitbuttoninput').length == 0) {
-                $('#limesurvey').append('<input id="onsubmitbuttoninput" name="move" value="default">');
+                // unsure we need it, already here (1st is move), the app()->getRequest("move") get it if not set after (by button without js of click action with js)
+                $('#limesurvey').append('<input id="onsubmitbuttoninput" name="move" value="default" type="hidden">');
             }
             //start the loading animation
             startLoadingBar();


### PR DESCRIPTION
Dev: for default action : see https://github.com/LimeSurvey/LimeSurvey/blob/ed9fc2b6455b0c09c6672dcd1a1d130139838e6b/themes/survey/vanilla/views/subviews/header/start_form.twig#L71
Dev: then same behaviour with and without js