### PR TITLE
Add a new dropdown 'token type' for numeric tokens.

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -13,7 +13,7 @@
 
 
 $config['versionnumber'] = '3.13.2';
-$config['dbversionnumber'] = 355;
+$config['dbversionnumber'] = 356;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['assetsversionnumber'] = '30050';

--- a/application/controllers/admin/database.php
+++ b/application/controllers/admin/database.php
@@ -82,6 +82,7 @@ class database extends Survey_Common_Action
                 'googleanalyticsapikey' => ['type'=> 'default', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
                 'googleanalyticsstyle' => ['type'=> '', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
                 'tokenlength' => ['type'=> '', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
+                'tokentype' => ['type'=> '', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
                 'adminemail' => ['type'=> '', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
                 'bounce_email' => ['type'=> '', 'default' => false, 'dbname'=>false, 'active'=>true, 'required'=>[]],
                 'gsid' => ['type'=> '', 'default' => 1, 'dbname'=>false, 'active'=>true, 'required'=>[]],
@@ -988,6 +989,8 @@ class database extends Survey_Common_Action
             $tokenlength = $this->_filterEmptyFields($oSurvey, 'tokenlength');
             $oSurvey->tokenlength = (int) (($tokenlength < 5 || $tokenlength > 36) ? 15 : $tokenlength);
 
+            $oSurvey->tokentype = $this->_filterEmptyFields($oSurvey, 'tokentype');
+            
             $event = new PluginEvent('beforeSurveySettingsSave');
             $event->set('modifiedSurvey', $oSurvey);
             App()->getPluginManager()->dispatchEvent($event);

--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -2084,6 +2084,7 @@ class SurveyAdmin extends Survey_Common_Action
                 'publicgraphs' => App()->request->getPost('publicgraphs') == '1' ? 'Y' : 'N',
                 'assessments' => App()->request->getPost('assessments') == '1' ? 'Y' : 'N',
                 'emailresponseto' => App()->request->getPost('emailresponseto'),
+                'tokentype' => App()->request->getPost('tokentype'),
                 'tokenlength' => $iTokenLength,
                 'gsid'  => App()->request->getPost('gsid', '1'),
             );

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -691,6 +691,7 @@ class tokens extends Survey_Common_Action
 
             $aData['thissurvey'] = getSurveyInfo($iSurveyId);
             $aData['surveyid'] = $iSurveyId;
+            $aData['tokenType'] = !empty(Token::model($iSurveyId)->survey->tokentype) ? Token::model($iSurveyId)->survey->tokentype : 'default';
             $aData['iTokenLength'] = !empty(Token::model($iSurveyId)->survey->tokenlength) ? Token::model($iSurveyId)->survey->tokenlength : 15;
 
             $aData['sidemenu']['state'] = false;
@@ -915,6 +916,7 @@ class tokens extends Survey_Common_Action
 
             $amount = (int) Yii::app()->request->getPost('amount');
             $iTokenLength = (int) Yii::app()->request->getPost('tokenlen');
+            $tokenType = (int) Yii::app()->request->getPost('tokentype');
 
             // Fill an array with all existing tokens
             $existingtokens = array();
@@ -941,7 +943,7 @@ class tokens extends Survey_Common_Action
 
                 $attempts = 0;
                 do {
-                    $token->token = Token::generateRandomToken($iTokenLength);
+                    $token->token = Token::generateRandomToken($iTokenLength, $tokenType);
                     $attempts++;
                 } while (isset($existingtokens[$token->token]) && $attempts < 50);
 
@@ -975,11 +977,13 @@ class tokens extends Survey_Common_Action
 
         } else {
             $iTokenLength = !empty(Token::model($iSurveyId)->survey->tokenlength) ? Token::model($iSurveyId)->survey->tokenlength : 15;
+            $tokenType = !empty(Token::model($iSurveyId)->survey->tokentype) ? Token::model($iSurveyId)->survey->tokentype : 'default';
 
             $thissurvey = getSurveyInfo($iSurveyId);
             $aData['thissurvey'] = $thissurvey;
             $aData['surveyid'] = $iSurveyId;
             $aData['tokenlength'] = $iTokenLength;
+            $aData['tokentype'] = $tokenType;
             $aData['dateformatdetails'] = getDateFormatData(Yii::app()->session['dateformat'], App()->language);
             $aData['aAttributeFields'] = getParticipantAttributes($iSurveyId);
             $this->_renderWrappedTemplate('token', array('dummytokenform'), $aData);
@@ -2356,6 +2360,7 @@ class tokens extends Survey_Common_Action
         }
 
         $aData['iTokenLength'] = !empty(Token::model($iSurveyId)->survey->tokenlength) ? Token::model($iSurveyId)->survey->tokenlength : 15;
+        $aData['tokenType'] = !empty(Token::model($iSurveyId)->survey->tokentype) ? Token::model($iSurveyId)->survey->tokentype : 'default';
 
         $thissurvey = getSurveyInfo($iSurveyId);
         $aAdditionalAttributeFields = $thissurvey['attributedescriptions'];

--- a/application/helpers/admin/survey_helper.php
+++ b/application/helpers/admin/survey_helper.php
@@ -29,6 +29,7 @@ function getSurveyDefaultSettings()
     'publicgraphs'             => 'N',
     'public'                   => 'Y',
     'autoredirect'             => 'N',
+    'tokentype'                => 'default',
     'tokenlength'              => 15,
     'allowregister'            => 'N',
     'usecookie'                => 'N',

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -1678,8 +1678,6 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
             $oTransaction->commit();
         }
 
-
-
         //Rename order to sortorder
 
         if ($iOldDBVersion < 318) {
@@ -2336,6 +2334,14 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
             $oTransaction->commit();
             $oDB->createCommand()->update('{{settings_global}}', ['stg_value'=>355], "stg_name='DBVersion'");
         }
+
+        if ($iOldDBVersion < 356) {
+            $oTransaction = $oDB->beginTransaction();
+            addColumn('{{surveys}}','tokentype',"string(16) not null default 'default'");
+            $oTransaction->commit();
+            $oDB->createCommand()->update('{{settings_global}}', ['stg_value'=>356], "stg_name='DBVersion'");
+        }
+
 
 
     } catch (Exception $e) {

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -41,6 +41,7 @@ use \LimeSurvey\PluginManager\PluginEvent;
  * @property string $allowregister Allow public registration (Y/N)
  * @property string $allowsave Is participant allowed save and resume later (Y/N)
  * @property integer $autonumber_start
+ * @property string $tokentype Token type: 'default' or 'numeric'
  * @property integer $tokenlength Token length: MIN:5 MAX:36
  * @property string $autoredirect Automatically load URL when survey complete: (Y/N)
  * @property string $allowprev Allow backwards navigation (Y/N)
@@ -472,6 +473,7 @@ class Survey extends LSActiveRecord
             array('format', 'in', 'range'=>array('G', 'S', 'A'), 'allowEmpty'=>true),
             array('googleanalyticsstyle', 'numerical', 'integerOnly'=>true, 'min'=>'0', 'max'=>'2', 'allowEmpty'=>true),
             array('autonumber_start', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>true),
+            array('tokentype', 'in', 'range'=>array('default','numeric'), 'allowEmpty'=>true),
             array('tokenlength', 'default', 'value'=>15),
             array('tokenlength', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>false, 'min'=>'5', 'max'=>'36'),
             array('bouncetime', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>true),

--- a/application/views/admin/survey/subview/accordion/_tokens_panel.php
+++ b/application/views/admin/survey/subview/accordion/_tokens_panel.php
@@ -36,6 +36,20 @@ App()->getClientScript()->registerScript("tokens-panel-variables", "
 <div id='tokens-panel' class="container-fluid">
     <div class="row">
         <div class="col-sm-12 col-md-6">
+            <!-- Set token type -->
+            <div class="form-group">
+                <label class=" control-label" for='tokentype'><?php  eT("Select token type:"); ?></label>
+                <div class="">
+                    <select name='tokentype' id='tokentype' class="form-control">
+                        <option value='default' <?php if($oSurvey->tokentype != 'numeric') { ?>
+                                selected='selected'
+                        <?php } ?> ><?php eT("Default") ?></option>
+                        <option value='numeric' <?php if($oSurvey->tokentype == 'numeric') { ?>
+                                selected='selected'
+                        <?php } ?> ><?php eT("Numeric") ?></option>
+                    </select>
+                </div>
+            </div>
             <!--  Set token length to -->
             <div class="form-group">
                 <label class=" control-label" for='tokenlength'><?php  eT("Set token length to:"); ?></label>

--- a/application/views/admin/token/dummytokenform.php
+++ b/application/views/admin/token/dummytokenform.php
@@ -27,6 +27,17 @@
                     </div>
                 </div>
 
+                <!-- Token type  -->
+                <div class="form-group">
+                    <label  class=" control-label" for='tokentype'><?php eT("Token type"); ?>:</label>
+                    <div class="">
+                        <select class='form-control' id='tokentype' name='tokentype'>
+                            <option value='default'><?php eT("Default") ?></option>
+                            <option value='numeric'><?php eT("Numeric") ?></option>
+                        </select>
+                    </div>
+                </div>
+
                 <!-- Token length  -->
                 <div class="form-group">
                     <label  class=" control-label" for='tokenlen'><?php eT("Token length"); ?>:</label>

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -548,6 +548,7 @@ function createDatabase($oDB){
             'emailresponseto' => "text NULL",
             'emailnotificationto' => "text NULL",
             'tokenlength' => "integer NOT NULL default '15'",
+            'tokentype' => "string(16) default 'default'",
             'showxquestions' => "string(1) default 'Y'",
             'showgroupinfo' => "string(1) default 'B'",
             'shownoanswer' => "string(1) default 'Y'",


### PR DESCRIPTION
This commit adds a new selection to let you choose between the normal tokens and numeric-only tokens.

![maim](https://user-images.githubusercontent.com/40419181/43395852-e938ef52-93ff-11e8-8780-29029cf40cf0.png)

![maim2](https://user-images.githubusercontent.com/40419181/43395906-128d64fa-9400-11e8-8ddc-44cf9858f570.png)

New feature # :
Dev: 
Dev: 