### PR TITLE
Add a new setting "forgotpasswordurl".

### DIFF
--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -317,6 +317,7 @@ class GlobalSettings extends Survey_Common_Action
         setGlobalSetting('RPCInterface', Yii::app()->getRequest()->getPost('RPCInterface'));
         setGlobalSetting('rpc_publish_api', (bool) Yii::app()->getRequest()->getPost('rpc_publish_api'));
         setGlobalSetting('characterset', Yii::app()->getRequest()->getPost('characterset'));
+        setGlobalSetting('forgotpasswordurl', Yii::app()->getRequest()->getPost('forgotpasswordurl'));
         setGlobalSetting('sideMenuBehaviour', Yii::app()->getRequest()->getPost('sideMenuBehaviour', 'adaptive'));
         $savetime = intval((float) Yii::app()->getRequest()->getPost('timeadjust') * 60).' minutes'; //makes sure it is a number, at least 0
         if ((substr($savetime, 0, 1) != '-') && (substr($savetime, 0, 1) != '+')) {

--- a/application/views/admin/authentication/login.php
+++ b/application/views/admin/authentication/login.php
@@ -131,11 +131,16 @@ echo viewHelper::getViewTestTag('login');
                                     <button type="submit" class="btn btn-default" name='login_submit' value='login'><?php eT('Log in');?></button><br />
                                     <br/>
                                     <?php
-                                    if (Yii::app()->getConfig("display_user_password_in_email") === true)
+                                    $fpu = getGlobalSetting("forgotpasswordurl");
+                                    if($fpu) {
+                                    ?>
+                                        <a href='<?php echo $fpu; ?>'><?php eT("Forgot your password?"); ?></a><br />
+                                    <?php
+                                    } elseif (Yii::app()->getConfig("display_user_password_in_email") === true)
                                     {
-                                        ?>
-                                        <a href='<?php echo $this->createUrl("admin/authentication/sa/forgotpassword"); ?>'><?php eT("Forgot your password?"); ?></a><br />
-                                        <?php
+                                    ?>
+                                            <a href='<?php echo $this->createUrl("admin/authentication/sa/forgotpassword"); ?>'><?php eT("Forgot your password?"); ?></a><br />
+                                    <?php
                                     }
                                     ?>
                                 </p>

--- a/application/views/admin/global_settings/_general.php
+++ b/application/views/admin/global_settings/_general.php
@@ -161,6 +161,16 @@ $dateformatdata=getDateFormatData(Yii::app()->session['dateformat']);
                 </div>
             </div>
         </div>
+        <div class="row ls-space margin top-10">
+            <div class='form-group col-xs-12'>
+                <label class='col-sm-12 text-left control-label' for='forgotpasswordurl'>
+                    <?php eT("Forgotten password URL:") ?>
+                </label>
+                <div class="col-sm-12">
+                    <input class="form-control" type='text' size='255' id='forgotpasswordurl' name='forgotpasswordurl' value="<?php echo htmlspecialchars(getGlobalSetting('forgotpasswordurl')); ?>" />
+                </div>
+            </div>
+        </div>
     </div>
     <div class="ls-flex-column ls-space padding left-5 right-5 col-md-5">
 


### PR DESCRIPTION
If it is set, use it on the login page, to link to an external page. We need this because all our users are LDAP users, where LS cannot change the password directly.

New setting:
![settings](https://user-images.githubusercontent.com/40419181/43819610-e6f8925c-9ae3-11e8-910b-363a74c11ba0.png)

Link on login page:
![login](https://user-images.githubusercontent.com/40419181/43819615-e9491d2e-9ae3-11e8-9af4-a103ee3a030c.png)
