### PR TITLE
issue #14050: Unable to import response from deactivated survey

### DIFF
--- a/application/controllers/admin/dataentry.php
+++ b/application/controllers/admin/dataentry.php
@@ -314,8 +314,7 @@ class dataentry extends Survey_Common_Action
             foreach ($sourceResponses as $sourceResponse) {
                 $iOldID = $sourceResponse->id;
                 // Using plugindynamic model because I dont trust surveydynamic.
-                $targetResponse = new PluginDynamic("{{survey_$iSurveyId}}");
-
+                $targetResponse = Response::create($iSurveyId);
                 foreach ($fieldMap as $sourceField => $targetField) {
                     $targetResponse[$targetField] = $sourceResponse[$sourceField];
                 }

--- a/application/models/Response.php
+++ b/application/models/Response.php
@@ -6,6 +6,11 @@
      */
     abstract class Response extends Dynamic
     {
+
+        /**
+         * @inheritdoc
+         * and delete related files before delete response
+         */
         public function beforeDelete()
         {
             if (parent::beforeDelete()) {
@@ -15,7 +20,6 @@
             return false;
         }
         /**
-         *
          * @param mixed $className Either the classname or the survey id.
          * @return Response
          */
@@ -164,6 +168,7 @@
             return array($success, $errors);
         }
 
+        /* @inheritdoc */
         public function delete($deleteFiles = false)
         {
             if ($deleteFiles) {
@@ -171,6 +176,8 @@
             }
             return parent::delete();
         }
+
+        /* @inheritdoc */
         public function relations()
         {
             $result = array(
@@ -179,10 +186,28 @@
             );
             return $result;
         }
+
+        /* @inheritdoc */
         public function tableName()
         {
             return '{{survey_'.$this->dynamicId.'}}';
         }
+
+        /* @inheritdoc */
+        public function rules()
+        {
+            $rules = array();
+            if($this->survey->isDateStamp) {
+                /* Since there are not default set an disable not null : set default to current datetime , see mantis #14050 */
+                /* but more : seems clean that current value is set by default to actual datetime (if not set) */
+                $rules = array_merge($rules,array(
+                    array('startdate', 'default', 'value'=>new CDbExpression('NOW()')),
+                    array('datestamp', 'default', 'value'=>new CDbExpression('NOW()')),
+                ));
+            }
+            return $rules;
+        }
+
         public function getSurveyId()
         {
             return $this->dynamicId;


### PR DESCRIPTION
Fixed issue #14050: Unable to import response from deactivated survey after update datestamp
Dev: set a default value to the 2 value for datestamp
Dev: didn't see why it work in 2.6 and not in 2.73 …

If someone found a better sentence (in less word …). Must test in msql and pgsql (but NOW() is a common sql word. 

If didn't use NOW : can not set to "0000-00-00 …" since i think it's only for mysql