### PR TITLE
Easiest solution for translation

### DIFF
--- a/application/core/LSCGettextMessageSource.php
+++ b/application/core/LSCGettextMessageSource.php
@@ -29,7 +29,7 @@ class LSCGettextMessageSource extends CGettextMessageSource
             $messageFile .= self::PO_FILE_EXT;
         }
 
-        if (false && $this->cachingDuration > 0 && $this->cacheID !== false && ($cache = Yii::app()->getComponent($this->cacheID)) !== null) {
+        if ($this->cachingDuration > 0 && $this->cacheID !== false && ($cache = Yii::app()->getComponent($this->cacheID)) !== null) {
             $key = self::CACHE_KEY_PREFIX.$messageFile.".".$category;
             if (($data = $cache->get($key)) !== false) {
                 return unserialize($data);

--- a/application/core/LSCGettextMessageSource.php
+++ b/application/core/LSCGettextMessageSource.php
@@ -22,26 +22,25 @@ class LSCGettextMessageSource extends CGettextMessageSource
         // Default catalog to langauge (e.g. de)
         // TODO: Where is catalog set (except default value)?
         $this->catalog = $language;
-
         $messageFile = $this->basePath.DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR.$this->catalog;
         if ($this->useMoFile) {
-                    $messageFile .= self::MO_FILE_EXT;
+            $messageFile .= self::MO_FILE_EXT;
         } else {
-                    $messageFile .= self::PO_FILE_EXT;
+            $messageFile .= self::PO_FILE_EXT;
         }
 
-        if ($this->cachingDuration > 0 && $this->cacheID !== false && ($cache = Yii::app()->getComponent($this->cacheID)) !== null) {
+        if (false && $this->cachingDuration > 0 && $this->cacheID !== false && ($cache = Yii::app()->getComponent($this->cacheID)) !== null) {
             $key = self::CACHE_KEY_PREFIX.$messageFile.".".$category;
             if (($data = $cache->get($key)) !== false) {
-                            return unserialize($data);
+                return unserialize($data);
             }
         }
 
         if (is_file($messageFile)) {
             if ($this->useMoFile) {
-                            $file = new CGettextMoFile($this->useBigEndian);
+                $file = new CGettextMoFile($this->useBigEndian);
             } else {
-                            $file = new CGettextPoFile();
+                $file = new CGettextPoFile();
             }
             $messages = $file->load($messageFile, $category);
             if (isset($cache) && isset($key)) {
@@ -50,7 +49,7 @@ class LSCGettextMessageSource extends CGettextMessageSource
             }
             return $messages;
         } else {
-                    return array();
+            return array();
         }
     }
 }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -20,17 +20,19 @@ Yii::import('application.helpers.sanitize_helper', true);
  * @param string $sToTranslate
  * @param string $sEscapeMode Valid values are html (this is the default, js and unescaped)
  * @param string $sLanguage
- * @return mixed|string
+ * @param string $source
+ * @return string
  */
-function gT($sToTranslate, $sEscapeMode = 'html', $sLanguage = null)
+function gT($sToTranslate, $sEscapeMode = 'html', $sLanguage = null, $source = null)
 {
-    return quoteText(Yii::t('', $sToTranslate, array(), null, $sLanguage), $sEscapeMode);
+    return quoteText(Yii::t('', $sToTranslate, array(), $source, $sLanguage), $sEscapeMode);
 }
 
 /**
  * Translation helper function which outputs right away.
  * @param string $sToTranslate
  * @param string $sEscapeMode
+ * @return string
  */
 function eT($sToTranslate, $sEscapeMode = 'html')
 {
@@ -42,11 +44,13 @@ function eT($sToTranslate, $sEscapeMode = 'html')
  * @param string $sTextToTranslate
  * @param integer $iCount
  * @param string $sEscapeMode
+ * @param string $sLanguage
+ * @param string $source
  * @return string
  */
-function ngT($sTextToTranslate, $iCount, $sEscapeMode = 'html')
+function ngT($sTextToTranslate, $iCount, $sEscapeMode = 'html', $sLanguage = null, $source = null)
 {
-    return quoteText(Yii::t('', $sTextToTranslate, $iCount), $sEscapeMode);
+    return quoteText(Yii::t('', $sTextToTranslate, $iCount, $source, $sLanguage), $sEscapeMode);
 }
 
 /**

--- a/application/libraries/PluginManager/PluginBase.php
+++ b/application/libraries/PluginManager/PluginBase.php
@@ -8,13 +8,11 @@ namespace LimeSurvey\PluginManager;
 abstract class PluginBase implements iPlugin
 {
     /**
-     *
      * @var LimesurveyApi
      */
     protected $api = null;
 
     /**
-     *
      * @var PluginEvent
      */
     protected $event = null;
@@ -69,9 +67,8 @@ abstract class PluginBase implements iPlugin
         if (!file_exists($basePath)) {
             return;
         }
-
         // Set plugin specific locale file to locale/<lang>/<lang>.mo
-        \Yii::app()->setComponent('pluginMessages'.$this->id, array(
+        \Yii::app()->setComponent('pluginMessages'.get_class($this), array(
             'class' => 'LSCGettextMessageSource',
             'cachingDuration' => 3600,
             'forceTranslation' => true,
@@ -324,33 +321,11 @@ abstract class PluginBase implements iPlugin
      */
     public function gT($sToTranslate, $sEscapeMode = 'html', $sLanguage = null)
     {
-        $translation = \quoteText(
-            \Yii::t(
-                '',
-                $sToTranslate,
-                array(),
-                'pluginMessages'.$this->id,
-                $sLanguage
-            ),
-            $sEscapeMode
-        );
-
-        // If we don't have a translation from the plugin, check core translations
-        if ($translation == $sToTranslate) {
-            $translationFromCore = \quoteText(
-                \Yii::t(
-                    '',
-                    $sToTranslate,
-                    array(),
-                    null,
-                    $sLanguage
-                ),
-                $sEscapeMode
-            );
-
-            return $translationFromCore;
+        $translation = gT($sToTranslate, $sEscapeMode, $sLanguage,'pluginMessages'.get_class($this));
+        if ($translation === $sToTranslate) {
+            /* translation from core */
+            return gT($sToTranslate, $sEscapeMode, $sLanguage,null);
         }
-
         return $translation;
 
     }


### PR DESCRIPTION
- Usage of get_class($this) allow to find source more easily
- This allow to use gT function in view without send whole translation or plugin in views or twig
- I think it can allow to update some string with translation more easily in twig public file too : see https://bugs.limesurvey.org/view.php?id=13711 , current solution is to do it with fixed string by language, here : can do it with fixed en_us string + translation.
- **This don't break current plugin translation**
