### PR TITLE
Dev: trim survey & quota redirect urls from leading & trailing spaces

### DIFF
--- a/application/models/QuotaLanguageSetting.php
+++ b/application/models/QuotaLanguageSetting.php
@@ -73,6 +73,7 @@ class QuotaLanguageSetting extends LSActiveRecord
             array('quotals_message', 'LSYii_Validators'),
             array('quotals_url', 'LSYii_Validators', 'isUrl'=>true),
             array('quotals_urldescrip', 'LSYii_Validators'),
+            array('quotals_url', 'filter', 'filter'=>'trim'),
             array('quotals_url', 'urlValidator'),
         );
     }

--- a/application/models/SurveyLanguageSetting.php
+++ b/application/models/SurveyLanguageSetting.php
@@ -120,6 +120,7 @@ class SurveyLanguageSetting extends LSActiveRecord
             array('surveyls_policy_notice', 'LSYii_Validators'),
             array('surveyls_policy_error', 'LSYii_Validators'),
             array('surveyls_policy_notice_label', 'LSYii_Validators'),
+            array('surveyls_url', 'filter', 'filter'=>'trim'),
             array('surveyls_url', 'LSYii_Validators', 'isUrl'=>true),
             array('surveyls_urldescription', 'LSYii_Validators'),
 


### PR DESCRIPTION
Spent a few hours today struggling with a problem initiated by having a leading space in the beginning of an URL. While having the leading space, the URL converted all `&` chars in URL to `&amp;` in database.

it of course looked like an `&` in the form, but ended up breaking the actual parameters since the redirection URLs contained `&amp;`-s instead. Anyway, there is no reason for the URLs to have leading or trailing spaces.