### PR TITLE
New feature: Allow filtering "Out of quota" separately in responses table

### DIFF
--- a/application/controllers/admin/responses.php
+++ b/application/controllers/admin/responses.php
@@ -457,6 +457,7 @@ class responses extends Survey_Common_Action
             }
 
             // rendering
+            $aData['survey']             = $survey;
             $aData['model']             = $model;
             $aData['bHaveToken']        = $bHaveToken;
             $aData['aDefaultColumns']   = $model->defaultColumns; // Some specific columns

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1952,7 +1952,7 @@ return $s->hasTokensTable; });
         $dynamic = SurveyDynamic::model($this->sid);
         if ($dynamic->bHaveToken) {
             $criteria = new CDbCriteria;
-            $criteria->addCondition('tokens.completed = \'Q\'');
+            $criteria->addCondition('tokens.completed = ' . Yii::app()->getDb()->quoteValue('Q'));
             $dynamic->with('tokens')->count($criteria);
             return intval($dynamic->with('tokens')->count($criteria)) > 0;
         }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -87,6 +87,7 @@ use \LimeSurvey\PluginManager\PluginEvent;
  * @property QuestionGroup[] $groups
  * @property Quota[] $quotas
  * @property Question[] $quotableQuestions
+ * @property bool $hasQuota
  *
  * @property array $fullAnswers
  * @property array $partialAnswers
@@ -1936,6 +1937,26 @@ return $s->hasTokensTable; });
         }
 
         return $dataSecurityNoticeLabel;
+
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasQuota()
+    {
+        if (!empty($this->quotas)) {
+            return true;
+        }
+        // check if any tokens have Quota completes (quota models deleted)
+        $dynamic = SurveyDynamic::model($this->sid);
+        if ($dynamic->bHaveToken) {
+            $criteria = new CDbCriteria;
+            $criteria->addCondition('tokens.completed = \'Q\'');
+            $dynamic->with('tokens')->count($criteria);
+            return intval($dynamic->with('tokens')->count($criteria)) > 0;
+        }
+        return false;
 
     }
 }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -87,7 +87,7 @@ use \LimeSurvey\PluginManager\PluginEvent;
  * @property QuestionGroup[] $groups
  * @property Quota[] $quotas
  * @property Question[] $quotableQuestions
- * @property bool $hasQuota
+ * @property bool $hasQuota Whether survey has implemented quotas. Chekcs either currently set quotas or any token results that have been closed by quota
  *
  * @property array $fullAnswers
  * @property array $partialAnswers
@@ -1941,6 +1941,7 @@ return $s->hasTokensTable; });
     }
 
     /**
+     * Whether survey has implemented quotas. Chekcs either currently set quotas or any token results that have been closed by quota
      * @return bool
      */
     public function getHasQuota()

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -632,7 +632,7 @@ class SurveyDynamic extends LSActiveRecord
             $criteria->addCondition('t.submitdate IS NULL');
         }
         if ($this->completed_filter == "Q") {
-            $criteria->addCondition('tokens.completed = \'Q\'');
+            $criteria->addCondition('tokens.completed = ' . Yii::app()->getDb()->quoteValue('Q'));
         }
 
         // When selection of responses come from statistics

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -19,6 +19,7 @@
  * Class SurveyDynamic
  * @property TokenDynamic $tokens
  * @property Survey $survey
+ * @property boolean $bHaveToken
  */
 class SurveyDynamic extends LSActiveRecord
 {
@@ -39,8 +40,6 @@ class SurveyDynamic extends LSActiveRecord
     /** @var Survey $survey */
     protected static $survey;
 
-    /** @var  boolean $bHaveToken */
-    protected $bHaveToken;
 
     /**
      * @inheritdoc
@@ -525,12 +524,9 @@ class SurveyDynamic extends LSActiveRecord
     /**
      * @return bool
      */
-    private function getbHaveToken()
+    public function getbHaveToken()
     {
-        if (!isset($this->bHaveToken)) {
-            $this->bHaveToken = tableExists('tokens_'.self::$sid) && Permission::model()->hasSurveyPermission(self::$sid, 'tokens', 'read'); // Boolean : show (or not) the token;
-        }
-        return $this->bHaveToken;
+        return tableExists('tokens_'.self::$sid) && Permission::model()->hasSurveyPermission(self::$sid, 'tokens', 'read'); // Boolean : show (or not) the token;
     }
 
 

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -14,6 +14,12 @@
  *
   * 	Files Purpose: lots of common functions
  */
+
+/**
+ * Class SurveyDynamic
+ * @property TokenDynamic $tokens
+ * @property Survey $survey
+ */
 class SurveyDynamic extends LSActiveRecord
 {
     /** @var string $completed_filter */
@@ -87,6 +93,7 @@ class SurveyDynamic extends LSActiveRecord
             TokenDynamic::sid(self::$sid);
             return array(
                 'survey'   => array(self::HAS_ONE, 'Survey', array(), 'condition'=>('sid = '.self::$sid)),
+                /** TODO make tokens singular. Its ONE token. */
                 'tokens'   => array(self::HAS_ONE, 'TokenDynamic', array('token' => 'token'))
             );
         } else {
@@ -627,6 +634,9 @@ class SurveyDynamic extends LSActiveRecord
 
         if ($this->completed_filter == "N") {
             $criteria->addCondition('t.submitdate IS NULL');
+        }
+        if ($this->completed_filter == "Q") {
+            $criteria->addCondition('tokens.completed = \'Q\'');
         }
 
         // When selection of responses come from statistics

--- a/application/views/admin/responses/listResponses_view.php
+++ b/application/views/admin/responses/listResponses_view.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * @var $this AdminController
+ * @var SurveyDynamic $model
+ * @var Survey $survey
+ * @var bool $bHaveToken
+ * @var array $aDefaultColumns
+ * @var string $language
+ * @var array $fieldmap
  */
 
 // DO NOT REMOVE This is for automated testing to validate we see that page
@@ -110,6 +116,15 @@ echo viewHelper::getViewTestTag('surveyResponsesBrowse');
                                 $model->lastpage)
                         );
 
+                        $completeOptions = [
+                            ''=>gT('All'),
+                            'Y'=>gT('Yes'),
+                            'N'=>gT('No'),
+                        ];
+                        if ($survey->hasQuota) {
+                            $completeOptions['Q'] = gT('Out of quota');
+                        }
+
                         $aColumns[] = array(
                             'header'=>gT("completed"),
                             'name'=>'completed_filter',
@@ -117,13 +132,8 @@ echo viewHelper::getViewTestTag('surveyResponsesBrowse');
                             'type'=>'raw',
                             'filter'=>TbHtml::dropDownList(
                                 'SurveyDynamic[completed_filter]',
-                                $model->completed_filter,[
-                                    ''=>gT('All'),
-                                    'Y'=>gT('Yes'),
-                                    'Q'=>gT('Out of quota'),
-                                    'N'=>gT('No'),
-                                    ]
-                                )
+                                $model->completed_filter, $completeOptions
+                            )
                         );
 
                         //add token to top of list if survey is not private

--- a/application/views/admin/responses/listResponses_view.php
+++ b/application/views/admin/responses/listResponses_view.php
@@ -117,8 +117,13 @@ echo viewHelper::getViewTestTag('surveyResponsesBrowse');
                             'type'=>'raw',
                             'filter'=>TbHtml::dropDownList(
                                 'SurveyDynamic[completed_filter]',
-                                $model->completed_filter,
-                                array(''=>gT('All'),'Y'=>gT('Yes'),'N'=>gT('No')))
+                                $model->completed_filter,[
+                                    ''=>gT('All'),
+                                    'Y'=>gT('Yes'),
+                                    'Q'=>gT('Out of quota'),
+                                    'N'=>gT('No'),
+                                    ]
+                                )
                         );
 
                         //add token to top of list if survey is not private


### PR DESCRIPTION
The "No" option will display only the responses whose token is "open" and the questionnaire can be re-opened to fill. The "out of quota" will display responses that are closed due to quotas. 