### PR TITLE
Fix JSON editor options to load the right content

### DIFF
--- a/application/extensions/yii-jsoneditor/JsonEditor.php
+++ b/application/extensions/yii-jsoneditor/JsonEditor.php
@@ -47,8 +47,9 @@
 		{
 			$htmlOptions = $this->htmlOptions;
             list($name, $id) = $this->resolveNameID();
-			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, $this->value, array(
-				'id' => $id
+			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, json_encode($this->value), array(
+				'id' => $id,
+                'encode' => false,
 			)));
 			$config = json_encode($this->editorOptions);
             App()->getClientScript()->registerScript("initJsonEditor" . $id, "$('#{$id}').jsonEditor($config);", CClientScript::POS_READY);


### PR DESCRIPTION
Fix JSON editor options to load the right content into the embedded JSON editor, issue was that content, whatever its type, was passed to CHtml::encode which expects a string due to lack of encode htmlOption for CHtml::textarea. Also added needed json_encode so that textarea value is a string in the end.

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 