### PR TITLE
Fixed issue #14133: lss with long group name broke when import

### DIFF
--- a/application/models/QuestionGroup.php
+++ b/application/models/QuestionGroup.php
@@ -68,6 +68,7 @@ class QuestionGroup extends LSActiveRecord
                 'message'=>'{attribute} "{value}" is already in use.'),
             array('language', 'length', 'min' => 2, 'max'=>20), // in array languages ?
             array('group_name,description', 'LSYii_Validators'),
+            array('group_name', 'length', 'min' => 0, 'max'=>100),
             array('group_order', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>true),
         );
     }


### PR DESCRIPTION
Dev: since import_helper didn't have good error system … fix it silently
This import_helper are reaaly awfull

1. Must remove all usage of insertRecords : all this function disable good error return
2. Must have a good check error if happen (example : on't include question inside group if group didn't exist
3. etc …