### PR TITLE
Fixed issue: {SID} placeholder does not work in email templates

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1361,6 +1361,7 @@ class tokens extends Survey_Common_Action
                         $to[] = ($emrow['firstname']." ".$emrow['lastname']." <{$sEmailaddress}>");
                     }
 
+                    $fieldsarray["{SID}"] = $iSurveyId;
                     foreach ($emrow as $attribute => $value) {
                         $fieldsarray['{'.strtoupper($attribute).'}'] = $value;
                     }


### PR DESCRIPTION
Fixed issue: {SID} placeholder does not work in email templates
Dev: It's already available in the placeholder list in the GUI (see image below) but it just gets replaced with an empty string.

<img width="554" alt="screen shot 2018-10-06 at 23 31 23" src="https://user-images.githubusercontent.com/34108452/46575969-1a7b6b80-c9c0-11e8-9fd5-6c11951dd19c.png">