### PR TITLE
Update parameter definition for list_participants function in RemoteControl API

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1981,7 +1981,7 @@ class remotecontrol_handle
      * @param int  $iLimit Number of participants to return
      * @param bool $bUnused If you want unused tokens, set true
      * @param bool|array $aAttributes The extented attributes that we want
-     * @param array $aConditions Optional conditions to limit the list, e.g. with array('email' => 'info@example.com')
+     * @param array|struct $aConditions Optional conditions to limit the list, e.g. with array('email' => 'info@example.com')
      * @return array The list of tokens
      */
     public function list_participants($sSessionKey, $iSurveyID, $iStart = 0, $iLimit = 10, $bUnused = false, $aAttributes = false, $aConditions = array())


### PR DESCRIPTION
add <struct> type to  parameter definition for list_participants function in RemoteControl API so the function take the parameters and use it like filter of data

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 