### PR TITLE
Add event to allow survey search tweaking

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1615,7 +1615,12 @@ class Survey extends LSActiveRecord
                 'pageSize'=>$pageSize,
             ),
         ));
-
+        
+        $oEvent = new \LimeSurvey\PluginManager\PluginEvent('beforeSurveySearch');
+        $oEvent->set('oCActiveDataProvider', $dataProvider);
+        App()->getPluginManager()->dispatchEvent($oEvent);
+        $dataProvider = $oEvent->get('oCActiveDataProvider');
+        
         $dataProvider->setTotalItemCount($this->count($criteria));
 
         return $dataProvider;


### PR DESCRIPTION
Add 'beforeSurveySearch' event dispatch after standard criteria/count/other search options have been build.

The handler gets the data provider and can modify/swap it. This allows further plugin-based search refinements like allowing a certain subset of users (that cannot be superadmin) to see all surveys or having virtualhost owned surveys.

One may also want to catch the 'beforeHasPermission' event to restrict access using the same rules ...

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 