### PR TITLE
Fixed issue #14416: LDAP participant names not sorted alphabetically in the survey creation form

### DIFF
--- a/application/views/admin/token/ldapform.php
+++ b/application/views/admin/token/ldapform.php
@@ -43,7 +43,9 @@
                         </label>
                         <div class="">
                             <select name='ldapQueries' class="form-control">
-                                <?php foreach ($ldap_queries as $q_number => $q): ?>
+                                <?php $names = array_column($ldap_queries, 'name');
+                                      array_multisort($names, $ldap_queries);
+                                      foreach ($ldap_queries as $q_number => $q): ?>
                                     <option value="<?php echo $q_number; ?>"><?php echo $q['name']; ?></option>
                                 <?php endforeach; ?>
                             </select>


### PR DESCRIPTION
Fixed issue #14416: Sort LDAP participant names alphabetically in the survey creation form

Dev: While creating a survey, if the "Import survey participants from LDAP" option is used and
participants are configured in the "/application/config/ldap.php" file, the UI does not display
those participants' names in sorted order making it difficult to search for a required option
from a long list of options.