### PR TITLE
New feature: Warn when activating a survey that is expired by config

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -143,7 +143,7 @@ use \LimeSurvey\PluginManager\PluginEvent;
  * @property bool $isNoKeyboard Show on-screen keyboard
  * @property bool $isAllowEditAfterCompletion Allow multiple responses or update responses with one token
  * @property SurveyLanguageSetting $defaultlanguage
- * @property boolean $isExpiredByConfig Whether survey is expired depending on the current time and survey configuration status
+ * @property boolean $isDateExpired Whether survey is expired depending on the current time and survey configuration status
  * @method mixed active()
  */
 class Survey extends LSActiveRecord
@@ -1120,7 +1120,7 @@ class Survey extends LSActiveRecord
      * @return bool
      * @throws Exception
      */
-    public function getIsExpiredByConfig()
+    public function getIsDateExpired()
     {
         if (!empty($this->expires)) {
             $sNow = date("Y-m-d H:i:s", strtotime(Yii::app()->getConfig('timeadjust'), strtotime(date("Y-m-d H:i:s"))));

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -143,6 +143,7 @@ use \LimeSurvey\PluginManager\PluginEvent;
  * @property bool $isNoKeyboard Show on-screen keyboard
  * @property bool $isAllowEditAfterCompletion Allow multiple responses or update responses with one token
  * @property SurveyLanguageSetting $defaultlanguage
+ * @property boolean $isExpiredByConfig Whether survey is expired depending on the current time and survey configuration status
  * @method mixed active()
  */
 class Survey extends LSActiveRecord
@@ -1113,6 +1114,23 @@ class Survey extends LSActiveRecord
         else {
             return 'running';
         }
+    }
+
+    /**
+     * @return bool
+     * @throws Exception
+     */
+    public function getIsExpiredByConfig()
+    {
+        if (!empty($this->expires)) {
+            $sNow = date("Y-m-d H:i:s", strtotime(Yii::app()->getConfig('timeadjust'), strtotime(date("Y-m-d H:i:s"))));
+            $sStop = ($this->expires != '') ? date("Y-m-d H:i:s", strtotime(Yii::app()->getConfig('timeadjust'), strtotime($this->expires))) : $sNow;
+
+            $oNow = new DateTime($sNow);
+            $oStop = new DateTime($sStop);
+            return $oStop < $oNow;
+        }
+        return false;
     }
 
 

--- a/application/views/admin/survey/activateSurvey_view.php
+++ b/application/views/admin/survey/activateSurvey_view.php
@@ -187,7 +187,7 @@
         <p class='col-sm-7 col-sm-offset-2'>
             <?php eT("Please note that once responses have collected with this survey and you want to add or remove groups/questions or change one of the settings above, you will need to deactivate this survey, which will move all data that has already been entered into a separate archived table."); ?><br /><br />
         </p>
-        <?php if($oSurvey->getIsExpiredByConfig()):?>
+        <?php if($oSurvey->getIsDateExpired()):?>
         <div class="row">
             <div class='col-sm-7 col-sm-offset-2'>
 

--- a/application/views/admin/survey/activateSurvey_view.php
+++ b/application/views/admin/survey/activateSurvey_view.php
@@ -1,3 +1,7 @@
+<?php
+/** @var Survey $oSurvey */
+
+?>
 <?php if ((isset($failedcheck) && $failedcheck) || (isset($failedgroupcheck) && $failedgroupcheck)): ?>
 <div class='side-body <?php echo getSideBodyClass(false); ?>'>
     <div class="row welcome survey-action">
@@ -183,6 +187,15 @@
         <p class='col-sm-7 col-sm-offset-2'>
             <?php eT("Please note that once responses have collected with this survey and you want to add or remove groups/questions or change one of the settings above, you will need to deactivate this survey, which will move all data that has already been entered into a separate archived table."); ?><br /><br />
         </p>
+        <?php if($oSurvey->getIsExpiredByConfig()):?>
+        <div class="row">
+            <div class='col-sm-7 col-sm-offset-2'>
+
+                <div class="alert alert-danger"><?= Yii::t('app', 'NB! The survey you are activating is currently expired! The survey will not be available for participants.')?><div>
+            </div>
+
+        </div>
+        <?php endif;?>
 
         <div class='col-sm-6 col-sm-offset-4'>
             <input type='hidden' name='ok' value='Y' />

--- a/application/views/admin/survey/activateSurvey_view.php
+++ b/application/views/admin/survey/activateSurvey_view.php
@@ -191,7 +191,7 @@
         <div class="row">
             <div class='col-sm-7 col-sm-offset-2'>
 
-                <div class="alert alert-danger"><?= Yii::t('app', 'NB! The survey you are activating is currently expired! The survey will not be available for participants.')?><div>
+                <div class="alert alert-warning"><?= Yii::t('app', 'Note: This survey has a past expiration date configured and is currently not available to participants. Please remember to update/remove the expiration date in the survey settings after activation.')?><div>
             </div>
 
         </div>


### PR DESCRIPTION
We have had some weird issues with survey settings somehow not being saved. And survey being activated with the expiry date set in past. 

It is only logical to have a warning when one tries to activate a survey that has the configuration that will end up in activating a survey which will not be ready for participating. 