### PR TITLE
Fixed issue: JsonEditor to not encode the value if it is already a valid json

### DIFF
--- a/application/extensions/yii-jsoneditor/JsonEditor.php
+++ b/application/extensions/yii-jsoneditor/JsonEditor.php
@@ -47,7 +47,13 @@
 		{
 			$htmlOptions = $this->htmlOptions;
             list($name, $id) = $this->resolveNameID();
-			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, json_encode($this->value), array(
+			$value = $this->value;
+			// not a json, encoding
+			if (!isJson($this->value)) {
+				$value = json_encode($this->value);
+			}
+
+			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, $value, array(
 				'id' => $id,
                 'encode' => false,
 			)));


### PR DESCRIPTION
If the value is already a valid JSON, do not encode it
related to 
https://github.com/LimeSurvey/LimeSurvey/pull/634