### PR TITLE
New feature: Add placeholder text for text and numeric responses

### DIFF
--- a/application/core/QuestionTypes/HugeFreeText/RenderHugeFreeText.php
+++ b/application/core/QuestionTypes/HugeFreeText/RenderHugeFreeText.php
@@ -39,6 +39,7 @@ class RenderHugeFreeText extends QuestionBaseRenderer
         $maxlength = "";
         $withColumn = false;
         $inputsize = null;
+        $placeholder = "";
 
         $drows = $this->setDefaultIfEmpty(
             $this->getQuestionAttribute('display_rows'), 
@@ -69,6 +70,10 @@ class RenderHugeFreeText extends QuestionBaseRenderer
             $extraclass .= " ls-input-sized";
         }
 
+        if (trim($this->getQuestionAttribute('placeholder',$this->sLanguage)) != '') {
+            $placeholder = htmlspecialchars($this->getQuestionAttribute('placeholder',$this->sLanguage));
+        }
+
         $answer = Yii::app()->twigRenderer->renderQuestion($this->getMainView(), array(
             'extraclass'             => $extraclass,
             'coreClass'              => "ls-answers answer-item text-item ".$sCoreClasses,
@@ -81,6 +86,7 @@ class RenderHugeFreeText extends QuestionBaseRenderer
             'dispVal'                => htmlspecialchars($this->mSessionValue),
             'inputsize'              => $inputsize,
             'maxlength'              => $maxlength,
+            'placeholder'            => $placeholder,
         ), true);
 
         if (!empty($this->getQuestionAttribute('time_limit', 'value'))) {

--- a/application/core/QuestionTypes/LongFreeText/RenderLongFreeText.php
+++ b/application/core/QuestionTypes/LongFreeText/RenderLongFreeText.php
@@ -39,6 +39,7 @@ class RenderLongFreeText extends QuestionBaseRenderer
         $maxlength = "";
         $withColumn = false;
         $inputsize = null;
+        $placeholder = "";
 
         $drows = $this->setDefaultIfEmpty(
             $this->getQuestionAttribute('display_rows'), 
@@ -69,6 +70,10 @@ class RenderLongFreeText extends QuestionBaseRenderer
             $extraclass .= " ls-input-sized";
         }
 
+        if (trim($this->getQuestionAttribute('placeholder',$this->sLanguage)) != '') {
+            $placeholder = htmlspecialchars($this->getQuestionAttribute('placeholder',$this->sLanguage));
+        }
+
         $answer = Yii::app()->twigRenderer->renderQuestion($this->getMainView(), array(
             'extraclass'             => $extraclass,
             'coreClass'              => "ls-answers answer-item text-item ".$sCoreClasses,
@@ -81,6 +86,7 @@ class RenderLongFreeText extends QuestionBaseRenderer
             'dispVal'                => htmlspecialchars($this->mSessionValue),
             'inputsize'              => $inputsize,
             'maxlength'              => $maxlength,
+            'placeholder'            => $placeholder,
         ), true);
 
         if (!empty($this->getQuestionAttribute('time_limit', 'value'))) {

--- a/application/core/QuestionTypes/Numerical/RenderNumerical.php
+++ b/application/core/QuestionTypes/Numerical/RenderNumerical.php
@@ -34,9 +34,14 @@ class RenderNumerical extends QuestionBaseRenderer
 
         $answer = '';
         $inputnames = [];
+        $placeholder = "";
 
         if (!empty($this->getQuestionAttribute('time_limit', 'value'))) {
             $answer .= $this->getTimeSettingRender();
+        }
+
+        if (trim($this->getQuestionAttribute('placeholder',$this->sLanguage)) != '') {
+            $placeholder = htmlspecialchars($this->getQuestionAttribute('placeholder',$this->sLanguage));
         }
 
         $answer .=  Yii::app()->twigRenderer->renderQuestion($this->getMainView(), array(
@@ -45,6 +50,7 @@ class RenderNumerical extends QuestionBaseRenderer
             'basename'=>$this->sSGQA, 
             'content' => $this->oQuestion,
             'coreClass'=> 'ls-answers '.$sCoreClasses,
+            'placeholder'=> $placeholder,
             ), true);
 
         $inputnames[] = [];

--- a/application/core/QuestionTypes/ShortFreeText/RenderShortFreeText.php
+++ b/application/core/QuestionTypes/ShortFreeText/RenderShortFreeText.php
@@ -35,9 +35,14 @@ class RenderShortFreeText extends QuestionBaseRenderer
 
         $answer = '';
         $inputnames = [];
+        $placeholder = "";
 
         if (!empty($this->getQuestionAttribute('time_limit', 'value'))) {
             $answer .= $this->getTimeSettingRender();
+        }
+
+        if (trim($this->getQuestionAttribute('placeholder',$this->sLanguage)) != '') {
+            $placeholder = htmlspecialchars($this->getQuestionAttribute('placeholder',$this->sLanguage));
         }
 
         $answer .=  Yii::app()->twigRenderer->renderQuestion($this->getMainView(), array(
@@ -46,6 +51,7 @@ class RenderShortFreeText extends QuestionBaseRenderer
             'basename'=>$this->sSGQA,
             'content' => $this->oQuestion,
             'coreClass'=> 'ls-answers '.$sCoreClasses,
+            'placeholder'=> $placeholder,
             ), true);
 
         $inputnames[] = [];

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2382,7 +2382,12 @@ function do_numerical($ia)
     } else {
         $integeronly = 0;
     }
-
+    if (trim($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]) != '') {
+        $placeholder = htmlspecialchars($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]);
+    } else {
+        $placeholder = '';
+    }
+ 
     $fValue     = $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]];
     $sSeparator = getRadixPointData($thissurvey['surveyls_numberformat']);
     $sSeparator = $sSeparator['separator'];
@@ -2413,6 +2418,7 @@ function do_numerical($ia)
         'integeronly'            => $integeronly,
         'maxlength'              => $maxlength,
         'suffix'                 => $suffix,
+        'placeholder'            => $placeholder,
         ), true);
 
     $inputnames = [];
@@ -2478,6 +2484,11 @@ function do_shortfreetext($ia)
     } else {
         $suffix = '';
     }
+    if (trim($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]) != '') {
+        $placeholder = htmlspecialchars($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]);
+    } else {
+        $placeholder = '';
+    }
     if ($thissurvey['nokeyboard'] == 'Y') {
         includeKeypad();
         $kpclass     = "text-keypad";
@@ -2517,6 +2528,7 @@ function do_shortfreetext($ia)
             'prefix'                 => $prefix,
             'suffix'                 => $suffix,
             'inputsize'              => $inputsize,
+            'placeholder'            => $placeholder,
             'withColumn'             => $withColumn
             ), true);
     } elseif ((int) ($aQuestionAttributes['location_mapservice']) == 1) {
@@ -2595,6 +2607,7 @@ function do_shortfreetext($ia)
             'questionHelp'           => $questionHelp,
             'question_text_help'     => $sQuestionHelpText,
             'inputsize'              => $inputsize,
+            'placeholder'            => $placeholder,
             'withColumn'             => $withColumn
             ), true);
     } elseif ((int) ($aQuestionAttributes['location_mapservice']) == 100) {
@@ -2660,6 +2673,7 @@ function do_shortfreetext($ia)
             'currentLat'=>$currentLatLong[0],
             'currentLong'=>$currentLatLong[1],
             'inputsize'              => $inputsize,
+            'placeholder'            => $placeholder,
             'withColumn'             => $withColumn
         );
         $answer = doRender('/survey/questions/answer/shortfreetext/location_mapservice/item_100', $itemDatas, true);
@@ -2682,6 +2696,7 @@ function do_shortfreetext($ia)
             'dispVal'=>$dispVal,
             'maxlength'=>$maxlength,
             'inputsize'              => $inputsize,
+            'placeholder'            => $placeholder,
             'withColumn'             => $withColumn
         );
         $answer = doRender('/survey/questions/answer/shortfreetext/text/item', $itemDatas, true);
@@ -2760,7 +2775,12 @@ function do_longfreetext($ia)
     } else {
         $inputsize = null;
     }
-
+    if (trim($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]) != '') {
+        $placeholder = htmlspecialchars($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]);
+    } else {
+        $placeholder = '';
+    }
+    
     $dispVal = ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) ?htmlspecialchars($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) : '';
 
     $answer = doRender('/survey/questions/answer/longfreetext/answer', array(
@@ -2775,6 +2795,7 @@ function do_longfreetext($ia)
         'dispVal'                => $dispVal,
         'inputsize'              => $inputsize,
         'maxlength'              => $maxlength,
+        'placeholder'            => $placeholder,
         ), true);
 
 
@@ -2831,7 +2852,12 @@ function do_hugefreetext($ia)
     } else {
         $inputsize = null;
     }
-
+    if (trim($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]) != '') {
+        $placeholder = htmlspecialchars($aQuestionAttributes['placeholder'][$_SESSION['survey_'.Yii::app()->getConfig('surveyID')]['s_lang']]);
+    } else {
+        $placeholder = '';
+    }
+ 
     $dispVal = "";
     if ($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]) {
         $dispVal = htmlspecialchars($_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$ia[1]]);
@@ -2849,6 +2875,7 @@ function do_hugefreetext($ia)
         'dispVal'=>$dispVal,
         'inputsize'=>$inputsize,
         'maxlength'=>$maxlength,
+        'placeholder'=>$placeholder,
     );
     $answer = doRender('/survey/questions/answer/longfreetext/answer', $itemDatas, true);
 

--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -796,6 +796,17 @@ class questionHelper
             "caption"=>gT('Insert page break in printable view')
         );
 
+        self::$attributes["placeholder"] = array(
+            "types"=>Question::QT_S_SHORT_FREE_TEXT.Question::QT_T_LONG_FREE_TEXT.Question::QT_U_HUGE_FREE_TEXT.Question::QT_N_NUMERICAL,
+            'category'=>gT('Display'),
+            'sortorder'=>12,
+            'inputtype'=>'text',
+            'expression'=>1,
+            'i18n'=>true,
+            "help"=>gT('A placeholder answer to a question. This will appear in the answer field and disappear when real answer text is entered.'),
+            "caption"=>gT('Placeholder answer')
+        );
+
         self::$attributes["prefix"] = array(
         "types"=>Question::QT_K_MULTIPLE_NUMERICAL_QUESTION.Question::QT_N_NUMERICAL.Question::QT_Q_MULTIPLE_SHORT_TEXT.Question::QT_S_SHORT_FREE_TEXT,
             'category'=>gT('Display'),

--- a/application/views/survey/questions/answer/longfreetext/answer.twig
+++ b/application/views/survey/questions/answer/longfreetext/answer.twig
@@ -9,6 +9,7 @@
  * @var maxlength
  * @var checkconditionFunction
  * @var dispVal
+ * @var placeholder
  */
  #}
 <!-- Long Free Text -->
@@ -24,6 +25,7 @@
         class="form-control {{ kpclass }}"
         name="{{ name }}"
         id="answer{{ name }}"
+        placeholder="{{ placeholder }}"
         rows="{{ drows }}"
         {% if inputsize %} cols="{{ inputsize }}" {% endif %}
         {% if maxlength %} maxlength="{{ maxlength }}" {% endif %}

--- a/application/views/survey/questions/answer/longfreetext/config.xml
+++ b/application/views/survey/questions/answer/longfreetext/config.xml
@@ -265,6 +265,18 @@
             <expression></expression>
         </attribute>
         <attribute>
+            <name>placeholder</name>
+            <category>Display</category>
+            <sortorder>12</sortorder>
+            <inputtype>text</inputtype>
+            <expression>1</expression>
+            <i18n>1</i18n>
+            <help>A placeholder answer to a question. This will appear in the answer field and disappear when real answer text is entered.</help>
+            <caption>Placeholder answer</caption>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+        </attribute>
+        <attribute>
             <name>text_input_width</name>
             <category>Display</category>
             <sortorder>100</sortorder>

--- a/application/views/survey/questions/answer/numerical/answer.twig
+++ b/application/views/survey/questions/answer/numerical/answer.twig
@@ -12,6 +12,7 @@
  * @var $integeronly
  * @var $maxlength
  * @var $suffix
+ * @var $placeholder
  */
 #}
 <!-- Numerical -->
@@ -38,6 +39,7 @@
         'class' : "form-control "~answertypeclass,
         'title' : gT('Only numbers may be entered in this field.'),
         'size' : (inputsize ? inputsize : null),
+        'placeholder' : placeholder,
         'maxlength' : (maxlength ? maxlength : null),
         'data-number' : 1,
         'data-integer' : integeronly,

--- a/application/views/survey/questions/answer/numerical/config.xml
+++ b/application/views/survey/questions/answer/numerical/config.xml
@@ -312,6 +312,18 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
+            <name>placeholder</name>
+            <category>Display</category>
+            <sortorder>12</sortorder>
+            <inputtype>text</inputtype>
+            <expression>1</expression>
+            <i18n>1</i18n>
+            <help>A placeholder answer to a question. This will appear in the answer field and disappear when real answer text is entered.</help>
+            <caption>Placeholder answer</caption>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+        </attribute>
+        <attribute>
             <name>printable_help</name>
             <category>Display</category>
             <sortorder>201</sortorder>

--- a/application/views/survey/questions/answer/shortfreetext/config.xml
+++ b/application/views/survey/questions/answer/shortfreetext/config.xml
@@ -528,6 +528,30 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
+            <name>placeholder</name>
+            <category>Display</category>
+            <sortorder>12</sortorder>
+            <inputtype>text</inputtype>
+            <expression>1</expression>
+            <i18n>1</i18n>
+            <help>A placeholder answer to a question. This will appear in the answer field and disappear when real answer text is entered.</help>
+            <caption>Placeholder answer</caption>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+        </attribute>
+        <attribute>
+            <name>placeholder</name>
+            <category>Display</category>
+            <sortorder>12</sortorder>
+            <inputtype>text</inputtype>
+            <expression>1</expression>
+            <i18n>1</i18n>
+            <help>Placeholder</help>
+            <caption>Placeholder</caption>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+        </attribute>
+        <attribute>
             <name>text_input_width</name>
             <category>Display</category>
             <sortorder>100</sortorder>

--- a/application/views/survey/questions/answer/shortfreetext/text/item.twig
+++ b/application/views/survey/questions/answer/shortfreetext/text/item.twig
@@ -9,6 +9,7 @@
  * $kpclass
  * $tiwidth
  * $dispVal
+ * $placeholder
  * $maxlength
  * $checkconditionFunction
  */
@@ -36,6 +37,7 @@
             name="{{ name }}"
             id="answer{{ name }}"
             value="{{ dispVal }}"
+            placeholder="{{ placeholder }}"
             {% if inputsize %}size="{{ inputsize }}" {% endif %}
             {% if maxlength %}maxlength="{{ maxlength }}" {% endif %}
             aria-labelledby="ls-question-text-{{ basename }}"

--- a/application/views/survey/questions/answer/shortfreetext/textarea/item.twig
+++ b/application/views/survey/questions/answer/shortfreetext/textarea/item.twig
@@ -11,6 +11,7 @@
  * @var $tiwidth
  * @var $checkconditionFunction      $checkconditionFunction.'(this.value, this.name, this.type)
  * @var $dispVal
+ * @var $placeholder
  */
 #}
 
@@ -36,6 +37,7 @@
                 name="{{ name }}"
                 id="{{ freeTextId }}"
                 rows="{{ drows }}"
+                placeholder="{{ placeholder }}"
                 {% if inputsize %}cols="{{ inputsize }}" {% endif %}
                 {% if maxlength %}maxlength="{{ maxlength }}" {% endif %}
                 aria-labelledby="ls-question-text-{{ basename }}"


### PR DESCRIPTION
Adds a "Placeholder answer" text box to the "Display" section during question edits

![editing](https://user-images.githubusercontent.com/1452303/52686609-9c008d00-2fa2-11e9-8eaa-f75bc2b1cea4.png)

Adds the placeholder attribute to short/long/huge text and numeric responses

![placeholder-example](https://user-images.githubusercontent.com/1452303/52686626-b5a1d480-2fa2-11e9-9264-611323c232d0.gif)
