### PR TITLE
New feature: Add reference to group relevance (if any) in question view

### DIFF
--- a/application/views/admin/survey/Question/question_view.php
+++ b/application/views/admin/survey/Question/question_view.php
@@ -1,3 +1,6 @@
+<?php
+/** @var Question $oQuestion */
+?>
 <div class='side-body <?php echo getSideBodyClass(true); ?>'>
     <div class="pagetitle h3"><?php eT('Question summary'); ?>  <small><em><?php echo  $qrrow['title'];?></em> (ID: <?php echo (int) $qid;?>)</small></div>
     <div class="row">
@@ -168,6 +171,19 @@
                         <td>
                             <?php
                             LimeExpressionManager::ProcessString("{" . $qrrow['relevance'] . "}", $qid);    // tests Relevance equation so can pretty-print it
+                            echo LimeExpressionManager::GetLastPrettyPrintExpression();
+                            ?>
+                        </td>
+                    </tr>
+                <?php endif; ?>
+
+                <!-- Group Relevance equation -->
+                <?php if (trim($oQuestion->groups->grelevance)!=''): ?>
+                    <tr>
+                        <td><?php eT("Group relevance:"); ?></td>
+                        <td>
+                            <?php
+                            templatereplace('{' . $oQuestion->groups->grelevance . '}');
                             echo LimeExpressionManager::GetLastPrettyPrintExpression();
                             ?>
                         </td>


### PR DESCRIPTION
Question view should display all logic that determines whether this question is shown or not. If question has a parent relevance from group applied, it really should be shown.