### PR TITLE
Fix#14495: Enforce filter to avoid 'comment' keyword

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -136,7 +136,7 @@ class Question extends LSActiveRecord
             }
             // #14495: comment suffix can't be used with P Question (collapse with table name in database)
             if ($oParentQuestion->type == "P") {
-                $aRules[] = array('title', 'match', 'pattern'=>'/.+comment$/', 'not'=>true, 'message'=> gT("'comment' suffix can not be used with multiple choice with comments."));
+                $aRules[] = array('title', 'match', 'pattern'=>'/comment$/', 'not'=>true, 'message'=> gT("'comment' suffix can not be used with multiple choice with comments."));
             }
         } else {
             // Disallow other if sub question have 'other' for title


### PR DESCRIPTION
Fixed issue #14495 : 
I already fixed this issue but we still can use the 'comment' keyword.
With this fix, 'comment' becomes forbidden.