### PR TITLE
Fix #14599: Crash when enabling evaluation on an empty survey

### DIFF
--- a/application/controllers/admin/assessments.php
+++ b/application/controllers/admin/assessments.php
@@ -252,6 +252,7 @@ class Assessments extends Survey_Common_Action
      */
     private function _collectGroupData($iSurveyID, &$aData = array())
     {
+        $aData['groups'] = [];
         $groups = QuestionGroup::model()->findAllByAttributes(array('sid' => $iSurveyID));
         foreach ($groups as $group) {
             $groupId = $group->attributes['gid'];


### PR DESCRIPTION
Fixed issue #14599