### PR TITLE
Fix the user's creation error when first connecting with the AuthCAS plugin

### DIFF
--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -256,7 +256,7 @@ function createDatabase($oDB){
         $oDB->createCommand()->createTable('{{permissions}}', array(
             'id' =>  "pk",
             'entity' =>  "string(50) NOT NULL",
-            'entity_id' =>  "integer NOT NULL",
+            'entity_id' =>  "integer NOT NULL default 0",
             'uid' =>  "integer NOT NULL",
             'permission' =>  "string(100) NOT NULL",
             'create_p' =>  "integer NOT NULL default 0",


### PR DESCRIPTION
When attempting to add a user to the database who is try to authentificate with the AuthCAS plugin :

```
Internal Server Error
CDbCommand failed to execute the SQL statement: SQLSTATE [HY000]: General error: 1364 Field 'entity_id' does not have a default value
An internal error occurred while the Web server was processing your request. Please contact the webmaster to report this problem.
```

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 