### PR TITLE
Fixed issue #14649: CDbException when a "default answer" option is not compatible with a question type

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6942,9 +6942,9 @@
                             $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
                         }
                         /* Add it in view for user with Permission surveycontent update right */
+                        $validityString=self::getValidityString($sgqa);
                         if($validityString)
                         {
-                            /* Add the string to be showned , no js error or another class ? */
                             $validTip .= Yii::app()->getController()->renderPartial('//survey/questions/question_help/error-tip', array(
                                 'qid'=>$qid,
                                 'coreId'    =>"vmsg_{$qid}_defaultvalueerror",

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6939,7 +6939,9 @@
                     if (!isset($_SESSION[$LEM->sessid][$sgqa]) && !is_null($LEM->knownVars[$sgqa]['default']))
                     {
                         $_SESSION[$LEM->sessid][$sgqa]=$LEM->ProcessString($LEM->knownVars[$sgqa]['default'], $qInfo['qid'], NULL, 1, 1, false, false, true);// Fill the $_SESSION to don't do it again a second time
-                        $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
+                        if(self::checkValidityAnswer($qInfo['type'],$_SESSION[$LEM->sessid][$sgqa],$sgqa,$qInfo,Permission::model()->hasSurveyPermission($LEM->sid, 'surveycontent', 'update'))) {
+                            $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
+                        }
                     }
                 }
             }
@@ -10136,12 +10138,13 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
          * @param string $value : the value
          * @param string $sgq : the sgqa
          * @param array $qinfo : an array with information from question
-         *
+         * @param boolean $setInvalidAnswerString : update the invalid string or not. Used for #14649 (invalid default value)
+         * 
          * @return boolean true : if question is OK to be put in session, false if must be set to null
          */
-        private static function checkValidityAnswer($type,$value,$sgq,$qinfo)
+        private static function checkValidityAnswer($type,$value,$sgq,$qinfo,$setInvalidAnswerString = true)
         {
-            if(isset($value) && $value!=="")
+            if(!empty($value))
             {
                 /* This function is called by a static function , then set it to static .... */
                 $LEM =& LimeExpressionManager::singleton();
@@ -10153,7 +10156,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case '5': // 5 point choice
                         if(!in_array($value,array("1","2","3","4","5")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10165,7 +10170,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                             {
                                 if($qinfo['info']['other']!='Y')
                                 {
-                                    $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                    if($setInvalidAnswerString) {
+                                        $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                    }
                                     return false;
                                 }
                             }
@@ -10173,7 +10180,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                             {
                                 if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                                 {
-                                    $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                    if($setInvalidAnswerString) {
+                                        $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                    }
                                     return false;
                                 }
                             }
@@ -10184,7 +10193,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                         {
                             if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                             {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                if($setInvalidAnswerString) {
+                                    $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                                }
                                 return false;
                             }
                         }
@@ -10192,28 +10203,36 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'F': // Array
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'B': // Array 10 point
                         if(!in_array($value,array("1","2","3","4","5","6","7","8","9","10")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'A': // Array 5 point
                         if(!in_array($value,array("1","2","3","4","5")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'E': // Array increase decrease same
                         if(!in_array($value,array("I","D","S")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10226,14 +10245,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'C': // Array Yes No Uncertain
                         if(!in_array($value,array("Y","N","U")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'H': // Array by column
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10241,7 +10264,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                         $scale=intval(substr($sgq,-1)); // Get the scale {SGQ}#0 or {SGQ}#1 actually
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language,$scale))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10257,14 +10282,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'G': // Gender
                         if(!in_array($value,array("M","F")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'I': // Language switch
                         if(!in_array($value,Survey::model()->findByPk($LEM->sid)->getAllLanguages()))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10272,14 +10301,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'N': // Numerical
                         if(!preg_match("/^[-]?(\d{1,20}\.\d{0,10}|\d{1,20})$/",$value)) // DECIMAL(30,10)
                         {
-                            $LEM->invalidAnswerString[$sgq]=gT("This question only accept 30 digits including 10 decimals.");
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=gT("This question only accept 30 digits including 10 decimals.");
+                            }
                             /* Show an error but don't unset value : this can happen without hack */
                         }
                         break;
                     case 'R':  // Ranking
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10289,7 +10322,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'Y': // Gender
                         if(!in_array($value,array("Y","N")))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
@@ -10302,14 +10337,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'M':
                         if($value!="Y" && (substr($sgq,-5)!='other' && $qinfo['info']['other']=='Y'))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;
                     case 'P':
                         if(substr($sgq,-7)!='comment' && $value!="Y" && (substr($sgq,-5)!='other' && $qinfo['info']['other']=='Y'))
                         {
-                            $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            if($setInvalidAnswerString) {
+                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
+                            }
                             return false;
                         }
                         break;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6941,17 +6941,18 @@
                         if(self::checkValidityAnswer($qInfo['type'],$_SESSION[$LEM->sessid][$sgqa],$sgqa,$qInfo,Permission::model()->hasSurveyPermission($LEM->sid, 'surveycontent', 'update'))) {
                             $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
                         }
-                        /* Add it in view for user with Permission surveycontent update right */
-                        $validityString=self::getValidityString($sgqa);
-                        if($validityString)
+                        /* cleanup  $LEM->validityString[$sgqa] */
+                        $validityString = self::getValidityString($sgqa);
+                        /* Add it in view for user with Permission surveycontent update right (double check, but I think it's more clear)*/
+                        if( $validityString && Permission::model()->hasSurveyPermission($LEM->sid, 'surveycontent', 'update') )
                         {
                             $validTip .= Yii::app()->getController()->renderPartial('//survey/questions/question_help/error-tip', array(
                                 'qid'=>$qid,
                                 'coreId'    =>"vmsg_{$qid}_defaultvalueerror",
                                 'vclass'=>'defaultvalueerror',
                                 'coreClass'=>'ls-em-tip em_defaultvalueerror',
-                                'vtip'  =>$validityString)
-                            , true);
+                                'vtip'  => sprintf(gT("Error in default value : %s"),$validityString)
+                            ), true);
                         }
                     }
                 }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6936,11 +6936,22 @@
                 $allSQs = explode('|',$LEM->qid2code[$qid]);
                 foreach ($allSQs as $sgqa)
                 {
-                    if (!isset($_SESSION[$LEM->sessid][$sgqa]) && !is_null($LEM->knownVars[$sgqa]['default']))
-                    {
+                    if (!isset($_SESSION[$LEM->sessid][$sgqa]) && !is_null($LEM->knownVars[$sgqa]['default'])) {
                         $_SESSION[$LEM->sessid][$sgqa]=$LEM->ProcessString($LEM->knownVars[$sgqa]['default'], $qInfo['qid'], NULL, 1, 1, false, false, true);// Fill the $_SESSION to don't do it again a second time
                         if(self::checkValidityAnswer($qInfo['type'],$_SESSION[$LEM->sessid][$sgqa],$sgqa,$qInfo,Permission::model()->hasSurveyPermission($LEM->sid, 'surveycontent', 'update'))) {
                             $LEM->updatedValues[$sgqa] = $updatedValues[$sgqa] = array('type'=>$qInfo['type'],'value'=>$_SESSION[$LEM->sessid][$sgqa]);
+                        }
+                        /* Add it in view for user with Permission surveycontent update right */
+                        if($validityString)
+                        {
+                            /* Add the string to be showned , no js error or another class ? */
+                            $validTip .= Yii::app()->getController()->renderPartial('//survey/questions/question_help/error-tip', array(
+                                'qid'=>$qid,
+                                'coreId'    =>"vmsg_{$qid}_defaultvalueerror",
+                                'vclass'=>'defaultvalueerror',
+                                'coreClass'=>'ls-em-tip em_defaultvalueerror',
+                                'vtip'  =>$validityString)
+                            , true);
                         }
                     }
                 }
@@ -10138,11 +10149,11 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
          * @param string $value : the value
          * @param string $sgq : the sgqa
          * @param array $qinfo : an array with information from question
-         * @param boolean $setInvalidAnswerString : update the invalid string or not. Used for #14649 (invalid default value)
+         * @param boolean $set : update the invalid string or not. Used for #14649 (invalid default value)
          * 
          * @return boolean true : if question is OK to be put in session, false if must be set to null
          */
-        private static function checkValidityAnswer($type,$value,$sgq,$qinfo,$setInvalidAnswerString = true)
+        private static function checkValidityAnswer($type,$value,$sgq,$qinfo,$set = true)
         {
             if(!empty($value))
             {
@@ -10156,23 +10167,19 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case '5': // 5 point choice
                         if(!in_array($value,array("1","2","3","4","5")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case '!': //List - dropdown
                     case 'L': //LIST drop-down/radio-button list
-                        if(substr($sgq,-5)!='other')// We must validate $value==="0", then don't use empty. $value is not set if irrelevant , then don't use $value!==null
+                        if(substr($sgq,-5)!='other')
                         {
                             if($value=="-oth-")
                             {
                                 if($qinfo['info']['other']!='Y')
                                 {
-                                    if($setInvalidAnswerString) {
-                                        $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                                    }
+                                    $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                                     return false;
                                 }
                             }
@@ -10180,9 +10187,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                             {
                                 if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                                 {
-                                    if($setInvalidAnswerString) {
-                                        $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                                    }
+                                    $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                                     return false;
                                 }
                             }
@@ -10193,9 +10198,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                         {
                             if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                             {
-                                if($setInvalidAnswerString) {
-                                    $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                                }
+                                $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                                 return false;
                             }
                         }
@@ -10203,36 +10206,28 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'F': // Array
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'B': // Array 10 point
                         if(!in_array($value,array("1","2","3","4","5","6","7","8","9","10")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'A': // Array 5 point
                         if(!in_array($value,array("1","2","3","4","5")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'E': // Array increase decrease same
                         if(!in_array($value,array("I","D","S")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10245,18 +10240,14 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'C': // Array Yes No Uncertain
                         if(!in_array($value,array("Y","N","U")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'H': // Array by column
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10264,9 +10255,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                         $scale=intval(substr($sgq,-1)); // Get the scale {SGQ}#0 or {SGQ}#1 actually
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language,$scale))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10282,18 +10271,14 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'G': // Gender
                         if(!in_array($value,array("M","F")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'I': // Language switch
                         if(!in_array($value,Survey::model()->findByPk($LEM->sid)->getAllLanguages()))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10301,18 +10286,14 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'N': // Numerical
                         if(!preg_match("/^[-]?(\d{1,20}\.\d{0,10}|\d{1,20})$/",$value)) // DECIMAL(30,10)
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=gT("This question only accept 30 digits including 10 decimals.");
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("This question only accept 30 digits including 10 decimals."),$set);
                             /* Show an error but don't unset value : this can happen without hack */
                         }
                         break;
                     case 'R':  // Ranking
                         if(!Answer::model()->getAnswerFromCode($qinfo['info']['qid'],$value,$language))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10322,9 +10303,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'Y': // Gender
                         if(!in_array($value,array("Y","N")))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10337,18 +10316,14 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     case 'M':
                         if($value!="Y" && (substr($sgq,-5)!='other' && $qinfo['info']['other']=='Y'))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
                     case 'P':
                         if(substr($sgq,-7)!='comment' && $value!="Y" && (substr($sgq,-5)!='other' && $qinfo['info']['other']=='Y'))
                         {
-                            if($setInvalidAnswerString) {
-                                $LEM->invalidAnswerString[$sgq]=sprintf(gT("%s is an invalid value for this question"),htmlspecialchars($value));
-                            }
+                            $LEM->addValidityString($sgq,$value,gT("%s is an invalid value for this question"),$set);
                             return false;
                         }
                         break;
@@ -10359,6 +10334,21 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
             return true;
         }
 
+        /**
+         * Set or log an invalid answer string
+         * @param string $sgqa : the SGQ (answer column / SGQA)
+         * @param string $message : the message
+         * @param boolean $add : add it to current validity or only og it
+         * @return void
+         */
+        public function addValidityString($sgqa,$value,$message,$add = true )
+        {
+            $sid = intval($this->sid); // Show 0 for null, more clear
+            Yii::log(sprintf("Survey %s invalid value %s for %s : %s (%s)",$sid,$value,$sgqa,$message,($add ? "added":"silently")),'error','application.LimeExpressionManager.invalidAnswerString.addValidityString');
+            if($add) {
+                $this->invalidAnswerString[$sgqa]=sprintf($message,Chtml::encode($value));
+            }
+        }
         /**
          * return the actual validity string , and reset the variable used ($_SESSION)
          * @param string $sgqa : the SGQ (answer name)


### PR DESCRIPTION
Dev: Add an option to set or not the invalid answer string
Dev: since getValidityString is call only for POSTED value, seem not really needed
Dev: but the param unsure it don't happen if user can not update survey

I like to shown the error on page for admin user, currently it don't work …