### PR TITLE
Dev: Added PluginEvent beforeAdminEmail, mirroring existing beforeTokenEmail

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -635,9 +635,27 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_notification'], $aReplacementVars, $redata, 'admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_notification_subj'], $aReplacementVars, $redata, 'admin_notification_subj', ($thissurvey['anonymized'] == "Y"), null, array(), true);
         foreach ($aEmailNotificationTo as $sRecipient) {
-        if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, getBounceEmail($surveyid), $aRelevantAttachments)) {
-                if ($debug > 0) {
-                    echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+            /* TEAMB-1102 */
+            $event = new PluginEvent('beforeAdminEmail');
+            $event->set('survey', $surveyid);
+            $event->set('type', 'confirm');
+            $event->set('model', 'confirm');
+            $event->set('subject', $sSubject);
+            $event->set('to', $sRecipient);
+            $event->set('body', $sMessage);
+            $event->set('from', $sFrom);
+            $event->set('bounce', getBounceEmail($surveyid));
+            App()->getPluginManager()->dispatchEvent($event);
+            $sSubject = $event->get('subject');
+            $sMessage = $event->get('body');
+            $sRecipient = $event->get('to');
+            $sFrom = $event->get('from');
+            $bounce = $event->get('bounce');
+            if ($event->get('send', true) != false) {
+                if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, $bounce, $aRelevantAttachments)) {
+                    if ($debug > 0) {
+                        echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+                    }
                 }
             }
         }
@@ -661,9 +679,27 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_responses'], $aReplacementVars, $redata, 'detailed_admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_responses_subj'], $aReplacementVars, $redata, 'detailed_admin_notification_subj', $thissurvey['anonymized'] == "Y", null, array(), true);
         foreach ($aEmailResponseTo as $sRecipient) {
-        if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, getBounceEmail($surveyid), $aRelevantAttachments)) {
-                if ($debug > 0) {
-                    echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+            /* TEAMB-1102 */
+            $event = new PluginEvent('beforeAdminEmail');
+            $event->set('survey', $surveyid);
+            $event->set('type', 'confirm');
+            $event->set('model', 'confirm');
+            $event->set('subject', $sSubject);
+            $event->set('to', $sRecipient);
+            $event->set('body', $sMessage);
+            $event->set('from', $sFrom);
+            $event->set('bounce', getBounceEmail($surveyid));
+            App()->getPluginManager()->dispatchEvent($event);
+            $sSubject = $event->get('subject');
+            $sMessage = $event->get('body');
+            $sRecipient = $event->get('to');
+            $sFrom = $event->get('from');
+            $bounce = $event->get('bounce');
+            if ($event->get('send', true) != false) {
+                if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, $bounce, $aRelevantAttachments)) {
+                    if ($debug > 0) {
+                        echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+                    }
                 }
             }
         }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -635,7 +635,6 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_notification'], $aReplacementVars, $redata, 'admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_notification_subj'], $aReplacementVars, $redata, 'admin_notification_subj', ($thissurvey['anonymized'] == "Y"), null, array(), true);
         foreach ($aEmailNotificationTo as $sRecipient) {
-            /* TEAMB-1102 */
             $event = new PluginEvent('beforeAdminEmail');
             $event->set('survey', $surveyid);
             $event->set('type', 'confirm');
@@ -679,7 +678,6 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_responses'], $aReplacementVars, $redata, 'detailed_admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_responses_subj'], $aReplacementVars, $redata, 'detailed_admin_notification_subj', $thissurvey['anonymized'] == "Y", null, array(), true);
         foreach ($aEmailResponseTo as $sRecipient) {
-            /* TEAMB-1102 */
             $event = new PluginEvent('beforeAdminEmail');
             $event->set('survey', $surveyid);
             $event->set('type', 'confirm');


### PR DESCRIPTION
While token emails have an API (beforeTokenEmail), admin emails do not.  This PluginEvent is needed so that all outgoing email is covered by APIs.

Fixed issue # : N/A
New feature # : N/A
Changed feature # : N/A
Dev: Added PluginEvent beforeAdminEmail, mirroring existing beforeTokenEmail, so that all outgoing email is covered by APIs.