### PR TITLE
Fixed issue #14268. LDAP import. duplicate filter does not work

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1704,8 +1704,8 @@ class tokens extends Survey_Common_Action
         if (!Yii::app()->request->getPost('submit')) {
             $this->_renderWrappedTemplate('token', array('ldapform'), $aData);
         } else {
-            $filterduplicatetoken = Yii::app()->request->getPost('filterduplicatetoken') == '1';
-            $filterblankemail = Yii::app()->request->getPost('filterblankemail') == '1';
+            $filterduplicatetoken = Yii::app()->request->getPost('filterduplicatetoken') == true;
+            $filterblankemail = Yii::app()->request->getPost('filterblankemail') == true;
 
             $ldap_queries = Yii::app()->getConfig('ldap_queries');
             $ldap_server = Yii::app()->getConfig('ldap_server');

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1704,8 +1704,8 @@ class tokens extends Survey_Common_Action
         if (!Yii::app()->request->getPost('submit')) {
             $this->_renderWrappedTemplate('token', array('ldapform'), $aData);
         } else {
-            $filterduplicatetoken = Yii::app()->request->getPost('filterduplicatetoken') == true;
-            $filterblankemail = Yii::app()->request->getPost('filterblankemail') == true;
+            $filterduplicatetoken = (Yii::app()->request->getPost('filterduplicatetoken') && Yii::app()->request->getPost('filterduplicatetoken') == 'on');
+            $filterblankemail = (Yii::app()->request->getPost('filterblankemail') && Yii::app()->request->getPost('filterblankemail') == 'on');
 
             $ldap_queries = Yii::app()->getConfig('ldap_queries');
             $ldap_server = Yii::app()->getConfig('ldap_server');

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1704,8 +1704,8 @@ class tokens extends Survey_Common_Action
         if (!Yii::app()->request->getPost('submit')) {
             $this->_renderWrappedTemplate('token', array('ldapform'), $aData);
         } else {
-            $filterduplicatetoken = (Yii::app()->request->getPost('filterduplicatetoken') && Yii::app()->request->getPost('filterduplicatetoken') == 'on');
-            $filterblankemail = (Yii::app()->request->getPost('filterblankemail') && Yii::app()->request->getPost('filterblankemail') == 'on');
+            $filterduplicatetoken = (Yii::app()->request->getPost('filterduplicatetoken') && (Yii::app()->request->getPost('filterduplicatetoken') == 'on' || Yii::app()->request->getPost('filterduplicatetoken') == '1'));
+            $filterblankemail = (Yii::app()->request->getPost('filterblankemail') && (Yii::app()->request->getPost('filterblankemail') == 'on' || Yii::app()->request->getPost('filterblankemail') == '1'));
 
             $ldap_queries = Yii::app()->getConfig('ldap_queries');
             $ldap_server = Yii::app()->getConfig('ldap_server');


### PR DESCRIPTION
LDAP import. Checkbox "filterduplicatetoken" and "filterblankemail" send values != '1'. 
there is no need to check the value of the variable, it is enough that it exists in the POST request.
without these changes is not working filter "Filter Duplicates", this fix solve problem in https://bugs.limesurvey.org/view.php?id=14268
