### PR TITLE
Proposed changes to enable password strength rules

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -1,0 +1,77 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+| -------------------------------------------------------------------
+| DATABASE CONNECTIVITY SETTINGS
+| -------------------------------------------------------------------
+| This file will contain the settings needed to access your database.
+|
+| For complete instructions please consult the 'Database Connection'
+| page of the User Guide.
+|
+| -------------------------------------------------------------------
+| EXPLANATION OF VARIABLES
+| -------------------------------------------------------------------
+|
+|    'connectionString' Hostname, database, port and database type for 
+|     the connection. Driver example: mysql. Currently supported:
+|                 mysql, pgsql, mssql, sqlite, oci
+|    'username' The username used to connect to the database
+|    'password' The password used to connect to the database
+|    'tablePrefix' You can add an optional prefix, which will be added
+|                 to the table name when using the Active Record class
+|
+*/
+return array(
+	'components' => array(
+		'db' => array(
+			'connectionString' => 'mysql:host=localhost;port=3306;dbname=;',
+			'emulatePrepare' => true,
+			'username' => '',
+			'password' => '',
+			'charset' => 'utf8mb4',
+			'tablePrefix' => '',
+		),
+		
+		// Uncomment the following line if you need table-based sessions
+		// 'session' => array (
+			// 'class' => 'application.core.web.DbHttpSession',
+			// 'connectionID' => 'db',
+			// 'sessionTableName' => '{{sessions}}',
+		// ),
+		
+		'urlManager' => array(
+			'urlFormat' => 'path',
+			'rules' => array(
+				// You can add your own rules here
+			),
+			'showScriptName' => true,
+		),
+	),
+	// For security issue : it's better to set runtimePath out of web access
+	// Directory must be readable and writable by the webuser
+	// 'runtimePath'=>'/var/limesurvey/runtime/'
+	// Use the following config variable to set modified optional settings copied from config-defaults.php
+	'config'=>array(
+	// debug: Set this to 1 if you are looking for errors. If you still get no errors after enabling this
+	// then please check your error-logs - either in your hosting provider admin panel or in some /logs directory
+	// on your webspace.
+	// LimeSurvey developers: Set this to 2 to additionally display STRICT PHP error messages and get full access to standard templates
+		'debug'=>1,
+		'debugsql'=>0, // Set this to 1 to enanble sql logging, only active when debug = 2
+	// Update default LimeSurvey config here
+	
+	),
+
+    'params' => array(
+        'passwordValidator' => array(
+        'min' => 10,
+        'max' => 22,
+        'upper' => 3,
+        'numeric' => 1,
+        'symbol' => 2,
+        ),
+    ),
+
+);
+/* End of file config.php */
+/* Location: ./application/config/config.php */

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -34,6 +34,7 @@
  * @property User $parentUser Parent user
  * @property string $parentUserName  Parent user's name
  */
+
 class User extends LSActiveRecord
 {
     /**
@@ -273,6 +274,7 @@ class User extends LSActiveRecord
         if (empty($this->password)) {
             return false;
         }
+
         // Password is OK
         if (password_verify($sPassword, $this->password)) {
             return true;
@@ -283,6 +285,81 @@ class User extends LSActiveRecord
             return true;
         }
         return false;
+    }
+
+    public function checkPasswordStrength($password,$settings = array()){
+        $uppercase = preg_match_all('@[A-Z]@', $password);
+        $lowercase = preg_match_all('@[a-z]@', $password);
+        $number    = preg_match_all('@[0-9]@', $password);
+        $specialChars = preg_match_all('@[^\w]@', $password);
+        $length = strlen($password);
+
+        $error = "";
+        if(isset($settings['min'])){
+          $min = $settings['min'];
+          if($length < $min) $error = "Password must be at least ".$min." long.";
+        }
+        if(isset($settings['max'])){
+          $max = $settings['max'];
+          if($length > $max) $error = "Password must be at most ".$max." long.";
+        }
+        if(isset($settings['upper'])){
+          $upper = $settings['upper'];
+          if($uppercase < $upper) $error = "Password must include at least ".$upper." uppercase letter".($upper != 1 ? 's' : '').".";
+        }
+        if(isset($settings['lower'])){
+          $lower = $settings['lower'];
+          if($lowercase < $lower) $error = "Password must include at least ".$lower." lowercase letter".($lower != 1 ? 's' : '').".";
+        }
+        if(isset($settings['numeric'])){
+          $numeric = $settings['numeric'];
+          if($number < $numeric) $error = "Password must include at least ".$numeric." number".($numeric != 1 ? 's' : '').".";
+        }
+        if(isset($settings['symbol'])){
+          $symbol = $settings['symbol'];
+          if($specialChars < $symbol) $error = "Password must include at least ".$symbol." special character".($symbol != 1 ? 's' : '').".";
+        }
+
+
+        return($error);
+    }
+
+    public function getPasswordHelpText($settings){
+        $txt = '';
+        if(isset($settings['min'])) $txt = 'Password should be at least '.$settings['min'].' characters in length';
+        if(isset($settings['max'])) $txt = 'Password should be at most '.$settings['max'].' characters in length';
+        if(isset($settings['min']) && isset($settings['max'])){
+          if($settings['min'] == $settings['max']){
+            $txt = 'Password should be exactly '.$settings['min'].' characters in length';
+          } else
+          if($settings['min'] < $settings['max']){
+            $txt = 'Password must be between '.$settings['min'].' - '.$settings['max'].' characters in length';
+          }
+        }
+
+        $txt1 = array();
+        if(isset($settings['upper'])) $txt1[] = $settings['upper'].' upper case letter'.($settings['upper'] != 1 ? 's' : '');
+        if(isset($settings['numeric'])) $txt1[] = $settings['numeric'].' number'.($settings['numeric'] != 1 ? 's' : '');
+        if(isset($settings['symbol'])) $txt1[] = $settings['symbol'].' special character'.($settings['symbol'] != 1 ? 's' : '');
+        if(!empty($txt1)){
+          $txt2 = '';
+          foreach($txt1 as $i => $tmp){
+            if($i == (count($txt1)-1)){
+              if($txt2) $txt2 .= " and ";
+            } else {
+              if($txt2) $txt2 .= ", ";
+            }
+            $txt2 .= $tmp;
+          }
+        }
+
+        if($txt && $txt2){
+          $txt = $txt.' and must include at least '.$txt2.'.';
+        } else
+        if($txt2){
+          $txt = 'Password must include at least '.$txt2.'.';
+        }
+        return($txt);
     }
 
     /**

--- a/application/views/admin/user/modifyuser.php
+++ b/application/views/admin/user/modifyuser.php
@@ -55,6 +55,9 @@ echo viewHelper::getViewTestTag('modifyUser');
                     <div class="">
                         <?php echo $form->passwordField($oUser, 'password',array('value'=>'', 'placeholder'=>html_entity_decode(str_repeat("&#9679;",10),ENT_COMPAT,'utf-8'))); ?>
                     </div>
+                    <div class="">
+                        <span class='text-info'><?php eT($passwordHelpText); ?></span>
+                    </div>
                 </div>
                 <?php endif; ?>
                 

--- a/application/views/admin/user/personalsettings.php
+++ b/application/views/admin/user/personalsettings.php
@@ -85,6 +85,9 @@
                                     <div class="">
                                         <?php echo CHtml::passwordField('password', '',array('disabled'=>true, 'class'=>'form-control','autocomplete'=>"off",'placeholder'=>html_entity_decode(str_repeat("&#9679;",10),ENT_COMPAT,'utf-8'))); ?>
                                     </div>
+                                    <div class="">
+                                        <span class='text-info'><?php eT($passwordHelpText); ?></span>
+                                    </div>
                                 </div>
                             </div>
                             <div class="col-md-6">


### PR DESCRIPTION
As posted in https://bugs.limesurvey.org/view.php?id=14636#c51463

Note that my proposed changes use the gettranslation feature, which of course should exist if merged into the master repo. 

A complement to this contribution would be to use the config params when LS automatically generates passwords for new user accounts. I didn't require this because I don't send out user passwords via email. That is, in my config I have:

	'display_user_password_in_email' => false,
	'display_user_password_in_html' => false,	