### PR TITLE
Develop order for plugins

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] ='4.0.0-alpha';
-$config['dbversionnumber'] = 410;
+$config['dbversionnumber'] = 411;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['assetsversionnumber'] = '30084';

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -2699,7 +2699,7 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
 
         if($iOldDBVersion < 411) {
             $oTransaction = $oDB->beginTransaction();
-            $oDB->createCommand()->addColumn('{{plugins}}','loadorder',"int default 0");
+            $oDB->createCommand()->addColumn('{{plugins}}','loadorder',"int NOT NULL default 0");
             $oDB->createCommand()->update('{{settings_global}}',array('stg_value'=>411),"stg_name='DBVersion'");
             $oTransaction->commit();
         }

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -2696,6 +2696,13 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
             $oDB->createCommand()->update('{{settings_global}}',array('stg_value'=>410),"stg_name='DBVersion'");
             $oTransaction->commit();
         }
+
+        if($iOldDBVersion < 411) {
+            $oTransaction = $oDB->beginTransaction();
+            $oDB->createCommand()->addColumn('{{plugins}}','loadorder',"int default 0");
+            $oDB->createCommand()->update('{{settings_global}}',array('stg_value'=>411),"stg_name='DBVersion'");
+            $oTransaction->commit();
+        }
       
     } catch (Exception $e) {
         Yii::app()->setConfig('Updating', false);

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -132,7 +132,7 @@ class PluginManager extends \CApplicationComponent
         }
 
         $newName = (string) $extensionConfig->xml->metadata->name;
-        $pluginOrder = (empty($extensionConfig->xml->order) || !is_int($extensionConfig->xml->order)) ? 0 : $extensionConfig->xml->order;
+        $pluginOrder = empty($extensionConfig->xml->order) ? 0 : (int) $extensionConfig->xml->order;
         $otherPlugin = Plugin::model()->findAllByAttributes(['name' => $newName]);
         if (!empty($otherPlugin)) {
             return [false, sprintf(gT('Plugin "%s" is already installed.'), $newName)];

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -142,7 +142,9 @@ class PluginManager extends \CApplicationComponent
         $plugin->name        = $newName;
         $plugin->version     = (string) $extensionConfig->xml->metadata->version;
         $plugin->active      = 0;
-        $plugin->loadorder   = $pluginOrder;
+        if(!empty($extensionConfig->xml->order)) {
+            $plugin->loadorder   = (int) $extensionConfig->xml->order;
+        }
         $plugin->plugin_type = $pluginType;
         $plugin->save();
         return [true, null];

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -132,7 +132,6 @@ class PluginManager extends \CApplicationComponent
         }
 
         $newName = (string) $extensionConfig->xml->metadata->name;
-        $pluginOrder = empty($extensionConfig->xml->order) ? 0 : (int) $extensionConfig->xml->order;
         $otherPlugin = Plugin::model()->findAllByAttributes(['name' => $newName]);
         if (!empty($otherPlugin)) {
             return [false, sprintf(gT('Plugin "%s" is already installed.'), $newName)];

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -20,6 +20,7 @@
  * @property string $name
  * @property integer $active
  * @property string $version
+ * @property integer $loadorder
  */
 class Plugin extends LSActiveRecord
 {
@@ -40,6 +41,13 @@ class Plugin extends LSActiveRecord
         return '{{plugins}}';
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        $this->loadorder = 0;
+    }
     /**
      * Set this plugin as load error in database, and saves the error message.
      * @param array $error Array with 'message' and 'file' keys (as get from error_get_last).

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -313,7 +313,7 @@ function createDatabase($oDB){
             'name' =>  "string(50) NOT NULL",
             'plugin_type' =>  "string(6) default 'user'",
             'active' =>  "int NOT NULL default 0",
-            'loadorder' =>  "int default 0",
+            'loadorder' =>  "int NOT NULL default 0",
             'version' =>  "string(32) NULL",
             'load_error' => 'int default 0',
             'load_error_message' => 'text'

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -313,6 +313,7 @@ function createDatabase($oDB){
             'name' =>  "string(50) NOT NULL",
             'plugin_type' =>  "string(6) default 'user'",
             'active' =>  "int NOT NULL default 0",
+            'loadorder' =>  "int default 0",
             'version' =>  "string(32) NULL",
             'load_error' => 'int default 0',
             'load_error_message' => 'text'


### PR DESCRIPTION
New feature #12127: Order of plugin 

Needed for example for https://gitlab.com/SondagesPro/ExportAndStats/getStatInSurvey/issues/2#note_162517567 : getStatInSurvey must happen after addScriptToQuestion.
(I have another issue where need to install a plugin after another one but don't find it currently

After in can add a `setOrder` or maybe `setOrderAfter($pluginName)` ? If a new plugin appear ?
