### PR TITLE
Fixed issue #14875: No error is shown at debug=0 if DB is broken

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -61,6 +61,10 @@
          */
         public function actionError()
         {
+            if($this->getConfig('DBVersion') < 200) {
+                /* Activate since DBVersion for 2.50 and up */
+                return;
+            }
             $oTemplate = Template::model()->getInstance(getGlobalSetting('defaulttheme'));
 
             $this->sTemplate = $oTemplate->sTemplateName;

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -169,8 +169,8 @@ class LSYii_Application extends CWebApplication
         } catch (Exception $exception) {
             /* Even if database can exist : don't throw exception, */
             /* settings_global was created before 1.80 */
-            throw new CHttpException(500, "Table settings_global not found");
             Yii::log("Table settings_global not found",'error');
+            throw new CHttpException(500, "Table settings_global not found");
         }
         /* Add some specific config using exiting other configs */
         $this->setConfig('globalAssetsVersion', /* Or create a new var ? */

--- a/application/core/LSYii_Controller.php
+++ b/application/core/LSYii_Controller.php
@@ -35,8 +35,9 @@ abstract class LSYii_Controller extends CController
 
         //Yii::app()->session->init();
         $this->loadLibrary('LS.LS');
-        // This will setConfig from database
+        // Usage of old function
         $this->loadHelper('globalsettings');
+        // Some functiion : traceVar
         $this->loadHelper('common');
         $this->loadHelper('expressions.em_manager');
         $this->loadHelper('replacements');
@@ -171,7 +172,7 @@ abstract class LSYii_Controller extends CController
             }
             return trim($sPublicUrl, "/").$url;
         } else {
-                    return parent::createAbsoluteUrl($route, $params, $schema, $ampersand);
+            return parent::createAbsoluteUrl($route, $params, $schema, $ampersand);
         }
     }
 

--- a/application/helpers/globalsettings_helper.php
+++ b/application/helpers/globalsettings_helper.php
@@ -13,22 +13,7 @@
  * See COPYRIGHT.php for copyright notices and details.
  *
  */
-//Ensure script is not run directly, avoid path disclosure
-//if (!isset($homedir) || isset($_REQUEST['$homedir'])) {die("Cannot run this script directly");}
-injectglobalsettings();
 
-
-function injectglobalsettings()
-{
-    $settings = SettingGlobal::model()->findAll();
-
-    //if ($dbvaluearray!==false)
-    if (count($settings) > 0) {
-        foreach ($settings as $setting) {
-            Yii::app()->setConfig($setting->getAttribute('stg_name'), $setting->getAttribute('stg_value'));
-        }
-    }
-}
 /**
  * Returns a global setting
  * @deprecated : use App()->getConfig($settingname)
@@ -39,25 +24,5 @@ function injectglobalsettings()
  */
 function getGlobalSetting($settingname)
 {
-    $dbvalue = Yii::app()->getConfig($settingname);
-
-    if ($dbvalue === false) {
-        $dbvalue = SettingGlobal::model()->findByPk($settingname);
-
-        if ($dbvalue === null) {
-            Yii::app()->setConfig($settingname, null);
-            $dbvalue = '';
-        } else {
-            $dbvalue = $dbvalue->getAttribute('stg_value');
-        }
-
-        if (Yii::app()->getConfig($settingname) !== false) {
-            // If the setting was not found in the setting table but exists as a variable (from config.php)
-            // get it and save it to the table
-            SettingGlobal::setSetting($settingname, Yii::app()->getConfig($settingname));
-            $dbvalue = Yii::app()->getConfig($settingname);
-        }
-    }
-
-    return $dbvalue;
+    return Yii::app()->getConfig($settingname);
 }

--- a/application/models/SettingGlobal.php
+++ b/application/models/SettingGlobal.php
@@ -78,7 +78,7 @@ class SettingGlobal extends LSActiveRecord
     }
 
     /** @inheritdoc
-     * Adding update of current application config after all is done
+     * Allways update of current application config after sucessfull save
      **/
 
     protected function afterSave()

--- a/application/models/SettingGlobal.php
+++ b/application/models/SettingGlobal.php
@@ -24,6 +24,20 @@
  */
 class SettingGlobal extends LSActiveRecord
 {
+
+    /**
+     * @var string[] settings that must only come from php files
+     */
+    private $disableByDb = array(
+        'versionnumber', // Come and leave it in version.php
+        'dbversionnumber', // Must keep it out of DB
+        'updatable', // If admin with ftp access disable updatable : leave it
+        'debug', // Currently not accessible, seem better
+        'debugsql', // Currently not accessible, seem better
+        'forcedsuperadmin', // This is for security
+        'defaultfixedtheme', // Because updating can broke instance
+        'demoMode', // No demoMode update via GUI
+    );
     /**
      * @inheritdoc
      * @return CActiveRecord
@@ -48,16 +62,7 @@ class SettingGlobal extends LSActiveRecord
     /** @inheritdoc */
     public function rules()
     {
-        /* settings that must only comme from php files */
-        $disableByDb = array(
-            'versionnumber', // Come and leave it in version.php
-            'dbversionnumber', // Must keep it out of DB
-            'updatable', // If admin with ftp access disable updatable : leave it
-            'debug', // Currently not accessible, seem better
-            'debugsql', // Currently not accessible, seem better
-            'forcedsuperadmin', // This is for security
-            'defaultfixedtheme', // Because updating can broke instance
-        );
+        $disableByDb = $this->disableByDb;
         /* Specific disable settings for demo mode */
         if (Yii::app()->getConfig("demoMode")) {
             $disableByDb = array_merge($disableByDb,array('sitename','defaultlang','defaulthtmleditormode','filterxsshtml'));

--- a/application/models/SettingGlobal.php
+++ b/application/models/SettingGlobal.php
@@ -77,6 +77,16 @@ class SettingGlobal extends LSActiveRecord
         return $aRules;
     }
 
+    /** @inheritdoc
+     * Adding update of current application config after all is done
+     **/
+
+    protected function afterSave()
+    {
+        parent::afterSave();
+        Yii::app()->setConfig($this->stg_name,$this->stg_value);
+    }
+
     /**
      * Update or set a setting in DB and update current app config if no error happen
      * Return self : then other script can use if(!$oSetting) { $oSetting->getErrors; }


### PR DESCRIPTION
Dev: really deprecate getGlobalSetting because getGlobalSetting('debug') can update version
Dev: and all is set when needed (see setSetting::model->setSettings …)