### PR TITLE
Dev: feature : allow plugin to use another plugin translation

### DIFF
--- a/application/libraries/PluginManager/PluginBase.php
+++ b/application/libraries/PluginManager/PluginBase.php
@@ -97,7 +97,7 @@ abstract class PluginBase implements iPlugin
 
         // Set plugin specific locale file to locale/<lang>/<lang>.mo
         \Yii::app()->setComponent(
-            'pluginMessages'.$this->id,
+            get_class($this).'Messages',
             [
                 'class'            => 'LSCGettextMessageSource',
                 'cachingDuration'  => 3600,
@@ -362,7 +362,7 @@ abstract class PluginBase implements iPlugin
                 '',
                 $sToTranslate,
                 array(),
-                'pluginMessages'.$this->id,
+                get_class($this).'Messages',
                 $sLanguage
             ),
             $sEscapeMode


### PR DESCRIPTION
Just update name of name of component , can be improved by `gT($sToTranslate, $sEscapeMode = 'html', $sLanguage = null,$pluginClass = null)`
