### PR TITLE
New feature #16781: autodetection of path in spss syntax

### DIFF
--- a/application/views/admin/export/spss_view.php
+++ b/application/views/admin/export/spss_view.php
@@ -32,8 +32,9 @@ echo viewHelper::getViewTestTag('exportSpss');
                 'name' => 'spssver',
                 'value'=> $spssver ,
                 'selectOptions'=>array(
-                    "1"=>gT("SPSS prior to 16 / PSPP",'unescaped'),
-                    "2"=>gT("SPSS v16 or newer",'unescaped')
+                    "1"=>gT("Prior to 16",'unescaped'),
+                    "2"=>gT("16 or up",'unescaped'),
+                    "3"=>gT("version with Python Plugin / Essentials",'unescaped')
                 )
             ));?>
         </div>
@@ -101,8 +102,9 @@ echo viewHelper::getViewTestTag('exportSpss');
         <br/><br/>
         <ol>
             <li><?php eT("Download the data and the syntax file.");?></li>
-            <li><?php eT("Open the syntax file in SPSS in Unicode mode.");?></li>
-            <li><?php echo sprintf(gT("Edit the %s line and complete the filename with a full path to the downloaded data file."),"'FILE='");?></li>
+	    <li><?php eT("Open the syntax file in SPSS in Unicode mode.");?></li>
+<em>The next step (editing the 'FILE=' line) is only necessary when you have selected a SPSS version without Python. If you selected the version for SPSS with the Python plugin / Essentials, just save the syntax and the data file in the same folder. The full path will be automatically detected when you run the syntax.</em>
+            <li><?php echo sprintf(gT("Edit the %s line and complete the filename with a full$ path to the downloaded data file."),"'FILE='");?></li>
             <li><?php eT("Choose 'Run/All' from the menu to run the import.");?></li>
         </ol>
     <?php eT("Your data should be imported now.");?></div>


### PR DESCRIPTION
I've added automatic path detection for the data file in the spss syntax so you do not have to edit the FILE= line. Everytime you save the syntax and the data file in the same folder, the path is automatically detected. Python is needed, but that is included in all newer versions of SPSS, see this table on https://www.spss-tutorials.com/python-for-spss-installing-and-testing/ .

I've made the automatic path detection optional. Next to the "Prior to 16" and '16 or up" I have added an extra option "version with Python Plugin / Essentials" for this new "feature". I edited the instructions accordingly.

We are using this in our company, maybe others find it useful too...