### PR TITLE
Fixed issue #14936: Preview group : relevance on question broken

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1613,7 +1613,7 @@ class SurveyRuntimeHelper
     private function setPreview()
     {
         $this->sSurveyMode = ($this->previewgrp) ? 'group' : 'question'; // Can be great to have a survey here …
-        buildsurveysession($this->iSurveyid,$this->sSurveyMode); // Preview part disable SurveyURLParameter , why ? Work without
+        buildsurveysession($this->iSurveyid,true); // Preview part disable SurveyURLParameter , why ? Work without
 
         /* Set steps for PHP notice */
         $_SESSION[$this->LEMsessid]['prevstep'] = 2;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -714,7 +714,7 @@
 
         /**
         * Set the previewmode
-        * @param boolean|string $previewmode 'question', 'group', false
+        * @param string|false $previewmode 'question', 'group', false
         * @return void
         */
         public static function SetPreviewMode($previewmode=false)
@@ -5674,7 +5674,7 @@
         /**
         * Jump to a specific question or group sequence.  If jumping forward, it re-validates everything in between
         * @param int $seq - the sequential step
-        * @param boolean $preview - if true, then treat this group/question as relevant, even if it is not, so that it can be displayed. @see var $sPreviewMode
+        * @param string|false $preview @see var $sPreviewMode
         * @param boolean $processPOST - add the updated value to be saved in the database
         * @param boolean $force - if true, then skip validation of current group (e.g. will jump even if there are errors)
         * @param boolean $changeLang

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -59,9 +59,9 @@
         */
         private $debugLevel=0;
          /**
-        * sPreviewMode used for relevance equation force to 1 in preview mode
-        * Maybe we can set it public
-        * @var string|boolean
+        * sPreviewMode used for relevance equation and to disable save value in DB
+        * 'question' or 'group' string force relevance to 1 if needed
+        * @var string|false
         */
         private $sPreviewMode=false;
         /**
@@ -3738,7 +3738,7 @@
                 $aid = (isset($fielddata['aid']) ? $fielddata['aid'] : '');
                 $sqid = (isset($fielddata['sqid']) ? $fielddata['sqid'] : '');
                 if($this->sPreviewMode=='question') $fielddata['relevance']=1;
-                if($this->sPreviewMode=='group') $fielddata['grelevance']=1;
+                if($this->sPreviewMode=='group' || $this->sPreviewMode=='question') $fielddata['grelevance']=1;
 
                 $questionNum = $fielddata['qid'];
                 $relevance = (isset($fielddata['relevance'])) ? $fielddata['relevance'] : 1;


### PR DESCRIPTION
Fixed issue #14987: Preview question not working
Dev: LimeExpressionManager:sPreviewMode
Dev: setVariableAndTokenMappingsForExpressionManager must have preview when it call
Dev: Don't need 1st step : preview must do whole
Dev: preview don't need checkForDataSecurityAccepted

Commit is ready, just want to check CodeFactor/scrut about issue with LimeExpressionManager:sPreviewMode string|false