### PR TITLE
Fixed issue #15004 show correct id attribute for additional attributes

### DIFF
--- a/themes/survey/vanilla/views/subviews/registration/register_form.twig
+++ b/themes/survey/vanilla/views/subviews/registration/register_form.twig
@@ -55,7 +55,7 @@
                 {% set registerKey = "register_" ~ key %}
                 <label for="{{ registerKey }}" class='{{ aSurveyInfo.class.registerformextraslabel }} control-label '> {{ aExtraAttribute.caption }} {% if aExtraAttribute.mandatory == 'Y' %}{{ include('./subviews/registration/required.twig') }}{% endif %}</label>
                 <div {{ aSurveyInfo.attr.registerformcolrowcdiv }} >
-                    {{ C.Html.textField(registerKey, aSurveyInfo.aAttribute[key],({'id' : "register_{$key}",'class' : 'form-control input-sm'})) }}
+                    {{ C.Html.textField(registerKey, aSurveyInfo.aAttribute[key],({'id' : registerKey,'class' : 'form-control input-sm'})) }}
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
Fixed issue #15004 Show correct id attribute for additional attributes on the registration form

Dev: should be merged in version Version 3.17.* as well
