### PR TITLE
fix JS error in firstStartTour onShow

### DIFF
--- a/application/core/LsDefaultDataSets.php
+++ b/application/core/LsDefaultDataSets.php
@@ -326,7 +326,7 @@ class LsDefaultDataSets
                         ."</div>"
                     ."</div>"
                 ."</div>",
-                'onShown' => "(function(tour){ console.ls.logT($('#notif-container').children()); $('#notif-container').children().remove(); })",
+                'onShown' => "(function(tour){ $('#notif-container').children().remove(); })",
                 'onEnd' => "(function(tour){window.location.reload();})",
                 'endOnOrphan' => true,
             )),


### PR DESCRIPTION
Fixes an invalid JavaScript code within the firstStartTour tutorial.

Issue:
Browser console output: "console.ls.logT is not a function"

Fix:
Remove (debug) call to invalid function "console.ls.logT" in firstStartTour onShow code.