### PR TITLE
Fixed issue #15237: Upload 3gpp, amr, aac audio files using File Upload Question

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -557,6 +557,21 @@ $config['iFileUploadTotalSpaceMB'] = 0;
 
 $config['uniq_upload_dir'] = false; // Use a single KCFinder upload directory for all surveys
 
+/**
+ * Allow to use a different MIME database for finfo_open
+ * @see https://www.php.net/manual/en/function.finfo-open.php
+ * Example : '/usr/share/misc/magic.mgc' for redhat based linux
+ */
+$config['magic_database'] = null;
+
+/**
+ * Allow to use a different magic file array 
+ * @see https://www.yiiframework.com/doc/api/1.1/CFileHelper#getExtensionByMimeType-detail
+ * This file must return a PHP array of extension by mimeTypes
+ * Example : https://github.com/LimeSurvey/LimeSurvey/blob/master/framework/utils/fileExtensions.php
+ */
+$config['magic_file'] = null;
+
 
 // defines if the CKeditor toolbar should be opened by default
 $config['ckeditexpandtoolbar'] = true;
@@ -724,6 +739,5 @@ $config['pluginCoreList'] = [
 ];
 
 $config['pluginWhitelist'] = [];
-
 return $config;
 //settings deleted

--- a/application/controllers/UploaderController.php
+++ b/application/controllers/UploaderController.php
@@ -177,13 +177,13 @@ class UploaderController extends SurveyController
                 Yii::app()->end();
             }
             /* extension checked : check mimeType */
-            $extByMimeType = LSFileHelper::getExtensionByMimeType($_FILES['uploadfile']['tmp_name'], null,false);
+            $extByMimeType = LSFileHelper::getExtensionByMimeType($_FILES['uploadfile']['tmp_name'], null);
             $disableCheck = false;
             if(is_null($extByMimeType)) {
                 /* Lack of finfo_open or mime_content_type ? But can be a not found extension too.*/
                 /* Check if can find mime type of favicon.ico , without extension */
                 /* Use CFileHelper because sure it work with included */
-                if(CFileHelper::getExtensionByMimeType(APPPATH."favicon.ico", null, false) != 'ico') {
+                if(CFileHelper::getExtensionByMimeType(APPPATH."favicon.ico", null) != 'ico') {
                     $disableCheck = true;
                     Yii::log("Unable to check mime type of files, check for finfo_open or mime_content_type function.",\CLogger::LEVEL_ERROR,'application.controller.uploader.upload');
                     if( YII_DEBUG || Permission::isForcedSuperAdmin(Permission::getUserId()) ) {
@@ -194,9 +194,11 @@ class UploaderController extends SurveyController
             }
             if(!$disableCheck && empty($extByMimeType)) {
                 // FileInfo is OK, but can not find the mime type of file …
+                $realMimeType = LSFileHelper::getMimeType($_FILES['uploadfile']['tmp_name'], null,false);
+                Yii::log("Unable to extension for mime type ".$realMimeType,\CLogger::LEVEL_ERROR,'application.controller.uploader.upload');
                 $return = array(
                     "success" => false,
-                    "msg" => gT("Sorry, unable to check this file type!"),
+                    "msg" => gT("Sorry, unable to check extension of this file type %s.", $realMimeType),
                 );
                 //header('Content-Type: application/json');
                 echo ls_json_encode($return);

--- a/application/controllers/UploaderController.php
+++ b/application/controllers/UploaderController.php
@@ -59,7 +59,7 @@ class UploaderController extends SurveyController
             }
             if (is_file($sFileDir.$sFileGetContent)) {
                 // Validate file before else 500 error by getMimeType
-                $mimeType = CFileHelper::getMimeType($sFileDir.$sFileGetContent, null, false);
+                $mimeType = LSFileHelper::getMimeType($sFileDir.$sFileGetContent, null, false);
                 if (is_null($mimeType)) {
                     $mimeType = "application/octet-stream"; // Can not really get content if not image
                 }
@@ -177,12 +177,13 @@ class UploaderController extends SurveyController
                 Yii::app()->end();
             }
             /* extension checked : check mimeType */
-            $extByMimeType = CFileHelper::getExtensionByMimeType($_FILES['uploadfile']['tmp_name'], null);
+            $extByMimeType = LSFileHelper::getExtensionByMimeType($_FILES['uploadfile']['tmp_name'], null,false);
             $disableCheck = false;
             if(is_null($extByMimeType)) {
                 /* Lack of finfo_open or mime_content_type ? But can be a not found extension too.*/
                 /* Check if can find mime type of favicon.ico , without extension */
-                if(CFileHelper::getExtensionByMimeType(APPPATH."favicon.ico", null, false) != 'ico') { // hope we have favicon.ico for a long time
+                /* Use CFileHelper because sure it work with included */
+                if(CFileHelper::getExtensionByMimeType(APPPATH."favicon.ico", null, false) != 'ico') {
                     $disableCheck = true;
                     Yii::log("Unable to check mime type of files, check for finfo_open or mime_content_type function.",\CLogger::LEVEL_ERROR,'application.controller.uploader.upload');
                     if( YII_DEBUG || Permission::isForcedSuperAdmin(Permission::getUserId()) ) {
@@ -202,7 +203,7 @@ class UploaderController extends SurveyController
                 Yii::app()->end();
             }
             if (!$disableCheck && !in_array($extByMimeType, $valid_extensions_array)) {
-                $realMimeType = CFileHelper::getMimeType($_FILES['uploadfile']['tmp_name'], null,false);
+                $realMimeType = LSFileHelper::getMimeType($_FILES['uploadfile']['tmp_name'], null,false);
                 $return = array(
                     "success" => false,
                     "msg" => sprintf(gT("Sorry, file type %s (extension : %s) is not allowed!"), $realMimeType,$extByMimeType)

--- a/application/core/LSFileHelper.php
+++ b/application/core/LSFileHelper.php
@@ -57,6 +57,10 @@ class LSFileHelper extends CFileHelper
      */
     public static function getMimeType($file,$magicFile=null,$checkExtension=true)
     {
+        $mimeType = parent::getMimeType($file,$magicFile,$checkExtension);
+        if((!empty($magicFile) && $mimeType != "application/octet-stream") || !is_null($magicFile)) {
+            return $mimeType;
+        }
         if(empty($magicFile) && Yii::app()->getConfig('magic_database')) {
             $magicFile = Yii::app()->getConfig('magic_database');
         }

--- a/application/core/LSFileHelper.php
+++ b/application/core/LSFileHelper.php
@@ -52,6 +52,7 @@ class LSFileHelper extends CFileHelper
     /**
      * @inheritdoc
      * Set $magicFile (magic dataBase) from config (if is null)
+     * Use the magic file set by user only iof needed (else keep pĥp default or MAGIC env)
      * @see https://www.php.net/manual/en/function.finfo-open.php
      * @return string the MIME type. Null is returned if the MIME type cannot be determined.
      */

--- a/application/core/LSFileHelper.php
+++ b/application/core/LSFileHelper.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * LimeSurvey
+ * Copyright (C) 2019 The LimeSurvey Project Team / Carsten Schmitz
+ * All rights reserved.
+ * License: GNU/GPL License v2 or later, see LICENSE.php
+ * LimeSurvey is free software. This version may have been modified pursuant
+ * to the GNU General Public License, and as distributed it includes or
+ * is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ * See COPYRIGHT.php for copyright notices and details.
+ *
+ * Extend CFileHelper to allow update of
+ * - magic database (can be set by MAGIC env, but unsure user can do it)
+ * - magic file (return PHP array of extension by mime-type)
+ * @author Denis Chenu
+ * @version 1.0.0
+ * 
+ */
+
+class LSFileHelper extends CFileHelper
+{
+
+    /**
+     * @inheritdoc
+     * Can not call parent since usage of self::getMimeType
+     * Set $magicFile (php array) from config (if is null)
+     * @see https://www.yiiframework.com/doc/api/1.1/CFileHelper#getExtensionByMimeType-detail
+     * @return string extension name. Null is returned if the extension cannot be determined.
+     */
+    public static function getExtensionByMimeType($file,$magicFile=null)
+    {
+        static $mimeTypes,$customMimeTypes=array();
+        if(empty($magicFile) && Yii::app()->getConfig('magic_file')) {
+            $magicFile = Yii::app()->getConfig('magic_file');
+        }
+        if(empty($magicFile) && $mimeTypes===null)
+            $mimeTypes=require(Yii::getPathOfAlias('system.utils.fileExtensions').'.php');
+        elseif($magicFile!==null && !isset($customMimeTypes[$magicFile]))
+            $customMimeTypes[$magicFile]=require($magicFile);
+        if(($mime=self::getMimeType($file))!==null)
+        {
+            $mime=strtolower($mime);
+            if($magicFile===null && isset($mimeTypes[$mime]))
+                return $mimeTypes[$mime];
+            elseif($magicFile!==null && isset($customMimeTypes[$magicFile][$mime]))
+                return $customMimeTypes[$magicFile][$mime];
+        }
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     * Set $magicFile (magic dataBase) from config (if is null)
+     * @see https://www.php.net/manual/en/function.finfo-open.php
+     * @return string the MIME type. Null is returned if the MIME type cannot be determined.
+     */
+    public static function getMimeType($file,$magicFile=null,$checkExtension=true)
+    {
+        if(empty($magicFile) && Yii::app()->getConfig('magic_database')) {
+            $magicFile = Yii::app()->getConfig('magic_database');
+        }
+        return parent::getMimeType($file,$magicFile,$checkExtension);
+    }
+}

--- a/application/core/LSFileHelper.php
+++ b/application/core/LSFileHelper.php
@@ -26,7 +26,7 @@ class LSFileHelper extends CFileHelper
      * Can not call parent since usage of self::getMimeType
      * Set $magicFile (php array) from config (if is null)
      * @see https://www.yiiframework.com/doc/api/1.1/CFileHelper#getExtensionByMimeType-detail
-     * @return string extension name. Null is returned if the extension cannot be determined.
+     * @return string|null extension name. Null is returned if the extension cannot be determined.
      */
     public static function getExtensionByMimeType($file,$magicFile=null)
     {
@@ -57,7 +57,7 @@ class LSFileHelper extends CFileHelper
      * Set $magicFile (magic dataBase) from config (if is null)
      * Use the magic file set by user only iof needed (else keep pĥp default or MAGIC env)
      * @see https://www.php.net/manual/en/function.finfo-open.php
-     * @return string the MIME type. Null is returned if the MIME type cannot be determined.
+     * @return string|null string if the MIME type. Null is returned if the MIME type cannot be determined.
      */
     public static function getMimeType($file,$magicFile=null,$checkExtension=true)
     {

--- a/application/core/LSFileHelper.php
+++ b/application/core/LSFileHelper.php
@@ -34,17 +34,20 @@ class LSFileHelper extends CFileHelper
         if(empty($magicFile) && Yii::app()->getConfig('magic_file')) {
             $magicFile = Yii::app()->getConfig('magic_file');
         }
-        if(empty($magicFile) && $mimeTypes===null)
+        if(empty($magicFile) && $mimeTypes===null) {
             $mimeTypes=require(Yii::getPathOfAlias('system.utils.fileExtensions').'.php');
-        elseif($magicFile!==null && !isset($customMimeTypes[$magicFile]))
+        }
+        elseif($magicFile!==null && !isset($customMimeTypes[$magicFile])) {
             $customMimeTypes[$magicFile]=require($magicFile);
-        if(($mime=self::getMimeType($file))!==null)
-        {
+        }
+        $mime = self::getMimeType($file);
+        if($mime !== null) {
             $mime=strtolower($mime);
-            if($magicFile===null && isset($mimeTypes[$mime]))
+            if($magicFile===null && isset($mimeTypes[$mime])) {
                 return $mimeTypes[$mime];
-            elseif($magicFile!==null && isset($customMimeTypes[$magicFile][$mime]))
+            } elseif($magicFile!==null && isset($customMimeTypes[$magicFile][$mime])) {
                 return $customMimeTypes[$magicFile][$mime];
+            }
         }
         return null;
     }


### PR DESCRIPTION
Dev: allowing to set mime database from config
Dev: allowing to set magic file (extension by magic type)
Dev: review file to check : ico can have image/vnd.microsoft.icon mime type (not in system.utils.fileExtensions)

Currently, checking with `'magic_database' => '/usr/share/misc/magic.mgc',` in Fedora : have ` finfo_file(): Null byte in regex ` … unsure it was Fedora issue or not …