### PR TITLE
Fixed issue #15334: in _deleteParticipant

### DIFF
--- a/application/views/admin/participants/modal_subviews/_deleteParticipant.php
+++ b/application/views/admin/participants/modal_subviews/_deleteParticipant.php
@@ -18,7 +18,7 @@
     <p><?php eT("Please choose one option."); ?></p>
     <select name='selectedoption' class="form-control" >
         <option value="po" selected><?php eT("Delete only from the central panel") ?></option>
-        <option value="pt"><?php eT("Delete from the central panel and associated surveys") ?></option>
+        <option value="ptt"><?php eT("Delete from the central panel and associated surveys") ?></option>
         <option value="ptta"><?php eT("Delete from central panel, associated surveys and all associated responses") ?></option>
     </select>
 </div>


### PR DESCRIPTION
**admin/participants/sa/displayParticipants** delete modal has different values for second option if you click on the delete Button directly, or select User and use the delete Button in the Dropdown Menu. According to **application/controllers/admin/participantsaction.php** there are 3 cases: po, ptt, ptta. 

If you click on the delete button directly in the user row the second value is pt.