### PR TITLE
Get answers dual scale

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1471,7 +1471,7 @@ class remotecontrol_handle
      * Get properties of a question in a survey.
      *
      * @see \Question for available properties.
-     * Some more properties are available_answers, subquestions, attributes, attributes_lang, answeroptions, defaultvalue
+     * Some more properties are available_answers, subquestions, attributes, attributes_lang, answeroptions, answeroptions_multiscale, defaultvalue
      *
      * @access public
      * @param string $sSessionKey Auth credentials
@@ -1580,7 +1580,7 @@ class remotecontrol_handle
                             }
                             $aResult['answeroptions'] = $aData;
                         } else {
-                                                    $aResult['answeroptions'] = 'No available answer options';
+                                                   $aResult['answeroptions'] = 'No available answer options';
                         }
                     } else if ($sPropertyName == 'answeroptions_multiscale') {
                         $oAttributes = Answer::model()->findAllByAttributes(array('qid' => $iQuestionID, 'language'=> $sLanguage), array('order'=>'sortorder'));
@@ -1597,10 +1597,7 @@ class remotecontrol_handle
                         } else {
                                                     $aResult['answeroptions'] = 'No available answer options';
                         }
-                    }
-                    
-                    
-                    else if ($sPropertyName == 'defaultvalue') {
+                    } else if ($sPropertyName == 'defaultvalue') {
                         $aResult['defaultvalue'] = DefaultValue::model()->findByAttributes(array('qid' => $iQuestionID, 'language'=> $sLanguage))->defaultvalue;
                     } else {
                         $aResult[$sPropertyName] = $oQuestion->$sPropertyName;

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1582,7 +1582,25 @@ class remotecontrol_handle
                         } else {
                                                     $aResult['answeroptions'] = 'No available answer options';
                         }
-                    } else if ($sPropertyName == 'defaultvalue') {
+                    } else if ($sPropertyName == 'answeroptions_multiscale') {
+                        $oAttributes = Answer::model()->findAllByAttributes(array('qid' => $iQuestionID, 'language'=> $sLanguage), array('order'=>'sortorder'));
+                        if (count($oAttributes) > 0) {
+                            $aData = array();
+                            foreach ($oAttributes as $oAttribute) {
+                                $aData[$oAttribute['scale_id']][$oAttribute['code']]['code'] = $oAttribute['code'];
+                                $aData[$oAttribute['scale_id']][$oAttribute['code']]['answer'] = $oAttribute['answer'];
+                                $aData[$oAttribute['scale_id']][$oAttribute['code']]['assessment_value'] = $oAttribute['assessment_value'];
+                                $aData[$oAttribute['scale_id']][$oAttribute['code']]['scale_id'] = $oAttribute['scale_id'];
+                                $aData[$oAttribute['scale_id']][$oAttribute['code']]['order'] = $oAttribute['sortorder'];
+                            }
+                            $aResult['answeroptions'] = $aData;
+                        } else {
+                                                    $aResult['answeroptions'] = 'No available answer options';
+                        }
+                    }
+                    
+                    
+                    else if ($sPropertyName == 'defaultvalue') {
                         $aResult['defaultvalue'] = DefaultValue::model()->findByAttributes(array('qid' => $iQuestionID, 'language'=> $sLanguage))->defaultvalue;
                     } else {
                         $aResult[$sPropertyName] = $oQuestion->$sPropertyName;


### PR DESCRIPTION
Provides a backwards-compatible workaround for [https://bugs.limesurvey.org/view.php?id=13312](https://bugs.limesurvey.org/view.php?id=13312).

Fixed issue # : 13312
New feature # :
Changed feature # :
Dev: Add additional property to retrieve all answer options of all scales
Dev: Add answeroptions_multiscale to list of possible properties in api documentation