### PR TITLE
Fix #15053: Error with non-numeric SID

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -430,8 +430,8 @@ class Survey extends LSActiveRecord
     public function rules()
     {
         return array(
-            array('sid', 'unique'),// Not in pk
             array('sid', 'numerical', 'integerOnly'=>true,'min'=>1), // max ?
+            array('sid', 'unique'),// Not in pk
             array('gsid', 'numerical', 'integerOnly'=>true),
             array('datecreated', 'default', 'value'=>date("Y-m-d")),
             array('startdate', 'default', 'value'=>null),


### PR DESCRIPTION
The previous pull request was not good enough.
The error only appears with PgSQL because when Limesurvey check the unique
rule, it executes a db request (only crash with pgsql).

If we put the "numeric" rule before the "unique" one, Limesurvey will block
a malformed sid.
