### PR TITLE
Add missing translation in tutorial question 29

### DIFF
--- a/application/core/LsDefaultDataSets.php
+++ b/application/core/LsDefaultDataSets.php
@@ -806,7 +806,7 @@ class LsDefaultDataSets
                 'title' => gT('Edit answer options'),
                 'content' => gT("As you can see, editing answer options is quite similar to editing subquestions.").'<br/>'
                 .gT('Remember the plus button').'<i class="icon-add text-success"></i>?'.'<br/>'
-                .'<p class="alert bg-warning">'."Please add at least two answer options to proceed.".'</p>',
+                .'<p class="alert bg-warning">'.gT("Please add at least two answer options to proceed.").'</p>',
                 'settings' => json_encode(array(
                     'element' => '#rowcontainer',
                     'delayOnElement' => "{element: 'element'}",


### PR DESCRIPTION
Fixed issue # : Tutorial question 29 is missing a gT(...) call for the text inside the alert box.
Dev:  The text "Please add at least two answer options to proceed." must be added to the .po translations. at translate.limesurvey.org

Add translation option for string "Please add at least two answer options to proceed.".
Wrapped string inside a gT(...)-call