### PR TITLE
Adds PostgreSQL 12 compatibility

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -789,7 +789,7 @@ class SurveyAdmin extends Survey_Common_Action
             $survey->autonumber_start = $new_autonumber_start;
             $survey->save();
             if (Yii::app()->db->getDriverName() == 'pgsql') {
-                $idDefault = Yii::app()->db->createCommand("SELECT pg_attrdef.adsrc FROM pg_attribute JOIN pg_class ON (pg_attribute.attrelid=pg_class.oid) JOIN pg_attrdef ON(pg_attribute.attrelid=pg_attrdef.adrelid AND pg_attribute.attnum=pg_attrdef.adnum) WHERE pg_class.relname='$sOldSurveyTableName' and pg_attribute.attname='id'")->queryScalar();
+                $idDefault = Yii::app()->db->createCommand("SELECT pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) FROM pg_attribute JOIN pg_class ON (pg_attribute.attrelid=pg_class.oid) JOIN pg_attrdef ON(pg_attribute.attrelid=pg_attrdef.adrelid AND pg_attribute.attnum=pg_attrdef.adnum) WHERE pg_class.relname='$sOldSurveyTableName' and pg_attribute.attname='id'")->queryScalar();
                 if (preg_match("/nextval\('(survey_\d+_id_seq\d*)'::regclass\)/", $idDefault, $matches)) {
                     $oldSeq = $matches[1];
                     Yii::app()->db->createCommand()->renameTable($oldSeq, $sNewSurveyTableName.'_id_seq');

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -166,7 +166,7 @@ class CPgsqlSchema extends CDbSchema
 	protected function findColumns($table)
 	{
 		$sql=<<<EOD
-SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, d.adsrc, a.attnotnull, a.atthasdef,
+SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, pg_get_expr(d.adbin,d.adrelid) as adsrc, a.attnotnull, a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped
@@ -231,7 +231,7 @@ SELECT conname, consrc, contype, indkey FROM (
 		CASE WHEN contype='f' THEN
 			pg_catalog.pg_get_constraintdef(oid)
 		ELSE
-			'CHECK (' || consrc || ')'
+			'CHECK (' || pg_get_expr(conbin, conrelid) || ')'
 		END AS consrc,
 		contype,
 		conrelid AS relid,


### PR DESCRIPTION
Fixed issue # : Removed g_attrdef.adsrc in PostgreSQL 12
New feature # : PostgreSQL 12 compatibility
Changed feature # : use pg_get_expr() as a replacement
Dev:
Dev: 