### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
 services:
     - mysql
 


### PR DESCRIPTION
New feature # : Added PHP 7.4 to travis
Dev: Majed6

7.4 has been released. See https://www.php.net/archive/2019.php#2019-11-28-1