### PR TITLE
[WIP] Dev: Issue with MSSQL and 0 or 0.1 or 0.001

### DIFF
--- a/application/controllers/admin/dataentry.php
+++ b/application/controllers/admin/dataentry.php
@@ -598,6 +598,9 @@ class dataentry extends Survey_Common_Action
                             $aDataentryoutput .= $fname['subquestion'].'&nbsp;';
                             /* Fix DB DECIMAL type */
                             $value = $idrow[$fname['fieldname']];
+                            if($value[0] === ".") {
+                                $value = "0".$value;
+                            }
                             if (strpos($value, ".")) {
                                 $value = rtrim(rtrim($value, "0"), ".");
                             }
@@ -974,6 +977,9 @@ class dataentry extends Survey_Common_Action
                         case "N": //NUMERICAL TEXT
                             /* Fix DB DECIMAL type */
                             $value = $idrow[$fname['fieldname']];
+                            if($value[0] === ".") {
+                                $value = "0".$value;
+                            }
                             if (strpos($value, ".")) {
                                 $value = rtrim(rtrim($value, "0"), ".");
                             }

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -100,7 +100,10 @@ class SurveyObj
             case 'K':
             case 'N':
                 $fullAnswer = $answerCode;
-                if (trim($fullAnswer) != '') {
+                if (trim($fullAnswer) !== '') {
+                    if($fullAnswer[0] === ".") {
+                        $fullAnswer = "0".$fullAnswer;
+                    }
                     if (strpos($fullAnswer, ".") !== false) {
                         $fullAnswer = rtrim(rtrim($fullAnswer, "0"), ".");
                     }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1096,7 +1096,7 @@ function getExtendedAnswer($iSurveyID, $sFieldCode, $sValue, $sLanguage)
     //Fieldcode used to determine question, $sValue used to match against answer code
     //Returns NULL if question type does not suit
     if (strpos($sFieldCode, "{$iSurveyID}X") === 0) {
-//Only check if it looks like a real fieldcode
+        //Only check if it looks like a real fieldcode
         $fieldmap = createFieldMap($survey, 'short', false, false, $sLanguage);
         if (isset($fieldmap[$sFieldCode])) {
             $fields = $fieldmap[$sFieldCode];
@@ -1121,7 +1121,12 @@ function getExtendedAnswer($iSurveyID, $sFieldCode, $sValue, $sLanguage)
                 break;
             case 'K':
             case 'N':
+                // Fix the value : Value is stored as decimal in SQL
                 if (trim($sValue) != '') {
+                    // issue #15685 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+                    if($sValue[0] === ".") {
+                        $sValue = "0".$sValue;
+                    }
                     if (strpos($sValue, ".") !== false) {
                         $sValue = rtrim(rtrim($sValue, "0"), ".");
                     }

--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -298,9 +298,25 @@ class ExpressionManager
     {
         /* When value come from DB : it's set to 1.000000 (DECIMAL) : must be fixed see #11163. Response::model() must fix this . or not ? */
         /* Don't return true always : user can entre non numeric value in a numeric value : we must compare as string then */
-        $arg1[0] = ($arg1[2] == "NUMBER" && strpos($arg1[0], ".")) ? rtrim(rtrim($arg1[0], "0"), ".") : $arg1[0];
-        $arg2[0] = ($arg2[2] == "NUMBER" && strpos($arg2[0], ".")) ? rtrim(rtrim($arg2[0], "0"), ".") : $arg2[0];
-        
+        $arg1[0] = $arg1[0];
+        if($arg1[2] == "NUMBER" && $arg1[0]!== "") {
+            if($arg1[0] === ".") {
+                $arg1 = "0".$arg1;
+            }
+            if (strpos($arg1, ".") !== false) {
+                $arg1 = rtrim(rtrim($arg1, "0"), ".");
+            }
+        }
+        $arg2[0] = $arg2[0];
+        if($arg2[2] == "NUMBER" && $arg2[0]!== "") {
+            if($arg2[0] === ".") {
+                $arg2 = "0".$arg2;
+            }
+            if (strpos($arg2, ".") !== false) {
+                $arg2 = rtrim(rtrim($arg2, "0"), ".");
+            }
+        }
+
         $bNumericArg1 = $arg1[0]!== "" && (!$arg1[0] || strval(floatval($arg1[0])) == strval($arg1[0]));
         $bNumericArg2 = $arg2[0]!== "" && (!$arg2[0] || strval(floatval($arg2[0])) == strval($arg2[0]));
         $bStringArg1 = !$arg1[0] || !$bNumericArg1;

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2739,8 +2739,12 @@ function do_multiplenumeric($ia)
                 $sValue                = null;
             }
 
+            // Fix the display value : Value is stored as decimal in SQL
+            if($sValue[0] == ".") {
+                // issue #15684 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+                $sValue = "0" . $sValue;
+            }
             $sUnformatedValue = $sValue ? $sValue : '';
-
             if (strpos($sValue, ".")) {
                 $sValue = rtrim(rtrim($sValue, "0"), ".");
                 $sValue = str_replace('.', $sSeparator, $sValue);
@@ -2928,7 +2932,11 @@ function do_numerical($ia)
     $sSeparator = getRadixPointData($thissurvey['surveyls_numberformat']);
     $sSeparator = $sSeparator['separator'];
 
-    // Fix the display value : Value is stored as decimal in SQL then return dot and 0 after dot. Seems only for numerical question type
+    // Fix the display value : Value is stored as decimal in SQL
+    if($fValue[0] == ".") {
+        // issue #15684 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+        $fValue = "0" . $fValue;
+    }
     if (strpos($fValue, ".")) {
         $fValue = rtrim(rtrim($fValue, "0"), ".");
     }

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -959,6 +959,9 @@ class SurveyDynamic extends LSActiveRecord
         }
         
         if ($oQuestion->type=='N' || ($oQuestion->parent_qid != 0 && $oQuestion->parents['type'] === "K")) {
+            if($aQuestionAttributes['answervalue'] !=="" && $aQuestionAttributes['answervalue'][0] === ".") { // issue #15685 mssql
+                $aQuestionAttributes['answervalue'] = "0".$aQuestionAttributes['answervalue'];
+            }
             if (strpos($aQuestionAttributes['answervalue'], ".") !== false) { // Remove last 0 and last . ALWAYS (see \SurveyObj\getShortAnswer)
                 $aQuestionAttributes['answervalue'] = rtrim(rtrim($aQuestionAttributes['answervalue'], "0"), ".");
             }


### PR DESCRIPTION
Fixed issue #15684: When reloading decimal value with 0 with MSSQL : 0 disappear
Fixed issue #15685: Issue when exporting decimal value in MSSQL 
Dev: check if value start by `. ` before removing lastb 0 and last dot
Dev: add 0 is start by .
Dev: Maybe can check with regexp, but use $string[0] seems the speediest solution ?