### PR TITLE
Dev: Optimisation on SQL request in Expression Manager

### DIFF
--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -454,9 +454,9 @@ class LSETwigViewRenderer extends ETwigViewRenderer
             // additionally checks for submit page to compensate when srid is needed to render other views
             if (
                 isset($_SESSION['survey_' . $surveyid]['srid'])
-                && $aDatas['aSurveyInfo']['active'] == 'Y'
-                && $aDatas['aSurveyInfo']['include_content'] !== 'submit'
-                && $aDatas['aSurveyInfo']['include_content'] !== 'submit_preview'
+                && isset($aDatas['aSurveyInfo']['active']) && $aDatas['aSurveyInfo']['active'] == 'Y'
+                && isset($aDatas['aSurveyInfo']['include_content']) && $aDatas['aSurveyInfo']['include_content'] !== 'submit'
+                && isset($aDatas['aSurveyInfo']['include_content']) && $aDatas['aSurveyInfo']['include_content'] !== 'submit_preview'
             ) {
                 $aDatas['aSurveyInfo']['bShowClearAll'] = true;
             }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5583,12 +5583,12 @@
                         $oResponse->setAttributes($aResponseAttributes, false);
                         if (!$oResponse->save()) {
                             $message = submitfailed('', print_r($response->getErrors())); // $response->getErrors() is array[string[]], then can not join
-
                             if (($this->debugLevel & LEM_DEBUG_VALIDATION_SUMMARY) == LEM_DEBUG_VALIDATION_SUMMARY) {
                                 $message .= CHTml::errorSummary($response,$this->gT('Error on response update'));  // Add SQL error according to debugLevel
                             }
                             LimeExpressionManager::addFrontendFlashMessage('error', $message, $this->sid);
-                        } else { // Action in case its saved with success : to be move in Response::aferSave ?
+                        } else {
+                            // Action in case its saved with success : to be move in Response::aferSave ?
                             // Save Timings if needed
                             if ($this->surveyOptions['savetimings']) {
                                 Yii::import("application.libraries.Save");
@@ -5623,15 +5623,17 @@
                     else
                     {
                         if ($finished && ($oResponse->submitdate == null || Survey::model()->findByPk($this->sid)->alloweditaftercompletion == 'Y')) {
+                            /* Reload current response : see https://github.com/LimeSurvey/LimeSurvey/commit/27957d68e9ae3226515524c1774493d86706233a?email_source=notifications&email_token=AAK7NRDQU4OF7RIIJOOMJG3Q3SZEDA5CNFSM4J36GC5KYY3PNVWWK3TUL52HS4DFVVBW63LNNF2EG33NNVSW45FKMNXW23LFNZ2F62LEZYBC53FN#commitcomment-36629677 */
+                            $oResponseFinished = Response::model($this->sid)->findByPk($oResponse->id);
                             if($this->surveyOptions['datestamp'])
                             {
-                                $oResponse->submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                                $oResponseFinished->submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
                             }
                             else
                             {
-                                $oResponse->submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
+                                $oResponseFinished->submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
                             }
-                            $oResponse->save();
+                            $oResponseFinished->save();
                         }
                     }
 

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5580,8 +5580,8 @@
                     $oResponse = Response::model($this->sid)->findByPk($_SESSION[$this->sessid]['srid']);
                     //If the responses already have been submitted once they are marked as completed already, so they shouldn't be changed.
                     if ($oResponse->submitdate == null || Survey::model()->findByPk($this->sid)->alloweditaftercompletion == 'Y') {
-                        $oResponse->setAttributes($aResponseAttributes, false);
-                        if (!$oResponse->save()) {
+                        $iCountUpdated = Response::model($this->sid)->updateByPk($oResponse->id,$aResponseAttributes);
+                        if (!$iCountUpdated) {
                             $message = submitfailed('', print_r($response->getErrors())); // $response->getErrors() is array[string[]], then can not join
                             if (($this->debugLevel & LEM_DEBUG_VALIDATION_SUMMARY) == LEM_DEBUG_VALIDATION_SUMMARY) {
                                 $message .= CHTml::errorSummary($response,$this->gT('Error on response update'));  // Add SQL error according to debugLevel

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5625,17 +5625,15 @@
                     else
                     {
                         if ($finished && ($oResponse->submitdate == null || Survey::model()->findByPk($this->sid)->alloweditaftercompletion == 'Y')) {
-                            /* Reload current response : see https://github.com/LimeSurvey/LimeSurvey/commit/27957d68e9ae3226515524c1774493d86706233a?email_source=notifications&email_token=AAK7NRDQU4OF7RIIJOOMJG3Q3SZEDA5CNFSM4J36GC5KYY3PNVWWK3TUL52HS4DFVVBW63LNNF2EG33NNVSW45FKMNXW23LFNZ2F62LEZYBC53FN#commitcomment-36629677 */
-                            $oResponseFinished = Response::model($this->sid)->findByPk($oResponse->id);
-                            if($this->surveyOptions['datestamp'])
-                            {
-                                $oResponseFinished->submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                            /* Less update : just do what you need to to */
+                            if($this->surveyOptions['datestamp']) {
+                                $submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                            } else {
+                                $submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
                             }
-                            else
-                            {
-                                $oResponseFinished->submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
+                            if (!Response::model($this->sid)->updateByPk($oResponse->id,array('submitdate'=>$submitdate))) {
+                                LimeExpressionManager::addFrontendFlashMessage('error', $this->gT('An error happen when try to submit your response.'), $this->sid);
                             }
-                            $oResponseFinished->save();
                         }
                     }
 

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5596,6 +5596,8 @@
                                 $cSave->set_answer_time();
                             }
                         }
+                    } else {
+                        LimeExpressionManager::addFrontendFlashMessage('error', $this->gT('This response was already submitted.'), $this->sid);
                     }
 
                     if ($finished) {


### PR DESCRIPTION
Move for ->find ->save to updateByPk 

With find+save : all value are updated : update whole line. With updateByPk : update ONLY the needed value.

With find+save : you update value from 1st page at 2nd page, with updateByPk : only value on page + lastpage + datestamp are updated : less SQL is **always** better. See the SQL log 