### PR TITLE
Dev: 2 different action for save : plugin event happen 2 times

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5623,15 +5623,17 @@
                     else
                     {
                         if ($finished && ($oResponse->submitdate == null || Survey::model()->findByPk($this->sid)->alloweditaftercompletion == 'Y')) {
+                            /* 2 different save must be done : 2 different event */
+                            $oResponseSubmit = Response::model($this->sid)->findByPk($oResponse->id);
                             if($this->surveyOptions['datestamp'])
                             {
-                                $oResponse->submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                                $oResponseSubmit->submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
                             }
                             else
                             {
-                                $oResponse->submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
+                                $oResponseSubmit->submitdate = date("Y-m-d H:i:s",mktime(0,0,0,1,1,1980));
                             }
-                            $oResponse->save();
+                            $oResponseSubmit->save();
                         }
                     }
 


### PR DESCRIPTION
Dev: this is just a test for https://github.com/LimeSurvey/LimeSurvey/commit/27957d68e9ae3226515524c1774493d86706233a#commitcomment-36629663

**But** before https://github.com/LimeSurvey/LimeSurvey/commit/27957d68e9ae3226515524c1774493d86706233a#commitcomment-36629663 beforeResponseSave didn't happen. Then : i think best solution is to use updateByPK : really optimum SQL. 
And add a new event in 4.X in a updateByPk for Response .
