### PR TITLE
Fixed issue #15684: When reloading decimal value with 0 with MSSQL : 0 disappear

### DIFF
--- a/application/controllers/admin/dataentry.php
+++ b/application/controllers/admin/dataentry.php
@@ -598,6 +598,9 @@ class dataentry extends Survey_Common_Action
                             $aDataentryoutput .= $fname['subquestion'].'&nbsp;';
                             /* Fix DB DECIMAL type */
                             $value = $idrow[$fname['fieldname']];
+                            if($value[0] === ".") {
+                                $value = "0".$value;
+                            }
                             if (strpos($value, ".")) {
                                 $value = rtrim(rtrim($value, "0"), ".");
                             }
@@ -974,6 +977,9 @@ class dataentry extends Survey_Common_Action
                         case "N": //NUMERICAL TEXT
                             /* Fix DB DECIMAL type */
                             $value = $idrow[$fname['fieldname']];
+                            if($value[0] === ".") {
+                                $value = "0".$value;
+                            }
                             if (strpos($value, ".")) {
                                 $value = rtrim(rtrim($value, "0"), ".");
                             }

--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -100,7 +100,11 @@ class SurveyObj
             case 'K':
             case 'N':
                 $fullAnswer = $answerCode;
-                if (trim($fullAnswer) != '') {
+                if (trim($fullAnswer) !== '') {
+                    // SQL DECIMAL
+                    if($fullAnswer[0] === ".") {
+                        $fullAnswer = "0".$fullAnswer;
+                    }
                     if (strpos($fullAnswer, ".") !== false) {
                         $fullAnswer = rtrim(rtrim($fullAnswer, "0"), ".");
                     }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1096,7 +1096,7 @@ function getExtendedAnswer($iSurveyID, $sFieldCode, $sValue, $sLanguage)
     //Fieldcode used to determine question, $sValue used to match against answer code
     //Returns NULL if question type does not suit
     if (strpos($sFieldCode, "{$iSurveyID}X") === 0) {
-//Only check if it looks like a real fieldcode
+        //Only check if it looks like a real fieldcode
         $fieldmap = createFieldMap($survey, 'short', false, false, $sLanguage);
         if (isset($fieldmap[$sFieldCode])) {
             $fields = $fieldmap[$sFieldCode];
@@ -1121,6 +1121,11 @@ function getExtendedAnswer($iSurveyID, $sFieldCode, $sValue, $sLanguage)
                 break;
             case 'K':
             case 'N':
+                // Fix the value : Value is stored as decimal in SQL
+                if($sValue[0] === ".") {
+                    // issue #15685 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+                    $sValue = "0".$sValue;
+                }
                 if (trim($sValue) != '') {
                     if (strpos($sValue, ".") !== false) {
                         $sValue = rtrim(rtrim($sValue, "0"), ".");

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2739,10 +2739,17 @@ function do_multiplenumeric($ia)
                 $sValue                = null;
             }
 
-            $sUnformatedValue = $sValue ? $sValue : '';
-
+            // Fix the display value : Value is stored as decimal in SQL. Issue when reloading survey
+            if($sValue[0] == ".") {
+                // issue #15684 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+                $sValue = "0" . $sValue;
+            }
             if (strpos($sValue, ".")) {
                 $sValue = rtrim(rtrim($sValue, "0"), ".");
+            }
+            // End of DECIMAL fix : get the nulber value
+            $sUnformatedValue = $sValue ? $sValue : '';
+            if (strpos($sValue, ".")) {
                 $sValue = str_replace('.', $sSeparator, $sValue);
             }
 
@@ -2928,7 +2935,11 @@ function do_numerical($ia)
     $sSeparator = getRadixPointData($thissurvey['surveyls_numberformat']);
     $sSeparator = $sSeparator['separator'];
 
-    // Fix the display value : Value is stored as decimal in SQL then return dot and 0 after dot. Seems only for numerical question type
+    // Fix the display value : Value is stored as decimal in SQL
+    if($fValue[0] == ".") {
+        // issue #15684 mssql SAVE 0.01 AS .0100000000, set it at 0.0100000000
+        $fValue = "0" . $fValue;
+    }
     if (strpos($fValue, ".")) {
         $fValue = rtrim(rtrim($fValue, "0"), ".");
     }


### PR DESCRIPTION
Fixed issue #15685: Issue when exporting decimal value in MSSQL
Dev: check if value start by . before removing last 0 and last dot
Dev: add 0 is start by .
Dev: Maybe can check with regexp, but use $string[0] seems the speediest solution ?
Dev: doing it for Survey doing , export, response browse and data edit
Dev: don't update ExpressionManager