### PR TITLE
Fix for empty token value when calling Token->generateToken()

### DIFF
--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -245,7 +245,7 @@ abstract class Token extends Dynamic
     {
         $token = Yii::app()->securityManager->generateRandomString($iTokenLength);
         if ($token === false) {
-            throw new CHttpException(500, 'Failed to generate random string for token. Please check your configuration and ensure that the openssl or mcrypt extension is enabled.');
+            throw new CHttpException(500, gT('Failed to generate random string for token. Please check your configuration and ensure that the openssl or mcrypt extension is enabled.'));
         }
         $token = str_replace(array('~', '_'), array('a', 'z'), $token);
         $event = new PluginEvent('afterGenerateToken');

--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -243,7 +243,11 @@ abstract class Token extends Dynamic
      */
     private function _generateRandomToken($iTokenLength)
     {
-        $token = str_replace(array('~', '_'), array('a', 'z'), Yii::app()->securityManager->generateRandomString($iTokenLength));
+        $token = Yii::app()->securityManager->generateRandomString($iTokenLength);
+        if ($token === false) {
+            throw new CHttpException(500, 'Failed to generate random string for token. Please check your configuration and ensure that the openssl or mcrypt extension is enabled.');
+        }
+        $token = str_replace(array('~', '_'), array('a', 'z'), $token);
         $event = new PluginEvent('afterGenerateToken');
         $event->set('surveyId', $this->getSurveyId());
         $event->set('iTokenLength', $iTokenLength);


### PR DESCRIPTION
On a Windows installation I had a mysterious problem where calls the remote API function `add_participants` were resulting in new participants with empty tokens.

I found out that the problem is:
* `Yii::app()->securityManager->generateRandomString()` always returns **false** if there is an error.
* In my Windows installation, out of the box, the random string function is failing, presumably because `mcrypt` and `openssl` extensions were disabled. I enabled `openssl` and my problem went away.
* `Token->_generateRandomToken()` doesn't check the return value.

I believe that `Token->_generateRandomToken()` should fail hard when it gets a failure value from the Yii framework random string function.

This patch enacts that policy. **Please edit the error message to suit your project's style, if the message is not to your liking.**