### PR TITLE
Fixed issue #15835: Answers were already translated when loading them for export.

### DIFF
--- a/application/helpers/admin/export/SurveyObj.php
+++ b/application/helpers/admin/export/SurveyObj.php
@@ -237,7 +237,7 @@ class SurveyObj
             case Question::QT_F_ARRAY_FLEXIBLE_ROW:
             case Question::QT_H_ARRAY_FLEXIBLE_COLUMN:
                 $answers = $this->getAnswers($questionId, 0);
-                $fullAnswer = (isset($answers[$answerCode])) ? $answers[$answerCode]->answerL10ns[$sLanguageCode]->answer : "";
+                $fullAnswer = (isset($answers[$answerCode])) ? $answers[$answerCode] : "";
                 break;
 
             default:


### PR DESCRIPTION
Fixed issue #15835 : Answers were already translated when loading them for export.
