### PR TITLE
Fixed issue #15859: Token can be truncated in SPSS export

### DIFF
--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -403,7 +403,7 @@ function activateSurvey($iSurveyID, $simulate = false)
                 }
                 break;
             case "token":
-                $aTableDefinition[$aRow['fieldname']] = 'string(35)'.$sCollation;
+                $aTableDefinition[$aRow['fieldname']] = 'string('.Token::MAX_LENGTH.')'.$sCollation;
                 break;
             case '*': // Equation
                 $aTableDefinition[$aRow['fieldname']] = "text";

--- a/application/helpers/admin/activate_helper.php
+++ b/application/helpers/admin/activate_helper.php
@@ -438,7 +438,7 @@ function activateSurvey($iSurveyID, $simulate = false)
                 $aTableDefinition[$aRow['fieldname']] = "string(5)";
         }
         if ($oSurvey->anonymized == 'N' && !array_key_exists('token', $aTableDefinition)) {
-            $aTableDefinition['token'] = 'string(35)'.$sCollation;
+            $aTableDefinition['token'] = 'string('.Token::MAX_LENGTH.')'.$sCollation;
         }
         if ($simulate) {
             $tempTrim = trim($aTableDefinition);

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -505,7 +505,7 @@ function SPSSFieldMap($iSurveyID, $prefix = 'V', $sLanguage = '')
                 break;
             case 'token';
                 $fieldtype = 'A';
-                $val_size = $survey->tokenlength;
+                $val_size = Token::MAX_LENGTH;
                 break;
             case 'id';
                 $fieldtype = 'F';

--- a/application/models/SurveyActivator.php
+++ b/application/models/SurveyActivator.php
@@ -173,7 +173,7 @@ class SurveyActivator
                     }
                     break;
                 case "token":
-                    $aTableDefinition[$aRow['fieldname']] = 'string(35)'.$this->collation;
+                    $aTableDefinition[$aRow['fieldname']] = 'string(' . Token::MAX_LENGTH . ')'.$this->collation;
                     break;
                 case Question::QT_ASTERISK_EQUATION:
                     $aTableDefinition[$aRow['fieldname']] = isset($aRow['answertabledefinition']) && !empty($aRow['answertabledefinition']) ? $aRow['answertabledefinition'] : "text";
@@ -208,7 +208,7 @@ class SurveyActivator
                     $aTableDefinition[$aRow['fieldname']] = (array_key_exists('encrypted', $aRow) && $aRow['encrypted'] == 'Y') ? "text" : isset($aRow['answertabledefinition']) && !empty($aRow['answertabledefinition']) ? $aRow['answertabledefinition'] : "string(5)";
             }
             if (!$this->survey->isAnonymized && !array_key_exists('token', $aTableDefinition)) {
-                $aTableDefinition['token'] = 'string(35)'.$this->collation;
+                $aTableDefinition['token'] = 'string('.Token::MAX_LENGTH.')'.$this->collation;
             }
         }
         $this->tableDefinition = $aTableDefinition;

--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -58,6 +58,8 @@ use \LimeSurvey\PluginManager\PluginEvent;
  */
 abstract class Token extends Dynamic
 {
+    /** @var int Maximum token length */
+    const MAX_LENGTH = 36;
 
     /**
      * Set defaults
@@ -165,7 +167,7 @@ abstract class Token extends Dynamic
             'lastname' => 'text',
             'email' => 'text',
             'emailstatus' => 'text',
-            'token' => "string(36) {$sCollation}",
+            'token' => "string(".self::MAX_LENGTH."}) {$sCollation}",
             'language' => 'string(25)',
             'blacklisted' => 'string(17)',
             'sent' => "string(17) DEFAULT 'N'",

--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -167,7 +167,7 @@ abstract class Token extends Dynamic
             'lastname' => 'text',
             'email' => 'text',
             'emailstatus' => 'text',
-            'token' => "string(".self::MAX_LENGTH."}) {$sCollation}",
+            'token' => "string(" . self::MAX_LENGTH . ") {$sCollation}",
             'language' => 'string(25)',
             'blacklisted' => 'string(17)',
             'sent' => "string(17) DEFAULT 'N'",


### PR DESCRIPTION
Token length is wrong. Or can be wrong in many cases. Token column in survey is set to 'string(36)'. Tokens can be imported or created via API in a longer format than set in the survey settings. So We are ending up truncated tokens in SPSS file. The survey->tokenlength should be also used while creating the token field in DB (and API/import length check) OR the SPSS should generate a field allowing max length that can come from DB (32).