### PR TITLE
Fixed issue #15924: Can not send invitations to imported participants where emailstatus IS NULL

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -2615,7 +2615,7 @@ class tokens extends Survey_Common_Action
         if ($request->getPost('bypassbademails') == '1') {
             return "emailstatus = 'OK'";
         } else {
-            return "emailstatus <> 'OptOut'";
+            return "emailstatus <> 'OptOut' OR emailstatus IS NULL";
         }
     }
 


### PR DESCRIPTION
Fixed issue [#15924](https://bugs.limesurvey.org/view.php?id=15924): Can not send invitations to imported participants where emailstatus IS NULL

Dev: although the WHERE condition "emailstatus <> 'OptOut'" *intuitively* should match everything that is not equal to "OptOut" it actually does *not* match NULL values in MySQL since it is not NULL-safe.

Dev: This is related to [#15772](https://bugs.limesurvey.org/view.php?id=15772) and [#15823](https://bugs.limesurvey.org/view.php?id=15823) since emailstatus should not be NULL in the first place.