### PR TITLE
Fixed issue #15984: Order of subquestion are not respected in print answers

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -83,8 +83,8 @@ class Question extends LSActiveRecord
             'groups' => array(self::BELONGS_TO, 'QuestionGroup', 'gid, language', 'together' => true),
             'parents' => array(self::HAS_ONE, 'Question', array("qid" => "parent_qid", "language" => "language")),
             'questionAttributes' => array(self::HAS_MANY, 'QuestionAttribute', 'qid'),
-            'subquestions' => array(self::HAS_MANY, 'Question', array('parent_qid'=>'qid', "language" => "language")),
-            'answers' => array(self::HAS_MANY, 'Answer', array('qid'=>'qid', "language" => "language"))
+            'subquestions' => array(self::HAS_MANY, 'Question', array('parent_qid'=>'qid', "language" => "language"), 'order'=> App()->getDb()->quoteColumnName('subquestions.question_order').' ASC'),
+            'answers' => array(self::HAS_MANY, 'Answer', array('qid'=>'qid', "language" => "language"), 'order'=> App()->getDb()->quoteColumnName('answers.sortorder').' ASC'),
         );
     }
 


### PR DESCRIPTION
Dev: fix order in relations
Dev: use App()->getDb()->quoteColumnName for security

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->
