### PR TITLE
 Fixed issue #16024: Language changer dropdown autoupdated : keybord navigation issue

### DIFF
--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -213,7 +213,16 @@ function activateLanguageChanger(){
         }
     });
     /* Language changer dropdown */
+    /* Don't activate change when using key up / key down */
+    $('.form-change-lang [name="lang"]').on('keypress keydown', function(event) {
+        var code = event.keyCode || event.which;
+        $(this).data('lastkey') = code;
+    });
     $('.form-change-lang [name="lang"]').on('change', function(event) {
+        if( $(this).data("lastkey") == 38 || $(this).data("lastkey") == 40) {
+            /* Last key is up or down : disable auto submit mantis #16024 */
+            return;
+        }
         var closestForm = $(this).closest('form');
         var newLang = $(this).val();
         if (!closestForm.length) {

--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -216,26 +216,32 @@ function activateLanguageChanger(){
     /* Don't activate change when using key up / key down */
     $('.form-change-lang [name="lang"]').on('keypress keydown keyup', function(event) {
         var code = event.keyCode || event.which;
-        $(this).data('lastkey',code);
+        /* packaje name : limesurvey */
+        $(this).data("limesurvey-lastkey",code);
+    });
+    $('.form-change-lang [name="lang"]').on('click', function(event) {
+        /* didn't work with chrome , chrom bug : onclick are an intrinsic event see https://www.w3.org/TR/html401/interact/forms.html#h-17.6 */
+        /* Happen rarely (keyboard + mouse + still have the button */
+        $(this).data("limesurvey-lastkey",null);
     });
     $('.form-change-lang [name="lang"]').on('change', function(event) {
-        if( $(this).data("lastkey") == 38 || $(this).data("lastkey") == 40) {
+        if( $(this).data("limesurvey-lastkey") == 38 || $(this).data("lastkey") == 40) {
             /* Last key is up or down : disable auto submit mantis #16024 */
             return;
         }
         var closestForm = $(this).closest('form');
         var newLang = $(this).val();
         if (!closestForm.length) {
-            /* we are not in a forum, can not submit directly */
+            /* we are not in a form, can not submit directly */
+            // Remind user can put language changer everywhere, not only in home page, but for example in clear all page etc … in form or not etc ...
             if (limesurveyForm.length == 1) {
                 /* The limesurvey form exist in document, move select and button inside and click */
                 applyChangeAndSubmit(newLang);
-                // TODO: Check all code below. When does it happen?
-                // Answer : remind user can put language changer everywhere, not only in home page, but for example in clear all page etc …
             } else {
                 // If there are no form : we can't use it */
                 if($(this).parent().data('targeturl')){
                     /* If we have a target url : just move location to this url with lang set */
+                    /* targeturl was used for preview gropup and question in 2.6lts : check if still used/usable */
                     var target=$(this).parent().data('targeturl');
                     /* adding lang in get param manually */
                     if(target.indexOf("?") >=0){
@@ -248,6 +254,7 @@ function activateLanguageChanger(){
                     return false;
                 }else{
                     /* No form, not targeturl : just see what happen */
+                    /* This must not happen : issue in theme */
                     $("<form>", {
                         "class":'ls-js-hidden',
                         "html": '<input type="hidden" name="lang" value="' + newLang + '" />',
@@ -259,7 +266,7 @@ function activateLanguageChanger(){
             }
         }else{
             /* we are inside a form : just submit : but remove other lang input if exist : be sure it's this one send */
-            $(this).closest('form').find("[name='lang']").not($(this).parent()).remove();
+            $(this).closest('form').find("[name='lang']").not(this).remove();
             $(this).closest('.form-change-lang').find(':submit').click();
         }
     });

--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -214,9 +214,9 @@ function activateLanguageChanger(){
     });
     /* Language changer dropdown */
     /* Don't activate change when using key up / key down */
-    $('.form-change-lang [name="lang"]').on('keypress keydown', function(event) {
+    $('.form-change-lang [name="lang"]').on('keypress keydown keyup', function(event) {
         var code = event.keyCode || event.which;
-        $(this).data('lastkey') = code;
+        $(this).data('lastkey',code);
     });
     $('.form-change-lang [name="lang"]').on('change', function(event) {
         if( $(this).data("lastkey") == 38 || $(this).data("lastkey") == 40) {


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #16024: Language changer dropdown autoupdated : keybord navigation issue
Dev: checked on chrome and firefox
Dev: disable change if last key was key up or down on select.
