### PR TITLE
Fix phone number validation error

### DIFF
--- a/assets/packages/expressions/em_javascript.js
+++ b/assets/packages/expressions/em_javascript.js
@@ -1284,6 +1284,11 @@ function LEMval(alias)
                 }
                 return value;
             }
+            else if (/^\+/.test(value))
+            {
+                // Treat values like "+1234" (e.g. phone numbers) as strings. Decimal doesn't like them, and the + sign shouldn't be just dropped silently anyway.
+                return value;
+            }
             else if(!isNaN(parseFloat(value)) && isFinite(value))
             {
                 var length = value.length;


### PR DESCRIPTION
Sorry I couldn't find an issue about this in Mantis, and your instructions say that for small fixes a bug is not required, so I decided to not create a yet another account just for this. :)

I'm having an issue with phone number validation in the front-end: I've created a "Short free text (S)" type field for the users to enter their phone number, and set it's validation regexp to `/^\+?[0-9\-\(\)\ ]+$/` (an optional plus sign followed by any number of digits, spaces, hyphens and braces). I might have set it to numeric initially, before changing to S. So, whenever I tried entering my phone number in it in its international form (with a leading + sign), the field was highlighted in red, even though it validated just fine in the backend. Looking at browser console, I noticed a bunch of JS errors in em_javascript.js, line 1294. This patch prevents the issue from occuring.

Interestingly, I couldn't reproduce the problem in https://survey.limesurvey.org/78184 (question _Do you regularly use any other software product in conjunction with LimeSurvey (e.g. email products, project management tools, MS Office)?_), Perhaps your field is configured differently. Still, preventing a JS error doesn't seem like a bad idea, however you look at it. :)