### PR TITLE
Fixed issue: JsonEditor to not encode the value if it is already a valid json (#1217)

### DIFF
--- a/application/extensions/yii-jsoneditor/JsonEditor.php
+++ b/application/extensions/yii-jsoneditor/JsonEditor.php
@@ -47,7 +47,13 @@
 		{
 			$htmlOptions = $this->htmlOptions;
             list($name, $id) = $this->resolveNameID();
-			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, json_encode($this->value), array(
+			$value = $this->value;
+			// not a json, encoding
+			if (!isJson($this->value)) {
+				$value = json_encode($this->value);
+			}
+
+			echo CHtml::tag('div', $htmlOptions, CHtml::textArea($name, $value, array(
 				'id' => $id,
                 'encode' => false,
 			)));


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
