### PR TITLE
Fixed issue #16247: Launch console can create new security.php file

### DIFF
--- a/application/commands/PluginCommand.php
+++ b/application/commands/PluginCommand.php
@@ -16,6 +16,15 @@
         public $connection;
 
         /**
+        * register some needed or a lot used part
+        */
+        public function init()
+        {
+            parent::init();
+            Yii::import('application.helpers.common_helper', true);
+        }
+
+        /**
          * Call for cron action
          * @param int $interval Minutes for interval
          * @return void

--- a/application/core/ConsoleApplication.php
+++ b/application/core/ConsoleApplication.php
@@ -44,15 +44,27 @@ class ConsoleApplication extends CConsoleApplication
 
         // Set webroot alias.
         Yii::setPathOfAlias('webroot', realpath(Yii::getPathOfAlias('application').'/../'));
-
         /* Because we have app now : we have to call again the config : can be done before : no real usage of url in console, but usage of getPathOfAlias */
         $coreConfig = require(__DIR__.'/../config/config-defaults.php');
         $consoleConfig = require(__DIR__.'/../config/console.php'); // Only for console : replace some config-defaults
         $emailConfig = require(__DIR__.'/../config/email.php');
         $versionConfig = require(__DIR__.'/../config/version.php');
         $updaterVersionConfig = require(__DIR__.'/../config/updater_version.php');
-        $lsConfig = array_merge($coreConfig, $consoleConfig, $emailConfig, $versionConfig, $updaterVersionConfig);
 
+        $lsConfig = array_merge(
+            $coreConfig,
+            $consoleConfig,
+            $emailConfig,
+            $versionConfig,
+            $updaterVersionConfig
+        );
+
+        if (file_exists(__DIR__.'/../config/security.php')) {
+            $securityConfig = require(  __DIR__.'/../config/security.php');
+            if (is_array($securityConfig)) {
+                $lsConfig = array_merge($lsConfig, $securityConfig);
+            }
+        }
         /* Custom config file */
         $configdir = $coreConfig['configdir'];
         if (file_exists( $configdir .  '/security.php')) {

--- a/application/core/LSSodium.php
+++ b/application/core/LSSodium.php
@@ -125,10 +125,10 @@ class LSSodium {
 	 * Write encryption key to version.php config file
 	 */
 	protected function generateEncryptionKeys(){
-	if(is_file(APPPATH.'config/security.php')) {
-	    // Never replace an existing file
+        if (is_file(APPPATH.'config/security.php')) {
+            // Never replace an existing file
             throw new CException(500, gT("Configuration file already exist"));
-	}
+        }
         $sEncryptionKeypair   = ParagonIE_Sodium_Compat::crypto_sign_keypair();
         $sEncryptionPublicKey = ParagonIE_Sodium_Compat::bin2hex(ParagonIE_Sodium_Compat::crypto_sign_publickey($sEncryptionKeypair));
         $sEncryptionSecretKey = ParagonIE_Sodium_Compat::bin2hex(ParagonIE_Sodium_Compat::crypto_sign_secretkey($sEncryptionKeypair));

--- a/application/core/LSSodium.php
+++ b/application/core/LSSodium.php
@@ -124,7 +124,11 @@ class LSSodium {
 	 * 
 	 * Write encryption key to version.php config file
 	 */
-	protected function generateEncryptionKeys(){			 	
+	protected function generateEncryptionKeys(){
+	if(is_file(APPPATH.'config/security.php')) {
+	    // Never replace an existing file
+            throw new CException(500, gT("Configuration file already exist"));
+	}
         $sEncryptionKeypair   = ParagonIE_Sodium_Compat::crypto_sign_keypair();
         $sEncryptionPublicKey = ParagonIE_Sodium_Compat::bin2hex(ParagonIE_Sodium_Compat::crypto_sign_publickey($sEncryptionKeypair));
         $sEncryptionSecretKey = ParagonIE_Sodium_Compat::bin2hex(ParagonIE_Sodium_Compat::crypto_sign_secretkey($sEncryptionKeypair));


### PR DESCRIPTION
Dev: Throw exception if file already exist
Dev: Read real default directory in ConsoleApplication

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
