### PR TITLE
Fixed issue #15037: Data protection statement texts not saved if text for checkbox is too long

### DIFF
--- a/application/views/admin/survey/editDataSecurityLocalSettings_view.php
+++ b/application/views/admin/survey/editDataSecurityLocalSettings_view.php
@@ -31,7 +31,7 @@ echo viewHelper::getViewTestTag('surveyTexts');
                 <div class="form-group">
                     <label class="control-label"><?php eT("Survey data policy checkbox label:"); ?></label>
                     <div class="">
-                        <?php echo CHtml::textField("dataseclabel_{$aSurveyLanguageSettings['surveyls_language']}",$aSurveyLanguageSettings['surveyls_policy_notice_label'],array('class'=>'form-control','size'=>"80",'id'=>"dataseclabel_{$aSurveyLanguageSettings['surveyls_language']}")); ?>
+                        <?php echo CHtml::textField("dataseclabel_{$aSurveyLanguageSettings['surveyls_language']}",$aSurveyLanguageSettings['surveyls_policy_notice_label'],array('class'=>'form-control','size'=>"80",'maxlength'=>192,'id'=>"dataseclabel_{$aSurveyLanguageSettings['surveyls_language']}")); ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixed issue #15037: Data protection statement texts not save if text for checkbox is too long.

Added maxlength = 192 in Data policy settings view for data sec label (editDataSecurityLocalSettings_view.php).
Also added a control in the controller (database.php): if there is an error while saving the language settings, the error is shown and the survey is not saved.
