### PR TITLE
Fixed issue #16316: Condition for list radio questions with question design "image_select" broken for questions on the same page

### DIFF
--- a/themes/question/image_select/survey/questions/answer/listradio/rows/answer_row.twig
+++ b/themes/question/image_select/survey/questions/answer/listradio/rows/answer_row.twig
@@ -13,7 +13,6 @@
  * @var code
  * @var answer
  * @var checkedState
- * @var sCheckconditionFunction
  * @var myfname
  * @var sValue
  **** Additional attributes:
@@ -43,9 +42,9 @@ question_template_attribute.horizontal_scroll   : {{question_template_attribute.
             id="answer{{ name}}{{ code }}"
             value="{{code}}"
             {{ checkedState }}
-            onclick='cancelBubbleThis(event); {{ sCheckconditionFunction }}'
+            onclick='cancelBubbleThis(event); checkconditions(this.value, this.name, this.type)'
         />
-        <label for="answer{{ name }}{{ code }}" class="imageselect-label" onclick='cancelBubbleThis(event); {{ sCheckconditionFunction }}'>
+        <label for="answer{{ name }}{{ code }}" class="imageselect-label" onclick='cancelBubbleThis(event);'>
 
          <img class="unforce-height" src="{{ answer }}" 
          style="{%if question_template_attribute.fix_width > 1%} 

--- a/themes/question/image_select/survey/questions/answer/listradio/rows/answer_row.twig
+++ b/themes/question/image_select/survey/questions/answer/listradio/rows/answer_row.twig
@@ -33,7 +33,7 @@ question_template_attribute.horizontal_scroll   : {{question_template_attribute.
 </p>#}
 
 <!-- answer_row -->
-<li id='javatbd{{ myfname }}' class='question-item answer-item checkbox-item imageselect-listitem {{ extra_class }}' {{ sDisplayStyle }} >
+<li id='javatbd{{ myfname }}' class='question-item answer-item radio-item imageselect-listitem {{ extra_class }}' {{ sDisplayStyle }} >
     <div class="imageselect-container">
         <input
             class="imageselect-checkbox"
@@ -42,13 +42,12 @@ question_template_attribute.horizontal_scroll   : {{question_template_attribute.
             id="answer{{ name}}{{ code }}"
             value="{{code}}"
             {{ checkedState }}
-            onclick='cancelBubbleThis(event); checkconditions(this.value, this.name, this.type)'
         />
-        <label for="answer{{ name }}{{ code }}" class="imageselect-label" onclick='cancelBubbleThis(event);'>
+        <label for="answer{{ name }}{{ code }}" class="imageselect-label">
 
-         <img class="unforce-height" src="{{ answer }}" 
-         style="{%if question_template_attribute.fix_width > 1%} 
-            width: {{question_template_attribute.fix_width}}px 
+         <img class="unforce-height" src="{{ answer }}"
+         style="{%if question_template_attribute.fix_width > 1%}
+            width: {{question_template_attribute.fix_width}}px
             {% endif %} {%if question_template_attribute.fix_height > 1%}
             height: {{question_template_attribute.fix_height}}px
             {% endif %}"/>
@@ -63,9 +62,9 @@ question_template_attribute.horizontal_scroll   : {{question_template_attribute.
 </li>
 <script>
     var imageselectjs_{{name}} = new IMAGESELECT("{{ name}}{{ code }}", {
-        keepAspect: {{question_template_attribute.keep_aspect ? 'true' : 'false'}}, 
+        keepAspect: {{question_template_attribute.keep_aspect ? 'true' : 'false'}},
         horizontalScroll: {{question_template_attribute.horizontal_scroll ? 'true' : 'false'}},
         crop_or_resize: {{question_template_attribute.crop_or_resize ? true : false}}
-        }); 
+        });
 </script>
 <!-- end of answer_row -->


### PR DESCRIPTION
Fixed issue #16316: Condition for list radio questions with question design "image_select" broken for questions on the same page

The image_select’s answer_row.twig for listradio was using {{ sCheckconditionFunction }} (which we believe it was carried over from multiple choice design) instead of the fixed “checkconditions” function