### PR TITLE
Fixed Issue #16103: Switching language without inline policy notice being ticked creates empty responses.

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -102,7 +102,7 @@ class SurveyRuntimeHelper
 
         if (!$this->previewgrp && !$this->previewquestion) {
             $this->initMove(); // main methods to init session, LEM, moves, errors, etc
-            $this->checkForDataSecurityAccepted();
+            $this->checkForDataSecurityAccepted(); // must be called after initMove to allow LEM to be initialized
             $this->checkQuotas(); // check quotas (then the process will stop here)
             $this->displayFirstPageIfNeeded();
             $this->saveAllIfNeeded();
@@ -1142,7 +1142,7 @@ class SurveyRuntimeHelper
                 $this->aSurveyInfo['aCompleted']['aPrintAnswers']['sText'] = gT("Print your answers.");
                 $this->aSurveyInfo['aCompleted']['aPrintAnswers']['sTitle'] =  $surveyActive ? $this->aSurveyInfo['aCompleted']['aPrintAnswers']['sText'] : gT("Note: This link only works if the survey is activated.");
             }
-            // Link to Public statistics 
+            // Link to Public statistics
             $this->aSurveyInfo['aCompleted']['aPublicStatistics']['show'] = false;
             if ($this->aSurveyInfo['publicstatistics'] == 'Y') {
                 $this->aSurveyInfo['aCompleted']['aPublicStatistics']['show']  = true;

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -101,8 +101,8 @@ class SurveyRuntimeHelper
         }
 
         if (!$this->previewgrp && !$this->previewquestion) {
-            $this->checkForDataSecurityAccepted();
             $this->initMove(); // main methods to init session, LEM, moves, errors, etc
+            $this->checkForDataSecurityAccepted();
             $this->checkQuotas(); // check quotas (then the process will stop here)
             $this->displayFirstPageIfNeeded();
             $this->saveAllIfNeeded();


### PR DESCRIPTION
Fixed Issue #16103: Switching language without inline policy notice being ticked creates empty responses.

Error Diagnose:
- After language was changed, LEM was set to dirty. 
- After showing the datapolicy error message, the process was killed, so the LEM was not regenerated.
- Still, the regular diplay process saved the dirty LEM on session. 
- Later when showing the first group, the InitDirtyStep was not called as it seems the LEM was dirty, but not TOO dirty. 
- So, a semi dirty LEM didn't have the surveyOptions['active'] attribute set to TRUE, which caused the saving process not to update the DB