### PR TITLE
Fixed issue #15783: Print answers : all is empty

### DIFF
--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -780,7 +780,7 @@ class SurveyDynamic extends LSActiveRecord
      * @param boolean $getComment
      * @return array | boolean
      */
-    public function getQuestionArray($oQuestion, $oResponses, $bHonorConditions, $subquestion = false, $getComment = false)
+    public function getQuestionArray($oQuestion, $oResponses, $bHonorConditions, $subquestion = false, $getComment = false, $sLanguage = null)
     {
 
         $attributes = QuestionAttribute::model()->getQuestionAttributes($oQuestion->qid);
@@ -792,22 +792,27 @@ class SurveyDynamic extends LSActiveRecord
             return false;
         }
 
+        // Use survey language is no language is specified
+        if (empty($sLanguage)) $sLanguage = $oQuestion->survey->language;
+
         $aQuestionAttributes = $oQuestion->attributes;
-        $aQuestionAttributes['questionSrc'] = $oQuestion->question;
-        $result = LimeExpressionManager::ProcessString($oQuestion->question, 40, NULL, 1, 1);
+        $aQuestionAttributes['language'] = $sLanguage;
+
+        $aQuestionAttributes['questionSrc'] = $oQuestion->questionl10ns[$sLanguage]->question;
+        $result = LimeExpressionManager::ProcessString($oQuestion->questionl10ns[$sLanguage]->question, 40, NULL, 1, 1);
         $aQuestionAttributes['question'] = $result;
 
-        $aQuestionAttributes['helpSrc'] = $oQuestion->help;
-        $result = LimeExpressionManager::ProcessString($oQuestion->help, 40, NULL, 1, 1);
+        $aQuestionAttributes['helpSrc'] = $oQuestion->questionl10ns[$sLanguage]->help;
+        $result = LimeExpressionManager::ProcessString($oQuestion->questionl10ns[$sLanguage]->help, 40, NULL, 1, 1);
         $aQuestionAttributes['help'] = $result;
 
 
-        $aQuestionAttributes['questionSrc'] = $oQuestion->question;
-        $result = LimeExpressionManager::ProcessString($oQuestion->question, 40, NULL, 1, 1);
+        $aQuestionAttributes['questionSrc'] = $oQuestion->questionl10ns[$sLanguage]->question;
+        $result = LimeExpressionManager::ProcessString($oQuestion->questionl10ns[$sLanguage]->question, 40, NULL, 1, 1);
         $aQuestionAttributes['question'] = $result;
 
-        $aQuestionAttributes['helpSrc'] = $oQuestion->help;
-        $result = LimeExpressionManager::ProcessString($oQuestion->help, 40, NULL, 1, 1);
+        $aQuestionAttributes['helpSrc'] = $oQuestion->questionl10ns[$sLanguage]->help;
+        $result = LimeExpressionManager::ProcessString($oQuestion->questionl10ns[$sLanguage]->help, 40, NULL, 1, 1);
         $aQuestionAttributes['help'] = $result;
 
         if (count($oQuestion->subquestions) > 0) {
@@ -818,9 +823,9 @@ class SurveyDynamic extends LSActiveRecord
                     continue;
                 }
 
-                $subQuestionArray = $this->getQuestionArray($oSubquestion, $oResponses, $bHonorConditions, true);
+                $subQuestionArray = $this->getQuestionArray($oSubquestion, $oResponses, $bHonorConditions, true, false, $sLanguage);
                 if ($oQuestion->type == "P") {
-                    $subQuestionArray['comment'] = $this->getQuestionArray($oSubquestion, $oResponses, $bHonorConditions, true, true);
+                    $subQuestionArray['comment'] = $this->getQuestionArray($oSubquestion, $oResponses, $bHonorConditions, true, true, $sLanguage);
                 }
 
                 $aQuestionAttributes['subquestions'][$oSubquestion->qid] = $subQuestionArray;
@@ -829,6 +834,11 @@ class SurveyDynamic extends LSActiveRecord
             }
             //Get other options
             if (in_array($oQuestion->type, ["M", "P"]) && $oQuestion->other == "Y") {
+                $oOtherQuestionL10n = new QuestionL10n();
+                $oOtherQuestionL10n->setAttributes($oQuestion->questionl10ns[$sLanguage]->attributes, false);
+                $oOtherQuestionL10n->setAttributes(array(
+                    "question" => !empty($attributes['other_replace_text'][$sLanguage]) ? $attributes['other_replace_text'][$sLanguage] : gT("Other"),
+                ), false);
                 $oOtherQuestion = new Question($oQuestion->attributes);
                 $oOtherQuestion->setAttributes(array(
                     "sid" => $oQuestion->sid,
@@ -836,12 +846,13 @@ class SurveyDynamic extends LSActiveRecord
                     "type" => "T",
                     "parent_qid" => $oQuestion->qid,
                     "qid" => "other",
-                    "question" => !empty($attributes['other_replace_text'][$oQuestion->language]) ? $attributes['other_replace_text'][$oQuestion->language] : gT("Other"),
                     "title" => "other",
                 ), false);
-                $aQuestionAttributes['subquestions']["other"] = $this->getQuestionArray($oOtherQuestion, $oResponses,  $bHonorConditions, true);
+                $oOtherQuestion->questionl10ns = [$sLanguage => $oOtherQuestionL10n];
+                
+                $aQuestionAttributes['subquestions']["other"] = $this->getQuestionArray($oOtherQuestion, $oResponses,  $bHonorConditions, true, false, $sLanguage);
                 if ($oQuestion->type == "P") {
-                    $aQuestionAttributes['subquestions']["other"]['comment'] = $this->getQuestionArray($oOtherQuestion, $oResponses, $bHonorConditions, true, true);
+                    $aQuestionAttributes['subquestions']["other"]['comment'] = $this->getQuestionArray($oOtherQuestion, $oResponses, $bHonorConditions, true, true, $sLanguage);
                 }
             }
         }
@@ -867,8 +878,7 @@ class SurveyDynamic extends LSActiveRecord
         }
 
         if ($aQuestionAttributes['questionclass'] === 'date') {
-            // FIXME Inexisting Question->language used here!
-            $aQuestionAttributes['dateformat'] = getDateFormatDataForQID($aQuestionAttributes, array_merge(self::$survey->attributes, $oQuestion->survey->languagesettings[$oQuestion->language]->attributes));
+            $aQuestionAttributes['dateformat'] = getDateFormatDataForQID($aQuestionAttributes, array_merge(self::$survey->attributes, $oQuestion->survey->languagesettings[$sLanguage]->attributes));
         }
 
         $aQuestionAttributes['answervalue'] = isset($oResponses[$fieldname]) ? $oResponses[$fieldname] : null;
@@ -879,8 +889,8 @@ class SurveyDynamic extends LSActiveRecord
             $aAnswers = (
                 $oQuestion->parent_qid == 0
                     ? $oQuestion->answers
-                    : ($oQuestion->parents != null
-                        ? $oQuestion->parents->answers
+                    : ($oQuestion->parent != null
+                        ? $oQuestion->parent->answers
                         : []
                     )
                 );
@@ -892,7 +902,7 @@ class SurveyDynamic extends LSActiveRecord
             if($oSelectedAnswerOption !== null){
                 $aQuestionAttributes['answeroption'] = $oSelectedAnswerOption->attributes;
             } elseif ($oQuestion->other == 'Y'){
-                $aQuestionAttributes['answervalue'] = !empty($attributes['other_replace_text'][$oQuestion->language]) ? $attributes['other_replace_text'][$oQuestion->language] : gT("Other");
+                $aQuestionAttributes['answervalue'] = !empty($attributes['other_replace_text'][$sLanguage]) ? $attributes['other_replace_text'][$sLanguage] : gT("Other");
                 $aQuestionAttributes['answeroption']['answer'] = isset($oResponses[$fieldname.'other']) ? $oResponses[$fieldname.'other'] : null;
             }
         }
@@ -907,19 +917,19 @@ class SurveyDynamic extends LSActiveRecord
         }
 
 
-        if ($oQuestion->parent_qid != 0 && $oQuestion->parents['type'] === "1") {
+        if ($oQuestion->parent_qid != 0 && $oQuestion->parent['type'] === "1") {
 
             $aAnswers = (
                 $oQuestion->parent_qid == 0
                     ? $oQuestion->answers
-                    : ($oQuestion->parents != null
-                        ? $oQuestion->parents->answers
+                    : ($oQuestion->parent != null
+                        ? $oQuestion->parent->answers
                         : []
                     )
             );
 
             foreach($aAnswers as $key=>$value){
-                $aAnswerText[$value['code']] = $value['answer'];
+                $aAnswerText[$value['code']] = Answer::model()->getAnswerFromCode($value->qid, $value->code, $sLanguage, $value->scale_id);
             }
 
             $tempFieldname = $fieldname.'#0';
@@ -934,11 +944,11 @@ class SurveyDynamic extends LSActiveRecord
         }
 
         // array dual scale headers
-        if (isset($attributes['dualscale_headerA']) && !empty($attributes['dualscale_headerA'][$oQuestion->language])){
-            $aQuestionAttributes['dualscale_header'][0] =  $attributes['dualscale_headerA'][$oQuestion->language];
+        if (isset($attributes['dualscale_headerA']) && !empty($attributes['dualscale_headerA'][$sLanguage])){
+            $aQuestionAttributes['dualscale_header'][0] =  $attributes['dualscale_headerA'][$sLanguage];
         }
-        if (isset($attributes['dualscale_headerB']) && !empty($attributes['dualscale_headerB'][$oQuestion->language])){
-            $aQuestionAttributes['dualscale_header'][1] =  $attributes['dualscale_headerB'][$oQuestion->language];
+        if (isset($attributes['dualscale_headerB']) && !empty($attributes['dualscale_headerB'][$sLanguage])){
+            $aQuestionAttributes['dualscale_header'][1] =  $attributes['dualscale_headerB'][$sLanguage];
         }
 
         if ($aQuestionAttributes['questionclass'] === 'ranking') {
@@ -961,8 +971,8 @@ class SurveyDynamic extends LSActiveRecord
         }
 
         /* Second (X) scale for array text and array number */
-        if ($oQuestion->parent_qid != 0 && in_array($oQuestion->parents['type'], [";", ":"])) {
-            $oScaleXSubquestions = Question::model()->findAll(array(
+        if ($oQuestion->parent_qid != 0 && in_array($oQuestion->parent['type'], [";", ":"])) {
+            $oScaleXSubquestions = Question::model()->with('questionl10ns')->findAll(array(
                 'condition' => "parent_qid = :parent_qid and scale_id = :scale_id",
                 'order' => "question_order ASC",
                 'params' => array(':parent_qid' => $aQuestionAttributes['parent_qid'], ':scale_id' => 1),
@@ -971,11 +981,11 @@ class SurveyDynamic extends LSActiveRecord
                 $tempFieldname = $fieldname.'_'.$oScaleSubquestion->title;
                 $aQuestionAttributes['answervalues'][$oScaleSubquestion->title] = isset($oResponses[$tempFieldname]) ? $oResponses[$tempFieldname] : null;
                 /* Isue with language, need #15907 fixed */
-                $aQuestionAttributes['answervalueslabels'][$oScaleSubquestion->title] = isset($oScaleSubquestion->question) ? $oScaleSubquestion->question : null;
+                $aQuestionAttributes['answervalueslabels'][$oScaleSubquestion->title] = isset($oScaleSubquestion->questionl10ns[$sLanguage]->question) ? $oScaleSubquestion->questionl10ns[$sLanguage]->question : null;
             }
         }
         
-        if ($oQuestion->type=='N' || ($oQuestion->parent_qid != 0 && $oQuestion->parents['type'] === "K")) {
+        if ($oQuestion->type=='N' || ($oQuestion->parent_qid != 0 && $oQuestion->parent['type'] === "K")) {
             if (strpos($aQuestionAttributes['answervalue'], ".") !== false) { // Remove last 0 and last . ALWAYS (see \SurveyObj\getShortAnswer)
                 $aQuestionAttributes['answervalue'] = rtrim(rtrim($aQuestionAttributes['answervalue'], "0"), ".");
             }
@@ -990,7 +1000,7 @@ class SurveyDynamic extends LSActiveRecord
         $oSurvey = self::$survey;
         $aGroupArray = array();
         $oResponses = SurveyDynamic::model($oSurvey->sid)->findByAttributes(array('id'=>$sSRID));
-        $oGroupList = array_filter($oSurvey->groups, function($oGroup) use ($sLanguage) { return $oGroup->language == $sLanguage; });
+        $oGroupList = $oSurvey->groups;
 
         foreach ($oGroupList as $oGroup) {
 
@@ -999,9 +1009,9 @@ class SurveyDynamic extends LSActiveRecord
             }
 
             $aAnswersArray = array();
-            $aQuestionArray = array_filter($oGroup->questions, function($oQuestion) use ($sLanguage) { return $oQuestion->language == $sLanguage;});
+            $aQuestionArray = $oGroup->questions;
             foreach ( $aQuestionArray as $oQuestion) {
-                $aQuestionArray = $this->getQuestionArray($oQuestion, $oResponses, $bHonorConditions);
+                $aQuestionArray = $this->getQuestionArray($oQuestion, $oResponses, $bHonorConditions, false, false, $sLanguage);
 
                 if ($aQuestionArray === false) {
                     continue;
@@ -1013,6 +1023,9 @@ class SurveyDynamic extends LSActiveRecord
             $aGroupAttributes = $oGroup->attributes;
             $aGroupAttributes['answerArray'] = $aAnswersArray;
             $aGroupAttributes['debug'] = $oResponses->attributes;
+            $aGroupAttributes['group_name'] = $oGroup->getGroupNameI10N($sLanguage);
+            $aGroupAttributes['description'] = $oGroup->getGroupDescriptionI10N($sLanguage);
+            $aGroupAttributes['language'] = $sLanguage;
             $aGroupArray[$oGroup->gid] = $aGroupAttributes;
 
         }


### PR DESCRIPTION
Fixed issue #15783: Print answers : all is empty

SurveyDynamic::getPrintAnswersArray and SurveyDynamic::getQuestionArray() were not taking into account the i10n tables for Group, Question and Answer.

Added a $sLanguage optional parameter to getQuestionArray, because language is not an attribute of the question now. 

Set as optional as to keep backwards compatibiity.
If the parameter is not set, the survey’s main language is used.

There was a comment in line 973 of SurveyDynamic.php ( https://github.com/LimeSurvey/LimeSurvey/blob/778ad15d3206e95a815db171543521e6fe7a4793/application/models/SurveyDynamic.php#L973 ) referring to an issue that may got solved by this fix. 