### PR TITLE
Fixed issue #15596: Problem saving question with question type list (options) design image_select

### DIFF
--- a/themes/question/image_select/survey/questions/answer/listradio/config.xml
+++ b/themes/question/image_select/survey/questions/answer/listradio/config.xml
@@ -80,6 +80,7 @@
             <category>Display</category>
             <sortorder>90</sortorder>
             <inputtype>integer</inputtype>
+            <min>-1</min>
             <default>-1</default>
             <help>Fix width of the images to this value. Leave empty to not change them.</help>
             <caption>Fix width</caption>

--- a/themes/question/image_select/survey/questions/answer/listradio/config.xml
+++ b/themes/question/image_select/survey/questions/answer/listradio/config.xml
@@ -80,8 +80,6 @@
             <category>Display</category>
             <sortorder>90</sortorder>
             <inputtype>integer</inputtype>
-            <min>-1</min>
-            <default>-1</default>
             <help>Fix width of the images to this value. Leave empty to not change them.</help>
             <caption>Fix width</caption>
         </attribute>


### PR DESCRIPTION
Fixed issue #15596: Problem saving question with question type list (options) design image_select
Added explicit min attribute as to have front_end validation not to fail

-----

Image_select question theme has an attribute “fix_width”, of type “integer”, with a default of “-1” and no explicit minimum set in the config.xml file. 
As there was no minimum set, the default minimum used was 1. That made front end validation to fail. 

That was not noticeable.
- When fix_width field was displayed on screen, 
   - No big red message appeared, but a warning message below the attribute.
   - The saving wheel kept spinning. 
- When fix_width field was not on screen (collapsed) 
   - a Jquery error appeared (“field not focusable”)

It is to highlight the default attribute in the config.xml it’s not needed, because the attribute should either be set to a positive value or left empty. Removing the <default> tag from the config.xml also seems to solve the issue, although not sure if not having a default value for the attribute is valid.

I personally would remove the default attribute, as I don't like "-1" as an attribute value. But not sure if it the best way to go as to not break anything.

What do you think?
