### PR TITLE
Fixed issue #16415: Can't upload files with Google Chrome

### DIFF
--- a/assets/scripts/ajaxupload.js
+++ b/assets/scripts/ajaxupload.js
@@ -509,7 +509,7 @@
             // "This page contains both secure and nonsecure items"
             // Anyway, it doesn't do any harm.
             iframe.setAttribute('id', id);
-            iframe.setAttribute('srcdoc', this._settings.action);
+            // iframe.setAttribute('srcdoc', this._settings.action);
 
             iframe.style.display = 'none';
             document.body.appendChild(iframe);
@@ -561,9 +561,6 @@
 
                 if (// For Safari
                     iframe.src == "javascript:'%3CHtml%3E%3C/html%3E';" ||
-                    // For Chrome
-                    iframe.src == "javascript:false" ||
-                    iframe.src == "javascript:false;" ||
                     // For FF, IE
                     iframe.src == "javascript:'<html></html>';"){
                         // First time around, do not delete.

--- a/assets/scripts/ajaxupload.js
+++ b/assets/scripts/ajaxupload.js
@@ -509,7 +509,6 @@
             // "This page contains both secure and nonsecure items"
             // Anyway, it doesn't do any harm.
             iframe.setAttribute('id', id);
-            // iframe.setAttribute('srcdoc', this._settings.action);
 
             iframe.style.display = 'none';
             document.body.appendChild(iframe);

--- a/assets/scripts/ajaxupload.js
+++ b/assets/scripts/ajaxupload.js
@@ -561,6 +561,9 @@
 
                 if (// For Safari
                     iframe.src == "javascript:'%3CHtml%3E%3C/html%3E';" ||
+                    // For Chrome
+                    iframe.src == "javascript:false" ||
+                    iframe.src == "javascript:false;" ||
                     // For FF, IE
                     iframe.src == "javascript:'<html></html>';"){
                         // First time around, do not delete.


### PR DESCRIPTION
Fixed issue #16415: Can't upload files with Google Chrome

From my understanding, this issue happens because of some false positive load events of the iframe.
I mean some load events are triggered for the iframe (example for the about:blank doc) while they should be ignored.

There are already some filters, so I am adding a new one.

This wasn't enough. Somehow it worked when we tested. 

This is a WIP.
We are rolling back prior bug change (the kne from couple of weeks ago) and reviewing that solution also.