### PR TITLE
New Feature #16429: Added config variable to implicitly declare MyISAM engine when creating tables in MySQL

### DIFF
--- a/application/config/config-sample-mysql.php
+++ b/application/config/config-sample-mysql.php
@@ -62,8 +62,6 @@ return array(
         // 'force_xmlsettings_for_survey_rendering' => true, // Uncomment if you want to force the use of the XML file rather than DB (for easy theme development)
         // 'use_asset_manager'=>true, // Uncomment if you want to use debug mode and asset manager at the same time
         // Update default LimeSurvey config here
-        'forceMyISAM' => false, // Set this to true to always specify ENGINE=MyISAM when creating tables. This can be useful if you're using MySQL replication, which ignores the default engine variable.
-        // If you have large survey tables (i.e lots of questions) in MyISAM, those cause issues if your replication is set to default to InnoDB. By specifying the engine in the CREATE TABLE statement, replication will pick this up and use MyISAM.
     )
 );
 /* End of file config.php */

--- a/application/config/config-sample-mysql.php
+++ b/application/config/config-sample-mysql.php
@@ -62,6 +62,8 @@ return array(
         // 'force_xmlsettings_for_survey_rendering' => true, // Uncomment if you want to force the use of the XML file rather than DB (for easy theme development)
         // 'use_asset_manager'=>true, // Uncomment if you want to use debug mode and asset manager at the same time
         // Update default LimeSurvey config here
+        'forceMyISAM' => false, // Set this to true to always specify ENGINE=MyISAM when creating tables. This can be useful if you're using MySQL replication, which ignores the default engine variable.
+        // If you have large survey tables (i.e lots of questions) in MyISAM, those cause issues if your replication is set to default to InnoDB. By specifying the engine in the CREATE TABLE statement, replication will pick this up and use MyISAM.
     )
 );
 /* End of file config.php */

--- a/application/core/db/MysqlSchema.php
+++ b/application/core/db/MysqlSchema.php
@@ -18,6 +18,10 @@ class MysqlSchema extends CMysqlSchema
             $options = 'DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
         }
 
+        if (Yii::app()->getConfig('forceMyISAM') === true) {
+            $options .= ' ENGINE=MyISAM';
+        }
+
         // Below copied from parent.
         $cols = array();
         foreach ($columns as $name => $type) {

--- a/application/core/db/MysqlSchema.php
+++ b/application/core/db/MysqlSchema.php
@@ -15,11 +15,7 @@ class MysqlSchema extends CMysqlSchema
     public function createTable($table, $columns, $options = null)
     {
         if (empty($options)) {
-            $options = 'DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
-        }
-
-        if (Yii::app()->getConfig('forceMyISAM') === true) {
-            $options .= ' ENGINE=MyISAM';
+            $options = 'ENGINE='.Yii::app()->getConfig('mysqlEngine').' DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
         }
 
         // Below copied from parent.


### PR DESCRIPTION
Dev:
Created a new MySQL config variable to enforce specification of the MyISAM database engine when creating a new table.
This is necessary to facilitate MySQL replication in the event that you have large survey tables (i.e. lots of columns). Reason for this is that MySQL replication ignores the default engine variable. Hence, if your replication is set to use InnoDB by default, replication will crash when trying to create the table (see https://dev.mysql.com/doc/refman/8.0/en/column-count-limit.html). By implicitly adding the ENGINE=MyISAM to the CREATE TABLE statement, this will be picked up by replication correctly.
See Mantis: https://bugs.limesurvey.org/view.php?id=16429