### PR TITLE
Fixed issue #15985: print answers: list with comments, comments not printed

### DIFF
--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -971,6 +971,12 @@ class SurveyDynamic extends LSActiveRecord
             }
         }
 
+        // If trying to retrieve main question ($getComment = false), retrieve comment in a new attribute
+        // Check if $getComment = false to avoid endless recursivity
+        if ($oQuestion->type=='O'&&!$getComment) {
+            $aQuestionAttributes['comment'] = $this->getQuestionArray($oQuestion, $oResponses, $bHonorConditions, true, true);
+        }
+
         return $aQuestionAttributes;
     }
 

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -849,7 +849,7 @@ class SurveyDynamic extends LSActiveRecord
         }
 
 
-        if ($getCommentOnly === true) {
+        if ($getCommentOnly) {
             $fieldname .= 'comment';
         }
 
@@ -973,7 +973,7 @@ class SurveyDynamic extends LSActiveRecord
 
         // If trying to retrieve main question ($getCommentOnly = false), retrieve comment in a new attribute
         // Check if $getCommentOnly = false to avoid endless recursivity
-        if ($oQuestion->type=='O'&&!$getCommentOnly) {
+        if ($oQuestion->type == 'O' && !$getCommentOnly) {
             $aQuestionAttributes['comment'] = $this->getQuestionArray($oQuestion, $oResponses, $bHonorConditions, true, true);
         }
 

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -363,7 +363,7 @@ class SurveyDynamic extends LSActiveRecord
     /**
      * Get buttons HTML for response browse view.
      * @deprecated , use getGridButtons ,
-     * 
+     *
      * @return string HTML
      */
     public function getButtons()
@@ -770,10 +770,10 @@ class SurveyDynamic extends LSActiveRecord
      * @param SurveyDynamic $oResponses
      * @param boolean $bHonorConditions
      * @param boolean $subquestion
-     * @param boolean $getComment
+     * @param boolean $getCommentOnly If should only returns the "comments" or "other" response.
      * @return array | boolean
      */
-    public function getQuestionArray($oQuestion, $oResponses, $bHonorConditions, $subquestion = false, $getComment = false)
+    public function getQuestionArray($oQuestion, $oResponses, $bHonorConditions, $subquestion = false, $getCommentOnly = false)
     {
 
         $attributes = QuestionAttribute::model()->getQuestionAttributes($oQuestion->qid);
@@ -849,7 +849,7 @@ class SurveyDynamic extends LSActiveRecord
         }
 
 
-        if ($getComment === true) {
+        if ($getCommentOnly === true) {
             $fieldname .= 'comment';
         }
 
@@ -964,16 +964,16 @@ class SurveyDynamic extends LSActiveRecord
                 $aQuestionAttributes['answervalueslabels'][$oScaleSubquestion->title] = isset($oScaleSubquestion->question) ? $oScaleSubquestion->question : null;
             }
         }
-        
+
         if ($oQuestion->type=='N' || ($oQuestion->parent_qid != 0 && $oQuestion->parents['type'] === "K")) {
             if (strpos($aQuestionAttributes['answervalue'], ".") !== false) { // Remove last 0 and last . ALWAYS (see \SurveyObj\getShortAnswer)
                 $aQuestionAttributes['answervalue'] = rtrim(rtrim($aQuestionAttributes['answervalue'], "0"), ".");
             }
         }
 
-        // If trying to retrieve main question ($getComment = false), retrieve comment in a new attribute
-        // Check if $getComment = false to avoid endless recursivity
-        if ($oQuestion->type=='O'&&!$getComment) {
+        // If trying to retrieve main question ($getCommentOnly = false), retrieve comment in a new attribute
+        // Check if $getCommentOnly = false to avoid endless recursivity
+        if ($oQuestion->type=='O'&&!$getCommentOnly) {
             $aQuestionAttributes['comment'] = $this->getQuestionArray($oQuestion, $oResponses, $bHonorConditions, true, true);
         }
 

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-with-comment.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-with-comment.twig
@@ -8,5 +8,12 @@
             {{question.answervalue}} - {{question.answeroption.answer}}
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-4 text-right">
+        </div>
+        <div class="col-md-8 text-left">
+            {{question.comment.answervalue|escape}}
+        </div>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This  was implemented on getFullResponseTable(), LSv2.6. 
But seems to got lost in the transitio to LSv3 when moving to SurveyDynamic::getPrintAnswersArray()

Implementing comments for question type 'O'
Rename getComment parameter.

