### PR TITLE
Fixed issue #15940: Export as printable : PHP Notice wuth debug

### DIFF
--- a/application/controllers/admin/export.php
+++ b/application/controllers/admin/export.php
@@ -1260,8 +1260,8 @@ class export extends Survey_Common_Action
     private function _exportPrintableHtmls($iSurveyID, $readFile = true)
     {
         $oSurvey = Survey::model()->findByPk($iSurveyID);
-        $assetsDir = substr(Template::getTemplateURL($oSurvey->template), 1);
-        $fullAssetsDir = Template::getTemplatePath($oSurvey->template);
+        $assetsDir = substr(Template::getTemplateURL($oSurvey->templateEffectiveName), 1);
+        $fullAssetsDir = Template::getTemplatePath($oSurvey->templateEffectiveName);
         $aLanguages = $oSurvey->getAllLanguages();
 
         Yii::import('application.helpers.common_helper', true);
@@ -1322,7 +1322,7 @@ class export extends Survey_Common_Action
         $file = "$tempdir/questionnaire_{$oSurvey->getPrimaryKey()}_{$language}.html";
 
         // remove first slash to get local path for local storage for template assets
-        $templateDir = Template::getTemplateURL($oSurvey->template);
+        $templateDir = Template::getTemplateURL($oSurvey->templateEffectiveName);
         $response = str_replace($templateDir, substr($templateDir, 1), $response);
 
         file_put_contents($file, $response);

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -836,6 +836,33 @@ class Survey extends LSActiveRecord
     }
 
     /**
+     * Returns the name of the template to be used for the survey.
+     * It resolves inheritance from group and from default settings.
+     * 
+     * @return string
+     * 
+     * @todo:  Cache this on a private attribute?
+     */
+    public function getTemplateEffectiveName()
+    {
+        // Fetch template name from model
+        // This was already filtered on afterFind, so if the one at load time is not valid, will be replaced by default one
+        // If it is "inherit", means it will inherit from group, so we will replace it.
+        $sTemplateName = $this->template;
+
+        // if it is "inherit", get template name form group
+        if ($sTemplateName == 'inherit') {            
+            if (!empty($this->oOptions->template)) {
+                $sTemplateName = $this->oOptions->template;
+            } else {
+                throw new CException("Unable to get a template name from group for survey {$this->sid}");
+            }
+        }  
+        
+        return $sTemplateName;
+    }
+
+    /**
      * Get surveymenu configuration
      * This will be made bigger in future releases, but right now it only collects the default menu-entries
      */

--- a/application/models/Template.php
+++ b/application/models/Template.php
@@ -285,7 +285,9 @@ class Template extends LSActiveRecord
     public static function getTemplatePath($sTemplateName = "")
     {
         // Make sure template name is valid
-        $sTemplateName = self::templateNameFilter($sTemplateName);
+        if (!self::checkIfTemplateExists($sTemplateName)) {
+            throw new \CException("Invalid {$sTemplateName} template directory");
+        }
 
         static $aTemplatePath = array();
         if (isset($aTemplatePath[$sTemplateName])) {
@@ -293,9 +295,8 @@ class Template extends LSActiveRecord
         }
 
         $oTemplate = self::model()->findByPk($sTemplateName);
-        if (empty($oTemplate))
-        {
-            throw new \Exception("Survey theme {$sTemplateName} not found.", 1);
+        if (empty($oTemplate)) {
+            throw new \CException("Survey theme {$sTemplateName} not found.", 1);
         }
 
         if (self::isStandardTemplate($sTemplateName)) {
@@ -375,7 +376,9 @@ class Template extends LSActiveRecord
     public static function getTemplateURL($sTemplateName = "")
     {
         // Make sure template name is valid
-        $sTemplateName = self::templateNameFilter($sTemplateName);
+        if (!self::checkIfTemplateExists($sTemplateName)) {
+            throw new \CException("Invalid {$sTemplateName} template directory");
+        }
 
         static $aTemplateUrl = array();
         if (isset($aTemplateUrl[$sTemplateName])) {

--- a/application/models/Template.php
+++ b/application/models/Template.php
@@ -284,6 +284,9 @@ class Template extends LSActiveRecord
      */
     public static function getTemplatePath($sTemplateName = "")
     {
+        // Make sure template name is valid
+        $sTemplateName = self::templateNameFilter($sTemplateName);
+
         static $aTemplatePath = array();
         if (isset($aTemplatePath[$sTemplateName])) {
             return $aTemplatePath[$sTemplateName];
@@ -367,6 +370,9 @@ class Template extends LSActiveRecord
      */
     public static function getTemplateURL($sTemplateName = "")
     {
+        // Make sure template name is valid
+        $sTemplateName = self::templateNameFilter($sTemplateName);
+
         static $aTemplateUrl = array();
         if (isset($aTemplateUrl[$sTemplateName])) {
             return $aTemplateUrl[$sTemplateName];

--- a/application/models/Template.php
+++ b/application/models/Template.php
@@ -293,6 +293,10 @@ class Template extends LSActiveRecord
         }
 
         $oTemplate = self::model()->findByPk($sTemplateName);
+        if (empty($oTemplate))
+        {
+            throw new \Exception("Survey theme {$sTemplateName} not found.", 1);
+        }
 
         if (self::isStandardTemplate($sTemplateName)) {
             return $aTemplatePath[$sTemplateName] = Yii::app()->getConfig("standardthemerootdir").DIRECTORY_SEPARATOR.$oTemplate->folder;


### PR DESCRIPTION
When using global template on a survey, the template name saved on DB is "inherit".
That was taken literal sometimes and caused errors, as there is no template called "inherit"

"inherit" template is now converted to the proper template name, set at global level.
