### PR TITLE
Fixed issue #16379: When debug mode is set, there is an error message displayed on clicking on User Roles Page

### DIFF
--- a/application/controllers/admin/PermissiontemplatesController.php
+++ b/application/controllers/admin/PermissiontemplatesController.php
@@ -313,7 +313,7 @@ class PermissiontemplatesController extends Survey_Common_Action
         }
 
         $this->getController()->renderPartial(
-            '/admin/usermanagement/partial/success', 
+            '/userManagement/partial/success',
             [
                 'sMessage' => gT('Roles successfully deleted'), 
                 'sDebug' => json_encode($success, JSON_PRETTY_PRINT), 

--- a/application/controllers/admin/PermissiontemplatesController.php
+++ b/application/controllers/admin/PermissiontemplatesController.php
@@ -260,8 +260,8 @@ class PermissiontemplatesController extends Survey_Common_Action
         $oPermissionTemplate->renewed_last = date('Y-m-d H:i:s');
         $save = $oPermissionTemplate->save();
         
-        $html = $this->getController()->renderPartial('/admin/usermanagement/partial/permissionsuccess', ['results' => $results], true);
-        return Yii::app()->getController()->renderPartial('/admin/usermanagement/partial/json', ["data"=>[
+        $html = $this->getController()->renderPartial('/userManagement/partial/permissionsuccess', ['results' => $results], true);
+        return Yii::app()->getController()->renderPartial('/userManagement/partial/json', ["data"=>[
             'success' => true,
             'html' => $html
         ]]);


### PR DESCRIPTION
The error message on the second picture was generated because of a missing view.
Path to view was fixed.
Path to view was also fixed for the batchdelete operation, which was failing too