### PR TITLE
Fixed issue #16434: Special characters shown as HTML entities in sidebar

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -575,7 +575,8 @@ class SurveyAdmin extends Survey_Common_Action
                         $questionText = isset($question->questionl10ns[$baselang])
                             ? $question->questionl10ns[$baselang]->question
                             : '';
-                        $curQuestion['question_flat'] = viewHelper::flatEllipsizeText($questionText, true);
+                        $decodedQuestionText = htmlspecialchars_decode(viewHelper::flatEllipsizeText($questionText, true));
+                        $curQuestion['question_flat'] = strip_tags($decodedQuestionText);
                         $curGroup['questions'][] = $curQuestion;
                     }
 


### PR DESCRIPTION
Ok, so special characters should be shown as they are and not as html entities.
What about special characters which form tags? Should they be shown? Isn't that a security issue?

My call for fixing this was to use strip_tags.
So, sending special characters to look good. But tags are not sent.

Text is flatten. After that. special chars are sent to the sidebar. Tags, which could be formed by special chars re-coded, are not sent.