### PR TITLE
fix composer.json license format to match composer standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "limesurvey/limesurvey",
 	"description" : "The most popular FOSS online survey tool on the web",
 	"homepage" : "https://www.limesurvey.org/",
-	"license" : "GPL 2.0",
+	"license": "GPL-2.0-only",
 	"authors" : [{
 			"name" : "LimeSurvey Team",
 			"email" : "support@limesurvey.org",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "limesurvey/limesurvey",
 	"description" : "The most popular FOSS online survey tool on the web",
 	"homepage" : "https://www.limesurvey.org/",
-	"license": "GPL-2.0-only",
+	"license": "GPL-2.0-or-later",
 	"authors" : [{
 			"name" : "LimeSurvey Team",
 			"email" : "support@limesurvey.org",


### PR DESCRIPTION
the license tag does not match the [composer standard](https://getcomposer.org/doc/04-schema.md#license)

not having standard licence causes eg crash for packagist automation.