### PR TITLE
Fix table name regex in buildXMLFromQuery

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -698,7 +698,7 @@ function buildXMLFromQuery($xmlwriter, $Query, $tagname = '', $excludes = array(
 {
     $iChunkSize = 3000; // This works even for very large result sets and leaves a minimal memory footprint
 
-    preg_match('/\bfrom\b\s*{{(\w+)}}/i', $Query, $MatchResults);
+    preg_match('/\bfrom\b\s*`?{{(\w+)}}`?/i', $Query, $MatchResults);
     if ($tagname != '') {
         $TableName = $tagname;
     } else {


### PR DESCRIPTION
When the table name gets quoted (on MySQL) the current regex doesn't match inside the query, which makes the following code malfunction and prevents survey copying