### PR TITLE
Fixed issue #16096: QueXML PDF doesn't show full checkboxes

### DIFF
--- a/application/libraries/admin/quexmlpdf.php
+++ b/application/libraries/admin/quexmlpdf.php
@@ -3547,8 +3547,8 @@ class quexmlpdf extends pdf
             }
 
             //draw the response boxes
-            $arraySize = count($subquestions);
-            for ($j = 0; $j < $arraySize; $j++) {
+            $subquestionCount = count($subquestions);
+            for ($j = 0; $j < $subquestionCount; $j++) {
                 $s = $subquestions[$j];
 
                 if ($i == 0) {


### PR DESCRIPTION
Variable name made overlapping with previous assignment which was counting categories. See line 3494
https://github.com/gabrieljenik/LimeSurvey/blob/bc0d8a495e95723a16be805fc3e9a2a89df08c46/application/libraries/admin/quexmlpdf.php#L3494