### PR TITLE
Fixed issue #16431: Overview of un-installed themes shows incorrectly parsed theme description - LS4

### DIFF
--- a/application/models/TemplateManifest.php
+++ b/application/models/TemplateManifest.php
@@ -1434,6 +1434,33 @@ class TemplateManifest extends TemplateConfiguration
         return $fontOptions;
     }
 
+    /**
+     * Twig statements can be used in Theme description
+     * Override method from TemplateConfiguration to use the description from the XML
+     */
+    public function getDescription()
+    {
+        $sDescription = $this->config->metadata->description;
+
+          // If wrong Twig in manifest, we don't want to block the whole list rendering
+          // Note: if no twig statement in the description, twig will just render it as usual
+        try {
+            $sDescription = App()->twigRenderer->convertTwigToHtml($this->config->metadata->description);
+        } catch (\Exception $e) {
+          // It should never happen, but let's avoid to anoy final user in production mode :)
+            if (YII_DEBUG) {
+                App()->setFlashMessage(
+                    "Twig error in template " .
+                    $this->sTemplateName .
+                    " description <br> Please fix it and reset the theme <br>" .
+                    $e,
+                    'error'
+                );
+            }
+        }
+
+          return $sDescription;
+    }
 
     /**
      * PHP getter magic method.

--- a/application/models/TemplateManifest.php
+++ b/application/models/TemplateManifest.php
@@ -1437,6 +1437,8 @@ class TemplateManifest extends TemplateConfiguration
     /**
      * Twig statements can be used in Theme description
      * Override method from TemplateConfiguration to use the description from the XML
+     * 
+     * @return string description from the xml
      */
     public function getDescription()
     {
@@ -1452,14 +1454,13 @@ class TemplateManifest extends TemplateConfiguration
                 App()->setFlashMessage(
                     "Twig error in template " .
                     $this->sTemplateName .
-                    " description <br> Please fix it and reset the theme <br>" .
-                    $e,
+                    " description <br> Please fix it and reset the theme <br>" . $e->getMessage(),
                     'error'
                 );
             }
         }
 
-          return $sDescription;
+        return $sDescription;
     }
 
     /**

--- a/application/models/TemplateManifest.php
+++ b/application/models/TemplateManifest.php
@@ -1437,7 +1437,6 @@ class TemplateManifest extends TemplateConfiguration
     /**
      * Twig statements can be used in Theme description
      * Override method from TemplateConfiguration to use the description from the XML
-     * 
      * @return string description from the xml
      */
     public function getDescription()

--- a/application/views/admin/themeoptions/index.php
+++ b/application/views/admin/themeoptions/index.php
@@ -58,7 +58,7 @@ $this->renderPartial('super/fullpagebar_view', array(
                                             <tr class="odd">
                                                 <td class="col-md-1"><?php echo $oTemplate->preview; ?></td>
                                                 <td class="col-md-2"><?php echo $oTemplate->sTemplateName; ?></td>
-                                                <td class="col-md-3"><?php echo $oTemplate->config->metadata->description; ?></td>
+                                                <td class="col-md-3"><?php echo $oTemplate->description; ?></td>
                                                 <td class="col-md-2"><?php eT('XML themes');?></td>
                                                 <td class="col-md-2"><?php echo $oTemplate->config->metadata->extends; ?></td>
                                                 <td class="col-md-1"><?php echo $oTemplate->buttons; ?></td>


### PR DESCRIPTION
For uninstalled themes, the description was taken directly from the config metadata directly. No parsing done.

Added templateManifest::getDescription() method for parsing descriptions on XML file. 
This is now used on the view.