### PR TITLE
Fixed issue #16461: Twice contact sentence for some error page

### DIFF
--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -308,7 +308,6 @@ class index extends CAction
             $aErrors = array(gT('Error'));
             $aMessage = array(
                 gT("We are sorry but the survey is expired and no longer available."),
-                sprintf(gT("Please contact %s ( %s ) for further assistance."), $thissurvey['adminname'], $thissurvey['adminemail']) /* Maybe better to move this to a global replacement 'surveycontact' */
             );
 
             $event = new PluginEvent('onSurveyDenied');
@@ -330,7 +329,6 @@ class index extends CAction
             $aErrors  = array(gT('Error'));
             $aMessage = array(
                 gT("This survey is not yet started."),
-                sprintf(gT("Please contact %s ( %s ) for further assistance."), $thissurvey['adminname'], $thissurvey['adminemail'])/* Maybe better to move this to a global replacement 'surveycontact' */
             );
 
             $event = new PluginEvent('onSurveyDenied');
@@ -354,7 +352,6 @@ class index extends CAction
             $aErrors  = array(gT('Error'));
             $aMessage = array(
                 gT("You have already completed this survey."),
-                sprintf(gT("Please contact %s ( %s ) for further assistance."), $thissurvey['adminname'], $thissurvey['adminemail'])/* Maybe better to move this to a global replacement 'surveycontact' */
             );
 
             $event = new PluginEvent('onSurveyDenied');
@@ -473,7 +470,6 @@ class index extends CAction
 
                     $aMessage = array(
                         gT("We are sorry but you are not allowed to enter this survey."),
-                        sprintf(gT("Please contact %s ( %s ) for further assistance."), $thissurvey['adminname'], $thissurvey['adminemail'])/* Maybe better to move this to a global replacement 'surveycontact' */
                     );
 
                     $event = new PluginEvent('onSurveyDenied');

--- a/themes/survey/vanilla/views/layout_errors.twig
+++ b/themes/survey/vanilla/views/layout_errors.twig
@@ -65,7 +65,7 @@
                     {% if aError.contact %}
                         {{ aError.contact }}
                     {% else %}
-                        {{gT("For further information please contact %s:")|format (aSurveyInfo.adminname)}}
+                        {{gT("For further information please contact %s:")|format (aSurveyInfo.admin)}}
                         {% if aSurveyInfo.adminemail %}
                             <br>
                             <a href='mailto:{{ aSurveyInfo.adminemail }}'>{{ aSurveyInfo.adminemail }}</a>


### PR DESCRIPTION
Fixed issue #16461: Twice contact sentence for some error page
Dev: remove extra, leave contact for theme only.
