### PR TITLE
Fixed issue #16481: Easy way to launch CDBException

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5058,11 +5058,18 @@
                             $value=NULL;  // can't upload a file via GET
                             break;
                     }
-                    $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
-                    $LEM->updatedValues[$knownVar['sgqa']]=array(
-                        'type'=>$knownVar['type'],
-                        'value'=>$value,
+                    /* Check validity # */
+                    $qinfo = array(
+                        'qid' => $knownVar['qid'],
+                        'other' => "Y", // Not known currently, but don't broke if set
                     );
+                    if (self::checkValidityAnswer($knownVar['type'],$value,$knownVar['sgqa'],$qinfo,false)) {
+                        $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
+                        $LEM->updatedValues[$knownVar['sgqa']]=array(
+                            'type'=>$knownVar['type'],
+                            'value'=>$value,
+                        );
+                    }
                 }
                 $LEM->_UpdateValuesInDatabase();
             }


### PR DESCRIPTION
Dev: use checkValidityAnswer to allow or not prefilling
Dev: set other to true : can be invalid, but don't broke DB