### PR TITLE
Fixed issue #16453: Sometimes we get duplicate question_orders on new questions

### DIFF
--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -865,7 +865,7 @@ class QuestionEditorController extends LSBaseController
                 unset($aQuestionData[$sLanguage]);
             }
         } else {
-            $aQuestionData['question_order'] = getMaxQuestionOrder($iQuestionGroupId);
+            $aQuestionData['question_order'] = getMaxQuestionOrder($iQuestionGroupId) + 1;
         }
 
         $oQuestion = new Question();


### PR DESCRIPTION
The QuestionEditorController was assigning the order to new questions based on getMaxQuestionOrder(), without increasing by one, so new questions had the same order as the last one on the group