### PR TITLE
Fixed issue #16454: Sometimes, question_order is assigned from survey_id

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -428,7 +428,7 @@ class Question extends LSActiveRecord
         $this->removeFromLastVisited();
 
         if (parent::delete()) {
-            Question::model()->updateQuestionOrder($this->gid, $this->sid);
+            Question::model()->updateQuestionOrder($this->gid);
             return true;
         }
         return false;

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -250,10 +250,12 @@ class Question extends LSActiveRecord
 
     /**
      * Fix sort order for questions in a group
+     * All questions in the group will be assigned a sequential question order,
+     * starting in the specified value
      * @param int $gid
-     * @param int $position
+     * @param int $startingOrder   the starting question order.
      */
-    public function updateQuestionOrder($gid, $position = 0)
+    public function updateQuestionOrder($gid, $startingOrder = 1)
     {
         $data = Yii::app()->db->createCommand()->select('qid')
             ->where(array('and', 'gid=:gid', 'parent_qid=0'))
@@ -262,7 +264,7 @@ class Question extends LSActiveRecord
             ->bindParam(':gid', $gid, PDO::PARAM_INT)
             ->query();
 
-        $position = intval($position);
+        $position = intval($startingOrder);
         foreach ($data->readAll() as $row) {
             Yii::app()->db->createCommand()->update(
                 $this->tableName(),


### PR DESCRIPTION
When deleting a question, the order of questions in the group were reassigned by calling updateQuestionOrder, but the survey ID was passed as starting position.

updateQuestionOrder definition was modified to use 1 as default value. Now reordering will follow the same schema as when questions are added, both starting from 1.

we found "database::actionUpdateQuestion()" to be deprecated. 
https://github.com/gabrieljenik/LimeSurvey/blob/1b975c60d3c4128fc72a542b07d3d981bb2eae9c/application/controllers/admin/database.php#L579
Should it be removed?