### PR TITLE
Fixed issue #16518: Cannot add condition based on Survey participant attributes

### DIFF
--- a/application/controllers/admin/conditionsaction.php
+++ b/application/controllers/admin/conditionsaction.php
@@ -663,8 +663,10 @@ protected function insertCondition(array $args)
 {
     // Extract p_scenario, p_cquestions, ...
     extract($args);
+
+    $editSourceTab = $request->getPost('editSourceTab');
     
-    if (isset($p_cquestions) && $p_cquestions != '') {
+    if (isset($p_cquestions) && $p_cquestions != '' && $editSourceTab == '#SRCPREVQUEST') {
         $conditionCfieldname = $p_cquestions;
     } elseif (isset($p_csrctoken) && $p_csrctoken != '') {
         $conditionCfieldname = $p_csrctoken;


### PR DESCRIPTION
Considering editSourceTab for setting up the condition fieldName

As the question select was initialized, the p_cquestions field had a value.
As so, it was always set, no matter if a token field was chosen.
So, when selecting a token field, a question field was wrongly set on the condition.