### PR TITLE
Fixed issue #16520: For specific screen navigation, condition is not saved properly

### DIFF
--- a/application/controllers/admin/conditionsaction.php
+++ b/application/controllers/admin/conditionsaction.php
@@ -668,6 +668,7 @@ protected function insertCondition(array $args)
         $conditionCfieldname = $p_cquestions;
     } elseif (isset($p_csrctoken) && $p_csrctoken != '') {
         $conditionCfieldname = $p_csrctoken;
+        $p_cqid = 0;  // Reset cqid if condition is based on token attribute
     }
     
     $condition_data = array(

--- a/assets/scripts/admin/conditions.js
+++ b/assets/scripts/admin/conditions.js
@@ -130,10 +130,6 @@ $(document).on('ready  pjax:scriptcomplete', function(){
     p2.methodId          = '#quick-add-method';
     p2.canswersToSelectId= '#quick-add-canswersToSelectId';
 	$('#quick-add-cquestions').change(p2.fun);
-
-	$('#csrctoken').change(function() {
-		$('#cqid').val(0);
-	});
 	
 	// At editing, if cquestions is set, populate answers
 	if ($('#cquestions').val() != '') {


### PR DESCRIPTION
Resetting cqid when using token fields