### PR TITLE
Fixed issue #16329: html not allowed in a labelset?

### DIFF
--- a/application/controllers/admin/questions.php
+++ b/application/controllers/admin/questions.php
@@ -1736,10 +1736,14 @@ class questions extends Survey_Common_Action
                 ); 
                 foreach ($oLabelSet->labels as $oLabel) {
                     if($oLabel->language === $sLanguage) {
-                        $aResult[$sLanguage]['labels'][] = array_map(
-                            function($attribute) { return \viewHelper::flatten($attribute); },
-                            $oLabel->attributes
-                        ); 
+                        $aLabels = $oLabel->attributes;
+                        array_walk(
+                            $aLabels,
+                            function(&$attribute, $key) {
+                                $attribute = $key == 'title' ? $attribute : \viewHelper::flatten($attribute); // Don't flatten the label title because it is OK to include HTML
+                            }
+                        );
+                        $aResult[$sLanguage]['labels'][] = $aLabels;
                     }
                 };
                 $aLanguages[$sLanguage] = getLanguageNameFromCode($sLanguage,false);

--- a/assets/scripts/admin/subquestions.js
+++ b/assets/scripts/admin/subquestions.js
@@ -614,9 +614,12 @@ function lspreview(lid)
                 console.ls.group('ParseLabels');                    
                 $.each(labelSet.labels, function(i,label){
                     console.ls.log('Label', i, label);                
+                    // Label title is not concatenated directly because it may have non-encoded HTML
+                    var $labelTitleDiv = $('<div class="col-md-8"></div>');
+                    $labelTitleDiv.text(label.title);
                     var $listItem = $listItemTemplate.clone();
                     $listItem.append('<div class="col-md-3 text-right" style="border-right: 4px solid #cdcdcd">'+label.code+'</div>');
-                    $listItem.append('<div class="col-md-8">'+(label.title || '')+'</div>');
+                    $listItem.append($labelTitleDiv);
                     $listItem.append('<div class="col-md-1"></div>');
                     $listItem.attr('data-label', JSON.stringify(label));
                     $itemList.append($listItem);


### PR DESCRIPTION
Stopped flatening labels' titles. Reviewed preview rendering as to allow html on labels' titles.