### PR TITLE
Fixed issue #15758: Slider settings not saved

### DIFF
--- a/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
+++ b/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
@@ -109,6 +109,7 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
                 $this->sliderOptionsArray['slider_reversed'] = 'false';
             }
 
+            $this->sliderOptionsArray['slider_showminmax'] = $this->getQuestionAttribute('slider_showminmax');
 
         } else {
             $this->sCoreClasses .= " text-list number-list";


### PR DESCRIPTION
Setting was saved. It was not shown correctly in the settings. Sending slider_showminmax variable to the view