### PR TITLE
Fixed issue #15945: Cannot add condition based on Survey participant attributes

### DIFF
--- a/application/controllers/admin/conditionsaction.php
+++ b/application/controllers/admin/conditionsaction.php
@@ -677,10 +677,11 @@ class conditionsaction extends Survey_Common_Action
         /** @var string $p_method */
         /** @var array $p_canswers */
         /** @var CHttpRequest $request */
-        /** @var string $editSourceTab */
         extract($args);
 
-        if (isset($p_cquestions) && $p_cquestions != '') {
+        $editSourceTab = $request->getPost('editSourceTab');
+
+        if (isset($p_cquestions) && $p_cquestions != '' && $editSourceTab == '#SRCPREVQUEST') {
             $conditionCfieldname = $p_cquestions;
         } elseif (isset($p_csrctoken) && $p_csrctoken != '') {
             $conditionCfieldname = $p_csrctoken;


### PR DESCRIPTION
Considering editSourceTab for setting up the condition fieldName

As the question select was initialized, the p_cquestions field had a value.
As so, it was always set, no matter if a token field was chosen.
So, when selecting a token field, a question field was wrongly set on the condition.