### PR TITLE
Fixed issue #16205: Slider left/right text and min/max not displayed correctly

### DIFF
--- a/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
+++ b/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
@@ -155,6 +155,7 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
         foreach ($this->aSubQuestions[0] as $oSubquestion) {
             $myfname = $this->sSGQA.$oSubquestion->title;
             $sSubquestionText = $this->setDefaultIfEmpty($oSubquestion->questionl10ns[$this->sLanguage]->question, "&nbsp;");
+            $labelText = $sSubquestionText;
 
             // color code missing mandatory questions red
             $alert = (
@@ -174,7 +175,7 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
                     'prefixclass'            => 'numeric',
                     'alert'                  => $alert,
                     'theanswer'              => $sSubquestionText,
-                    'labelText'              => $sSubquestionText,
+                    'labelText'              => $labelText,
                     'labelname'              => 'answer'.$myfname,
                     'myfname'                => $myfname,
                     'dispVal'                => $dispVal,
@@ -247,7 +248,7 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
                         'labelname'              => 'answer'.$myfname,
                         'alert'                  => $alert,
                         'theanswer'              => $theanswer,
-                        'labelText'              => $sSubquestionText,
+                        'labelText'              => $labelText,
                         'myfname'                => $myfname,
                         'dispVal'                => $dispVal,
                         'sliderleft'             => $sliderleft,


### PR DESCRIPTION
The renderer was correctly processing the subquestion text to strip the labels, but ended passing the original subquestion text to the view.