### PR TITLE
Fixed issue #16531: Validation regex including unicode characters fails

### DIFF
--- a/assets/packages/expressions/em_javascript.js
+++ b/assets/packages/expressions/em_javascript.js
@@ -850,7 +850,8 @@ function LEMregexMatch(sRegExp,within)
         var flags = sRegExp.replace(/.*\/([gimy]*)$/, '$1');
         var pattern = sRegExp.replace(new RegExp('^/(.*?)/'+flags+'$'), '$1').trim();
         var reg = new RegExp(pattern, flags); // Note that the /u flag crashes IE11
-        return reg.test(within);
+        var decodedValue = html_entity_decode(within);
+        return reg.test(decodedValue);
     }
     catch (err) {
         return false;


### PR DESCRIPTION
Decoding html before running regex. This (a decode string) is similar to what the PHP side regex function gets.