### PR TITLE
Fixed issue #16508: Can't run survey with child theme because of enheritance problems

### DIFF
--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -1058,7 +1058,7 @@ class TemplateConfig extends CActiveRecord
             $oNewTemplateConfiguration->cssframework_name = $aDatas['cssframework_name'];
             $oNewTemplateConfiguration->cssframework_css  = self::formatToJsonArray($aDatas['cssframework_css']);
             $oNewTemplateConfiguration->cssframework_js   = self::formatToJsonArray($aDatas['cssframework_js']);
-            $oNewTemplateConfiguration->options           = self::formatToJsonArray($aDatas['aOptions']);
+            $oNewTemplateConfiguration->options           = self::formatToJsonArray($aDatas['aOptions'], true);
             $oNewTemplateConfiguration->packages_to_load  = self::formatToJsonArray($aDatas['packages_to_load']);
 
 
@@ -1084,9 +1084,10 @@ class TemplateConfig extends CActiveRecord
      * Convert the values to a json.
      * It checks that the correct values is inserted.
      * @param array|object $oFiled the filed to convert
+     * @param boolean $bConvertEmptyToString formats empty values as empty strings instead of objects.
      * @return string  json
      */
-    public static function formatToJsonArray($oFiled)
+    public static function formatToJsonArray($oFiled, $bConvertEmptyToString = false)
     {
         // encode then decode will convert the SimpleXML to a normal object
         $jFiled = json_encode($oFiled);
@@ -1102,6 +1103,8 @@ class TemplateConfig extends CActiveRecord
                 $jFiled      = json_encode($oFiled);
             }
         }
+        // Converts empty objects to empty strings
+        if ($bConvertEmptyToString) $jFiled = str_replace('{}','""',$jFiled);
         return $jFiled;
     }
 

--- a/application/models/TemplateManifest.php
+++ b/application/models/TemplateManifest.php
@@ -1009,7 +1009,13 @@ class TemplateManifest extends TemplateConfiguration
         if (file_exists(realpath($this->xmlFile))) {
             $bOldEntityLoaderState = libxml_disable_entity_loader(true); // @see: http://phpsecurity.readthedocs.io/en/latest/Injection-Attacks.html#xml-external-entity-injection
             $sXMLConfigFile        = file_get_contents(realpath($this->xmlFile)); // @see: Now that entity loader is disabled, we can't use simplexml_load_file; so we must read the file with file_get_contents and convert it as a string
-            $oXMLConfig = simplexml_load_string($sXMLConfigFile);
+            $oDOMConfig = new DOMDocument;
+            $oDOMConfig->loadXML($sXMLConfigFile);
+            $oXPath = new DOMXpath($oDOMConfig);
+            foreach ($oXPath->query('//comment()') as $oComment) {
+                $oComment->parentNode->removeChild($oComment);
+            }
+            $oXMLConfig = simplexml_import_dom($oDOMConfig);
             foreach ($oXMLConfig->config->xpath("//file") as $oFileName) {
                         $oFileName[0] = get_absolute_path($oFileName[0]);
             }


### PR DESCRIPTION
This was a ticket ported from LTS.

The issue was not reproducible here because of this line:
https://github.com/LimeSurvey/LimeSurvey/blob/master/application/models/TemplateConfiguration.php#L1259

Still, we port some of the fixes added on LTS
1- Removed xml comments after loading config.xml.
2 - Had empty nodes to be saved in DB as empty strings.

