### PR TITLE
Fixed issue #16535: Changing language at question preview leads to loading the wrong page

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1603,6 +1603,22 @@ class SurveyRuntimeHelper
 
         $this->preview         = ($this->previewquestion || $this->previewgrp);
 
+        if ($this->preview) {
+            // When previewing groups or questions, the survey URL must include the
+            // respective parameters. Otherwise, changing language doesn't work.
+            $surveyUrlParams = array(
+                "action" => $this->param['action'],
+                "sid" => $this->iSurveyid,
+            );
+            if (isset($this->param['gid'])) {
+                $surveyUrlParams['gid'] = $this->param['gid'];
+            }
+            if (isset($this->param['qid'])) {
+                $surveyUrlParams['qid'] = $this->param['qid'];
+            }
+            $this->aSurveyInfo['surveyUrl'] = App()->createUrl("/survey/index", $surveyUrlParams);
+        }
+
         $this->sLangCode       = App()->language;
     }
 


### PR DESCRIPTION
Information about preview mode is not included in the language changer forms.
Updated the form's action when on previewgroup or previewquestion mode.

Should happen on LTS as well.
Already created a ticket for it.