### PR TITLE
Fixed issue #16555: bootswatch Image uploaded via Survey theme option are uploaded in Global directory

### DIFF
--- a/themes/survey/bootswatch/options/options.twig
+++ b/themes/survey/bootswatch/options/options.twig
@@ -332,7 +332,9 @@
                             {{ gT("Upload") }}
                         </label>
                     </span>
-
+                        {% if templateConfiguration.sid is not empty %}
+                            <input type='hidden' name='surveyid' value='{{ templateConfiguration.sid }}' />
+                        {% endif %}
                         <input type='hidden' name='templatename' value='{{ templateConfiguration.template_name }}' />
                         <input type='hidden' name='templateconfig' value='{{ templateConfiguration.id }}' />
                         <input type='hidden' name='action' value='templateuploadimagefile' />

--- a/themes/survey/fruity/options/options.twig
+++ b/themes/survey/fruity/options/options.twig
@@ -1112,7 +1112,9 @@
                             {{ gT("Upload") }}
                         </label>
                     </span>
-
+                        {% if templateConfiguration.sid is not empty %}
+                            <input type='hidden' name='surveyid' value='{{ templateConfiguration.sid }}' />
+                        {% endif %}
                         <input type='hidden' name='templatename' value='{{ templateConfiguration.template_name }}' />
                         <input type='hidden' name='templateconfig' value='{{ templateConfiguration.id }}' />
                         <input type='hidden' name='action' value='templateuploadimagefile' />

--- a/themes/survey/vanilla/options/options.twig
+++ b/themes/survey/vanilla/options/options.twig
@@ -322,7 +322,9 @@
                             {{ gT("Upload") }}
                         </label>
                     </span>
-                        <input type='hidden' name='surveyid' value='{{ templateConfiguration.sid }}' />
+                        {% if templateConfiguration.sid is not empty %}
+                            <input type='hidden' name='surveyid' value='{{ templateConfiguration.sid }}' />
+                        {% endif %}
                         <input type='hidden' name='templatename' value='{{ templateConfiguration.template_name }}' />
                         <input type='hidden' name='templateconfig' value='{{ templateConfiguration.id }}' />
                         <input type='hidden' name='action' value='templateuploadimagefile' />


### PR DESCRIPTION
Dev: Add hidden input surveyid
Dev: Check if empty : no need to send if empty