### PR TITLE
Fixed issue #16536: Batch editing reminder sent date leads to wrong data being added

### DIFF
--- a/application/views/admin/token/massive_actions/_update.php
+++ b/application/views/admin/token/massive_actions/_update.php
@@ -419,15 +419,12 @@
 <?php App()->getClientScript()->registerScript("Tokens:MassActionUpdateView_Scripts", "
 
    var bindBSSwitch = function(formGroup){
-       console.log(\"bindBSSwitch run on:\",formGroup);
-    //Script to update the completed settings
-    formGroup.find('.YesNoSwitch').on('switchChange.bootstrapSwitch', function(e, state){
-        
-        formGroup.find('.selector_datechange').css('display', (state ? '' : 'none'));
-        //formGroup.find('.selector_submitField').val(state ? 'Y' : 'N');
-
-    });
-   };
+        console.log(\"bindBSSwitch run on:\",formGroup);
+        //Script to update the completed settings
+        formGroup.find('.YesNoSwitch').on('switchChange.bootstrapSwitch', function(e, state){        
+            formGroup.find('.selector_datechange').css('display', (state ? '' : 'none'));
+        });
+    };
 
    var bindDatepicker = function(myFormGroup){
     myFormGroup.find('.action_datepickerUpdateHiddenField').on('change dp.change', function(){

--- a/application/views/admin/token/massive_actions/_update.php
+++ b/application/views/admin/token/massive_actions/_update.php
@@ -419,7 +419,6 @@
 <?php App()->getClientScript()->registerScript("Tokens:MassActionUpdateView_Scripts", "
 
    var bindBSSwitch = function(formGroup){
-        console.log(\"bindBSSwitch run on:\",formGroup);
         //Script to update the completed settings
         formGroup.find('.YesNoSwitch').on('switchChange.bootstrapSwitch', function(e, state){        
             formGroup.find('.selector_datechange').css('display', (state ? '' : 'none'));

--- a/application/views/admin/token/massive_actions/_update.php
+++ b/application/views/admin/token/massive_actions/_update.php
@@ -90,8 +90,8 @@
 
                             <div class="col-sm-7 col-sm-offset-1">
                                 <?php if ($oSurvey->anonymized != 'Y'):?>
-                                    <div id="massedit_sent-date-container" class="date-container selector_datechange"  style="display: none;">
-                                        <div id="completed-date_datetimepicker" class="input-group date">
+                                    <div id="massedit_completed-date-container" class="date-container selector_datechange"  style="display: none;">
+                                        <div id="massedit_completed-date_datetimepicker" class="input-group date">
                                             <input
                                                 class="YesNoDatePicker form-control"
                                                 id="massedit_completed-date"
@@ -210,9 +210,9 @@
                             </div>
 
                             <div class="col-sm-8">
-                                <div id="sent-date-container" class="date-container selector_datechange" style="display: none;">
+                                <div id="massedit_sent-date-container" class="date-container selector_datechange" style="display: none;">
                                     <!-- Sent Date -->
-                                    <div id="sent-date_datetimepicker" class="input-group date">
+                                    <div id="massedit_sent-date_datetimepicker" class="input-group date">
                                         <input
                                             class="YesNoDatePicker form-control"
                                             id="massedit_sent-date"
@@ -424,7 +424,7 @@
     formGroup.find('.YesNoSwitch').on('switchChange.bootstrapSwitch', function(e, state){
         
         formGroup.find('.selector_datechange').css('display', (state ? '' : 'none'));
-        formGroup.find('.selector_submitField').val(state ? 'Y' : 'N');
+        //formGroup.find('.selector_submitField').val(state ? 'Y' : 'N');
 
     });
    };

--- a/application/views/admin/token/tokenform.php
+++ b/application/views/admin/token/tokenform.php
@@ -127,7 +127,7 @@ foreach ($tokendata as $Key => $Value) {
 
                     <?php if ($oSurvey->anonymized != 'Y'):?>
                         <div class="">
-                            <div id="sent-date-container" class="date-container"  <?php if (!$bCompletedValue):?>style="display: none;"<?php endif; ?>>
+                            <div id="completed-date-container" class="date-container"  <?php if (!$bCompletedValue):?>style="display: none;"<?php endif; ?>>
                             <div id="completed-date_datetimepicker" class="input-group date">
                                 <input class="YesNoDatePicker form-control" id="completed-date" type="text" value="<?php echo isset($completed) ? $completed : ''?>" name="completed-date" data-date-format="<?php echo $dateformatdetails['jsdate']; ?> HH:mm">
                                 <span class="input-group-addon"><span class="fa fa-calendar"></span></span>

--- a/assets/scripts/admin/tokens.js
+++ b/assets/scripts/admin/tokens.js
@@ -38,19 +38,19 @@ $.fn.YesNoDate = function(options)
             {
                 // Show date
                 $elDateContainer.show();
-                $elHiddenInput.attr('value', moment().format($elDate.data('date-format')));
+                $elHiddenInput.val(moment().format($elDate.data('date-format')));
             }
             else
             {
                 // Hide date, set hidden input to "N"
                 $elDateContainer.hide();
-                $elHiddenInput.attr('value', 'N');
+                $elHiddenInput.val('N');
             }
         });
 
         // When user change date
         $elDate.on('dp.change', function(e){
-            $elHiddenInput.attr('value', e.date.format($elDate.data('date-format')));
+            $elHiddenInput.val(e.date.format($elDate.data('date-format')));
         })
     };
     return that;
@@ -183,14 +183,6 @@ $(document).on('ready  pjax:scriptcomplete', function(){
     {
         $('#general').stickLabelOnLeft();
 
-        $('.yes-no-date-container').each(function(i,el){
-            $(this).YesNoDate();
-        });
-
-        $('.yes-no-container').each(function(i,el){
-            $(this).YesNo();
-        });
-
         $('#validfrom').datetimepicker({locale: $('#validfrom').data('locale')});
         $('#validuntil').datetimepicker({locale: $('#validuntil').data('locale')});
 
@@ -199,6 +191,29 @@ $(document).on('ready  pjax:scriptcomplete', function(){
             $prev.data("DateTimePicker").show();
         });
     }
+
+    var modal = $('#massive-actions-modal-edit-0');
+    if (modal.length) {
+        modal.on('shown.bs.modal', function () {
+            $('.yes-no-date-container').each(function(i,el){
+                $(this).YesNoDate().onReadyMethod();
+            });
+        
+            $('.yes-no-container').each(function(i,el){
+                $(this).YesNo().onReadyMethod();
+            });
+        });
+    }
+
+    $(document).on('actions-updated', function() {
+        $('.yes-no-date-container').each(function(i,el){
+            $(this).YesNoDate().onReadyMethod();
+        });
+    
+        $('.yes-no-container').each(function(i,el){
+            $(this).YesNo().onReadyMethod();
+        });
+    });
 
     var initialScrollValue = $('.scrolling-wrapper').scrollLeft();
     var useRtl = $('input[name="rtl"]').val() === '1';


### PR DESCRIPTION
Reviewed fields initialization and jquery handling.
- Fixed some element IDs on the mass edit modal dialog.
- Changed update method of hidden input from attr('value',xxx) to val(xxx)
- Added initialization of YesNo and YesNoDate fields on "shown.bs.modal" and "actions-updated" event.
