### PR TITLE
Fixed issue #16326: Statistics filters do not reflect percentages and totals

### DIFF
--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -1521,7 +1521,7 @@ class statistics_helper
                     elseif ($al[0] == "NoAnswer") {
                         foreach ($oResponses as $oResponse){
                             $sResponseColumn = $al[2];
-                            if ($oResponse->$sResponseColumn == ''){
+                            if ($oResponse->$sResponseColumn === ''){
                                 $row += 1;
                             }
                         }
@@ -1573,7 +1573,7 @@ class statistics_helper
                     //  ==> value is NULL
                     foreach ($oResponses as $oResponse){
                         $sResponseColumn = $rt;
-                        if ($oResponse->$sResponseColumn == '' || $oResponse->$sResponseColumn == ' '){
+                        if ($oResponse->$sResponseColumn === '' || $oResponse->$sResponseColumn == ' '){
                             $row += 1;
                         }
                     }
@@ -2242,6 +2242,12 @@ class statistics_helper
         } elseif (incompleteAnsFilterState() == "complete") {
             $criteria->addCondition("submitdate is not null");
         }
+
+        //check for any "sql" that has been passed from another script
+        if (!empty($sql)) {
+            $criteria->addCondition($sql);
+        }
+
         // prepare and decrypt data
         $oResponses = Response::model($surveyid)->findAll($criteria);
         foreach($oResponses as $key => $oResponse){
@@ -2301,7 +2307,7 @@ class statistics_helper
                     elseif ($al[0] == "NoAnswer") {
                         foreach ($oResponses as $oResponse){
                             $sResponseColumn = $al[2];
-                            if ($oResponse->$sResponseColumn == ''){
+                            if ($oResponse->$sResponseColumn === ''){
                                 $row += 1;
                             }
                         }
@@ -2352,16 +2358,13 @@ class statistics_helper
                     //  ==> value is NULL
                     foreach ($oResponses as $oResponse){
                         $sResponseColumn = $rt;
-                        if ($oResponse->$sResponseColumn == '' || $oResponse->$sResponseColumn == ' '){
+                        if ($oResponse->$sResponseColumn === '' || $oResponse->$sResponseColumn == ' '){
                             $row += 1;
                         }
                     }
                 }
 
             }
-
-            //check for any "sql" that has been passed from another script
-            if (!empty($sql)) {$query .= " AND $sql"; }
 
             //store temporarily value of answer count of question type '5' and 'A'.
             $tempcount = -1; //count can't be less han zero


### PR DESCRIPTION
In LS3, each value is retrieved by a query to the DB. In LS4, the responses are retrieved first, and then each value is calculated by looping through the responses.
Some filters that were added to the query in LS3 were not working on LS4 because the SQL was still appended to a query that's never used. This was solved by adding the filters to the response selection criteria.
Also, the value for "No answer" that was calculated by comparing to empty string in SQL query (LS3), in LS4 was implemented with an "equal" operator (==). That comparison also matched null values, so it was replaced with an "identical" operator (===).