### PR TITLE
DEV #16488: Reviewing updateQuestionOrder usage

### DIFF
--- a/application/controllers/admin/questions.php
+++ b/application/controllers/admin/questions.php
@@ -1445,7 +1445,7 @@ class questions extends Survey_Common_Action
             }
         } else {
             Question::model()->deleteAllById($qid);
-            Question::model()->updateSortOrder($oQuestion->gid, $surveyid);
+            Question::model()->updateQuestionOrder($oQuestion->gid);
         }
 
         $sMessage = gT("Question was successfully deleted.");

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -966,22 +966,31 @@ function groupOrderThenQuestionOrder($a, $b)
 
 //FIXME insert UestionGroup model to here
 /**
- * @param integer $sid
+ * Shifts the sortorder for questions, creating extra spaces at the start of the group
+ * This is an alias for updateQuestionOrder()
+ * 
+ * @param integer $sid SID is not needed anymore, but is left here for backward compatibility
  * @param integer $gid
  * @param integer $shiftvalue
+ * 
+ * @return void
  */
-function shiftOrderQuestions($sid, $gid, $shiftvalue) //Function shifts the sortorder for questions
+function shiftOrderQuestions($sid, $gid, $shiftvalue)
 {
-    $sid = (int) $sid;
     $gid = (int) $gid;
     $shiftvalue = (int) $shiftvalue;
 
-    $baselang = Survey::model()->findByPk($sid)->language;
-
-    Question::model()->updateQuestionOrder($gid, $baselang, $shiftvalue);
+    Question::model()->updateQuestionOrder($gid, $shiftvalue);
 }
 
-function fixSortOrderGroups($surveyid) //Function rewrites the sortorder for groups
+/**
+ * Rewrites the sortorder for groups
+ * 
+ * @param integer $surveyid
+ * 
+ * @return void
+ */
+function fixSortOrderGroups($surveyid)
 {
     $baselang = Survey::model()->findByPk($surveyid)->language;
     QuestionGroup::model()->updateGroupOrder($surveyid, $baselang);

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1346,7 +1346,7 @@ class remotecontrol_handle
 
                     DefaultValue::model()->deleteAllByAttributes(array('qid' => $iQuestionID));
                     QuotaMember::model()->deleteAllByAttributes(array('qid' => $iQuestionID));
-                    Question::updateSortOrder($iGroupID, $iSurveyID);
+                    Question::updateQuestionOrder($iGroupID);
 
                     return (int) $iQuestionID;
                 } catch (Exception $e) {
@@ -1697,7 +1697,7 @@ class remotecontrol_handle
 
                     try {
                         $bSaveResult = $oQuestion->save(); // save the change to database
-                        Question::model()->updateQuestionOrder($oQuestion->gid, $oQuestion->language);
+                        Question::model()->updateQuestionOrder($oQuestion->gid);
                         $aResult[$sFieldName] = $bSaveResult;
                         //unset fields that failed
                         if (!$bSaveResult) {

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -196,6 +196,8 @@ class Question extends LSActiveRecord
 
     /**
      * Rewrites sort order for questions in a group
+     * This is very similar to updateQuestionOrder(). Should lead to same results.
+     * Leaving it for backward compatibility and in case I am missing something about their behaviour.
      *
      * @static
      * @access public
@@ -222,11 +224,14 @@ class Question extends LSActiveRecord
     /**
      * Fix sort order for questions in a group
      * @param int $gid
-     * @param string $language
      * @param int $position
      */
-    public function updateQuestionOrder($gid, $language, $position = 0)
+    public function updateQuestionOrder($gid, $position = 1)
     {
+        // The language is needed to avoid duplicates in the data selection,
+        // so we use the survey's base language
+        $language = QuestionGroup::model()->findByAttributes(array('gid' => $gid))->survey->language;
+
         $data = Yii::app()->db->createCommand()->select('qid')
             ->where(array('and', 'gid=:gid', 'language=:language', 'parent_qid=0'))
             ->order('question_order, title ASC')


### PR DESCRIPTION
- Removed language from Question::updateQuestionOrder parameters.
  The method now uses the survey base language to work.
- Changed how order is handled in `actionUpdateQuestion` (`database.php`)
- Removed call to `Question::updateQuestionOrder` in `actionInsertCopyQuestion()` (database.php), because order was already handled.
- Updated `shiftOrderQuestions` (common_helper.php) for not using language inside of it.
  This function is not used anymore in Limesurvey's codebase, but still it might be used by others, or in the future.
- Calls to Question::updateSortOrder where replaced by Question::updateQuestionOrder for consistency.
  `updateSortOrder` is not removed from the codebase, just in case.
