### PR TITLE
Fixed issue #16269: "Start bounce processing" menu item doesn't work

### DIFF
--- a/application/views/admin/survey/topbar/token_bar.php
+++ b/application/views/admin/survey/topbar/token_bar.php
@@ -211,7 +211,7 @@ if (!$onlyclose) {
             $isDisabled = true;
         }
 
-        if (($oSurvey->bounceprocessing != 'N' || ($oSurvey->bounceprocessing == 'G' && getGlobalSetting('bounceaccounttype') != 'off'))) {
+        if (!($oSurvey->bounceprocessing != 'N' || ($oSurvey->bounceprocessing == 'G' && getGlobalSetting('bounceaccounttype') != 'off'))) {
             $errorMessages[] = gT("Bounce processing is deactivated either application-wide or for this survey in particular.");
             $isDisabled = true;
         }


### PR DESCRIPTION
Validation is inverted, so it considers the bounce processing is disabled when it's not.