### PR TITLE
Fixed issue #16538: Can add 2 survey participantes with the same token with the RPC api

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1809,7 +1809,7 @@ class remotecontrol_handle
                 if ($bCreateToken) {
                     $token->generateToken();
                 }
-                if ($token->encryptSave()) {
+                if ($token->encryptSave(true)) {
                     $aParticipant = $token->getAttributes();
                 } else {
                     $aParticipant["errors"] = $token->errors;

--- a/tests/unit/helpers/RemoteControlTest.php
+++ b/tests/unit/helpers/RemoteControlTest.php
@@ -33,6 +33,79 @@ class RemoteControlTest extends TestBaseClass
     }
 
     /**
+     * Test the add_participants API call.
+     */
+    public function testAddParticipants()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        \Yii::import('application.helpers.viewHelper', true);
+        \Yii::import('application.libraries.BigData', true);
+        $dbo = \Yii::app()->getDb();
+
+        // Make sure the Authdb is in database (might not be the case if no browser login attempt has been made).
+        $plugin = \Plugin::model()->findByAttributes(array('name'=>'Authdb'));
+        if (!$plugin) {
+            $plugin = new \Plugin();
+            $plugin->name = 'Authdb';
+            $plugin->active = 1;
+            $plugin->save();
+        } else {
+            $plugin->active = 1;
+            $plugin->save();
+        }
+        App()->getPluginManager()->loadPlugin('Authdb', $plugin->id);
+        // Clear login attempts.
+        $query = sprintf('DELETE FROM {{failed_login_attempts}}');
+        $dbo->createCommand($query)->execute();
+
+        // Import survey
+        $filename = self::$surveysFolder . '/survey_archive_265831.lsa';
+        self::importSurvey($filename);
+        //self::$testHelper->activateSurvey(self::$surveyId);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        $participant = array();
+        $participant['firstname'] = 'Test Participant 1';
+        $participant['email'] = 'test@example.com';
+        $participant['token'] = 'abc123';
+
+        $result = $handler->add_participants($sessionKey, self::$surveyId, [$participant], false);
+        $this->assertCount(1, $result, 'Exactly one result');
+        $this->assertArrayNotHasKey('errors', $result[0]);
+        $this->assertEquals('Test Participant 1', $result[0]['firstname'], '$result = ' . json_encode($result));
+        $tid = $result[0]['tid'];
+
+        // Check created token
+        $createdParticipant = \Token::model(self::$surveyId)->findByPk($tid);
+        $createdParticipant->decrypt();
+        $this->assertEquals('abc123', $createdParticipant->token);
+        $this->assertEquals('test@example.com', $createdParticipant->email);
+
+        // Check that duplicates cannot be created
+        $participant['firstname'] = 'Test Participant 2';
+        $participant['email'] = 'test2@example.com';
+        $participant['token'] = 'abc123';
+
+        $result = $handler->add_participants($sessionKey, self::$surveyId, [$participant], false);
+        $this->assertCount(1, $result, 'Exactly one response');
+        $this->assertArrayHasKey('errors', $result[0]);
+
+        // Cleanup
+        self::$testSurvey->delete();
+        self::$testSurvey = null;
+    }
+
+    /**
      * Test the add_response API call.
      */
     public function testAddResponse()
@@ -211,4 +284,5 @@ class RemoteControlTest extends TestBaseClass
         $result = $handler->get_group_properties($sessionKey, $group->gid, ['group_name'], 'de');
         $this->assertEquals('Das Deutsch title', $result['group_name']);
     }
+
 }


### PR DESCRIPTION
Adding validation to the save operation.

What I have seen is that encryptSave doesn't do validation by default.
I haven't updated that, but shouldn't we? Why it was set to false?