### PR TITLE
Fixed issue #16235: Welcome page show again if cookies are enable and survey is already done

### DIFF
--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -362,7 +362,7 @@ class index extends CAction
         //CHECK FOR PREVIOUSLY COMPLETED COOKIE
         //If cookies are being used, and this survey has been completed, a cookie called "PHPSID[sid]STATUS" will exist (ie: SID6STATUS) and will have a value of "COMPLETE"
         $sCookieName = "LS_".$surveyid."_STATUS";
-        if (!$previewmode && isset($_COOKIE[$sCookieName]) && $_COOKIE[$sCookieName] == "COMPLETE" && $thissurvey['usecookie'] == "Y" && $tokensexist != 1 && (!isset($param['newtest']) || $param['newtest'] != "Y")) {
+        if (!$previewmode && isset($_COOKIE[$sCookieName]) && $_COOKIE[$sCookieName] == "COMPLETE" && $thissurvey['usecookie'] == "Y" && $tokensexist != 1) {
 
             $aErrors  = array(gT('Error'));
             $aMessage = array(


### PR DESCRIPTION
newTest param shouldn't be considered for this validation