### PR TITLE
Fixed issue #16483: Adding condition triggers bulk update for complete database

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -806,6 +806,12 @@
         public static function UpgradeConditionsToRelevance($surveyId=NULL, $qid=NULL)
         {
             LimeExpressionManager::SetDirtyFlag();  // set dirty flag even if not conditions, since must have had a DB change
+
+            // Get survey ID from question if qid is specified and surveyId is null
+            if(is_null($surveyId) && !empty($qid)) {
+                $surveyId = Question::model()->findByPk($qid)->sid;
+            }
+
             // Cheat and upgrade question attributes here too.
             self::UpgradeQuestionAttributes(true,$surveyId,$qid);
 


### PR DESCRIPTION
Function updated to get the survey ID from the question if surveyId is null and a qid is specified.

UpgradeConditionsToRelevance receives two params: surveyId and qid. If the qid is specified, it should only update that question (as per the function doc). But, if surveyId is null, it loops trough all the surveys, which only makes sense if no qid is specified.