### PR TITLE
Fixed issue #16566: We cannot create multiple choice questions 

### DIFF
--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -268,7 +268,7 @@ class QuestionEditorController extends LSBaseController
         );
 
         // Store changes to the actual question data, by either storing it, or updating an old one
-        $oQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => $questionData['question']['qid']]);
+        $oQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => (int)$questionData['question']['qid']]);
         if ($oQuestion == null || $questionCopy == true) {
             $oQuestion = $this->storeNewQuestionData($questionData['question']);
         } else {
@@ -348,7 +348,7 @@ class QuestionEditorController extends LSBaseController
         }
 
         // Compile the newly stored data to update the FE
-        $oNewQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => $oQuestion->qid]);
+        $oNewQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => (int)$oQuestion->qid]);
         $aCompiledQuestionData = $this->getCompiledQuestionData($oNewQuestion);
         $aQuestionAttributeData = QuestionAttribute::model()->getQuestionAttributes($oQuestion->qid);
         $aQuestionGeneralOptions = $this->getGeneralOptions(
@@ -695,7 +695,7 @@ class QuestionEditorController extends LSBaseController
         if (!Permission::model()->hasSurveyPermission($iSurveyId, 'surveycontent', 'read')) {
             throw new CHttpException(403);
         }
-        $oQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => $iQuestionId]);
+        $oQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $iSurveyId, ':qid' => (int)$iQuestionId]);
 
         if ($oQuestion == null) {
             $oQuestion = QuestionCreate::getInstance($iSurveyId, $sQuestionType);

--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -1172,7 +1172,7 @@ class QuestionEditorController extends LSBaseController
         $this->cleanSubquestions($oQuestion, $dataSet);
         foreach ($dataSet as $aSubquestions) {
             foreach ($aSubquestions as $aSubquestionDataSet) {
-                $oSubQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $oQuestion->sid, ':qid' => $aSubquestionDataSet['qid']]);
+                $oSubQuestion = Question::model()->find('sid = :sid AND qid = :qid', [':sid' => $oQuestion->sid, ':qid' => (int)$aSubquestionDataSet['qid']]);
                 if ($oSubQuestion != null && !$isCopyProcess) {
                     $oSubQuestion = $this->updateQuestionData($oSubQuestion, $aSubquestionDataSet);
                 } elseif (!$oQuestion->survey->isActive) {


### PR DESCRIPTION
Random characters sometimes could come on qid when creating new questions as those are used by vue to identify internally new rows.

Before issue #16469, QuestionEditorController tried to find the questions using 'findByPk', which automatically casts the value to int, removing characters. 

Now, 'find' is used because the survey ID is added to the search criterias.
qid is not casted and no objects are found.

When saving a new question, Question object is empty, and the resulting SQL fails in Postgres because of the data type.
Solved by casting 'qid' to int.