### PR TITLE
Fixed issue #15864: When deleting a question at LS 4 the system switches to the "Settings" menu

### DIFF
--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -693,12 +693,13 @@ class SurveyAdmin extends Survey_Common_Action
      * Load list questions view for a specified survey by $surveyid
      *
      * @param int $surveyid Goven Survey ID
+     * @param string  $landOnSideMenuTab Name of the side menu tab. Default behavior is to land on settings tab.
      * 
      * @return string
      * @access public
      * @todo   php warning (Missing return statement)
      */
-    public function listquestions($surveyid)
+    public function listquestions($surveyid, $landOnSideMenuTab = 'settings')
     {
         $iSurveyID = sanitize_int($surveyid);
         // Reinit LEMlang and LEMsid: ensure LEMlang are set to default lang, surveyid are set to this survey id
@@ -720,6 +721,7 @@ class SurveyAdmin extends Survey_Common_Action
         $aData['surveyid']                              = $iSurveyID;
         $aData['display']['menu_bars']['listquestions'] = true;
         $aData['sidemenu']['listquestions']             = true;
+        $aData['sidemenu']['landOnSideMenuTab']         = $landOnSideMenuTab;
         $aData['surveybar']['returnbutton']['url']      = $this->getController()->createUrl(
             "admin/survey/sa/listsurveys"
         );

--- a/application/views/admin/survey/topbar/question_topbar.php
+++ b/application/views/admin/survey/topbar/question_topbar.php
@@ -291,7 +291,7 @@ if ($hasDeletePermission && $oSurvey->active === 'N') {
     $buttons['delete'] = [
         'url' => '#',
         'dataurl' => $this->createUrl("admin/questions/sa/delete/"),
-        'postdata' => json_encode(["surveyid" => $sid, "qid" => $qid, "gid" => $gid]),
+        'postdata' => json_encode(["surveyid" => $sid, "qid" => $qid, "gid" => $gid, "redirectTo" => 'groupoverview']),
         'name' => gT("Delete"),
         'type' => 'confirm',
         'id' => 'delete_button',


### PR DESCRIPTION
The 'delete' method now supports the 'redirectTo' parameter: to question list or group overview. Depending on that, the sidebar is set as well