### PR TITLE
Fixed issue #16573: Others than the survey owners are not allowed to edit questions anymore

### DIFF
--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -585,11 +585,11 @@ class QuestionEditorController extends LSBaseController
         $oQuestion = $this->getQuestionObject($iQuestionId);
 
         $aPermissions = [
-            "read" => Permission::model()->hasSurveyPermission($oQuestion->sid, 'survey', 'read'),
-            "update" => Permission::model()->hasSurveyPermission($oQuestion->sid, 'survey', 'update'),
+            "read" => Permission::model()->hasSurveyPermission($oQuestion->sid, 'surveycontent', 'read'),
+            "update" => Permission::model()->hasSurveyPermission($oQuestion->sid, 'surveycontent', 'update'),
             "editorpreset" => App()->session['htmleditormode'],
             "script" =>
-                Permission::model()->hasSurveyPermission($oQuestion->sid, 'survey', 'update')
+                Permission::model()->hasSurveyPermission($oQuestion->sid, 'surveycontent', 'update')
                 && SettingsUser::getUserSetting('showScriptEdit', App()->user->id),
         ];
 


### PR DESCRIPTION
actionGetQuestionPermissions was checking the 'survey' permission instead of 'surveycontent'.