### PR TITLE
Fixed issue #15980: No results shown for selected date questions at statistics

### DIFF
--- a/application/views/admin/export/statistics_subviews/_question.php
+++ b/application/views/admin/export/statistics_subviews/_question.php
@@ -135,9 +135,11 @@
 
             /*
             * all "free text" types (T, U, S)  get the same prefix ("T")
+            * Equations are treated the same way
             */
             case "T": // Long free text
             case "U": // Huge free text
+            case '*': // Equation
                 echo '<div class="statistics-responses-label-group ls-space padding bottom-5 top-15 ls-flex-item">';
                 $myfield2="T$myfield";
                 echo "\t<input type='checkbox'  name='summary[]' value='$myfield2'";
@@ -906,7 +908,6 @@
 
             //Boilerplate questions are only used to put some text between other questions -> no analysis needed
             case "X": //This is a boilerplate question and it has no business in this script
-            case '*': // EQUATION
                 echo '<h4 class="question-selector-title">'.$oStatisticsHelper::_showSpeaker($niceqtext).'</h4><br/>';
                 eT("This question type can't be selected.");
                 break;


### PR DESCRIPTION
- Date/Time responses are treated as "Answer" when the value is not null, and "No answer" when it's null.
- Equation questions are handled as text. It seems they always have a value, so "Not displayed" may always be 0.
- Condition had to be updated as to work with dates. It may have an impact on some DB engine (not sure).
