### PR TITLE
Fixed issue #16599: Cannot update answers (checkUniqueness bug)

### DIFF
--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -1262,7 +1262,9 @@ class QuestionEditorController extends LSBaseController
         $this->cleanAnsweroptions($oQuestion, $dataSet);
         foreach ($dataSet as $aAnswerOptions) {
             foreach ($aAnswerOptions as $iScaleId => $aAnswerOptionDataSet) {
-                $aAnswerOptionDataSet['sortorder'] = (int) $aAnswerOptionDataSet['sortorder'];
+                foreach ([sortorder, aid, qid, scale_id] as $key) {
+                    $aAnswerOptionDataSet[$key] = (int) $aAnswerOptionDataSet[$key];
+                }
                 $oAnswer = Answer::model()->findByPk($aAnswerOptionDataSet['aid']);
                 if ($oAnswer == null || $isCopyProcess) {
                     $oAnswer = new Answer();

--- a/application/controllers/QuestionEditorController.php
+++ b/application/controllers/QuestionEditorController.php
@@ -1262,7 +1262,7 @@ class QuestionEditorController extends LSBaseController
         $this->cleanAnsweroptions($oQuestion, $dataSet);
         foreach ($dataSet as $aAnswerOptions) {
             foreach ($aAnswerOptions as $iScaleId => $aAnswerOptionDataSet) {
-                foreach ([sortorder, aid, qid, scale_id] as $key) {
+                foreach (['sortorder', 'aid', 'qid', 'scale_id'] as $key) {
                     $aAnswerOptionDataSet[$key] = (int) $aAnswerOptionDataSet[$key];
                 }
                 $oAnswer = Answer::model()->findByPk($aAnswerOptionDataSet['aid']);


### PR DESCRIPTION
Dev: This fixes an issue with saving Type O (and maybe other) questions.

Dev: Introduces int casting for aid, qid and scale_id to prevent false
Dev: positive in Answer::checkUniqueness because of type mismatch.

Fixed issue #16599: Cannot update Answers (Type O) – Answer::checkUniqueness bug
Fixed issue #16313: Issues saving/modifying answers: "Answer codes must be unique by question"