### PR TITLE
Fixed issue #16591 to #16594: Lime Survey 4.3.10+200812 Stored Cross Site Scripting (Users)

### DIFF
--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -109,6 +109,10 @@ class UserManagementController extends LSBaseController
         }
 
         $aUser = Yii::app()->request->getParam('User');
+        // Sanitize full name to prevent XSS attack
+        if (isset($aUser['full_name'])) {
+            $aUser['full_name'] = flattenText($aUser['full_name'], false, true);
+        }
         $passwordTest = Yii::app()->request->getParam('password_repeat', false);
         if (!empty($passwordTest)) {
             if ($passwordTest !== $aUser['password']) {
@@ -181,7 +185,7 @@ class UserManagementController extends LSBaseController
         $times = App()->request->getParam('times', 5);
         $passwordSize = (int) App()->request->getParam('passwordsize', 5);
         $passwordSize = $passwordSize < 8 || is_nan($passwordSize) ? 8 : $passwordSize;
-        $prefix = App()->request->getParam('prefix', 'randuser_');
+        $prefix = flattenText(App()->request->getParam('prefix', 'randuser_'));
         $email = App()->request->getParam('email', User::model()->findByPk(App()->user->id)->email);
 
         $randomUsers = [];

--- a/application/controllers/admin/SurveymenuController.php
+++ b/application/controllers/admin/SurveymenuController.php
@@ -63,6 +63,13 @@ class SurveymenuController extends Survey_Common_Action
         $success = false;
         if (Yii::app()->request->isPostRequest) {
             $aSurveymenu = Yii::app()->request->getPost('Surveymenu', []);
+            // Sanitize title and description to prevent XSS attack
+            if (isset($aSurveymenu['title'])) {
+                $aSurveymenu['title'] = flattenText($aSurveymenu['title'], false, true);
+            }
+            if (isset($aSurveymenu['description'])) {
+                $aSurveymenu['description'] = flattenText($aSurveymenu['description'], false, true);
+            }
             if ($aSurveymenu['id'] == '') {
                 unset($aSurveymenu['id']);
                 $aSurveymenu['created_at'] = date('Y-m-d H:i:s');


### PR DESCRIPTION
Fixed issue #16591: Lime Survey 4.3.10+200812 Stored Cross Site Scripting (Survey Menu)
Fixed issue #16592: Lime Survey 4.3.10+200812 Stored Cross Site Scripting (User Details)
Fixed issue #16593: Lime Survey 4.3.10+200812 Stored Cross Site Scripting (UserName)
Fixed issue #16594: Lime Survey 4.3.10+200812 Stored Cross Site Scripting (Permission Roles)

Flattening everywhere