### PR TITLE
Fixed issue #16313: Issues saving/modifying answers: "Answer codes must be unique by question"

### DIFF
--- a/application/models/Answer.php
+++ b/application/models/Answer.php
@@ -108,7 +108,7 @@ class Answer extends LSActiveRecord
 
     public function checkUniqueness($attribute, $params)
     {
-        if($this->code !== $this->oldCode || $this->qid !== $this->oldQid || $this->scale_id !== $this->oldScaleId)
+        if($this->code !== $this->oldCode || $this->qid != $this->oldQid || $this->scale_id != $this->oldScaleId)
         {
             $model = self::model()->find('code = ? AND qid = ? AND scale_id = ?', array($this->code, $this->qid, $this->scale_id));
             if($model != null)


### PR DESCRIPTION
Replaced comparison operators as they could end up having different types
