### PR TITLE
Fixed issue #16373: Bootstrap Buttons not aligned when filtered

### DIFF
--- a/assets/packages/template-core/template-core.js
+++ b/assets/packages/template-core/template-core.js
@@ -114,6 +114,8 @@ var TemplateCoreClass = function () {
                 }, data);
                 if (data.style == 'hidden') {
                     $(this).closest(".question-container").removeClass("ls-hidden");
+                    // Show bootstrap button container
+                    $(this).closest(".bootstrap-buttons-div").removeClass("ls-hidden");
                 }
             });
             $(".question-container:not(.ls-hidden)").on('relevance:off', "[id^='javatbd']", function (event, data) {
@@ -127,6 +129,8 @@ var TemplateCoreClass = function () {
                     if ($(questionContainer).find("[id^='javatbd']").filter(':not(.ls-hidden)').length == 0) {
                         $(questionContainer).addClass("ls-hidden");
                     }
+                    // Hide bootstrap button container
+                    $(this).closest(".bootstrap-buttons-div").addClass("ls-hidden");
                 }
             });
         },


### PR DESCRIPTION
The element that is normally hidden by relevance (with ID starting with 'javatbd') is inside a "bootstrap-buttons-div" element in the case of bootstrap buttons. The "bootstrap-buttons-div" element has a 'fixed' size (ex: col-12). So when hidding, the space remains blank even if the button is hidden.

Changed 'hideQuestionWithRelevanceSubQuestion' (template-core.js) to also hide the "bootstrap-buttons-div".