### PR TITLE
Fixed issue #16547: Action buttons don't work on plugin details page (Plugin management)

### DIFF
--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -184,7 +184,7 @@ class Plugin extends LSActiveRecord
     /**
      * @return string HTML
      */
-    protected function getActivateButton()
+    public function getActivateButton()
     {
         $activateUrl = App()->getController()->createUrl(
             '/admin/pluginmanager',
@@ -212,7 +212,7 @@ class Plugin extends LSActiveRecord
     /**
      * @return string HTML
      */
-    protected function getDeactivateButton()
+    public function getDeactivateButton()
     {
         $deactivateUrl = App()->getController()->createUrl(
             '/admin/pluginmanager',

--- a/application/views/admin/pluginmanager/overview.php
+++ b/application/views/admin/pluginmanager/overview.php
@@ -74,16 +74,12 @@
             <?php if ($plugin['active']): ?>
                 <div class="col-sm-2"><span class="fa fa-check text-success"></span></div>
                 <div class="col-sm-2">
-                    <a data-toggle="tooltip" title="<?php eT('Deactivate'); ?>" href='#activate' data-action='activate' data-id='<?php echo $plugin['id']; ?>' class='ls_action_changestate btn btn-warning btn-xs btntooltip'>
-                       <span class='fa fa-power-off'></span>
-                    </a>
+                    <?= $plugin->getDeactivateButton() ?>
                 </div>
             <?php else: ?>
                 <div class="col-sm-2"><span class="fa fa-times text-warning"></span></div>
                 <div class="col-sm-2">
-                    <a data-toggle="tooltip" title="<?php eT('Activate'); ?>" href='#activate' data-action='activate' data-id='<?php echo $plugin['id']; ?>' class='ls_action_changestate btn btn-default btn-xs btntooltip'>
-                       <span class='fa fa-power-off'></span>
-                    </a>
+                    <?= $plugin->getActivateButton() ?>
                 </div>
             <?php endif; ?>
         </div>


### PR DESCRIPTION
Reused getActivateButton() and getDeactivateButton() from Plugin model. Had to change the methods to 'public'.