### PR TITLE
Fixed issue #16636: False warning about the screen resolution

### DIFF
--- a/application/views/admin/authentication/login.php
+++ b/application/views/admin/authentication/login.php
@@ -154,4 +154,7 @@ $( document ).ready(function() {
     $('#user').focus();
     $("#width").val($(window).width());
 });
+$( window ).resize(function() {
+    $("#width").val($(window).width());;
+});
 </script>


### PR DESCRIPTION
The window size used for validation was only retrieved on "document ready" event of the login page.
Added a handler for the window resize event to keep the 'width' field updated until form sumbission.
