### PR TITLE
Fixed issue #16229: Random answer order currently broken

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -660,6 +660,22 @@ class Question extends LSActiveRecord
             return $aAnswerOptions[$scale_id];
         }
 
+        // Random order
+        if ($this->getQuestionAttribute('random_order') == 1 && $this->getQuestionType()->subquestions == 0){
+            foreach($aAnswerOptions as $scaleId => $aScaleArray) {
+                $keys = array_keys($aScaleArray);
+                shuffle($keys); // See: https://forum.yiiframework.com/t/order-by-rand-and-total-posts/68099
+
+                $aNew = array();
+                foreach($keys as $key) {
+                    $aNew[$key] = $aScaleArray[$key];
+                }
+                $aAnswerOptions[$scaleId] = $aNew;
+            }
+
+            return $aAnswerOptions;
+        }
+
         // Alphabetic ordrer
         $alphasort = $this->getQuestionAttribute('alphasort');
         if ($alphasort == 1) {


### PR DESCRIPTION
Only ordering answers if the question have subquestions.