### PR TITLE
Fixed issue #16650: Timing not recorded when exporting results

### DIFF
--- a/application/helpers/admin/export/Writer.php
+++ b/application/helpers/admin/export/Writer.php
@@ -298,7 +298,7 @@ abstract class Writer implements IWriter
         foreach ($oSurvey->responses as $response) {
             // prepare the data for decryption
             $sTokenTableName='tokens_'.$oSurvey->id;
-            $aResponse = array();
+            $aResponse = $response;
             if (tableExists($sTokenTableName)) {
                 $oToken = Token::model($oSurvey->id);
                 $oToken->setAttributes($response, false); 


### PR DESCRIPTION
Made the response to be based on the queried response and not start from scratch. Timings are there initially. If starting from scratch, we loose them.