### PR TITLE
Fixed issue #16647: Can't select seperator for CPDB export - export doesn't recognise text

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -2214,17 +2214,13 @@ function CPDBExport($data, $filename)
     header("Content-Disposition: attachment; filename=".$filename.".csv");
     header("Content-type: text/comma-separated-values; charset=UTF-8");
     header("Cache-Control: must-revalidate, no-store, no-cache");
-    $tokenoutput = chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'));
+    echo chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF')); // UTF-8 BOM
 
+    $handler = fopen('php://output', 'w');
     foreach ($data as $key=>$value) {
-        foreach ($value as $values) {
-            $tokenoutput .= trim($values).',';
-        }
-        $tokenoutput = substr($tokenoutput, 0, -1); // remove last comma
-        $tokenoutput .= "\n";
-
+        fputcsv($handler, $value);
     }
-    echo $tokenoutput;
+    fclose($handler);
     exit;
 }
 


### PR DESCRIPTION
Used 'fputcsv' in CPDBExport() with default args.