### PR TITLE
Fixed issue #16658: queXMLPDF export shows JS script

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -1025,7 +1025,18 @@ function getXMLDataSingleTable($iSurveyID, $sTableName, $sDocType, $sXMLTableTag
 */
 function QueXMLCleanup($string, $allow = '<p><b><u><i><em>')
 {
-    return str_replace("&", "&amp;", html_entity_decode(trim(strip_tags(str_ireplace("<br />", "\n", $string), $allow)), ENT_QUOTES, 'UTF-8'));
+    $sAllowedTags = str_replace(">","",str_replace("<","",str_replace("><",",",$allow)));
+    $sResult = str_ireplace("<br />", "\n", $string);
+    $oPurifier = new CHtmlPurifier();
+    $oPurifier->options = array(
+        'HTML.Allowed'=>$sAllowedTags,
+        'Output.Newline'=> "\n"
+    );
+    $sResult = $oPurifier->purify($sResult);
+    $sResult = trim($sResult);
+    $sResult = html_entity_decode($sResult, ENT_QUOTES, 'UTF-8');
+    $sResult = str_replace("&", "&amp;", $sResult);
+    return $sResult;
 }
 
 /**


### PR DESCRIPTION
Updated QueXMLCleanup. Replaced "strip_tags" by CHtmlPurifier. strip_tags removed the tags but kept their inner content (the javascript in this case).