### PR TITLE
Fixed issue #16506: Fruity theme: question type Matrix (texts), you do not see the sums of the total columns and grand total.

### DIFF
--- a/application/views/survey/questions/answer/arrays/texts/columns/col_total.twig
+++ b/application/views/survey/questions/answer/arrays/texts/columns/col_total.twig
@@ -12,7 +12,7 @@
         &nbsp;
     {% else %}
         <label class="sr-only">{{ gT("Total") }}</label>
-        <input title="[[ROW_NAME]] total" size="{{ inputsize }}" value="" type="text" disabled="disabled" class="disabled form-control"  data-number='1' />
+        <input title="[[ROW_NAME]] total" size="{{ inputsize }}" value="" type="text" disabled="disabled" class="disabled form-control total"  data-number='1' />
     {% endif %}
 </td>
 

--- a/application/views/survey/questions/answer/arrays/texts/rows/cells/td_grand_total.twig
+++ b/application/views/survey/questions/answer/arrays/texts/rows/cells/td_grand_total.twig
@@ -13,7 +13,7 @@
 
 {% else %}
     <td class="total grand information-item">
-        <input type="text" {% if inputsize %}size="{{ inputsize }}" {% endif %} value="" disabled="disabled" class="disabled form-control" data-number='1' />
+        <input type="text" {% if inputsize %}size="{{ inputsize }}" {% endif %} value="" disabled="disabled" class="disabled form-control total" data-number='1' />
     </td>
 {% endif %}
 <!-- end of td_grand_total -->


### PR DESCRIPTION
Updating CSS clasess for the inputs as to have the data to be more visible
