### PR TITLE
New feature #16710: add onUpdateResponse plugin event

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5597,6 +5597,15 @@
                             $cSave = new Save();
                             $cSave->set_answer_time();
                         }
+
+                        $event = new PluginEvent('onUpdateResponse');
+                        $event->set('surveyId', $this->sid);
+                        $event->set('responseId', $oResponse->id);
+                        $event->set('step', $thisstep);
+                        $event->set('responseAttributes', $aResponseAttributes);
+                        $event->set('finished', $finished);
+
+
                     } else {
                         LimeExpressionManager::addFrontendFlashMessage('error', $this->gT('This response was already submitted.'), $this->sid);
                     }


### PR DESCRIPTION
Add the plugin event for any actual data submission/update of the response.

Will do the same pull request for develop branch of v4.