### PR TITLE
Fixed issue #16685: Delete Plugin files is not working

### DIFF
--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -276,7 +276,7 @@ class PluginManager extends \CApplicationComponent
         $this->shutdownObject->enable();
 
         $result = array();
-        foreach ($this->pluginDirs as $pluginDir) {
+        foreach ($this->pluginDirs as $pluginType => $pluginDir) {
             $currentDir = Yii::getPathOfAlias($pluginDir);
             if (is_dir($currentDir)) {
                 foreach (new \DirectoryIterator($currentDir) as $fileInfo) {
@@ -292,6 +292,15 @@ class PluginManager extends \CApplicationComponent
                             if (file_exists($file) && $this->_checkWhitelist($pluginName)) {
                                 try {
                                     $result[$pluginName] = $this->getPluginInfo($pluginName, $pluginDir);
+                                    // getPluginInfo returns false instead of an array when config is not found.
+                                    // So we build an "empty" array
+                                    if (!$result[$pluginName]) {
+                                        $result[$pluginName] = array(
+                                            'extensionConfig' => null,
+                                            'pluginType' => $pluginType,
+                                            'load_error' => 0,
+                                        );
+                                    }
                                 } catch (\Throwable $ex) {
                                     // Load error.
                                     $error = [
@@ -313,7 +322,8 @@ class PluginManager extends \CApplicationComponent
                             $result[$pluginName] = [
                                 'pluginName' => $pluginName,
                                 'load_error' => 1,
-                                'isCompatible' => false
+                                'isCompatible' => false,
+                                'pluginType' => $plugin->plugin_type,
                             ];
                         } else {
                         }

--- a/application/views/admin/pluginmanager/scanFilesResult.php
+++ b/application/views/admin/pluginmanager/scanFilesResult.php
@@ -20,7 +20,10 @@
             <label class='control-label col-sm-4'>
                 <?php echo $name; ?>
             </label>
-            <?php if ($scannedPlugin['isCompatible']): ?>
+            <?php if ($scannedPlugin['load_error'] == 0 && $scannedPlugin['extensionConfig'] == null): ?>
+                <i class='fa fa-ban text-warning'></i>&nbsp;
+                <span class='text-warning'><?php eT('Missing configuration file.'); ?></span>
+            <?php elseif ($scannedPlugin['isCompatible']): ?>
                 <?php echo CHtml::beginForm($installUrl, 'post', ['style' => 'display: inline-block;']); ?>
                     <input type='hidden' name='pluginName' value='<?php echo $name; ?>' />
                     <button href='' class='btn btn-success' data-toggle='tooltip' title='<?php eT('Install this plugin'); ?>'>
@@ -33,18 +36,17 @@
                           && !$scannedPlugin['isCompatible']): ?>
                 <i class='fa fa-ban text-warning'></i>&nbsp;
                 <span class='text-warning'><?php eT('Plugin is not compatible with your LimeSurvey version.'); ?></span>
-            <?php elseif ($scannedPlugin['load_error'] == 0 && $scannedPlugin['extensionConfig'] == null): ?>
-                <i class='fa fa-ban text-warning'></i>&nbsp;
-                <span class='text-warning'><?php eT('Missing configuration file.'); ?></span>
             <?php else: ?>
                 <i class='fa fa-exclamation-triangle text-warning'></i>&nbsp;
                 <span class='text-warning'><?php eT('Load error. Please contact the plugin author.'); ?></span>
             <?php endif; ?>
 
-            <a href='' class='btn btn-danger' data-toggle='tooltip' title='<?php eT('Delete this plugin from the file system'); ?>'>
-                <i class='fa fa-trash'></i>&nbsp;
-                Delete files
-            </a>
+            <?php if (isset($scannedPlugin['deleteUrl'])): ?>
+                <a href='#' class='btn btn-danger' data-target='#confirmation-modal' data-toggle='modal' data-href='<?=$scannedPlugin['deleteUrl']?>' data-message='<?php eT('Are you sure you want to delete this plugin from the file system?'); ?>' type='submit'>
+                    <i class='fa fa-trash'></i>&nbsp;
+                    <span data-toggle='tooltip' title='<?php eT('Delete this plugin from the file system'); ?>'>Delete files</span>
+                </a>
+            <?php endif; ?>
         </div>
     <?php endforeach; ?>
 </div>


### PR DESCRIPTION
The 'Delete files' button existed but had no action assigned.
Added new 'delete files' feature. Limited to the 'upload' plugin type.
Added pluginType to the info returned by the scanPlugins method