### PR TITLE
Fixed issue #16642: PHP warning when showing array questions

### DIFF
--- a/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
+++ b/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
@@ -144,7 +144,7 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
         } else {
             $extraanswerwidth = $separatorwidth;
         }
-        $cellwidth = $columnswidth / $this->numrows;
+        $cellwidth = $columnswidth / ($this->numrows ? $this->numrows : 1);
 
         // Header row and colgroups
         $aData['answerwidth'] = $this->answerwidth;

--- a/application/views/survey/questions/answer/arrays/dualscale/answer_dropdown.twig
+++ b/application/views/survey/questions/answer/arrays/dualscale/answer_dropdown.twig
@@ -16,9 +16,9 @@
 <!-- Column groups -->
 <colgroup>
     <col class="answertext" style='width: {{ answerwidth }}%;' />
-    <col class="dsheader" style='width: {{ cellwidth }}%;' />
+    <col class="dsheader" />
     <col class="ddarrayseparator" style='width: {{ separatorwidth }}%'/>
-    <col class="dsheader"  style='width: {{ cellwidth }}%;' />
+    <col class="dsheader" />
 </colgroup>
 <!-- Header -->
 {% if leftheader != '' or rightheader !='' %}


### PR DESCRIPTION
For dual scale questions, the 'cellwidth' variable calculation involved the number of labels. But, the number of labels is only calculated when the question is shown as radios, and not when it's shown as dropdown.

However, fixing the 'cellwidth' calculation (diving by 1 when 'numrows' is not set) affected the rendering because the "answer_dropdown" view used the 'cellwidth' value for styling and it now changed from "INF" (infinity) to an actual number. So, the use of 'cellwidth' in dropdown view was removed in order to not alter how the question was rendered.