### PR TITLE
Fixed issue #16644: Audit log not save all actions

### DIFF
--- a/application/core/plugins/AuditLog/AuditLog.php
+++ b/application/core/plugins/AuditLog/AuditLog.php
@@ -337,7 +337,7 @@
         {
             $event = $this->getEvent();
             $iSurveyID=$event->get('iSurveyID');
-            if (!$this->checkSetting('AuditLog_Log_TokenSave') || !$this->get('auditing', 'Survey', $iSurveyID, false)) {
+            if (!$this->checkSetting('AuditLog_Log_TokenSave') || !$this->get('auditing', 'Survey', $iSurveyID, true)) {
                 return;
             }
 
@@ -615,7 +615,7 @@
             $event = $this->getEvent();
             $oModifiedSurvey = $event->get('modifiedSurvey');
             $iSurveyID = $oModifiedSurvey->sid;
-            if (!$this->checkSetting('AuditLog_Log_SurveySettings') || !$this->get('auditing', 'Survey', $iSurveyID, false)) {
+            if (!$this->checkSetting('AuditLog_Log_SurveySettings') || !$this->get('auditing', 'Survey', $iSurveyID, true)) {
                 return;
             }
 


### PR DESCRIPTION
There was a mismatch between the default values for "Audit log for this survey" setting. The default value shown on screen was Yes (true), and for most events it was indeed treated as 'true' by default when logging actions. But for tokens and survey settings, it defaulted to 'false' when logging actions.

It was fixed by defaulting to 'true' in all cases, as shown in the screen and expected by the user.