### PR TITLE
Fixed issue #16560: After downloading tokens for the first time, need to refresh for a second download

### DIFF
--- a/application/views/admin/token/token_bar.php
+++ b/application/views/admin/token/token_bar.php
@@ -228,7 +228,7 @@
             <?php endif;?>
 
             <?php if(isset($token_bar['exportbutton']['form'])):?>
-                <a class="btn btn-success" href="#" role="button" id="save-button">
+                <a class="btn btn-success" href="#" role="button" id="export-button" data-submit-form=1>
                     <span class="fa fa fa-export" ></span>
                        <?php eT("Download CSV file"); ?>
                 </a>


### PR DESCRIPTION
When "save buttons" are clicked, they are disabled, the spinner is shown, and the form is submitted. It is expected that the submit ends in a redirect.
The export button was identified as a "save button", but ended in a file download.
In this case, since a file is donwloaded, the page remains in the same state, with the spinner displayed and the button disabled.

It was changed to be handled as an "export button".