### PR TITLE
Normalize htmleditor import

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -354,7 +354,7 @@ class SurveyAdministrationController extends LSBaseController
         App()->getClientScript()->registerPackage('jquery-json');
         App()->getClientScript()->registerPackage('bootstrap-switch');
         Yii::app()->loadHelper('surveytranslator');
-        Yii::app()->loadHelper('admin/htmleditor');
+        Yii::app()->loadHelper('admin.htmleditor');
 
         $esrow = $this->fetchSurveyInfo('newsurvey');
 
@@ -2855,7 +2855,7 @@ class SurveyAdministrationController extends LSBaseController
      */
     private function getDataSecurityEditData($survey)
     {
-        Yii::app()->loadHelper("admin/htmleditor");
+        Yii::app()->loadHelper("admin.htmleditor");
         $aData = $aTabTitles = $aTabContents = array();
 
         $aData['scripts'] = PrepareEditorScript(false, $this);

--- a/application/controllers/admin/assessments.php
+++ b/application/controllers/admin/assessments.php
@@ -215,7 +215,7 @@ class Assessments extends Survey_Common_Action
         $aData['surveyid'] = $iSurveyID;
         $aData['action'] = $action;
         
-        Yii::app()->loadHelper('admin/htmleditor');
+        Yii::app()->loadHelper('admin.htmleditor');
 
         $this->prepareDataArray($aData);
 

--- a/application/controllers/admin/htmleditor_pop.php
+++ b/application/controllers/admin/htmleditor_pop.php
@@ -20,7 +20,7 @@ class htmleditor_pop extends Survey_Common_Action
 
     public function index()
     {
-        Yii::app()->loadHelper('admin/htmleditor');
+        Yii::app()->loadHelper('admin.htmleditor');
         $aData = array(
             'ckLanguage' => sTranslateLangCode2CK(Yii::app()->session['adminlang']),
             'sFieldName' => sanitize_xss_string(App()->request->getQuery('name')), // The fieldname : an input name

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -266,7 +266,7 @@ class labels extends Survey_Common_Action
             // Make languages array from the current row
             $lslanguages = explode(" ", trim($model->languages));
 
-            Yii::app()->loadHelper("admin/htmleditor");
+            Yii::app()->loadHelper("admin.htmleditor");
 
             $aViewUrls['output'] = PrepareEditorScript(false, $this->getController());
 

--- a/application/controllers/admin/surveyadmin.php
+++ b/application/controllers/admin/surveyadmin.php
@@ -214,7 +214,7 @@ class SurveyAdmin extends Survey_Common_Action
         $this->_registerScriptFiles();
         Yii::app()->loadHelper('surveytranslator');
         $esrow = $this->_fetchSurveyInfo('newsurvey');
-        Yii::app()->loadHelper('admin/htmleditor');
+        Yii::app()->loadHelper('admin.htmleditor');
 
         //$aViewUrls['output']  = PrepareEditorScript(false, $this->getController());
         $aData                = $this->_generalTabNewSurvey();
@@ -1644,7 +1644,7 @@ class SurveyAdmin extends Survey_Common_Action
      */
     private function _getDataSecurityEditData($survey)
     {
-        Yii::app()->loadHelper("admin/htmleditor");
+        Yii::app()->loadHelper("admin.htmleditor");
         $aData = $aTabTitles = $aTabContents = array();
 
         $aData['scripts'] = PrepareEditorScript(false, $this->getController());

--- a/application/controllers/admin/translate.php
+++ b/application/controllers/admin/translate.php
@@ -50,7 +50,7 @@ class translate extends Survey_Common_Action
         $langs = $oSurvey->additionalLanguages;
 
         Yii::app()->loadHelper("database");
-        Yii::app()->loadHelper("admin/htmleditor");
+        Yii::app()->loadHelper("admin.htmleditor");
 
         if (empty($tolang) && count($langs) > 0) {
             $tolang = $langs[0];

--- a/application/views/admin/translate/translatetabs_view.php
+++ b/application/views/admin/translate/translatetabs_view.php
@@ -1,6 +1,6 @@
 <div id='tab-<?php echo $type;?>' class='tab-pane fade in <?php if($activeTab){echo "active";}?>'>
 <?php
-Yii::app()->loadHelper('admin/htmleditor');
+Yii::app()->loadHelper('admin.htmleditor');
 echo PrepareEditorScript(true, Yii::app()->getController());
 ?>
 

--- a/application/views/surveyAdministration/newSurvey_view.php
+++ b/application/views/surveyAdministration/newSurvey_view.php
@@ -13,7 +13,7 @@ echo viewHelper::getViewTestTag('createSurvey');
 <!-- new survey view -->
 <?php
     extract($arrayed_data);
-    //Yii::app()->loadHelper('admin/htmleditor');
+    //Yii::app()->loadHelper('admin.htmleditor');
     //PrepareEditorScript(false, $this);
     $active = Yii::app()->request->getParam('tab', 'create');
 ?>

--- a/application/views/surveyAdministration/tabCreate_view.php
+++ b/application/views/surveyAdministration/tabCreate_view.php
@@ -10,7 +10,7 @@
 <?php
 extract($data);
 
-Yii::app()->loadHelper('admin/htmleditor');
+Yii::app()->loadHelper('admin.htmleditor');
 
 $cs = Yii::app()->getClientScript();
 $cs->registerPackage('bootstrap-select2');


### PR DESCRIPTION
Sometimes it was being loaded as `admin.htmleditor` and some others as `admin/htmleditor`
That caused some collisions and error `function redeclare` as the file was included twice. as the alias check was failing.