### PR TITLE
Dev #16726  new config setting for date format and question code   patching

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -404,6 +404,9 @@ $config['quexmlusequestiontitleasid'] = false;
 // QueXML: If set to true, the Data/Time answers will be formated with the survey's date format
 $config['quexmlkeepsurveydateformat'] = false;
 
+// QueXML: Width of the question title column in MM
+$config['quexmlquestiontitlewidth'] = 14;
+
 $config['minlengthshortimplode'] = 20; // Min length required to use short_implode instead of standard implode
 $config['maxstringlengthshortimplode'] = 100; // short_implode: Max length of returned string
 

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -1381,6 +1381,9 @@ function quexml_reformat_date(&$element, $qid, $iSurveyID)
 
     // Change the value in the DOM element
     $element->setAttribute("defaultValue", $value);
+
+    // Change length
+    $element->getElementsByTagName("free")->item(0)->getElementsByTagName("length")->item(0)->nodeValue = strlen($value);
 }
 
 /**

--- a/application/libraries/admin/quexmlpdf.php
+++ b/application/libraries/admin/quexmlpdf.php
@@ -800,6 +800,16 @@ class quexmlpdf extends pdf
     protected $cornerLines = true;
 
     /**
+     * Initialize from config
+     *
+     */
+    public function __construct()
+    {
+        $this->questionTitleWidth = Yii::app()->getConfig('quexmlquestiontitlewidth', $this->questionTitleWidth);
+        parent::__construct();
+    }
+
+    /**
      * Return the length of the longest word
      *
      * @param mixed $txt

--- a/application/libraries/admin/quexmlpdf.php
+++ b/application/libraries/admin/quexmlpdf.php
@@ -1967,7 +1967,7 @@ class quexmlpdf extends pdf
                 }
 
                 if (Yii::app()->getConfig('quexmlusequestiontitleasid')) {
-                    $qtmp['title'] = ((string) $qu->response->attributes()->varName).$this->questionTitleSuffix;
+                    $qtmp['title'] = explode('_', (string) $qu->response->attributes()->varName)[0].$this->questionTitleSuffix;
                 } else {
                     $qtmp['title'] = $sl.$qcount.$this->questionTitleSuffix;
                 }


### PR DESCRIPTION
For date questions, the length of the placeholders is set accoding to the format of the question
Question Title Column width can be set from config-defaults
For questions with subquestion, the question code is shown withouth the subquestion part. [Bug]