### PR TITLE
Fixed issue #16274: Fruity Theme : Setting font didn't work

### DIFF
--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -272,6 +272,8 @@ var ThemeOptions = function () {
                 JSON.parse($('#TemplateConfiguration_packages_to_load').val()) :
                 $(this).data('inheritvalue');
 
+            if (currentPackageObject === 'inherit') currentPackageObject = {add:[]};
+
             if ($('#simple_edit_options_font').val() === 'inherit') {
 
                 $('#TemplateConfiguration_packages_to_load').val('inherit');


### PR DESCRIPTION
If no current "package to load" object, creating an empty one