### PR TITLE
Set default folder for getFileList(); to "global"

### DIFF
--- a/application/controllers/admin/LimeSurveyFileManager.php
+++ b/application/controllers/admin/LimeSurveyFileManager.php
@@ -138,6 +138,10 @@ class LimeSurveyFileManager extends Survey_Common_Action
      */
     public function getFileList($folder, $iSurveyId = null)
     {
+        if ($folder == '') {
+            $folder = 'global';
+        }
+
         // Get real folder name from alias.
         if (in_array($folder, array_keys($this->globalDirectoriesMap))) {
             $folder = $this->globalDirectoriesMap[$folder];


### PR DESCRIPTION
Set default folder for getFileList();
Could be fixed via url generation as well...
https://bugs.limesurvey.org/view.php?id=16130
Fixed issue #16130
