### PR TITLE
Fixed issue #16442: Unable to use string with "on" in theme option label

### DIFF
--- a/application/controllers/admin/themeoptions.php
+++ b/application/controllers/admin/themeoptions.php
@@ -614,7 +614,6 @@ class themeoptions  extends Survey_Common_Action
             $oModelWithInheritReplacement->sTemplateName
         );
         $oParentOptions = (array) $oSimpleInheritanceTemplate->oOptions;
-        $oParentOptions = TemplateConfiguration::translateOptionLabels($oParentOptions);
 
         $aData = array(
             'model'=>$model,

--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -1018,7 +1018,6 @@ class TemplateConfiguration extends TemplateConfig
         $oTemplate->setOptionInheritance();
 
         $oOptions = (array) $oSimpleInheritanceTemplate->oOptions;
-        $oOptions = TemplateConfiguration::translateOptionLabels($oOptions);
 
         //We add some extra values to the option page
         //This is just a dirty hack, and somewhere in the future we will correct it
@@ -1550,48 +1549,5 @@ class TemplateConfiguration extends TemplateConfig
             }
             $this->options = json_encode($aOptions);
         }
-    }
-
-    /**
-     * Translates the Option Labels.
-     *
-     * @param $oOptions
-     * @return mixed
-     */
-    public static function translateOptionLabels($oOptions)
-    {
-        // translation of database values, to match labels on the page
-        foreach ($oOptions as $key => $value) {
-            if ($key == 'showpopups') {
-                $oOptions[$key] = str_replace(
-                    array('1', '0', '-1'),
-                    array(
-                        gT("Popup"),
-                        gT("On page"),
-                        gT("No")),
-                    $value
-                );
-            } elseif ($key == 'notables') {
-                $oOptions[$key] = str_replace(
-                    array('2', '1', '0'),
-                    array(
-                        gT("Always on"),
-                        gT("Small screens"),
-                        gT("Off")),
-                    $value
-                );
-            } else {
-                $oOptions[$key] = str_replace(
-                    array('on', 'off', 'top', 'bottom'),
-                    array(
-                        gT("Yes"),
-                        gT("No"),
-                        gT("Top"),
-                        gT("Bottom")),
-                    $value
-                );
-            }
-        }
-        return $oOptions;
     }
 }


### PR DESCRIPTION
Dev: User theme options must not be update totally like this
Dev: New settings already use optionlabels
Dev: just in case … 
