### PR TITLE
New feature: Make invitation/reminder sending rate configurable

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -112,6 +112,7 @@ $config['showpopups']         = 2; // Show popup messages if mandatory or condit
 // -1 = Do not show the message at all (in this case, users will still see the question-specific tips indicating which questions must be answered).
 
 $config['maxemails']          = 50; // The maximum number of emails to send in one go (this is to prevent your mail server or script from timeouting when sending mass mail)
+$config['sendingrate']        = 60; // Number of seconds to wait until next email batch is sent
 
 // Experimental parameters, only change if you know what you're doing
 //

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -112,7 +112,7 @@ $config['showpopups']         = 2; // Show popup messages if mandatory or condit
 // -1 = Do not show the message at all (in this case, users will still see the question-specific tips indicating which questions must be answered).
 
 $config['maxemails']          = 50; // The maximum number of emails to send in one go (this is to prevent your mail server or script from timeouting when sending mass mail)
-$config['sendingrate']        = 60; // Number of seconds to wait until next email batch is sent
+$config['sendingrate']        = 60; // Number of seconds to wait until the next email batch is sent
 
 // Experimental parameters, only change if you know what you're doing
 //

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -219,6 +219,11 @@ class GlobalSettings extends Survey_Common_Action
             $maxemails = 1;
         }
 
+        $sendingrate = Yii::app()->getRequest()->getPost('sendingrate');
+        if (sanitize_int(Yii::app()->getRequest()->getPost('sendingrate')) < 1) {
+            $sendingrate = 60;
+        }
+
         $defaultlang = sanitize_languagecode(Yii::app()->getRequest()->getPost('defaultlang'));
         $aRestrictToLanguages = explode(' ', sanitize_languagecodeS(Yii::app()->getRequest()->getPost('restrictToLanguages')));
         if (!in_array($defaultlang, $aRestrictToLanguages)) {
@@ -301,6 +306,7 @@ class GlobalSettings extends Survey_Common_Action
         SettingGlobal::setSetting('repeatheadings', $repeatheadingstemp);
 
         SettingGlobal::setSetting('maxemails', sanitize_int($maxemails));
+        SettingGlobal::setSetting('sendingrate', sanitize_int($sendingrate));
         $iSessionExpirationTime = (int) (Yii::app()->getRequest()->getPost('iSessionExpirationTime',7200));
         if ($iSessionExpirationTime == 0) {
             $iSessionExpirationTime = 7200;

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -97,7 +97,7 @@
             <label class="control-label" for="sendingrate"><?php eT("Email sending rate:"); ?></label>
             <div>
                 <?php echo Chtml::numberField("sendingrate", App()->getConfig('sendingrate'), array('class' => 'form-control', 'size' => 5, 'min' => 1)); ?>
-                <span class="hint"><?php eT("Number of seconds to wait until next email batch is sent."); ?></span>
+                <span class="hint"><?php eT("Number of seconds to wait until the next email batch is sent."); ?></span>
             </div>
         </div>
     </div>

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -96,7 +96,7 @@
         <div class="form-group">
             <label class="control-label" for="sendingrate"><?php eT("Email sending rate:"); ?></label>
             <div>
-                <?php echo Chtml::textField("sendingrate", getGlobalSetting('maxemails'), array('class' => 'form-control', 'size' => '5')); ?>
+                <?php echo Chtml::textField("sendingrate", getGlobalSetting('sendingrate'), array('class' => 'form-control', 'size' => '5')); ?>
                 <span class="hint"><?php eT("Number of seconds to wait until next email batch is sent."); ?></span>
             </div>
         </div>

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -93,6 +93,13 @@
                 <input class="form-control"  type='text' size='5' id='maxemails' name='maxemails' value="<?php echo htmlspecialchars(getGlobalSetting('maxemails')); ?>" />
             </div>
         </div>
+        <div class="form-group">
+            <label class="control-label" for="sendingrate"><?php eT("Email sending rate:"); ?></label>
+            <div>
+                <?php echo Chtml::textField("sendingrate", getGlobalSetting('maxemails'), array('class' => 'form-control', 'size' => '5')); ?>
+                <span class="hint"><?php eT("Number of seconds to wait until next email batch is sent."); ?></span>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -96,7 +96,7 @@
         <div class="form-group">
             <label class="control-label" for="sendingrate"><?php eT("Email sending rate:"); ?></label>
             <div>
-                <?php echo Chtml::textField("sendingrate", getGlobalSetting('sendingrate'), array('class' => 'form-control', 'size' => '5')); ?>
+                <?php echo Chtml::numberField("sendingrate", App()->getConfig('sendingrate'), array('class' => 'form-control', 'size' => 5, 'min' => 1)); ?>
                 <span class="hint"><?php eT("Number of seconds to wait until next email batch is sent."); ?></span>
             </div>
         </div>

--- a/application/views/admin/token/emailwarning.php
+++ b/application/views/admin/token/emailwarning.php
@@ -2,7 +2,7 @@
 <div class="jumbotron message-box message-box-warning">
     <h2><?php eT("Warning"); ?></h2>
     <?php echo CHtml::form(array("admin/tokens/sa/email/action/{$sSubAction}/surveyid/{$surveyid}"), 'post', ['id' => 'tokenSubmitInviteForm']); ?>
-        <?php echo sprintf(gT("There are more emails pending than can be sent in one batch. Continue sending emails by clicking below, or wait %s seconds."), '<span id="tokensendcounter">20</span>'); ?>
+        <span id="tokenSendNotice"><?php printf(ngT("There are more emails pending than can be sent in one batch. Continue sending emails by clicking below, or wait %s{n}%s second.|There are more emails pending than can be sent in one batch. Continue sending emails by clicking below, or wait %s{n}%s seconds.", Yii::app()->getConfig('sendingrate')), '<span id="tokenSendCounter">', '</span>'); ?></span>
         <br />
         <br />
         <?php echo str_replace("{EMAILCOUNT}", (string) $lefttosend, gT("There are {EMAILCOUNT} emails still to be sent.")); ?>
@@ -47,7 +47,7 @@
     <div class="progress">
         <div class="progress-bar progress-bar-striped active" id="countdown-progress" role="progressbar" aria-valuenow="70"
         aria-valuemin="0" aria-valuemax="100" style="width:100%">
-            <span class="sr-only">20 seconds to go</span>
+            <span class="sr-only"><?php neT("{n} second to go|{n} seconds to go", Yii::app()->getConfig('sendingrate')); ?></span>
         </div>
     </div>
 </div>
@@ -56,7 +56,7 @@ App()->getClientScript()->registerScript('TokenInviteLooper', "
     $('#countdown-progress').css('-webkit-animation-duration', '1s');
     $('#countdown-progress').css('-moz-animation-duration', '1s');
     $('#countdown-progress').css('animation-duration', '1s');
-    window.countdownTimerTokenSend = 20;
+    window.countdownTimerTokenSend = " . Yii::app()->getConfig('sendingrate') . ";
     var intervaltoRenew = window.setInterval(function(){
         if(window.countdownTimerTokenSend === 0){
             $('body').append('<div class=\"overlay\"></div>');
@@ -68,15 +68,15 @@ App()->getClientScript()->registerScript('TokenInviteLooper', "
             return;
         }
         window.countdownTimerTokenSend--;
-        $('#countdown-progress').css('width', (window.countdownTimerTokenSend*5)+'%');
-        $('#tokensendcounter').text(window.countdownTimerTokenSend);
+        $('#countdown-progress').css('width', (window.countdownTimerTokenSend*100/" . Yii::app()->getConfig('sendingrate') . ")+'%');
+        $('#tokenSendCounter').text(window.countdownTimerTokenSend);
     },1000);
 
     $('#cancelAutomaticSubmission').on('click', function(evt){
         evt.preventDefault();
         clearInterval(intervaltoRenew);
         $('#countdown-progress').css('width', '0%');
-        $('#tokensendcounter').text('X');
+        $('#tokenSendNotice').text('" . gT("There are more emails pending than can be sent in one batch. Continue sending emails by clicking below.") . "');
     });
 
 ", LSYii_ClientScript::POS_POSTSCRIPT);


### PR DESCRIPTION
Dev: This patch makes currently hardcoded 20 second automatic email sending rate configurable.

Dev: Most SMTP providers limit sending rates on their side. This patch, combined with "Email batch size" parameter, now allows for a very flexible solution to the problem. For example, you can set LimeSurvey to send 30 emails per 1 minute OR you can set it to 1 email per 2 seconds which could be a big improvement on some SMTP platforms to not being blocked by spam filters.

Dev: While at it, convert related strings to be translatable, allow for plural translation forms and make notice to the survey administrator more sensical when a "Cancel automatic sending" button is clicked.

With small adjustments in _email.php (`<span> -> <p>`) the patch could be merged to LS3.x branch too.

P.S. This patch is against master because https://github.com/LimeSurvey/LimeSurvey/blob/master/CONTRIBUTING.md says it should be so, but only **after** I pulled a request github PR template said it should be in develop? 

P.P.S. I could not create a ticket on bugs.limesurvey.org because I'm using my github account to login to limesurvey.org, but it seems Mantis doesn't support this?
