### PR TITLE
Fixed issue: wrong port and TLS description in bounce email/smtp settings

### DIFF
--- a/application/config/email.php
+++ b/application/config/email.php
@@ -42,7 +42,7 @@ $config['emailsmtphost']      = 'localhost'; // Sets the SMTP host. You can also
 
 $config['emailsmtpuser']      = ''; // SMTP authorisation username - only set this if your server requires authorization - if you set it you HAVE to set a password too
 $config['emailsmtppassword']  = ''; // SMTP authorisation password - empty password is not allowed
-$config['emailsmtpssl']       = ''; // Set this to 'ssl' or 'tls' to use SSL/TLS for SMTP connection
+$config['emailsmtpssl']       = ''; // Set this to 'ssl' to use SSL/TLS or 'tls' to use StartTLS for SMTP connection
 
 $config['emailsmtpdebug']     = 0; // Settings this to 1 activates SMTP debug mode
 

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -99,13 +99,13 @@ class tokens extends Survey_Common_Action
                 $hostname       = getGlobalSetting('bounceaccounthost');
                 $username       = getGlobalSetting('bounceaccountuser');
                 $pass           = LSActiveRecord::decryptSingle(getGlobalSetting('bounceaccountpass'));
-                $hostencryption = strtoupper(getGlobalSetting('bounceencryption'));
+                $hostencryption = strtolower(getGlobalSetting('bounceencryption'));
             } else {
                 $accounttype    = strtoupper($thissurvey['bounceaccounttype']);
                 $hostname       = $thissurvey['bounceaccounthost'];
                 $username       = $thissurvey['bounceaccountuser'];
                 $pass           = LSActiveRecord::decryptSingle($thissurvey['bounceaccountpass']);
-                $hostencryption = strtoupper($thissurvey['bounceaccountencryption']);
+                $hostencryption = strtolower($thissurvey['bounceaccountencryption']);
             }
 
             @list($hostname, $port) = explode(':', $hostname);
@@ -113,25 +113,21 @@ class tokens extends Survey_Common_Action
             if (empty($port)) {
                 if ($accounttype == "IMAP") {
                     switch ($hostencryption) {
-                        case "OFF":
+                        case "off":
+                        case "tls":
                             $hostname = $hostname.":143";
                             break;
-                        case "SSL":
-                            $hostname = $hostname.":993";
-                            break;
-                        case "TLS":
+                        case "ssl":
                             $hostname = $hostname.":993";
                             break;
                     }
                 } else {
                     switch ($hostencryption) {
-                        case "OFF":
+                        case "off":
+                        case "tls":
                             $hostname = $hostname.":110";
                             break;
-                        case "SSL":
-                            $hostname = $hostname.":995";
-                            break;
-                        case "TLS":
+                        case "ssl":
                             $hostname = $hostname.":995";
                             break;
                     }
@@ -153,13 +149,13 @@ class tokens extends Survey_Common_Action
 
             switch ($hostencryption) // novalidate-cert to have personal CA , maybe option.
             {
-                case "OFF":
+                case "off":
                     $flags .= "/notls"; // Really Off
                     break;
-                case "SSL":
+                case "ssl":
                     $flags .= "/ssl/novalidate-cert";
                     break;
-                case "TLS":
+                case "tls":
                     $flags .= "/tls/novalidate-cert";
                     break;
             }

--- a/application/views/admin/globalsettings/_bounce.php
+++ b/application/views/admin/globalsettings/_bounce.php
@@ -58,7 +58,7 @@
     <div class="">
         <?php $this->widget('yiiwheels.widgets.buttongroup.WhButtonGroup', array(
                 'name' => 'bounceencryption',
-                'value'=> getGlobalSetting('bounceencryption') ,
+                'value'=> strtolower(getGlobalSetting('bounceencryption')),
                 'selectOptions'=>array(
                 "off"=>gT("Off (insecure)",'unescaped'),
                 "ssl"=>"SSL/TLS",

--- a/application/views/admin/globalsettings/_bounce.php
+++ b/application/views/admin/globalsettings/_bounce.php
@@ -60,9 +60,9 @@
                 'name' => 'bounceencryption',
                 'value'=> getGlobalSetting('bounceencryption') ,
                 'selectOptions'=>array(
-                "off"=>gT("Off",'unescaped'),
-                "SSL"=>"SSL",
-                "TLS"=>"TLS"
+                "off"=>gT("Off (insecure)",'unescaped'),
+                "ssl"=>"SSL/TLS",
+                "tls"=>"StartTLS"
                 )
                 ));?>
     </div>

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -64,9 +64,9 @@
                     'name' => 'emailsmtpssl',
                     'value'=> getGlobalSetting('emailsmtpssl') ,
                     'selectOptions'=>array(
-                        ""=>gT("Off",'unescaped'),
-                        "ssl"=>gT("SSL",'unescaped'),
-                        "tls"=>gT("TLS",'unescaped')
+                        ""=>gT("Off (insecure)",'unescaped'),
+                        "ssl"=>gT("SSL/TLS",'unescaped'),
+                        "tls"=>gT("StartTLS",'unescaped')
                     )
                 ));?>
             </div>

--- a/application/views/admin/token/bounce.php
+++ b/application/views/admin/token/bounce.php
@@ -98,9 +98,9 @@
                                         'name' => 'bounceaccountencryption',
                                         'value'=> $settings['bounceaccountencryption'] ,
                                         'selectOptions'=>array(
-                                            "Off"=>gT("Off",'unescaped'),
-                                            "SSL"=>gT("SSL",'unescaped'),
-                                            "TLS"=>gT("TLS",'unescaped')
+                                            "off"=>gT("Off (insecure)",'unescaped'),
+                                            "ssl"=>gT("SSL/TLS",'unescaped'),
+                                            "tls"=>gT("StartTLS",'unescaped')
                                         )
                                     ));?>
                                 </div>

--- a/application/views/admin/token/bounce.php
+++ b/application/views/admin/token/bounce.php
@@ -96,7 +96,7 @@
                                 <div class="default controls">
                                     <?php $this->widget('yiiwheels.widgets.buttongroup.WhButtonGroup', array(
                                         'name' => 'bounceaccountencryption',
-                                        'value'=> $settings['bounceaccountencryption'] ,
+                                        'value'=> strtolower($settings['bounceaccountencryption']),
                                         'selectOptions'=>array(
                                             "off"=>gT("Off (insecure)",'unescaped'),
                                             "ssl"=>gT("SSL/TLS",'unescaped'),


### PR DESCRIPTION
Dev: As per imap_open() manual {hostname/ssl} could be actually both SSL or implicit TLS connection depending on PHP configuration/version, which almost always uses standard IMAPS/POP3S ports. And {hostname/tls} means that a client requires a server to allow STARTTLS which usually runs on the same port as plain text IMAP/POP3. Make sure we won't set wrong port here if an administrator didn't specify one.

Dev: The same goes for SMTP connection and PHPMailer library. If "tls" is specified the SMTPSecure option in the library initiates STARTTLS support not the implicit TLS connection, see https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php#L2024

Dev: While at it, inform administrators that not using SSL/TLS or StartTLS makes a connection very insecure.

Dev: Also, make values lowercase as most of their default options in the code are lowercase.

The fix should be compatible with LS3.x branch.