### PR TITLE
Dev: disable account type buttons if global configuration is used

### DIFF
--- a/assets/scripts/admin/tokenbounce.js
+++ b/assets/scripts/admin/tokenbounce.js
@@ -9,14 +9,14 @@ var LS = LS || {
 function updateParameters()
 {
 if ($('#bounceprocessing input:radio:checked').val()!='L'){
-        $("#bounceaccounttype label").attr('disabled','disabled');
+        $("#bounceaccounttype label").addClass('disabled');
         $("#bounceaccounthost").attr('disabled','disabled');
         $("#bounceaccountuser").attr('disabled','disabled');
         $("#bounceaccountpass").attr('disabled','disabled');
         $('#bounceaccountencryption label').addClass('disabled');
     }
     else {
-        $("#bounceaccounttype label").removeAttr('disabled');
+        $("#bounceaccounttype label").removeClass('disabled');
         $("#bounceaccounthost").removeAttr('disabled');
         $("#bounceaccountuser").removeAttr('disabled');
         $("#bounceaccountpass").removeAttr('disabled');

--- a/assets/scripts/admin/tokenbounce.js
+++ b/assets/scripts/admin/tokenbounce.js
@@ -9,14 +9,14 @@ var LS = LS || {
 function updateParameters()
 {
 if ($('#bounceprocessing input:radio:checked').val()!='L'){
-        $("#bounceaccounttype").attr('disabled','disabled');
+        $("#bounceaccounttype label").attr('disabled','disabled');
         $("#bounceaccounthost").attr('disabled','disabled');
         $("#bounceaccountuser").attr('disabled','disabled');
         $("#bounceaccountpass").attr('disabled','disabled');
         $('#bounceaccountencryption label').addClass('disabled');
     }
     else {
-        $("#bounceaccounttype").removeAttr('disabled');
+        $("#bounceaccounttype label").removeAttr('disabled');
         $("#bounceaccounthost").removeAttr('disabled');
         $("#bounceaccountuser").removeAttr('disabled');
         $("#bounceaccountpass").removeAttr('disabled');


### PR DESCRIPTION
Dev: It is still possible to click on the buttons, even though the labels are disabled, but at least this shows a clear indication to the user.