### PR TITLE
Fixed issue #16808: Dump while accesing statistics

### DIFF
--- a/application/controllers/admin/statistics.php
+++ b/application/controllers/admin/statistics.php
@@ -125,6 +125,7 @@ class statistics extends Survey_Common_Action
 
         // Set language for questions and answers to base language of this survey
         $aData['language']= $oSurvey->language;
+        $language = $oSurvey->language;
 
         //Call the javascript file
         App()->getClientScript()->registerScriptFile(App()->getConfig('adminscripts').'statistics.js', CClientScript::POS_BEGIN);


### PR DESCRIPTION
The '$language' variable in the 'run' method (statistics controller) was removed by the last commit, but it was still being used.
Solved by setting $language = $oSurvey->language;