### PR TITLE
DEV #16785: Revert VueJs Topbars II

### DIFF
--- a/application/controllers/admin/emailtemplates.php
+++ b/application/controllers/admin/emailtemplates.php
@@ -69,24 +69,16 @@ class emailtemplates extends Survey_Common_Action
             $aData['defaulttexts'][$key] = templateDefaultTexts($aData['bplangs'][$key], $sEscapeMode);
         }
 
-            $aData['sidemenu']['state'] = false;
-            $aData['title_bar']['title'] = $survey->currentLanguageSettings->surveyls_title." (".gT("ID").":".$iSurveyId.")";
-
-
-            $aData['surveybar']['savebutton']['form'] = 'frmeditgroup';
-            $aData['surveybar']['saveandclosebutton']['form'] = 'frmeditgroup';
-            $aData['topBar']['showSaveButton'] = true;
-            if (!Permission::model()->hasSurveyPermission($iSurveyId, 'surveylocale', 'update')) {
-                unset($aData['surveybar']['savebutton']);
-                unset($aData['surveybar']['saveandclosebutton']);
-                $aData['topBar']['showSaveButton'] = false;
-            }
-            $aData['surveybar']['closebutton']['url'] = 'surveyAdministration/view/surveyid/'.$iSurveyId; // Close button
+        $aData['sidemenu']['state'] = false;
+        $aData['title_bar']['title'] = $survey->currentLanguageSettings->surveyls_title." (".gT("ID").":".$iSurveyId.")";
 
         $aData['surveyid'] = $iSurveyId;
         $aData['subaction'] = gT("Edit email templates");
         $aData['ishtml'] = $ishtml;
         $aData['grplangs'] = $grplangs;
+
+        $aData['topBar']['name'] = 'baseTopbar_view';
+        $aData['topBar']['rightSideView'] = 'topbars/emailtemplatesTopbarRight_view';
         
         App()->getClientScript()->registerPackage('emailtemplates');
         App()->getClientScript()->registerPackage('expressionscript');

--- a/application/helpers/LayoutHelper.php
+++ b/application/helpers/LayoutHelper.php
@@ -452,6 +452,28 @@ class LayoutHelper
     }
 
     /**
+     * New Topbar
+     * @param $aData
+     */
+    public static function renderTopbar($aData) {
+
+        $aData['topBar'] = isset($aData['topBar']) ? $aData['topBar'] : [];
+        $aData['topBar'] = array_merge(
+            [
+                'name' => 'surveyTopbar_view',
+                'topbarId' => 'surveybarid',
+            ],
+            $aData['topBar']
+        );
+        if (!empty($aData['topBar']['leftSideView'])) $aData['topBar']['leftSideContent'] = App()->getController()->renderPartial($aData['topBar']['leftSideView'], $aData, true);
+        if (!empty($aData['topBar']['rightSideView'])) $aData['topBar']['rightSideContent'] = App()->getController()->renderPartial($aData['topBar']['rightSideView'], $aData, true);
+
+        Yii::app()->getClientScript()->registerPackage('admintoppanel');
+        return Yii::app()->getController()->renderPartial("/topbars/" . $aData['topBar']['name'], $aData['topBar'], true);
+    }
+
+    /**
+     * Vue Topbar
      * @param $aData
      */
     public function renderGeneraltopbar($aData) {

--- a/application/views/admin/emailtemplates/emailtemplates_view.php
+++ b/application/views/admin/emailtemplates/emailtemplates_view.php
@@ -10,7 +10,6 @@ $count=0;
 // DO NOT REMOVE This is for automated testing to validate we see that page
 echo viewHelper::getViewTestTag('surveyEmailTemplates');
 
-
 App()->getClientScript()->registerScript( "EmailTemplateViews_variables", "
 var sReplaceTextConfirmation='".gT("This will replace the existing text. Continue?","js")."';
 var sKCFinderLanguage='".sTranslateLangCode2CK(App()->language)."';

--- a/application/views/admin/super/layout_insurvey.php
+++ b/application/views/admin/super/layout_insurvey.php
@@ -35,10 +35,9 @@ $this->_showHeaders($aData, false);
         echo '<div '
         . 'class="ls-flex-column align-items-flex-start align-content-flex-start col-11 ls-flex-item transition-animate-width main-content-container" '
         . '>';
-            //New general top bar (VueComponent)
-            $this->_generaltopbar($aData);
 
             echo '<div id="pjax-content" class="col-12">';
+                echo LayoutHelper::renderTopbar($aData);
 
                 //Rendered through /admin/responses/browsemenubar_view
                 //$this->_browsemenubar($aData);
@@ -65,7 +64,6 @@ $this->_showHeaders($aData, false);
 
                     echo $content;
                     
-                    $this->_generaltopbarAdditions($aData);
                 echo "</div>\n";
             echo "</div>\n";
         echo "</div>\n";

--- a/application/views/admin/topbars/emailtemplatesTopbarRight_view.php
+++ b/application/views/admin/topbars/emailtemplatesTopbarRight_view.php
@@ -1,0 +1,7 @@
+<!-- Save -->
+<?php if(Permission::model()->hasSurveyPermission($surveyid, 'surveylocale', 'update')): ?>
+<a id="save-button" class="btn btn-success" role="button">
+    <i class="fa fa-floppy-o"></i>
+    <?php eT("Save");?>
+</a>
+<?php endif; ?>

--- a/application/views/layouts/layout_questioneditor.php
+++ b/application/views/layouts/layout_questioneditor.php
@@ -38,12 +38,10 @@ $layoutHelper->renderSurveySidemenu($aData);
 echo '<div '
     . 'class="ls-flex-column align-items-flex-start align-content-flex-start col-11 ls-flex-item transition-animate-width main-content-container" '
     . '>';
-//New general top bar (VueComponent)
-if (!isset($aData['renderSpecificTopbar'])) {
-    $layoutHelper->renderGeneraltopbar($aData);
-}
 
 echo '<div id="pjax-content" class="col-12">';
+
+echo LayoutHelper::renderTopbar($aData);
 
 echo '<div id="in_survey_common" '
     . 'class="container-fluid ls-flex-column fill col-12"'
@@ -55,10 +53,6 @@ $layoutHelper->notifications();
 
 echo $content;
 
-//$this->_generaltopbarAdditions($aData);
-if (!isset($aData['renderSpecificTopbar'])) {
-    $layoutHelper->renderGeneralTopbarAdditions($aData);
-}
 echo "</div>\n";
 echo "</div>\n";
 echo "</div>\n";

--- a/application/views/topbars/baseTopbar_view.php
+++ b/application/views/topbars/baseTopbar_view.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Base toolbar layout
+ *
+ * This is the base view for toolbars that have one part aligned to the left and one part aligned to the right
+ * 
+ * @var string $topbarId defaults to 'surveybarid'
+ * @var string $leftSideContent the left side content
+ * @var string $rightSideContent the right side content
+ * 
+ */
+?>
+
+<div class='menubar surveybar' id="<?= !(empty($topbarId)) ? $topbarId : 'surveybarid' ?>">
+    <div class='row container-fluid'>
+        <?php if (!empty($leftSideContent)): ?>
+            <!-- Left Side -->
+            <div class="<?= !empty($rightSideContent) ? 'col-md-8' : 'col-md-12'?>">
+                <?= $leftSideContent ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if (!empty($rightSideContent)): ?>
+            <!-- Right Side -->
+            <div class="<?= !empty($leftSideContent) ? 'col-md-4' : 'col-md-12'?> pull-right text-right">
+                <?= $rightSideContent ?>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/application/views/topbars/includes/surveyTopbarLeft_view.php
+++ b/application/views/topbars/includes/surveyTopbarLeft_view.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Left side buttons for general Survey Topbar
+ */
+?>
+Survey common buttons will be here!

--- a/application/views/topbars/surveyTopbar_view.php
+++ b/application/views/topbars/surveyTopbar_view.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * General Survey Topbar
+ *
+ * @var string $rightSide the optional right side content
+ * 
+ */
+
+$leftSideFixed = App()->getController()->renderPartial('/topbars/includes/surveyTopbarLeft_view', get_defined_vars(), true);
+
+App()->getController()->renderPartial(
+    '/topbars/baseTopbar_view',
+    [
+        'topbarId' => $topbarId,
+        'leftSideContent' => $leftSideFixed . (!empty($leftSideContent) ? $leftSideContent : ''),
+        'rightSideContent' => !empty($rightSideContent) ? $rightSideContent : '',
+    ]
+);
+?>
+


### PR DESCRIPTION
Integrated the new top bar system into the new controllers.
Needed a way for sharing topBars among views and also a general framework where to place common topBar parts (ease maintenance).

Key parts:
LayoutHelper:renderTopbar() called from layouts.
Base top bar with Left and Right side configurable.
Totally overridable if needed.
Implemented it for email templates.

WIP
Next step survey toolbar, which is shared among many screens.