### PR TITLE
Fixed issue: Allow to login if LDAP user's DN contains double quotes

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -524,7 +524,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
             // If specifed, check group membership
             if ($groupsearchbase != '' && $groupsearchfilter != '') {
                 $keywords = array('$username', '$userdn');
-                $substitutions = array($username, $userdn);
+                $substitutions = array($username, ldap_escape($userdn, "", LDAP_ESCAPE_FILTER));
                 $filter = str_replace($keywords, $substitutions, $groupsearchfilter);
                 $groupsearchres = ldap_search($ldapconn, $groupsearchbase, $filter);
                 $grouprescount = ldap_count_entries($ldapconn, $groupsearchres);


### PR DESCRIPTION
Dev: Patch fixes an issue where LDAP users with double quotes or other special characters in their DN could not login if a group filter is set.

Should be applied to LS3.x branch too.