### PR TITLE
Fixed issue #16776  question index marks pages with fully answered questions as unanswered

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6826,11 +6826,15 @@
                         }
                         // what about optional vs. mandatory comment and 'other' fields?
                         break;
+                    
                     case Question::QT_COLON_ARRAY_MULTI_FLEX_NUMBERS:
                         $anyUnanswered = false;
                         $qattr = isset($LEM->qattr[$qid]) ? $LEM->qattr[$qid] : array();
                         if (isset($qattr['multiflexible_checkbox']) && $qattr['multiflexible_checkbox'] == 1)
                         {
+                            // For Numeric Array question types with Checkbox layout, if is enough for mandatory, we flag it as answered. If not, we flag it as anunserwed. 
+                            // So we use the same logic as for reviewing mandatory violations.                       
+
                             // Need to check whether there is at least one checked box per row
                             foreach ($LEM->q2subqInfo[$qid]['subqs'] as $sq)
                             {
@@ -6857,10 +6861,7 @@
                         }
                         else
                         {
-                            if (count($unansweredSQs) > 0)
-                            {
-                                $anyUnanswered = true; // TODO - what about 'other'?
-                            }
+                            $anyUnanswered = (count($unansweredSQs) > 0);
                         }
                         break;
                     default:

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6826,6 +6826,43 @@
                         }
                         // what about optional vs. mandatory comment and 'other' fields?
                         break;
+                    case Question::QT_COLON_ARRAY_MULTI_FLEX_NUMBERS:
+                        $anyUnanswered = false;
+                        $qattr = isset($LEM->qattr[$qid]) ? $LEM->qattr[$qid] : array();
+                        if (isset($qattr['multiflexible_checkbox']) && $qattr['multiflexible_checkbox'] == 1)
+                        {
+                            // Need to check whether there is at least one checked box per row
+                            foreach ($LEM->q2subqInfo[$qid]['subqs'] as $sq)
+                            {
+                                if (!isset($_SESSION[$LEM->sessid]['relevanceStatus'][$sq['rowdivid']]) || $_SESSION[$LEM->sessid]['relevanceStatus'][$sq['rowdivid']])
+                                {
+                                    $rowCount=0;
+                                    $numUnanswered=0;
+                                    foreach ($sgqas as $s)
+                                    {
+                                        if (strpos($s, $sq['rowdivid']."_") !== false) // Test complete subquestion code (#09493)
+                                        {
+                                            ++$rowCount;
+                                            if (array_search($s,$unansweredSQs) !== false) {
+                                                ++$numUnanswered;
+                                            }
+                                        }
+                                    }
+                                    if ($rowCount > 0 && $rowCount == $numUnanswered)
+                                    {
+                                        $anyUnanswered = true;
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (count($unansweredSQs) > 0)
+                            {
+                                $anyUnanswered = true; // TODO - what about 'other'?
+                            }
+                        }
+                        break;
                     default:
                         $anyUnanswered = (count($unansweredSQs) > 0);
                         break;

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,4 +7,4 @@ Unit tests are tests that NOT use the Facebook webdriver or headless browser. Fu
 
 Functional tests are divided into back-end (survey administration) and front-end (survey taking) tests.
 
-Unit tests are divided into models, helpers, controllers, etc.
+Unit tests are divided into models, helpers, controllers, etc...


### PR DESCRIPTION
For Numeric Array question types with Checkbox layout, if is enough for mandatory, we flag it as answered. If not, we flag it as anunserwed.