### PR TITLE
Fixed issue #16733: When importing a theme bigger in size than the allowed php.ini settings, there is no proper description of the error

### DIFF
--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -131,17 +131,14 @@ class labels extends Survey_Common_Action
         $action = returnGlobal('action');
         $aViewUrls = array();
 
+        LSUploadHelper::checkUploadedFileSizeAndRedirect('the_file', App()->createUrl("/admin/labels/sa/newlabelset"));
+
         if ($action == 'importlabels') {
             Yii::app()->loadHelper('admin/import');
 
             $sFullFilepath = Yii::app()->getConfig('tempdir').DIRECTORY_SEPARATOR.randomChars(20);
             $aPathInfo = pathinfo($_FILES['the_file']['name']);
             $sExtension = !empty($aPathInfo['extension']) ? $aPathInfo['extension'] : '';
-
-            if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-                Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-                $this->getController()->redirect(App()->createUrl("/admin/labels/sa/newlabelset"));
-            }
 
             if (!@move_uploaded_file($_FILES['the_file']['tmp_name'], $sFullFilepath)) {
                 Yii::app()->setFlashMessage(gT("An error occurred uploading your file. This may be caused by incorrect permissions for the application /tmp folder."), 'error');

--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -765,6 +765,8 @@ $url .= "_view"; });
     {
         $this->checkPermission('import');
 
+        LSUploadHelper::checkUploadedFileSizeAndRedirect('the_file', array('admin/participants/sa/importCSV'));
+
         if ($_FILES['the_file']['name'] == '') {
             Yii::app()->setFlashMessage(gT('Please select a file to import!'), 'error');
             Yii::app()->getController()->redirect(array('admin/participants/sa/importCSV'));
@@ -774,11 +776,7 @@ $url .= "_view"; });
         $aPathinfo = pathinfo($_FILES['the_file']['name']);
         $sExtension = $aPathinfo['extension'];
         $bMoveFileResult = false;
-        if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-            Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-            Yii::app()->getController()->redirect(array('admin/participants/sa/importCSV'));
-            Yii::app()->end();
-        } elseif (strtolower($sExtension) == 'csv') {
+        if (strtolower($sExtension) == 'csv') {
             $bMoveFileResult = @move_uploaded_file($_FILES['the_file']['tmp_name'], $sFilePath);
             $filterblankemails = Yii::app()->request->getPost('filterbea');
         } else {

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1989,12 +1989,13 @@ class tokens extends Survey_Common_Action
             $aModelErrorList = array();
             $aFirstLine = array();
 
+            LSUploadHelper::checkUploadedFileSizeAndRedirect('the_file', App()->createUrl('admin/tokens', array('sa' => 'import', 'surveyid' => $iSurveyId)));
+
             $oFile = CUploadedFile::getInstanceByName("the_file");
             $sPath = Yii::app()->getConfig('tempdir');
             $sFileName = $sPath . '/' . randomChars(20);
-            if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-                Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-            } elseif (strtolower($oFile->getExtensionName()) != 'csv') {
+
+            if (strtolower($oFile->getExtensionName()) != 'csv') {
                 Yii::app()->setFlashMessage(gT("Only CSV files are allowed."), 'error');
             } elseif (!@$oFile->saveAs($sFileName)) {
                 Yii::app()->setFlashMessage(sprintf(gT("Upload file not found. Check your permissions and path (%s) for the upload directory"), $sPath), 'error');


### PR DESCRIPTION
Applying the patch to:
- CPDB (Import CSV)
- Labelset import
- Token import
- Question import (had to add 'action' and 'sid' to the URL)