### PR TITLE
Fixed issue #16656  uploading files in chrome corrupts the response and loses the uploaded file

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8929,6 +8929,13 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                                         // Check all possible file uploads
                                         for ($i = 0; $i < $iSize; $i++)
                                         {
+                                            // Decode html entities
+                                            $aFiles[$i]->title = html_entity_decode($aFiles[$i]->title, ENT_QUOTES);
+                                            $aFiles[$i]->comment = html_entity_decode($aFiles[$i]->comment, ENT_QUOTES);
+                                            $aFiles[$i]->name = html_entity_decode($aFiles[$i]->name, ENT_QUOTES);
+                                            $aFiles[$i]->filename = html_entity_decode($aFiles[$i]->filename, ENT_QUOTES);
+                                            $aFiles[$i]->ext = html_entity_decode($aFiles[$i]->ext, ENT_QUOTES);
+
                                             $aFiles[$i]->filename = get_absolute_path ($aFiles[$i]->filename) ;
                                             if (file_exists($tmp . $aFiles[$i]->filename))
                                             {
@@ -8943,6 +8950,13 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                                                 }
                                                 $aFiles[$i]->filename = $sDestinationFileName;
                                             }
+
+                                            // Re-encode html entities
+                                            $aFiles[$i]->title = htmlentities($aFiles[$i]->title, ENT_QUOTES);
+                                            $aFiles[$i]->comment = htmlentities($aFiles[$i]->comment, ENT_QUOTES);
+                                            $aFiles[$i]->name = htmlentities($aFiles[$i]->name, ENT_QUOTES);
+                                            $aFiles[$i]->filename = htmlentities($aFiles[$i]->filename, ENT_QUOTES);
+                                            $aFiles[$i]->ext = htmlentities($aFiles[$i]->ext, ENT_QUOTES);
                                         }
                                         $value = ls_json_encode($aFiles);  // so that EM doesn't try to parse it.
                                     }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5561,6 +5561,26 @@
                                 $val=NULL;
                             }
                             break;
+                        case '|': //FILE UPLOAD QUESTION
+                            if (!preg_match('/_filecount$/', $key))
+                            {
+                                $aFiles = json_decode($val);
+                                $iSize=@count($aFiles);
+                                if (!is_null($aFiles) && $iSize > 0)
+                                {
+                                    for ($i = 0; $i < $iSize; $i++)
+                                    {
+                                        // Decode html entities
+                                        $aFiles[$i]->title = html_entity_decode($aFiles[$i]->title, ENT_QUOTES);
+                                        $aFiles[$i]->comment = html_entity_decode($aFiles[$i]->comment, ENT_QUOTES);
+                                        $aFiles[$i]->name = html_entity_decode($aFiles[$i]->name, ENT_QUOTES);
+                                        $aFiles[$i]->filename = html_entity_decode($aFiles[$i]->filename, ENT_QUOTES);
+                                        $aFiles[$i]->ext = html_entity_decode($aFiles[$i]->ext, ENT_QUOTES);
+                                    }
+                                    $val = ls_json_encode($aFiles);
+                                }
+                            }
+                            break;
                         default:
                             // @todo : control length of DB string, if answers in single choice is valid too (for example) ?
                             break;
@@ -8952,11 +8972,11 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                                             }
 
                                             // Re-encode html entities
-                                            $aFiles[$i]->title = htmlentities($aFiles[$i]->title, ENT_QUOTES);
-                                            $aFiles[$i]->comment = htmlentities($aFiles[$i]->comment, ENT_QUOTES);
-                                            $aFiles[$i]->name = htmlentities($aFiles[$i]->name, ENT_QUOTES);
-                                            $aFiles[$i]->filename = htmlentities($aFiles[$i]->filename, ENT_QUOTES);
-                                            $aFiles[$i]->ext = htmlentities($aFiles[$i]->ext, ENT_QUOTES);
+                                            $aFiles[$i]->title = htmlentities($aFiles[$i]->title, ENT_QUOTES, null, false);
+                                            $aFiles[$i]->comment = htmlentities($aFiles[$i]->comment, ENT_QUOTES, null, false);
+                                            $aFiles[$i]->name = htmlentities($aFiles[$i]->name, ENT_QUOTES, null, false);
+                                            $aFiles[$i]->filename = htmlentities($aFiles[$i]->filename, ENT_QUOTES, null, false);
+                                            $aFiles[$i]->ext = htmlentities($aFiles[$i]->ext, ENT_QUOTES, null, false);
                                         }
                                         $value = ls_json_encode($aFiles);  // so that EM doesn't try to parse it.
                                     }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -117,6 +117,23 @@ function loadanswers()
                         // otherwise we would erase any answer with condition such as EQUALS-NO-ANSWER on such
                         // question types (NKD)
                         $_SESSION['survey_'.$surveyid][$column] = '';
+                    } elseif ($_SESSION['survey_'.$surveyid]['fieldmap'][$column]['type'] == '|' && !preg_match('/_filecount$/', $column)) {
+                        $aFiles = json_decode($value);
+                        $iSize=@count($aFiles);
+                        if (!is_null($aFiles) && $iSize > 0)
+                        {
+                            for ($i = 0; $i < $iSize; $i++)
+                            {
+                                // Encode html entities
+                                $aFiles[$i]->title = htmlentities($aFiles[$i]->title, ENT_QUOTES, null, false);
+                                $aFiles[$i]->comment = htmlentities($aFiles[$i]->comment, ENT_QUOTES, null, false);
+                                $aFiles[$i]->name = htmlentities($aFiles[$i]->name, ENT_QUOTES, null, false);
+                                $aFiles[$i]->filename = htmlentities($aFiles[$i]->filename, ENT_QUOTES, null, false);
+                                $aFiles[$i]->ext = htmlentities($aFiles[$i]->ext, ENT_QUOTES, null, false);
+                            }
+                            $value = ls_json_encode($aFiles);  // so that EM doesn't try to parse it.
+                            $_SESSION['survey_'.$surveyid][$column] = $value;
+                        }
                     } else {
                         $_SESSION['survey_'.$surveyid][$column] = $value;
                     }

--- a/assets/scripts/modaldialog.js
+++ b/assets/scripts/modaldialog.js
@@ -120,10 +120,10 @@ function displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show
                 display += '<tr><td class="upload placeholder"><div class="upload-placeholder" /></td>';
 
             if (show_title != 0)
-                display += '<td class="upload title">'+htmlspecialchars(jsonobj[i].title)+'</td>';
+                display += '<td class="upload title">'+htmlentities(jsonobj[i].title,null,null,false)+'</td>';
             if (show_comment != 0)
-                display += '<td class="upload comment">'+htmlspecialchars(jsonobj[i].comment)+'</td>';
-            display +='<td class="upload edit">'+htmlspecialchars(decodeURIComponent(jsonobj[i].name))+'</td><td>'+'<a class="btn btn-primary" onclick="javascript:upload_'+fieldname+'();$(\'#upload_'+fieldname+'\').click();"><span class="fa fa-pencil"></span>&nbsp;'+uploadLang.editFile+'</a></td></tr>';
+                display += '<td class="upload comment">'+htmlentities(jsonobj[i].comment,null,null,false)+'</td>';
+            display +='<td class="upload edit">'+htmlentities(decodeURIComponent(jsonobj[i].name),null,null,false)+'</td><td>'+'<a class="btn btn-primary" onclick="javascript:upload_'+fieldname+'();$(\'#upload_'+fieldname+'\').click();"><span class="fa fa-pencil"></span>&nbsp;'+uploadLang.editFile+'</a></td></tr>';
         }
         display += '</tbody></table>';
 

--- a/assets/scripts/uploader.js
+++ b/assets/scripts/uploader.js
@@ -55,7 +55,7 @@ function doFileUpload()
             else
                 previewblock += "<div class='upload-placeholder' />";
 
-            previewblock += "<span class='file-name'>" + escapeHtml(decodeURIComponent(json[i - 1].name)) + "</span>";
+            previewblock += "<span class='file-name'>" + htmlentities(decodeURIComponent(json[i - 1].name),null,null,false) + "</span>";
             previewblock += "</div>";
 
             previewblock += "<div class='file-info'><fieldset>";
@@ -63,11 +63,11 @@ function doFileUpload()
             {
                 if ($('#' + fieldname + '_show_title').val() == 1)
                 {
-                    previewblock += "<div class='form-group'><label class='control-label col-xs-4' for='" + fieldname + "_title_" + i + "'>" + uploadLang.titleFld + "</label>" + "<div class='input-container'><input class='form-control' type='text' value='" + escapeHtml(json[i - 1].title) + "' id='" + fieldname + "_title_" + i + "' /></div></div>";
+                    previewblock += "<div class='form-group'><label class='control-label col-xs-4' for='" + fieldname + "_title_" + i + "'>" + uploadLang.titleFld + "</label>" + "<div class='input-container'><input class='form-control' type='text' value='" + htmlentities(json[i - 1].title,null,null,false) + "' id='" + fieldname + "_title_" + i + "' /></div></div>";
                 }
                 if ($('#' + fieldname + '_show_comment').val() == 1)
                 {
-                    previewblock += "<div class='form-group'><label class='control-label col-xs-4' for='" + fieldname + "_comment_" + i + "'>" + uploadLang.commentFld + "</label>" + "<div class='input-container'><input class='form-control' type='text' value='" + escapeHtml(json[i - 1].comment) + "' id='" + fieldname + "_comment_" + i + "' /></div></div>";
+                    previewblock += "<div class='form-group'><label class='control-label col-xs-4' for='" + fieldname + "_comment_" + i + "'>" + uploadLang.commentFld + "</label>" + "<div class='input-container'><input class='form-control' type='text' value='" + htmlentities(json[i - 1].comment,null,null,false) + "' id='" + fieldname + "_comment_" + i + "' /></div></div>";
                 }
 
             }
@@ -75,10 +75,10 @@ function doFileUpload()
             previewblock += "</fieldset></div>";
 
             previewblock += "<input type='hidden' id='" + fieldname + "_size_" + i + "' value=" + json[i - 1].size + " />" +
-                "<input type='hidden' id='" + fieldname + "_name_" + i + "' value=" + json[i - 1].name + " />" +
+                "<input type='hidden' id='" + fieldname + "_name_" + i + "' value=" + htmlentities(json[i - 1].name,null,null,false) + " />" +
                 "<input type='hidden' id='" + fieldname + "_file_index_" + i + "' value=" + i + " />" +
-                "<input type='hidden' id='" + fieldname + "_filename_" + i + "' value=" + json[i - 1].filename + " />" +
-                "<input type='hidden' id='" + fieldname + "_ext_" + i + "' value=" + json[i - 1].ext + "  />";
+                "<input type='hidden' id='" + fieldname + "_filename_" + i + "' value=" + htmlentities(json[i - 1].filename,null,null,false) + " />" +
+                "<input type='hidden' id='" + fieldname + "_ext_" + i + "' value=" + htmlentities(json[i - 1].ext) + "  />";
 
             previewblock += "</li>";
 
@@ -274,13 +274,13 @@ function passJSON(fieldname, show_title, show_comment, pos)
             json += '{ ';
 
             if ($("#" + fieldname + "_show_title").val() == 1)
-                json += '"title":"' + $("#" + fieldname + "_title_" + i).val().replace(/"/g, '\\"') + '",';
+                json += '"title":"' + htmlentities($("#" + fieldname + "_title_" + i).val(),null,null,false) + '",';
             if ($("#" + fieldname + "_show_comment").val() == 1)
-                json += '"comment":"' + $("#" + fieldname + "_comment_" + i).val().replace(/"/g, '\\"') + '",';
+                json += '"comment":"' + htmlentities($("#" + fieldname + "_comment_" + i).val(),null,null,false) + '",';
             json += '"size":"' + $("#" + fieldname + "_size_" + i).val() + '",' +
-                '"name":"' + $("#" + fieldname + "_name_" + i).val() + '",' +
-                '"filename":"' + $("#" + fieldname + "_filename_" + i).val() + '",' +
-                '"ext":"' + $("#" + fieldname + "_ext_" + i).val() + '"}';
+                '"name":"' + htmlentities($("#" + fieldname + "_name_" + i).val(),null,null,false) + '",' +
+                '"filename":"' + htmlentities($("#" + fieldname + "_filename_" + i).val(),null,null,false) + '",' +
+                '"ext":"' + htmlentities($("#" + fieldname + "_ext_" + i).val(),null,null,false) + '"}';
 
             filecount += 1;
         }
@@ -376,4 +376,215 @@ function escapeHtml(unsafe)
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
         .replace(/'/g, "&#039;");
+}
+
+function htmlentities (string, quote_style, charset, double_encode) {
+    // Convert all applicable characters to HTML entities
+    //
+    // version: 1107.2516
+    // discuss at: http://phpjs.org/functions/htmlentities
+    // +   original by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // +    revised by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // +   improved by: nobbler
+    // +    tweaked by: Jack
+    // +   bugfixed by: Onno Marsman
+    // +    revised by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // +    bugfixed by: Brett Zamir (http://brett-zamir.me)
+    // +      input by: Ratheous
+    // +   improved by: Rafał Kukawski (http://blog.kukawski.pl)
+    // -    depends on: get_html_translation_table
+    // *     example 1: htmlentities('Kevin & van Zonneveld');
+    // *     returns 1: 'Kevin &amp; van Zonneveld'
+    // *     example 2: htmlentities("foo'bar","ENT_QUOTES");
+    // *     returns 2: 'foo&#039;bar'
+    var hash_map = {},
+        symbol = '',
+        entity = '',
+        self = this;
+    string += '';
+    double_encode = !!double_encode || double_encode == null;
+
+    if (false === (hash_map = this.get_html_translation_table('HTML_ENTITIES', quote_style))) {
+        return false;
+    }
+    hash_map["'"] = '&#039;';
+
+    if (double_encode) {
+        for (symbol in hash_map) {
+            entity = hash_map[symbol];
+            string = string.split(symbol).join(entity);
+        }
+    } else {
+        string = string.replace(/([\s\S]*?)(&(?:#\d+|#x[\da-f]+|[a-z][\da-z]*);|$)/g, function (ignore, text, entity) {
+            return self.htmlentities(text, quote_style, charset) + entity;
+        });
+    }
+
+    return string;
+}
+
+function get_html_translation_table (table, quote_style) {
+    // Returns the internal translation table used by htmlspecialchars and htmlentities
+    //
+    // version: 1107.2516
+    // discuss at: http://phpjs.org/functions/get_html_translation_table
+    // +   original by: Philip Peterson
+    // +    revised by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // +   bugfixed by: noname
+    // +   bugfixed by: Alex
+    // +   bugfixed by: Marco
+    // +   bugfixed by: madipta
+    // +   improved by: KELAN
+    // +   improved by: Brett Zamir (http://brett-zamir.me)
+    // +   bugfixed by: Brett Zamir (http://brett-zamir.me)
+    // +      input by: Frank Forte
+    // +   bugfixed by: T.Wild
+    // +      input by: Ratheous
+    // %          note: It has been decided that we're not going to add global
+    // %          note: dependencies to php.js, meaning the constants are not
+    // %          note: real constants, but strings instead. Integers are also supported if someone
+    // %          note: chooses to create the constants themselves.
+    // *     example 1: get_html_translation_table('HTML_SPECIALCHARS');
+    // *     returns 1: {'"': '&quot;', '&': '&amp;', '<': '&lt;', '>': '&gt;'}
+    var entities = {},
+        hash_map = {},
+        decimal = 0,
+        symbol = '';
+    var constMappingTable = {},
+        constMappingQuoteStyle = {};
+    var useTable = {},
+        useQuoteStyle = {};
+
+    // Translate arguments
+    constMappingTable[0] = 'HTML_SPECIALCHARS';
+    constMappingTable[1] = 'HTML_ENTITIES';
+    constMappingQuoteStyle[0] = 'ENT_NOQUOTES';
+    constMappingQuoteStyle[2] = 'ENT_COMPAT';
+    constMappingQuoteStyle[3] = 'ENT_QUOTES';
+
+    useTable = !isNaN(table) ? constMappingTable[table] : table ? table.toUpperCase() : 'HTML_SPECIALCHARS';
+    useQuoteStyle = !isNaN(quote_style) ? constMappingQuoteStyle[quote_style] : quote_style ? quote_style.toUpperCase() : 'ENT_COMPAT';
+
+    if (useTable !== 'HTML_SPECIALCHARS' && useTable !== 'HTML_ENTITIES') {
+        throw new Error("Table: " + useTable + ' not supported');
+        // return false;
+    }
+
+    entities['38'] = '&amp;';
+    if (useTable === 'HTML_ENTITIES') {
+        entities['160'] = '&nbsp;';
+        entities['161'] = '&iexcl;';
+        entities['162'] = '&cent;';
+        entities['163'] = '&pound;';
+        entities['164'] = '&curren;';
+        entities['165'] = '&yen;';
+        entities['166'] = '&brvbar;';
+        entities['167'] = '&sect;';
+        entities['168'] = '&uml;';
+        entities['169'] = '&copy;';
+        entities['170'] = '&ordf;';
+        entities['171'] = '&laquo;';
+        entities['172'] = '&not;';
+        entities['173'] = '&shy;';
+        entities['174'] = '&reg;';
+        entities['175'] = '&macr;';
+        entities['176'] = '&deg;';
+        entities['177'] = '&plusmn;';
+        entities['178'] = '&sup2;';
+        entities['179'] = '&sup3;';
+        entities['180'] = '&acute;';
+        entities['181'] = '&micro;';
+        entities['182'] = '&para;';
+        entities['183'] = '&middot;';
+        entities['184'] = '&cedil;';
+        entities['185'] = '&sup1;';
+        entities['186'] = '&ordm;';
+        entities['187'] = '&raquo;';
+        entities['188'] = '&frac14;';
+        entities['189'] = '&frac12;';
+        entities['190'] = '&frac34;';
+        entities['191'] = '&iquest;';
+        entities['192'] = '&Agrave;';
+        entities['193'] = '&Aacute;';
+        entities['194'] = '&Acirc;';
+        entities['195'] = '&Atilde;';
+        entities['196'] = '&Auml;';
+        entities['197'] = '&Aring;';
+        entities['198'] = '&AElig;';
+        entities['199'] = '&Ccedil;';
+        entities['200'] = '&Egrave;';
+        entities['201'] = '&Eacute;';
+        entities['202'] = '&Ecirc;';
+        entities['203'] = '&Euml;';
+        entities['204'] = '&Igrave;';
+        entities['205'] = '&Iacute;';
+        entities['206'] = '&Icirc;';
+        entities['207'] = '&Iuml;';
+        entities['208'] = '&ETH;';
+        entities['209'] = '&Ntilde;';
+        entities['210'] = '&Ograve;';
+        entities['211'] = '&Oacute;';
+        entities['212'] = '&Ocirc;';
+        entities['213'] = '&Otilde;';
+        entities['214'] = '&Ouml;';
+        entities['215'] = '&times;';
+        entities['216'] = '&Oslash;';
+        entities['217'] = '&Ugrave;';
+        entities['218'] = '&Uacute;';
+        entities['219'] = '&Ucirc;';
+        entities['220'] = '&Uuml;';
+        entities['221'] = '&Yacute;';
+        entities['222'] = '&THORN;';
+        entities['223'] = '&szlig;';
+        entities['224'] = '&agrave;';
+        entities['225'] = '&aacute;';
+        entities['226'] = '&acirc;';
+        entities['227'] = '&atilde;';
+        entities['228'] = '&auml;';
+        entities['229'] = '&aring;';
+        entities['230'] = '&aelig;';
+        entities['231'] = '&ccedil;';
+        entities['232'] = '&egrave;';
+        entities['233'] = '&eacute;';
+        entities['234'] = '&ecirc;';
+        entities['235'] = '&euml;';
+        entities['236'] = '&igrave;';
+        entities['237'] = '&iacute;';
+        entities['238'] = '&icirc;';
+        entities['239'] = '&iuml;';
+        entities['240'] = '&eth;';
+        entities['241'] = '&ntilde;';
+        entities['242'] = '&ograve;';
+        entities['243'] = '&oacute;';
+        entities['244'] = '&ocirc;';
+        entities['245'] = '&otilde;';
+        entities['246'] = '&ouml;';
+        entities['247'] = '&divide;';
+        entities['248'] = '&oslash;';
+        entities['249'] = '&ugrave;';
+        entities['250'] = '&uacute;';
+        entities['251'] = '&ucirc;';
+        entities['252'] = '&uuml;';
+        entities['253'] = '&yacute;';
+        entities['254'] = '&thorn;';
+        entities['255'] = '&yuml;';
+    }
+
+    if (useQuoteStyle !== 'ENT_NOQUOTES') {
+        entities['34'] = '&quot;';
+    }
+    if (useQuoteStyle === 'ENT_QUOTES') {
+        entities['39'] = '&#39;';
+    }
+    entities['60'] = '&lt;';
+    entities['62'] = '&gt;';
+
+
+    // ascii decimals to real symbols
+    for (decimal in entities) {
+        symbol = String.fromCharCode(decimal);
+        hash_map[symbol] = entities[decimal];
+    }
+
+    return hash_map;
 }


### PR DESCRIPTION
Encoding the upload attributes for handling and rendering in the survey participant taking process.
Saving them raw, not encoded, as to comply with the scripts which already read the DB and expect the data that way.

Still, probably, there might be a few places where adapting may be needed.
