### PR TITLE
Fixed issue #16749: Make sure Vanilla and Bootswatch look like Fruity

### DIFF
--- a/themes/survey/vanilla/config.xml
+++ b/themes/survey/vanilla/config.xml
@@ -89,6 +89,9 @@
 
     <!-- Here datas about how LimeSurvey should load the theme -->
     <engine>
+        <!-- core: use core options view file, custom: use customized options.twig view file -->
+        <optionspage>core</optionspage>
+
         <!-- If empty, bootstrap css/js files will not be loaded. In the future, we may have more engines, like foundation -->
         <cssframework>
             <name>bootstrap</name>


### PR DESCRIPTION
BootsWatch already works like Fruity.
Added options page entry to Vanilla's config to enable the core options page. Tested with basic settings and seems to work OK.
Also, themes that extended Vanilla before and after the change work too.