### PR TITLE
Fixed issue #16670: Extended theme shows all options in one page

### DIFF
--- a/application/models/TemplateManifest.php
+++ b/application/models/TemplateManifest.php
@@ -892,7 +892,7 @@ class TemplateManifest extends TemplateConfiguration
     }
 
     /**
-     * Delete files and engine node inside the DOM
+     * Delete engine node inside the DOM, except the optionspage configuration
      *
      * @param DOMDocument   $oNewManifest  The DOMDOcument of the manifest
      */
@@ -903,12 +903,15 @@ class TemplateManifest extends TemplateConfiguration
         // Then we delete the nodes that should be inherit
         $aNodesToDelete     = array();
         //$aNodesToDelete[]   = $oConfig->getElementsByTagName('files')->item(0);
-        $aNodesToDelete[]   = $oConfig->getElementsByTagName('engine')->item(0);
+
+        $oEngine            = $oConfig->getElementsByTagName('engine')->item(0);
+        $aNodesToDelete[]   = $oEngine->childNodes;
 
         foreach ($aNodesToDelete as $node) {
             // If extended template already extend another template, it will not have those nodes
-            if (is_a($node, 'DOMNode')) {
-                $oConfig->removeChild($node);
+            // Don't remove 'optionspage' node
+            if (is_a($node, 'DOMNode') && $node->nodeName != 'optionspage') {
+                $oEngine->removeChild($node);
             }
         }
     }


### PR DESCRIPTION
When the theme config is copied, the engine node is removed (apparently it caused issues before).
Since the optionspage config is inside the engine node, it's removed from the extended theme config, and then the options.twig is used.
One option is to move the optionspage out of the engine node, so it's not removed.
Other option is to remove the engine node contents EXCEPT optionspage, instead of the whole engine node. This option seems easier and it was the one implemented.