### PR TITLE
Fixed issue # 16824: Quota : Back to the previous page, one click is not recognized, you need to click again

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1722,7 +1722,7 @@ function checkCompletedQuota($surveyid, $return = false)
             // Answers are the same in quota + an answer is submitted at this time (bPostedField)
             //  OR all questions is hidden (bAllHidden)
             $bAllHidden = QuestionAttribute::model()
-                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute', array(':attribute'=>'hidden')) == count($aQuotaQid);
+                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute AND value=:value', array(':attribute'=>'hidden',':value'=>1)) == count($aQuotaQid);
 
             if ($iMatchedAnswers == count($aQuotaFields) && ($bPostedField || $bAllHidden)) {
                 if ($oQuota->qlimit == 0) {


### PR DESCRIPTION
In LS3, the 'hidden' attribute is only stored if it's set to 1. But, in LS4, the attribute is always in the table (set to 0 by default).
Since the code was not checking for the value, $bAllHidden was always 'true' in LS4.