### PR TITLE
Fixed issue #16854: Cannot attach PDF to email invitation (email template for surveys)

### DIFF
--- a/application/controllers/admin/emailtemplates.php
+++ b/application/controllers/admin/emailtemplates.php
@@ -147,7 +147,7 @@ class emailtemplates extends Survey_Common_Action
                 );
 
                 $aLanguageSetting = SurveyLanguageSetting::model()->find('surveyls_survey_id = :ssid AND surveyls_language = :sl', array(':ssid' => $iSurveyId, ':sl' => $langname));
-                $aLanguageSetting->setAttributes($attributes, false);
+                $aLanguageSetting->setAttributes($attributes);
                 if (!$aLanguageSetting->save()){
                     $sErrors = '<br/>';
                     foreach ($aLanguageSetting->getErrors() as $sError) {

--- a/application/controllers/admin/emailtemplates.php
+++ b/application/controllers/admin/emailtemplates.php
@@ -147,7 +147,7 @@ class emailtemplates extends Survey_Common_Action
                 );
 
                 $aLanguageSetting = SurveyLanguageSetting::model()->find('surveyls_survey_id = :ssid AND surveyls_language = :sl', array(':ssid' => $iSurveyId, ':sl' => $langname));
-                $aLanguageSetting->setAttributes($attributes);
+                $aLanguageSetting->setAttributes($attributes, false);
                 if (!$aLanguageSetting->save()){
                     $sErrors = '<br/>';
                     foreach ($aLanguageSetting->getErrors() as $sError) {

--- a/application/models/SurveyLanguageSetting.php
+++ b/application/models/SurveyLanguageSetting.php
@@ -135,6 +135,8 @@ class SurveyLanguageSetting extends LSActiveRecord
 
             array('surveyls_dateformat', 'numerical', 'integerOnly'=>true, 'min'=>'1', 'max'=>'12', 'allowEmpty'=>true),
             array('surveyls_numberformat', 'numerical', 'integerOnly'=>true, 'min'=>'0', 'max'=>'1', 'allowEmpty'=>true),
+
+            array('attachments', 'attachmentsInfo'),
         );
     }
 
@@ -183,6 +185,30 @@ class SurveyLanguageSetting extends LSActiveRecord
         }
     }
 
+    /**
+     * Defines the customs validation rule attachmentsInfo
+     *
+     * @param mixed $attribute
+     */
+    public function attachmentsInfo($attribute)
+    {
+        if (empty($this->$attribute)) return;
+
+        $value = [];
+        $attachmentsByType = unserialize($this->$attribute);
+        if (is_array($attachmentsByType)) {
+            foreach ($attachmentsByType as $type => $attachments) {
+                if (is_array($attachments)) {
+                    foreach ($attachments as $key => $attachment) {
+                        if (isset($attachment['url']) && isset($attachment['size']) && isset($attachment['relevance'])) {
+                            $value[$type][$key] = $attachment;
+                        }
+                    }
+                }
+            }
+        }
+        return serialize($value);
+    }
 
     /**
      * Returns the token's captions


### PR DESCRIPTION
Previously, at emailtemplates controller's 'update' method, the settings were saved directly using updateAll. After commit '2c8ccdd5', in order to apply the model's validation, the settings are saved using 'setAttributes($attributes)' and 'save()'.
The setAttributes method, by default, only assigns 'safe' attributes (attributes that have a validation rule). That excludes the 'attachments' attribute.
Passing 'false' as second parameter solves the issue.