### PR TITLE
Fixed issue #16849: Question radio button with Question Theme "Bootstrap Buttons" does not keep value in "Other" field

### DIFF
--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/assets/scripts/bootstrapbuttons.js
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/assets/scripts/bootstrapbuttons.js
@@ -1,12 +1,25 @@
 function doBootstrapRadio(){
-    $(".button-item .bootstrap-radio").change(function(){
-        name = $(this).attr('name');
-        // conditionaly show or hide "other" input field
-        if ($(this).val() === '-oth-'){
-            $("#div" + name + "other").removeClass('ls-js-hidden');
-        } else {
-            $("#div" + name + "other").addClass('ls-js-hidden');
-            $("#answer" + name + "othertext").val('').trigger("change");
-        }
+    $(document).off('ready.bbothersetup').on('ready.bbothersetup', function() {
+
+        // Setup the change event for bootstrap button's "other" option
+        $(".button-item .bootstrap-radio").on('change.bbother', function() {
+            name = $(this).attr('name');
+            // conditionaly show or hide "other" input field
+            if ($(this).val() === '-oth-') {
+                var value =  $("#answer" + name + "othertextaux").val();
+                $("#div" + name + "other").removeClass('ls-js-hidden');
+                $("#answer" + name + "othertext").val(value).trigger("change");
+            } else {
+                $("#div" + name + "other").addClass('ls-js-hidden');
+                $("#answer" + name + "othertext").val('').trigger("change");
+                $("#answer" + name + "othertextaux").val('');
+            }
+        });
+
+        // Trigger the change event for the checked bootstrap buttons
+        $(".button-item .bootstrap-radio:checked").trigger("change");
+
+        // Unbind this setup event
+        $(document).off('ready.bbothersetup');
     });
 }

--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_other.twig
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_other.twig
@@ -34,6 +34,11 @@
         <label for="answer{{ name }}othercbox">
             {{ gT('Other') }}
         </label>
+        <input
+        type="hidden"
+        id="answer{{ name }}othertextaux"
+        {{ answer_other }}
+        >
     </div>
 </div>
 <script>doBootstrapRadio();</script>


### PR DESCRIPTION
There were two problems:
1) The 'other' answer value from the DB was never used by the theme to feed it into the screen ($answer_other was not used in answer_row_other.twig).
2) The show/hide code is part of the radio's 'change' event, which was only trigger on an actual change, not initially to setup the screen

An additional problem is that, in this theme, the 'other' input control is outside the scope of answer_row_other.twig, so the value cannot be directly assigned when rendering. Instead, a hidden input had to be added to hold the value until it can be transfered by javascript to the actual control.

At last, as the doBootstrapRadio is called multiple times (once per question in the screen), the event assignment happens multiple times as well.