### PR TITLE
Fixed issue #16894: Not possible to batch-edit owners for Central Participant database

### DIFF
--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -673,7 +673,7 @@ class participantsaction extends Survey_Common_Action
             $aResults['global']['message'] = gT('Nothing to update');
         }
 
-        Yii::app()->getController()->renderPartial('/admin/surveymenu/massive_action/_update_results', array('aResults' => $aResults));
+        Yii::app()->getController()->renderPartial('/admin/participants/massive_actions/_update_results', array('aResults' => $aResults));
     }
 
     /**

--- a/application/models/Participant.php
+++ b/application/models/Participant.php
@@ -2237,8 +2237,7 @@ class Participant extends LSActiveRecord
     }
     public function getOwnerOptions()
     {
-
-        return [];
+        return CHtml::listData(User::model()->findAll(),'uid','full_name');
     }
 
     /**

--- a/application/views/admin/participants/massive_actions/_update.php
+++ b/application/views/admin/participants/massive_actions/_update.php
@@ -34,7 +34,7 @@
                 </div>
                 <label class="col-sm-3 control-label"  for='owner_uid'><?php eT("Owner?"); ?></label>
                 <div class="col-sm-8">
-                    <?php echo TbHtml::dropDownList('owner_uid', 'lskeep', array_merge(['lskeep' => gT('Keep old value')], $model->getOwnerOptions()), ['disabled'=>'disabled','class'=>'custom-data selector_submitField'] );?>
+                    <?php echo TbHtml::dropDownList('owner_uid', 'lskeep', ['lskeep' => gT('Keep old value')] + $model->getOwnerOptions(), ['disabled'=>'disabled','class'=>'custom-data selector_submitField'] );?>
                 </div>
             </div>
         <?php } ?>

--- a/application/views/admin/participants/massive_actions/_update_results.php
+++ b/application/views/admin/participants/massive_actions/_update_results.php
@@ -14,7 +14,7 @@
     <?php unset($aResults['global']); ?>
     <table class="table table-striped">
         <thead>
-            <th><?php eT('Survey menu entry ID');?></th>
+            <th><?php eT('Participant ID');?></th>
             <th><?php eT('Status');?></th>
         </thead>
         <tbody>


### PR DESCRIPTION
The Participant::getOwnerOptions() method was fixed to return an empty list.
Also fixed some UI bugs