### PR TITLE
Fixed issue #16898: Pop Up Editor does not work inside the Question Editor

### DIFF
--- a/application/views/questionAdministration/answerOptionRow.twig
+++ b/application/views/questionAdministration/answerOptionRow.twig
@@ -117,7 +117,7 @@
             <span class="input-group-addon">
                 {{ getEditor(
                     "editanswer",
-                    "answer_"~language~"_"~question.qid~"_"~scale_id,
+                    "answeroptions["~answerOption.aid~"]["~scale_id~"][answeroptionl10n]["~language~"]",
                     "["~gT("Answer option:", "js")~"]("~language~")",
                     question.sid,
                     question.gid,

--- a/application/views/questionAdministration/subquestionRow.twig
+++ b/application/views/questionAdministration/subquestionRow.twig
@@ -101,11 +101,11 @@
             <span class="input-group-addon">
                 {{ getEditor(
                     "editanswer",
-                    "subquestion_"~language~"_"~subquestion.qid~"_"~scale_id,
+                    "subquestions["~subquestion.qid~"]["~scale_id~"][subquestionl10n]["~language~"]",
                     "["~gT("Subquestion:", "js")~"]("~language~")",
                     subquestion.sid,
                     gid,
-                    subquestion.qid,
+                    (subquestion.qid matches '/^\\d+$/') ? subquestion.qid : "",
                     'editanswer'
                 ) }}
             </span>

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -91,9 +91,12 @@ $(document).on('ready pjax:scriptcomplete', function () {
    * @return {void}
    */
   function updateRowProperties() {
-    const sID = $('input[name=sid]').val();
-    const gID = $('input[name=gid]').val();
-    const qID = $('input[name=qid]').val();
+    var sID = $('input[name=sid]').val();
+    var gID = $('input[name=gid]').val();
+    var qID = $('input[name=qid]').val();
+    sID = $.isNumeric(sID) ? sID : '';
+    gID = $.isNumeric(gID) ? gID : '';
+    qID = $.isNumeric(qID) ? qID : '';
 
     /**
      * This function adjusts the alternating table rows
@@ -130,17 +133,22 @@ $(document).on('ready pjax:scriptcomplete', function () {
         updateIfEmpty($(this).find('.assessment'), 'id', `assessment_${uniqueRowId}_${scaleId}`);
         updateIfEmpty($(this).find('.assessment'), 'name', `assessment_${uniqueRowId}_${scaleId}`);
         // Newly inserted row editor button
-        $(this).find('.editorLink').attr(
-          'href',
-          `javascript:start_popup_editor(
-            'answer_${language}_${uniqueRowId}_${scaleId}','[Answer:](${language})','${sID}','${gID}','${qID}','editanswer','editanswer'
-          )`
-        );
-        $(this).find('.editorLink').attr('id', `answer_${language}_${uniqueRowId}_${scaleId}_ctrl`);
-        $(this).find('.btneditanswerena').attr('id', `answer_${language}_${uniqueRowId}_${scaleId}_popupctrlena`);
-        $(this).find('.btneditanswerena').attr('name', `answer_${language}_${uniqueRowId}_${scaleId}_popupctrlena`);
-        $(this).find('.btneditanswerdis').attr('id', `answer_${language}_${uniqueRowId}_${scaleId}_popupctrldis`);
-        $(this).find('.btneditanswerdis').attr('name', `answer_${language}_${uniqueRowId}_${scaleId}_popupctrldis`);
+        $(this).find('.editorLink').each(function( index ) {
+          var inputName = $(this).closest('.input-group').find('input[type=text]').first().attr('name');
+          if (inputName) {
+            $(this).attr(
+              'href',
+              `javascript:start_popup_editor(
+                '${inputName}','[Answer:](${language})','${sID}','${gID}','${qID}','editanswer','editanswer'
+              )`
+            );
+            $(this).attr('id', `${inputName}_ctrl`);
+            $(this).find('.btneditanswerena').attr('id', `${inputName}_popupctrlena`);
+            $(this).find('.btneditanswerena').attr('name', `${inputName}_popupctrlena`);
+            $(this).find('.btneditanswerdis').attr('id', `${inputName}_popupctrldis`);
+            $(this).find('.btneditanswerdis').attr('name', `${inputName}_popupctrldis`);
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
There were issues with the triggering of the popup editor, both for answers and for subquestions.
These were mainly related to the identification of the target field, and also the values of SID, GID and QID passed to the editor.
Some problems originated in the twigs, but the updateRowProperties() method (questionEditor.js) was also causing problems.
