### PR TITLE
Fixed issue #16764: Language changer displays languages in current language instead of native language

### DIFF
--- a/themes/survey/vanilla/views/subviews/navigation/language_changer_top_menu.twig
+++ b/themes/survey/vanilla/views/subviews/navigation/language_changer_top_menu.twig
@@ -42,7 +42,7 @@
             {% for value, lang in aLCD.aListLang %}
                 <li class="{{ aSurveyInfo.class.lctdropdownli }}" {{ aSurveyInfo.attr.lctdropdownli }}>
                     <a href='#' data-limesurvey-lang='{{ value }}' class="{{ aSurveyInfo.class.lctdropdownlia }} animate" {{ aSurveyInfo.attr.lctdropdownlia }}>
-                        {{gT( lang )}}
+                        {{lang}}
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
Fixed issue #16764: Language changer displays languages in current language instead of native language