### PR TITLE
Fixed issue #16909: Slow loading when the questionnaire has a large number of quotas (500+)

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1722,7 +1722,7 @@ function checkCompletedQuota($surveyid, $return = false)
             // Answers are the same in quota + an answer is submitted at this time (bPostedField)
             //  OR all questions is hidden (bAllHidden)
             $bAllHidden = QuestionAttribute::model()
-                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute AND value=:value', array(':attribute'=>'hidden',':value'=>1)) == count($aQuotaQid);
+                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute AND value=:value', array(':attribute'=>'hidden',':value'=>1)) <= count($aQuotaQid);
 
             if ($iMatchedAnswers == count($aQuotaFields) && ($bPostedField || $bAllHidden)) {
                 if ($oQuota->qlimit == 0) {

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1667,7 +1667,7 @@ function checkCompletedQuota($surveyid, $return = false)
     if (!$aMatchedQuotas) {
         $aMatchedQuotas = array();
         /** @var Quota[] $aQuotas */
-        $aQuotas = Quota::model()->findAllByAttributes(array('sid' => $surveyid));
+        $aQuotas = Quota::model()->with('languagesettings', 'quotaMembers.question')->findAllByAttributes(array('sid' => $surveyid));
         // if(!$aQuotasInfo || empty($aQuotaInfos)) {
         if (!$aQuotas || empty($aQuotas)) {
             return $aMatchedQuotas;

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1722,7 +1722,7 @@ function checkCompletedQuota($surveyid, $return = false)
             // Answers are the same in quota + an answer is submitted at this time (bPostedField)
             //  OR all questions is hidden (bAllHidden)
             $bAllHidden = QuestionAttribute::model()
-                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute AND value=:value', array(':attribute'=>'hidden',':value'=>1)) <= count($aQuotaQid);
+                ->countByAttributes(array('qid'=>$aQuotaQid), 'attribute=:attribute AND value=:value', array(':attribute'=>'hidden',':value'=>1)) == count($aQuotaQid);
 
             if ($iMatchedAnswers == count($aQuotaFields) && ($bPostedField || $bAllHidden)) {
                 if ($oQuota->qlimit == 0) {


### PR DESCRIPTION
Slow loading when the questionnaire has a large quotas 500+
Fixed issue #16909:
