### PR TITLE
Skip check for deprecated MySQL options

### DIFF
--- a/application/models/InstallerConfigForm.php
+++ b/application/models/InstallerConfigForm.php
@@ -274,8 +274,8 @@ class InstallerConfigForm extends CFormModel
             $mariadb = preg_match('/MariaDB/i', $this->getMySqlConfigValue('version'));
             $match = preg_match('/^\d+\.\d+\.\d+/', $this->getMySqlConfigValue('version'), $version);
             if (!$match
-                    || ($mariadb && version_compare($version[0], '10.2.0') < 0)
-                    || (!$mariadb && version_compare($version[0], '5.7.0') <= 0)) {
+                    || (!$mariadb && version_compare($version[0], '5.7.0') <= 0)
+                    || ($mariadb && version_compare($version[0], '10.2.0') < 0)) {
                 // Only for older db-engine
                 if (!$this->isInnoDbLargeFilePrefixEnabled()) {
                     $this->addError($attribute, gT('You need to enable large_file_prefix setting in your database configuration in order to use InnoDB engine for LimeSurvey!'));

--- a/application/models/InstallerConfigForm.php
+++ b/application/models/InstallerConfigForm.php
@@ -271,11 +271,18 @@ class InstallerConfigForm extends CFormModel
         }
 
         if ($this->isMysql && $this->dbengine === self::ENGINE_TYPE_INNODB) {
-            if (!$this->isInnoDbLargeFilePrefixEnabled()) {
-                $this->addError($attribute, gT('You need to enable large_file_prefix setting in your database configuration in order to use InnoDB engine for LimeSurvey!'));
-            }
-            if (!$this->isInnoDbBarracudaFileFormat()) {
-                $this->addError($attribute, gT('Your database configuration needs to have innodb_file_format and innodb_file_format_max set to use the Barracuda format in order to use InnoDB engine for LimeSurvey!'));
+            $mariadb = preg_match('/MariaDB/i', $this->getMySqlConfigValue('version'));
+            $match = preg_match('/^\d+\.\d+\.\d+/', $this->getMySqlConfigValue('version'), $version);
+            if (!$match
+                    || ($mariadb && version_compare($version[0], '10.2.0') < 0)
+                    || (!$mariadb && version_compare($version[0], '5.7.0') <= 0)) {
+                // Only for older db-engine
+                if (!$this->isInnoDbLargeFilePrefixEnabled()) {
+                    $this->addError($attribute, gT('You need to enable large_file_prefix setting in your database configuration in order to use InnoDB engine for LimeSurvey!'));
+                }
+                if (!$this->isInnoDbBarracudaFileFormat()) {
+                    $this->addError($attribute, gT('Your database configuration needs to have innodb_file_format and innodb_file_format_max set to use the Barracuda format in order to use InnoDB engine for LimeSurvey!'));
+                }
             }
         }
     }


### PR DESCRIPTION
innodb_file_format, innodb_file_format_max and large_file_prefix options are deprecated since MySQL 5.7 and MariaDB 10.2
https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html
https://mariadb.com/kb/en/innodb-system-variables
Solve the issue https://forums.limesurvey.org/forum/installation-a-update-issues/120918-error-to-install-ls-4-1-17-with-mysql-8-and-innodb

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
