### PR TITLE
FIxed issue #15611: No HTML wrapper in public stats

### DIFF
--- a/application/controllers/Statistics_userController.php
+++ b/application/controllers/Statistics_userController.php
@@ -247,9 +247,12 @@ class Statistics_userController extends SurveyController
             //~ $prb->hide();
         }
 
+        $data['aSurveyInfo'] = getSurveyInfo($iSurveyID);
+        $data['graphUrl'] = Yii::app()->getController()->createUrl("admin/statistics/sa/graph");
+
         Yii::app()->getClientScript()->registerScriptFile(Yii::app()->getConfig('generalscripts') . 'statistics_user.js');
-        $this->layout = "public";
-        $this->render('/statistics_user_view', $data);
+        $data['aSurveyInfo']['include_content'] = 'statistics_user';
+        Yii::app()->twigRenderer->renderTemplateFromFile('layout_statistics_user.twig', $data, false);
 
         //Delete all Session Data
         Yii::app()->session['finished'] = true;

--- a/themes/survey/bootswatch/config.xml
+++ b/themes/survey/bootswatch/config.xml
@@ -255,6 +255,16 @@
                     <file type="view" role="subview">./subviews/printanswers/printanswers_foot.twig</file>
                 </printanswers>
 
+                <statistics_user>
+                    <screen_title  type="data"  role="title" twig="on"><![CDATA[ {{gT('Public statistics')}} ]]></screen_title>
+                    <file type="view" role="layout">layout_statistics_user.twig</file>
+                    <file type="view" role="subview">./subviews/content/outerframe.twig</file>
+                    <file type="view" role="content">./subviews/content/statistics_user.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_head.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_content.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_foot.twig</file>
+                </statistics_user>
+
                 <pdf>
                     <screen_title  type="data"  role="title" twig="on"><![CDATA[ {{gT('PDF')}} ]]></screen_title>
                     <file type="view" role="layout">layout_print.twig</file>

--- a/themes/survey/vanilla/config.xml
+++ b/themes/survey/vanilla/config.xml
@@ -273,6 +273,16 @@
                     <file type="view" role="subview">./subviews/printanswers/printanswers_foot.twig</file>
                 </printanswers>
 
+                <statistics_user>
+                    <screen_title  type="data"  role="title" twig="on"><![CDATA[ {{gT('Public statistics')}} ]]></screen_title>
+                    <file type="view" role="layout">layout_statistics_user.twig</file>
+                    <file type="view" role="subview">./subviews/content/outerframe.twig</file>
+                    <file type="view" role="content">./subviews/content/statistics_user.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_head.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_content.twig</file>
+                    <file type="view" role="subview">./subviews/statistics_user/statistics_user_foot.twig</file>
+                </statistics_user>
+
                 <pdf>
                     <screen_title  type="data"  role="title" twig="on"><![CDATA[ {{gT('PDF')}} ]]></screen_title>
                     <file type="view" role="layout">layout_print.twig</file>

--- a/themes/survey/vanilla/views/layout_statistics_user.twig
+++ b/themes/survey/vanilla/views/layout_statistics_user.twig
@@ -1,0 +1,33 @@
+{#
+    LimeSurvey
+    Copyright (C) 2007-2020 The LimeSurvey Project Team / Louis Gac
+    All rights reserved.
+    License: GNU/GPL License v2 or later, see LICENSE.php
+    LimeSurvey is free software. This version may have been modified pursuant
+    to the GNU General Public License, and as distributed it includes or
+    is derivative of works licensed under the GNU General Public License or
+    other free or open source software licenses.
+    See COPYRIGHT.php for copyright notices and details.
+
+    (¯`·._.·(¯`·._.· Public Statistics Layout  ·._.·´¯)·._.·´¯)
+
+    This is the layout that will be used to show the public statistics. 
+
+#}
+{% extends 'layout_global.twig' %}
+{% block ajaxindicator %}{% endblock %}
+{% block pjaxbegin %}{% endblock %}
+{% block body %}
+    {% block nav_bar %}
+        {{ parent() }}
+    {% endblock %}
+    {{ registerScript("StatisticsUserBaseScripts", "var graphUrl = " ~ graphUrl ~ ";", "POS_BEGIN") }}
+    {% block content %}
+        {% set sViewContent =  './subviews/content/' ~ aSurveyInfo.include_content ~ '.twig' %}
+        {% include './subviews/content/outerframe.twig' with {'include_content': sViewContent } %}
+    {% endblock %}
+{% endblock %}
+{% block footer %}
+    {{ parent() }}
+{% endblock %}
+{% block pjaxend %}{% endblock %}

--- a/themes/survey/vanilla/views/subviews/content/statistics_user.twig
+++ b/themes/survey/vanilla/views/subviews/content/statistics_user.twig
@@ -1,0 +1,21 @@
+{# 
+    LimeSurvey 
+    Copyright (C) 2007-2020 The LimeSurvey Project Team / Louis Gac 
+    All rights reserved. 
+    License: GNU/GPL License v2 or later, see LICENSE.php 
+    LimeSurvey is free software. This version may have been modified pursuant 
+    to the GNU General Public License, and as distributed it includes or 
+    is derivative of works licensed under the GNU General Public License or 
+    other free or open source software licenses. 
+    See COPYRIGHT.php for copyright notices and details. 
+ 
+    (¯`·._.·(¯`·._.· Public Statistics Layout  ·._.·´¯)·._.·´¯) 
+ 
+    This file displays the page shown to user when viewing the statistics after taking a survey. 
+ 
+    NOTE: see layout_main.twig for more infos 
+#}<section> 
+        {{ include('./subviews/statistics_user/statistics_user_head.twig') }} 
+        {{ include('./subviews/statistics_user/statistics_user_content.twig') }} 
+        {{ include('./subviews/statistics_user/statistics_user_foot.twig') }} 
+    </section>

--- a/themes/survey/vanilla/views/subviews/statistics_user/index.html
+++ b/themes/survey/vanilla/views/subviews/statistics_user/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<title>LimeSurvey</title>
+</head>
+<body>
+</body>
+</html>
+
+
+

--- a/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_content.twig
+++ b/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_content.twig
@@ -1,0 +1,5 @@
+<div class="public-stats__content">
+    {% if statisticsoutput %}
+        {{ statisticsoutput }}
+    {% endif %}
+</div>

--- a/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_foot.twig
+++ b/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_foot.twig
@@ -1,0 +1,5 @@
+            </div>
+            <input type='hidden' class='hidemenubutton'/>
+        </div>
+    </div>
+</div>

--- a/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_head.twig
+++ b/themes/survey/vanilla/views/subviews/statistics_user/statistics_user_head.twig
@@ -1,0 +1,29 @@
+
+{#
+    LimeSurvey
+    Copyright (C) 2007-2020 The LimeSurvey Project Team / Louis Gac
+    All rights reserved.
+    License: GNU/GPL License v2 or later, see LICENSE.php
+    LimeSurvey is free software. This version may have been modified pursuant
+    to the GNU General Public License, and as distributed it includes or
+    is derivative of works licensed under the GNU General Public License or
+    other free or open source software licenses.
+    See COPYRIGHT.php for copyright notices and details.
+
+    (¯`·._.·(¯`·._.· Public Statistics Header ._.·´¯)·._.·´¯)
+
+    This is the head for the public statistics page.
+
+#}
+
+<div class="container public-stats">
+    <div class="row">
+        <div class="col-sm-12">
+            <div id='statsContainer'>
+                <div id='statsHeader'>
+                    <h2 class='statsSurveyTitle public-stats__title'>{{ aSurveyInfo.surveyls_title }}</h2>
+                    <div class='statsNumRecords public-stats__num-records'>{{ gT("Total records in survey") }} : {{ totalrecords }}</div>
+                </div>
+
+
+


### PR DESCRIPTION
Created new twig views for statistics for using as frame (based on print view)
