### PR TITLE
Fixed issue #16930: HTML Editor inline mode not working in Question Editor View

### DIFF
--- a/application/helpers/admin/htmleditor_helper.php
+++ b/application/helpers/admin/htmleditor_helper.php
@@ -221,6 +221,17 @@
         $toolbaroption = "";
         $sFileBrowserAvailable = '';
         $htmlformatoption = "";
+
+        // Compose JS variable name that will hold the CKEditor instance.
+        // This variable is named after the fieldname.
+        // As to sanitize it and not creating JS syntax errors:
+        // - replace any opening square brackets or "-" from the fieldname, to "_"
+        // - remove closing square brackets
+        // 
+        // Note: This sanitization process is not much needed now, but leave it in case is usefull for laters.
+        // This was used before by this function, when in prior times, fieldname could be derived 
+        // from the name of a textarea, and not just the id (as now)
+        // The name of a texarea can contain quare brackets. Then we needed to sanitize.
         $oCKeditorVarName = "oCKeditor_".preg_replace("/[-\[]/", "_", $fieldname);
         $oCKeditorVarName = str_replace(']', '', $oCKeditorVarName);
 


### PR DESCRIPTION
Adding comments.

Extra side comments:
On LS3 ckeditor configuration wrapper and utilities were coded in a way that sometimes the textarea (and control) was fecthed by name and sometimes by id, using a single value for fecthing using name or id criteria. Something like GetByName(YXZ) or GetById(YXZ).

On LS4 textareas can have different name and id. Which is good.
Now the wrapper was fixed as to get only elements by Id.