### PR TITLE
Fixed issue #16932: When creating a survey with the default demo contents, the process halts

### DIFF
--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -459,8 +459,13 @@ class QuestionAttribute extends LSActiveRecord
 
     /**
      * Returns the value for attribute 'question_template'.
+     * Fetches the question_template from a question model.
+     * 
+     * Be carefull this attribute is not present in all questions.
+     * Even more, standard question types where question theme are not used (or custom question theme are not used),
+     * the attribute is missing. In those cases, the deault "core" is used.
      *
-     * @return string|null question_template or null if it not exists
+     * @return string question_template or 'core' if it not exists
      */
     public static function getQuestionTemplateValue($questionID){
         $question_template = QuestionAttribute::model()->findByAttributes([
@@ -468,7 +473,7 @@ class QuestionAttribute extends LSActiveRecord
             'attribute' => 'question_template'
         ]);
 
-        return $question_template->value;
+        return !empty($question_template) ? $question_template->value : 'core';
     }
 
     /**


### PR DESCRIPTION
Process halts as after creating demo question, there is a redirection to the question view, which had a problem.
question_template attribute was missing (is missing from most of the questions as usually don't use custom themes) and that was somehow expected by the code.

Fixed by using a default value, in case attribute is missing: Core