### PR TITLE
Fixed issue #16926: Reorder SQs and AOs for subquestion & answer options

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2642,6 +2642,7 @@ class QuestionAdministrationController extends LSBaseController
                 $subquestion->gid        = $question->gid;
                 $subquestion->parent_qid = $question->qid;
                 $subquestion->question_order = $questionOrder;
+                $questionOrder++;
                 $subquestion->title      = $data['code'];
                 if ($scaleId === 0) {
                     $subquestion->relevance  = $data['relevance'];


### PR DESCRIPTION
Missing to increment the order the counter. Fixed.