### PR TITLE
Fixed issue #16910: Any plugin public function can be done without any control on rights

### DIFF
--- a/application/controllers/admin/PluginHelper.php
+++ b/application/controllers/admin/PluginHelper.php
@@ -97,9 +97,12 @@ class PluginHelper extends Survey_Common_Action
 
         $pluginManager = App()->getPluginManager();
         $pluginInstance = $refClass->newInstance($pluginManager, $record->id);
+        /* Check if method is in allowed list */
+        if(is_array($pluginInstance->allowedPublicMethods) && !in_array($methodName,$pluginInstance->allowedPublicMethods)) {
+            throw new \CHttpException(400, sprintf(gT("Forbidden call of method %s for plugin %s"),$methodName,$pluginName));
+        }
 
         Yii::app()->setPlugin($pluginInstance);
-
         // Get plugin method, abort if not found
         try {
             $refMethod = $refClass->getMethod($methodName);

--- a/application/core/plugins/AuditLog/AuditLog.php
+++ b/application/core/plugins/AuditLog/AuditLog.php
@@ -5,6 +5,9 @@
         static protected $description = 'Core: Create an audit log of changes';
         static protected $name = 'auditlog';
 
+        /** @inheritdoc, this plugin didn't have any public method */
+        public $allowedPublicMethods = array();
+
         protected $settings = array(
             'AuditLog_Log_UserSave' => array(
                 'type' => 'checkbox',

--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -6,6 +6,9 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
     static protected $description = 'Core: LDAP authentication';
     static protected $name = 'LDAP';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     /**
      * Can we autocreate users? For the moment this is disabled, will be moved
      * to a setting when we have more robust user creation system.

--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -7,6 +7,9 @@ class Authdb extends AuthPluginBase
     static protected $description = 'Core: Database authentication + exports';
     static protected $name = 'LimeSurvey internal database';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
         /**

--- a/application/core/plugins/Authwebserver/Authwebserver.php
+++ b/application/core/plugins/Authwebserver/Authwebserver.php
@@ -5,7 +5,10 @@ class Authwebserver extends LimeSurvey\PluginManager\AuthPluginBase
     
     static protected $description = 'Core: Webserver authentication';
     static protected $name = 'Webserver';
-    
+
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     protected $settings = array(
         'strip_domain' => array(
             'type' => 'checkbox',

--- a/application/core/plugins/ComfortUpdateChecker/ComfortUpdateChecker.php
+++ b/application/core/plugins/ComfortUpdateChecker/ComfortUpdateChecker.php
@@ -17,9 +17,11 @@ class ComfortUpdateChecker extends PluginBase
     static protected $description = 'Update Checker for Comfort Update users';
 
     static protected $name = 'ComfortUpdateChecker';
-    
-    protected $settings = [
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
+    protected $settings = [
         'only_security_update' => array(
             'type' => 'checkbox',
             'label' => 'Notification only for security updates',

--- a/application/core/plugins/ExportR/ExportR.php
+++ b/application/core/plugins/ExportR/ExportR.php
@@ -3,13 +3,15 @@ class ExportR extends \LimeSurvey\PluginManager\PluginBase
 {
     
     protected $storage = 'DbStorage';
-       
+
     static protected $description = 'Core: R-export';
     static protected $name = 'Export results to R';
-    
+
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
-        
         /**
          * Here you should handle subscribing to the events your plugin will handle
          */

--- a/application/core/plugins/ExportSTATAxml/ExportSTATAxml.php
+++ b/application/core/plugins/ExportSTATAxml/ExportSTATAxml.php
@@ -6,7 +6,10 @@ class ExportSTATAxml extends \LimeSurvey\PluginManager\PluginBase
        
     static protected $description = 'Core: Export survey results to a STATA xml file';
     static protected $name = 'STATA Export';
-    
+
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
         

--- a/application/core/plugins/PasswordRequirement/PasswordRequirement.php
+++ b/application/core/plugins/PasswordRequirement/PasswordRequirement.php
@@ -7,6 +7,9 @@ class PasswordRequirement  extends \LimeSurvey\PluginManager\PluginBase {
      */
     protected $storage = 'DbStorage';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     protected $settings = [
         'needsNumber' => array(
             'label' => 'Require at least one digit',

--- a/application/core/plugins/UpdateCheck/UpdateCheck.php
+++ b/application/core/plugins/UpdateCheck/UpdateCheck.php
@@ -30,6 +30,9 @@ class UpdateCheck extends PluginBase
      */
     protected $storage = 'DbStorage';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array('checkAll');
+
     /**
      * @return void
      */
@@ -66,7 +69,7 @@ class UpdateCheck extends PluginBase
     public function beforeControllerAction()
     {
         $controller = $this->getEvent()->get('controller');
-        $doUpdateCheckFlag = Yii::app()->session['do_extensions_update_check'];
+        $doUpdateCheckFlag = true; //Yii::app()->session['do_extensions_update_check'];
 
         if ($controller == 'admin' && $doUpdateCheckFlag) {
 

--- a/application/core/plugins/customToken/customToken.php
+++ b/application/core/plugins/customToken/customToken.php
@@ -5,6 +5,9 @@ class customToken extends PluginBase {
     static protected $name = 'customToken';
     static protected $description = 'At token generation this plugin enforces certain token formats like Numeric, non-ambiguous or uppercase tokens';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
         /**

--- a/application/core/plugins/expressionFixedDbVar/expressionFixedDbVar.php
+++ b/application/core/plugins/expressionFixedDbVar/expressionFixedDbVar.php
@@ -3,9 +3,9 @@
  * expressionFixedDbVar : add some fixed DB var : SEED, STARTDATE … 
  *
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2019 Denis Chenu <http://www.sondages.pro>
+ * @copyright 2019 LimeSurvey - Denis Chenu
  * @license GPL version 3
- * @version 1.0.0
+ * @version 1.0.1
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,11 @@ class expressionFixedDbVar extends PluginBase
     static protected $description = 'Add SEED and other DB var in ExpressionScript Engine.';
     static protected $name = 'expressionFixedDbVar';
 
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     /**
-    * @var array[] the settings
+    * @inheritdoc
     */
     protected $settings = array(
         'SEED' => array(

--- a/application/core/plugins/expressionQuestionForAll/expressionQuestionForAll.php
+++ b/application/core/plugins/expressionQuestionForAll/expressionQuestionForAll.php
@@ -4,9 +4,9 @@
  * This don't manage subquestion Scale Y or Scale X
  * 
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2019 Denis Chenu <http://www.sondages.pro>
+ * @copyright 2019 LimeSurvey - Denis Chenu
  * @license GPL version 3
- * @version 1.0.0
+ * @version 1.0.1
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,9 @@ class expressionQuestionForAll extends PluginBase
 {
     static protected $description = 'Add QCODE.question for question with subquestion for expression Manager.';
     static protected $name = 'expressionQuestionForAll';
+
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
 
     public function init()
     {

--- a/application/core/plugins/expressionQuestionHelp/expressionQuestionHelp.php
+++ b/application/core/plugins/expressionQuestionHelp/expressionQuestionHelp.php
@@ -3,9 +3,9 @@
  * expressionQuestionHelp : add QCODE.help for expression Manager
  *
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2019 Denis Chenu <http://www.sondages.pro>
+ * @copyright 2019 LimeSurvey - Denis Chenu
  * @license GPL version 3
- * @version 1.0.0
+ * @version 1.0.1
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,9 @@ class expressionQuestionHelp extends PluginBase
     static protected $description = 'Add .help to properties of questions.';
     static protected $name = 'expressionQuestionHelp';
 
-    
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
         $this->subscribe('setVariableExpressionEnd','addQuestionHelp');

--- a/application/core/plugins/mailSenderToFrom/mailSenderToFrom.php
+++ b/application/core/plugins/mailSenderToFrom/mailSenderToFrom.php
@@ -4,9 +4,9 @@
  * Needed for some smtp server, see mantis issue #10529 <https://bugs.limesurvey.org/view.php?id=10529>
  *
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2019 Denis Chenu <http://www.sondages.pro>
+ * @copyright 2019 LimeSurvey - Denis Chenu
  * @license MIT
- * @version 1.0.0
+ * @version 1.0.1
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,7 +18,9 @@ class mailSenderToFrom extends PluginBase
     static protected $description = 'Set sender to the SMTP user.';
     static protected $name = 'mailSenderToFrom';
 
-    
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
     public function init()
     {
         $this->subscribe('beforeEmail','beforeEmail');

--- a/application/core/plugins/oldUrlCompat/oldUrlCompat.php
+++ b/application/core/plugins/oldUrlCompat/oldUrlCompat.php
@@ -3,9 +3,9 @@
  * Plugin to redirect old url system (index.php?sid=surveyid) to the new url
  *
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2016 LimeSurvey team <https://www.limesurvey.org>
+ * @copyright 2016-2020 LimeSurvey team <https://www.limesurvey.org>
  * @license GPL v3
- * @version 0.0.1
+ * @version 0.1.0
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,16 +22,14 @@ class oldUrlCompat extends PluginBase
     static protected $name = 'oldUrlCompat';
     static protected $description = 'Old url (pre-2.0) compatible system';
 
-    /** init broke plugin management */
-    //~ public function init()
-    //~ {
-        //~ $this->subscribe('afterPluginLoad','oldUrlCompat');
-    //~ }
-    public function __construct(\LimeSurvey\PluginManager\PluginManager $manager, $id)
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
+
+    public function init()
     {
-        parent::__construct($manager, $id);
-        $this->subscribe('afterPluginLoad', 'oldUrlCompat');
+        $this->subscribe('afterPluginLoad','oldUrlCompat');
     }
+
     /**
      * Forward survey controller if we are in default controller and a sid GET parameters is set
      * @return void

--- a/application/core/plugins/statFunctions/statFunctions.php
+++ b/application/core/plugins/statFunctions/statFunctions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author Denis Chenu <denis@sondages.pro>
- * @copyright 2019 Denis Chenu <http://www.sondages.pro>
+ * @copyright 2019 LimeSurvey - Denis Chenu
  * @license GPL version 3
  * @version 0.1.1
  *
@@ -22,6 +22,9 @@ class statFunctions extends PluginBase
 {
     protected static $description = 'Add some function in ExpressionScript Engine to get count from other responses';
     protected static $name = 'statCountFunctions';
+
+    /** @inheritdoc, this plugin didn't have any public method */
+    public $allowedPublicMethods = array();
 
     public function init()
     {

--- a/application/libraries/PluginManager/PluginBase.php
+++ b/application/libraries/PluginManager/PluginBase.php
@@ -43,7 +43,8 @@ abstract class PluginBase implements iPlugin
     private $store = null;
 
     /**
-     * @var array
+     * Global settings of plugin
+     * @var array[]
      */
     protected $settings = [];
 
@@ -59,6 +60,12 @@ abstract class PluginBase implements iPlugin
      * @var \SimpleXMLElement|null
      */
     public $config = null;
+
+    /**
+     * List of allowed public method, null mean all metod are allowed. Else method must be in the list
+     * @var string[]|null
+     */
+    public $allowedPublicMethods = null;
 
     /**
      * Constructor for the plugin
@@ -161,7 +168,9 @@ abstract class PluginBase implements iPlugin
      */
     public function getPluginSettings($getValues = true)
     {
-
+        if(!Permission::model()->hasGlobalPermission('settings','read')) {
+            throw new CHttpException(403);
+        }
         $settings = $this->settings;
         foreach ($settings as $name => &$setting) {
             if ($getValues) {
@@ -247,6 +256,9 @@ abstract class PluginBase implements iPlugin
      */
     public function saveSettings($settings)
     {
+        if(!Permission::model()->hasGlobalPermission('settings','update')) {
+            throw new CHttpException(403);
+        }
         foreach ($settings as $name => $setting) {
             $this->set($name, $setting);
         }


### PR DESCRIPTION
Dev: allowedPublicMethods to null by default, used only for compatible plugin
Dev: add Permission checker on getPluginSettings and saveSettings