### PR TITLE
Bugfix: Register assets in short free text

### DIFF
--- a/application/core/QuestionTypes/ShortFreeText/RenderShortFreeText.php
+++ b/application/core/QuestionTypes/ShortFreeText/RenderShortFreeText.php
@@ -31,6 +31,7 @@ class RenderShortFreeText extends QuestionBaseRenderer
     public function render($sCoreClasses = '')
     {
         $result =  @do_shortfreetext($this->aFieldArray);
+        $this->registerAssets();
         return $result;
 
         $answer = '';


### PR DESCRIPTION
How to reproduce:

disable the Limesurvey XSS filter at
Global settings -> Security -> “Filter HTML for XSS” = “No”.

Create a "Short Free Text" question.

Add a script to the question. Example: `console.log (" I'm here ")`

Preview the issue.

Check to see if you’re here in the developer tools console of your browser.

The correction:
The method needs to be refactored but the change resolves the bug.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
