### PR TITLE
Fixed issue #16948: Uploading an image through the theme options fails

### DIFF
--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -228,14 +228,9 @@ class themes extends Survey_Common_Action
             LSUploadHelper::checkUploadedFileSizeAndRenderJson('file', $debug);
             
             $checkImageContent = LSYii_ImageValidator::validateImage($_FILES["file"]);
-            $checkImageFilename = LSYii_ImageValidator::validateImage($_FILES["file"]['name']);
-            if ($checkImageContent['check'] === false || $checkImageFilename['check'] === false) {
-                $message = $checkImageContent['check'] === false 
-                    ? $checkImageContent['uploadresult'] 
-                    : ($checkImageFilename['check'] === false ? $checkImageFilename['uploadresult']: null);
-                $debug = $checkImageContent['check'] === false 
-                    ? $checkImageContent['debug'] 
-                    : ($checkImageFilename['check'] === false ? $checkImageFilename['debug']: null);
+            if ($checkImageContent['check'] === false) {
+                $message = $checkImageContent['check'] === false ? $checkImageContent['uploadresult'] : null;
+                $debug = $checkImageContent['check'] === false ? $checkImageContent['debug'] : null;
                 return Yii::app()->getController()->renderPartial(
                     '/admin/super/_renderJson',
                     array('data' => ['success' => $success, 'message' => $message, 'debug' => $debug]),


### PR DESCRIPTION
Removing call for $checkImageFilename

I think bug was introduced here:
https://github.com/LimeSurvey/LimeSurvey/commit/3376b3ca24d0209015080c48ab1dd33593696a2d