### PR TITLE
Fixed issue #16954 & #16237: Themes Variations are saved, but not applied, can't be used

### DIFF
--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -333,6 +333,64 @@ var ThemeOptions = function () {
         });
     }
 
+    var removeVariationsFromField = function (fieldSelector) {
+        if ($(fieldSelector).val() === 'inherit') return;
+        try {
+            var currentValue = JSON.parse($(fieldSelector).val());
+        } catch (error) {
+            var currentValue = {};
+        }
+        var empty = true;
+        ['add','replace','remove'].forEach(function(action){
+            if (currentValue.hasOwnProperty(action)) {
+                currentValue[action] = currentValue[action].filter(function (item) {
+                    var itemToTest = action=='replace' ? item[1] : item;
+                    return !(/^css\/variations\/.*$/.test(itemToTest));
+                });
+                if (currentValue[action].length) empty = false;;
+            }
+        });
+        if (!empty) {
+            $(fieldSelector).val(JSON.stringify(currentValue));
+        } else {
+            $(fieldSelector).val(inheritPossible ? "inherit" : JSON.stringify({}));
+        }
+    }
+
+    var addVariationToField = function (file, fieldSelector, action) {
+        var defaultValue = {};
+        defaultValue[action] = [];
+
+        try {
+            var currentValue = JSON.parse($(fieldSelector).val());
+        } catch (error) {
+        }
+
+        if (!currentValue || currentValue==='inherit') var currentValue = defaultValue;
+        if (!currentValue.hasOwnProperty(action)) currentValue[action] = [];
+
+        if (action == 'replace') {
+            currentValue[action].push(["css/bootstrap.css", file]);
+        } else {
+            currentValue[action].push(file);
+        }
+        $(fieldSelector).val(JSON.stringify(currentValue));
+    }
+
+    var hotswapTheme = function () {
+        $('#simple_edit_options_cssframework').on('change', function (evt) {
+            var selectedTheme = $('#simple_edit_options_cssframework').val();
+            var selectedThemeMode = $('#simple_edit_options_cssframework').find("option[value='"+selectedTheme+"']").attr('data-mode') || 'add';
+
+            var filesField = selectedThemeMode == 'add' ? '#TemplateConfiguration_files_css' : '#TemplateConfiguration_cssframework_css';
+            removeVariationsFromField('#TemplateConfiguration_files_css');
+            removeVariationsFromField('#TemplateConfiguration_cssframework_css');
+            if (selectedTheme != 'inherit') {
+                addVariationToField(selectedTheme, filesField, selectedThemeMode);
+            }
+        });
+    }
+
     ///////////////
     // Event methods
     // -- These methods are triggered on events. Please see `bind´ method for more information
@@ -368,7 +426,8 @@ var ThemeOptions = function () {
         hotswapGeneralInherit();
         hotswapColorPicker();
         hotswapFontField();
-        hotswapFruityTheme();
+        //hotswapFruityTheme();
+        hotswapTheme();
     };
 
     var run = function () {

--- a/themes/survey/bootswatch/config.xml
+++ b/themes/survey/bootswatch/config.xml
@@ -70,6 +70,27 @@
         <brandlogo type="buttons" category="Images" width="4" title="Logo" options="on|off" optionlabels="Yes|No">on</brandlogo>
         <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">themes/survey/bootswatch/files/logo.png</brandlogofile>
         <hideprivacyinfo type="buttons" category="Simple options" width="4" title="Hide privacy info" options="on|off" optionlabels="Yes|No">off</hideprivacyinfo>
+        <cssframework type="dropdown" category="Simple options" width="12" title="Variations" parent="cssframework">
+            <dropdownoptions>
+                <option data-mode="replace" value="css/variations/basic.min.css">Basic Bootstrap</option>
+                <option data-mode="replace" value="css/variations/cerulean.min.css">Cerulean</option>
+                <option data-mode="replace" value="css/variations/cosmos.min.css">Cosmos</option>
+                <option data-mode="replace" value="css/variations/cyborg.min.css">Cyborg</option>
+                <option data-mode="replace" value="css/variations/darkly.min.css">Darkly</option>
+                <option data-mode="replace" value="css/variations/flatly.min.css">Flatly</option>
+                <option data-mode="replace" value="css/variations/journal.min.css">Journal</option>
+                <option data-mode="replace" value="css/variations/lumen.min.css">Lumen</option>
+                <option data-mode="replace" value="css/variations/paper.min.css">Paper</option>
+                <option data-mode="replace" value="css/variations/readable.min.css">Readable</option>
+                <option data-mode="replace" value="css/variations/sandstone.min.css">Sandstone</option>
+                <option data-mode="replace" value="css/variations/simplex.min.css">Simplex</option>
+                <option data-mode="replace" value="css/variations/slate.min.css">Slate</option>
+                <option data-mode="replace" value="css/variations/spacelab.min.css">Spacelab</option>
+                <option data-mode="replace" value="css/variations/superhero.min.css">Superhero</option>
+                <option data-mode="replace" value="css/variations/united.min.css">United</option>
+                <option data-mode="replace" value="css/variations/yeti.min.css">Yeti</option>
+            </dropdownoptions>
+        </cssframework>
     </options>
 
     <!-- Here datas about how LimeSurvey should load the theme -->

--- a/themes/survey/fruity/config.xml
+++ b/themes/survey/fruity/config.xml
@@ -675,7 +675,7 @@
             </optgroup>
             </dropdownoptions>
         </font>
-        <cssframework type="dropdown" category="Fonts" width="12" title="Variations" parent="cssframework">noto
+        <cssframework type="dropdown" category="Simple options" width="12" title="Variations" parent="cssframework">
             <dropdownoptions>
                 <option value="css/variations/sea_green.css">Sea Green</option>
                 <option value="css/variations/apple_blossom.css">Apple Blossom</option>
@@ -684,7 +684,7 @@
                 <option value="css/variations/free_magenta.css">Free Magenta</option>
                 <option value="css/variations/purple_tentacle.css">Purple Tentacle</option>
                 <option value="css/variations/sunset_orange.css">Sunset Orange</option>
-                <option value="css/variations/skyline_blue.css">Skyline Blue</option>';
+                <option value="css/variations/skyline_blue.css">Skyline Blue</option>
             </dropdownoptions>
         </cssframework>
     </options>


### PR DESCRIPTION
Added new attribute to variation tag: data-mode="replace".
When that is present the related CSS file is saved to the framework_css field. If not, is added to the files_css list.

This is because bootswatch and fruity manage variations differently.

Moved variation selector from Font to Simple options.