### PR TITLE
Fixed Issue #17026: Custom themes not uploading files

### DIFF
--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -178,7 +178,8 @@ class themes extends Survey_Common_Action
         $action = returnGlobal('action');
         if ($action == 'templateuploadimagefile') {
             return $this->templateuploadimagefile();
-        } elseif ($action == 'templateupload') {
+        } 
+        if ($action == 'templateupload') {
             return $this->templateupload();
         }
 

--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -172,6 +172,16 @@ class themes extends Survey_Common_Action
      */
     public function upload()
     {
+        // Code for backward compatiblity with custom themes that are expecting to upload images to upload subaction. 
+        // That happens as their options.twig are outdated.
+        // Now that the upload subaction doesn't handle all uploads, weneed to dispatch to the proper.
+        $action = returnGlobal('action');
+        if ($action == 'templateuploadimagefile') {
+            return $this->templateuploadimagefile();
+        } elseif ($action == 'templateupload') {
+            return $this->templateupload();
+        }
+
         $sTemplateName = Yii::app()->request->getPost('templatename');
         if (Permission::model()->hasGlobalPermission('templates', 'import') || Permission::model()->hasTemplatePermission($sTemplateName)) {
             Yii::app()->loadHelper('admin/template');


### PR DESCRIPTION
Code for backward compatiblity with custom themes that are expecting to upload images to upload subaction.
That happens as their options.twig are outdated.
Now that the upload subaction doesn't handle all uploads, weneed to dispatch to the proper.
