### PR TITLE
Display actual model errors if survey import fails

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1431,8 +1431,7 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
             $iNewSID = $results['newsid'] = $newSurvey->sid;
             $results['surveys']++;
         } else {
-            $results['error'] = gT("Unable to import survey.");
-            $results['error'] .= CHtml::errorSummary($newSurvey);
+            $results['error'] = CHtml::errorSummary($newSurvey, gT("Unable to import survey."));
             return $results;
         }
     }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1432,6 +1432,7 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
             $results['surveys']++;
         } else {
             $results['error'] = gT("Unable to import survey.");
+            $results['error'] .= CHtml::errorSummary($newSurvey);
             return $results;
         }
     }


### PR DESCRIPTION
after 7ece09b8cb737adbac6bc2b49b4d85cdaf6acd98 we we ended up errors while copying/importing surveys but had only a vague general "error" to work with. 

This will add the yii standard model  errorSummary so that one can understand what actually went wrong. 
