### PR TITLE
fix composer.json license format to match composer standard-V3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "limesurvey/limesurvey",
 	"description" : "The most popular FOSS online survey tool on the web",
 	"homepage" : "https://www.limesurvey.org/",
-	"license" : "GPL 2.0",
+	"license" : "GPL-2.0-or-later",
 	"authors" : [{
 			"name" : "LimeSurvey Team",
 			"email" : "support@limesurvey.org",


### PR DESCRIPTION
#1454 for V3
composer license has an invalid value 
syncing to master