### PR TITLE
Fixed issue #16937: Easy way to launch CDBException

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1748,6 +1748,9 @@ class SurveyRuntimeHelper
             $this->aMoveResult = LimeExpressionManager::JumpTo($qSec + 1, 'question', false, true);
             $this->aStepInfo = LimeExpressionManager::GetStepIndexInfo($this->aMoveResult['seq']);
         }
+        
+        // "Save" starting values to response. 
+        // In the case of preview will not be "saved"", but will be incorporated in the response handled in memory.
         LimeExpressionManager::SaveStartingValues();
     }
 

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1748,6 +1748,7 @@ class SurveyRuntimeHelper
             $this->aMoveResult = LimeExpressionManager::JumpTo($qSec + 1, 'question', false, true);
             $this->aStepInfo = LimeExpressionManager::GetStepIndexInfo($this->aMoveResult['seq']);
         }
+        LimeExpressionManager::SaveStartingValues();
     }
 
 

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -642,6 +642,7 @@ class SurveyRuntimeHelper
             $this->setPrevStep();
             $this->checkIfFinished();
             $this->setStep();
+            $this->saveStartingValues();
 
             // CHECK UPLOADED FILES
             // TMSW - Move this into LEM::NavigateForwards?
@@ -1866,5 +1867,16 @@ class SurveyRuntimeHelper
         }
 
         return $aQuestionClass;
+    }
+
+    /**
+     * Saves the starting values, if any is set
+     */
+    private function saveStartingValues()
+    {
+        // Don't save the starting values if on Welcome screen
+        if ($this->sSurveyMode != 'survey' && $_SESSION[$this->LEMsessid]['step'] == 0) return;
+
+        LimeExpressionManager::SaveStartingValues();
     }
 }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5017,6 +5017,7 @@ class LimeExpressionManager
                 }
             }
 
+            // Save seed data.
             if (isset($_SESSION[$this->sessid]['startingValues']['seed'])) {
                 $sdata['seed'] = $_SESSION[$this->sessid]['startingValues']['seed'];
             }
@@ -9757,15 +9758,25 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
      */
     public static function SaveStartingValues()
     {
+        // Init
         $LEM =& LimeExpressionManager::singleton();
 
+        // If not starting values, retun
+        if (!isset($_SESSION[$LEM->sessid]['startingValues'])) return false;
+        if (!is_array($_SESSION[$LEM->sessid]['startingValues'])) return false;
+        if (!array_key_exists('startingValues', $_SESSION[$LEM->sessid])) return false;
+
         // set seed key if it doesn't exist to be able to pass count of startingValues check at next IF
-        if (array_key_exists('startingValues', $_SESSION[$LEM->sessid]) && !array_key_exists('seed', $_SESSION[$LEM->sessid]['startingValues'])) {
+        // GJ: I think this is to assure that starting values always have a seed entry and then be able to check more easily
+        // If there are other starting values, besides the seed.
+        // I think this piece of code may never be reached by the execution thread. There is always a seed.
+        if (!array_key_exists('seed', $_SESSION[$LEM->sessid]['startingValues'])){        
             $_SESSION[$LEM->sessid]['startingValues']['seed'] = '';
         }
 
+        // Check if there are other starting values, besides the seed
         // NOTE: now that we use a seed, count($_SESSION[$LEM->sessid]['startingValues']) start at 1
-        if (isset($_SESSION[$LEM->sessid]['startingValues']) && is_array($_SESSION[$LEM->sessid]['startingValues']) && count($_SESSION[$LEM->sessid]['startingValues']) > 1) {
+        if (count($_SESSION[$LEM->sessid]['startingValues']) > 1) {
             foreach ($_SESSION[$LEM->sessid]['startingValues'] as $k => $value) {
                 if (isset($LEM->knownVars[$k])) {
                     $knownVar = $LEM->knownVars[$k];

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9755,6 +9755,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
 
     /**
      * Save the starting values to the database
+     * @return boolean|void
      */
     public static function SaveStartingValues()
     {
@@ -9766,9 +9767,6 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
             return false;
         }
         if (!is_array($_SESSION[$LEM->sessid]['startingValues'])) {
-            return false;
-        }
-        if (!array_key_exists('startingValues', $_SESSION[$LEM->sessid])) {
             return false;
         }
 

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9817,11 +9817,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                         $value = null;  // can't upload a file via GET
                         break;
                 }
-                $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
-                $LEM->updatedValues[$knownVar['sgqa']] = array(
-                    'type' => $knownVar['type'],
-                    'value' => $value,
+                /* Check validity # */
+                $qinfo = array(
+                    'qid' => $knownVar['qid'],
+                    'other' => "Y", // Not known currently, but don't broke if set
                 );
+                if (self::checkValidityAnswer($knownVar['type'],$value,$knownVar['sgqa'],$qinfo,false)) {
+                    $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
+                    $LEM->updatedValues[$knownVar['sgqa']]=array(
+                        'type'=>$knownVar['type'],
+                        'value'=>$value,
+                    );
+                }
                 unset($_SESSION[$LEM->sessid]['startingValues'][$k]);
             }
             $LEM->_UpdateValuesInDatabase();

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9762,9 +9762,15 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         $LEM =& LimeExpressionManager::singleton();
 
         // If not starting values, retun
-        if (!isset($_SESSION[$LEM->sessid]['startingValues'])) return false;
-        if (!is_array($_SESSION[$LEM->sessid]['startingValues'])) return false;
-        if (!array_key_exists('startingValues', $_SESSION[$LEM->sessid])) return false;
+        if (!isset($_SESSION[$LEM->sessid]['startingValues'])) {
+            return false;
+        }
+        if (!is_array($_SESSION[$LEM->sessid]['startingValues'])) {
+            return false;
+        }
+        if (!array_key_exists('startingValues', $_SESSION[$LEM->sessid])) {
+            return false;
+        }
 
         // set seed key if it doesn't exist to be able to pass count of startingValues check at next IF
         // GJ: I think this is to assure that starting values always have a seed entry and then be able to check more easily


### PR DESCRIPTION
SaveStartingValues was moved from StartSurvey to InitMove. InitMove is not being called from the preview mode. So now, we call SaveStartingValues from the preview.