### PR TITLE
Fixed issue #17089: Date format problem

### DIFF
--- a/application/views/admin/token/tokenform.php
+++ b/application/views/admin/token/tokenform.php
@@ -333,13 +333,13 @@ foreach ($tokendata as $Key => $Value) {
                     <div id="remind-date-container" data-parent="#remind-switch" class="selector__date-container_hidden date-container" <?php if (!$bRemindSwitchValue){ echo "style='display:none;'"; }?> >
 
                         <div id="remind-date_datetimepicker" class="input-group date">
-                        <input class="YesNoDatePicker form-control" id="remind-date" type="text" value="<?php echo isset($remindersent) && $remindersent!='N' ? convertToGlobalSettingFormat($remindersent,true) : ''?>" name="remind-date" data-date-format="<?php echo $dateformatdetails['jsdate']; ?> HH:mm">
+                        <input class="YesNoDatePicker form-control" id="remind-date" type="text" value="<?php echo isset($remindersent) && $remindersent!='N' ? $remindersent : ''?>" name="remind-date" data-date-format="<?php echo $dateformatdetails['jsdate']; ?> HH:mm">
                         <span class="input-group-addon"><span class="fa fa-calendar"></span></span>
                         </div>
                     </div>
                 </div>
                 </div>
-                <input class='form-control hidden YesNoDateHidden' type='text' size='20' id='remindersent' name='remindersent' value="<?php if (isset($remindersent) && $remindersent!='N') {echo convertToGlobalSettingFormat($remindersent,true); } else {echo "N"; }?>" />
+                <input class='form-control hidden YesNoDateHidden' type='text' size='20' id='remindersent' name='remindersent' value="<?php if (isset($remindersent) && $remindersent!='N') {echo $remindersent; } else {echo "N"; }?>" />
             </div>
                 
             <!-- Reminder count, Uses left -->


### PR DESCRIPTION
This patch is for the edit tokens screen.
This happens because the dates are somehow double converted (calling 2 times convertToGlobalSettingFormat)

This was already fixed for the invitation sent date. Now doing it for the reminder date.