### PR TITLE
Fixed issue #16455: Public statistics for Ranking question not shown

### DIFF
--- a/application/controllers/Statistics_userController.php
+++ b/application/controllers/Statistics_userController.php
@@ -316,26 +316,26 @@ class Statistics_userController extends SurveyController
                 case Question::QT_SEMICOLON_ARRAY_MULTI_FLEX_TEXT:  //ARRAY (Multi Flex) (Text)
                 case Question::QT_COLON_ARRAY_MULTI_FLEX_NUMBERS:  //ARRAY (Multi Flex) (Numbers)
                     $resultsScale0 = Question::model()->with('questionl10ns')->findAll([
-                        'condition' => 'language=:language AND parent_qid=:parent_qid AND scale_id=:scale:id',
+                        'condition' => 'language=:language AND parent_qid=:parent_qid AND scale_id=:scale_id',
                         'params'    => [':language' => $this->sLanguage, ':parent_qid' => $flt->qid, ':scale_id' => 0],
                         'order'     => 'question_order'
                     ]);
                     $resultsScale1 = Question::model()->with('questionl10ns')->findAll([
-                        'condition' => 'language=:language AND parent_qid=:parent_qid AND scale_id=:scale:id',
+                        'condition' => 'language=:language AND parent_qid=:parent_qid AND scale_id=:scale_id',
                         'params'    => [':language' => $this->sLanguage, ':parent_qid' => $flt->qid, ':scale_id' => 1],
                         'order'     => 'question_order'
                     ]);
                     foreach ($resultsScale0 as $rowScale0) {
                         foreach ($resultsScale1 as $rowScale1) {
-                            $allfields[] = $SGQidentifier . reset($rowScale0) . "_" . $rowScale1['title'];
+                            $allfields[] = $SGQidentifier . $rowScale0['title'] . "_" . $rowScale1['title'];
                         }
                     }
                     break;
                 case Question::QT_R_RANKING_STYLE: //RANKING
-                    $results = Question::model()->with('questionl10ns')->findAll([
-                        'condition' => 'language=:language AND parent_qid=:parent_qid',
-                        'params'    => [':language' => $this->sLanguage, ':parent_qid' => $flt->qid],
-                        'order'     => 'question_order'
+                    $results = Answer::model()->with('answerl10ns')->findAll([
+                        'condition' => 'language=:language AND qid=:qid',
+                        'params'    => [':language' => $this->sLanguage, ':qid' => $flt->qid],
+                        'order'     => 'sortorder'
                     ]);
                     $count = count($results);
                     //loop through all answers. if there are 3 items to rate there will be 3 statistics

--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -211,7 +211,7 @@ function createChart($iQuestionID, $iSurveyID, $type = null, $lbl, $gdata, $graw
             $labelTmp = array();
             while (isset($gdata[$i])) {
                 $aHelperArray = array_keys($lbl);
-                if ($gdata[$i] == 0 || ($sQuestionType == Question::QT_O_LIST_WITH_COMMENT && substr($aHelperArray[$i], 0, strlen($sLanguageCode->gT("Comments"))) == $sLanguageCode->gT("Comments"))) {
+                if ($gdata[$i] == 0 || ($sQuestionType == Question::QT_O_LIST_WITH_COMMENT && substr($aHelperArray[$i], 0, strlen(gT("Comments"))) == gT("Comments"))) {
                     array_splice($gdata, $i, 1);
                 } else {
                     $i++;
@@ -601,7 +601,7 @@ class userstatistics_helper
             list($qsid, $qgid, $qqid) = explode("X", substr($rt, 1, strlen($rt)), 3);
 
             //select details for this question
-            $nresult = Question::model()->find('language=:language AND parent_qid=0 AND qid=:qid', array(':language' => $language, ':qid' => $qqid));
+            $nresult = Question::model()->with('questionl10ns')->find('language=:language AND parent_qid=0 AND t.qid=:qid', array(':language' => $language, ':qid' => $qqid));
             $qtitle = $nresult->title;
             $qtype = $nresult->type;
             $qquestion = flattenText($nresult->questionl10ns[$language]->question);
@@ -609,14 +609,14 @@ class userstatistics_helper
             $qother = $nresult->other;
 
             //1. Get list of answers
-            $result = Question::model()->findAll(array(
+            $result = Question::model()->with('questionl10ns')->findAll(array(
                 'order'     => 'question_order',
                 'condition' => 'language=:language AND parent_qid=:qid AND scale_id=0',
                 'params'    => array(':language' => $language, ':qid' => $qqid)
             ));
             foreach ($result as $row) {
-                $mfield = substr($rt, 1, strlen($rt)) . $row['title'];
-                $alist[] = array($row['title'], flattenText($row['question']), $mfield);
+                $mfield = substr($rt, 1, strlen($rt)) . $row->title;
+                $alist[] = array($row->title, flattenText($row->questionl10ns[$language]->question), $mfield);
             }
 
             //Add the "other" answer if it exists
@@ -686,27 +686,31 @@ class userstatistics_helper
             list($qsid, $qgid, $qqid) = explode("X", substr($rt, 1, strpos($rt, "-") - ($lengthofnumeral + 1)), 3);
 
             //get question data
-            $nquery = "SELECT title, type, question FROM {{questions}} WHERE parent_qid=0 AND qid='$qqid' AND language='{$language}'";
-            $nresult = Yii::app()->db->createCommand($nquery)->query();
+            $nresult = Question::model()->with('questionl10ns')->findAll(array(
+                'order'     => 'question_order',
+                'condition' => 'language=:language AND t.qid=:qid',
+                'params'    => array(':language' => $language, ':qid' => $qqid)
+            ));
 
             //loop through question data
-            foreach ($nresult->readAll() as $nrow) {
-                $nrow = array_values($nrow);
-                $qtitle = flattenText($nrow[0]) . " [" . substr($rt, strpos($rt, "-") - ($lengthofnumeral), $lengthofnumeral) . "]";
-                $qtype = $nrow[1];
-                $qquestion = flattenText($nrow[2]) . "[" . gT("Ranking") . " " . substr($rt, strpos($rt, "-") - ($lengthofnumeral), $lengthofnumeral) . "]";
+            foreach ($nresult as $nrow) {
+                $qtitle = flattenText($nrow->title) . " [" . substr($rt, strpos($rt, "-") - ($lengthofnumeral), $lengthofnumeral) . "]";
+                $qtype = $nrow->type;
+                $qquestion = flattenText($nrow->questionl10ns[$language]->question) . "[" . gT("Ranking") . " " . substr($rt, strpos($rt, "-") - ($lengthofnumeral), $lengthofnumeral) . "]";
             }
 
             //get answers
-            $query = "SELECT code, answer FROM {{answers}} WHERE qid='$qqid' AND scale_id=0 AND language='{$language}' ORDER BY sortorder, answer";
-            $result = Yii::app()->db->createCommand($query)->query();
+            $result = Answer::model()->with('answerl10ns')->findAll([
+                'condition' => 'language=:language AND qid=:qid',
+                'params'    => [':language' => $language, ':qid' => $qqid],
+                'order'     => 'sortorder'
+            ]);
 
             //loop through answers
-            foreach ($result->readAll() as $row) {
-                $row = array_values($row);
+            foreach ($result as $row) {
                 //create an array containing answer code, answer and fieldname(??)
                 $mfield = substr($rt, 1, strpos($rt, "-") - 1);
-                $alist[] = array("$row[0]", flattenText($row[1]), $mfield);
+                $alist[] = array("$row->code", flattenText($row->answerl10ns[$language]->answer), $mfield);
             }
         } else {
             if ($firstletter == "|") {
@@ -827,10 +831,10 @@ class userstatistics_helper
             //N = numerical input
             //K = multiple numerical input
             elseif ($firstletter == "N" || $firstletter == "K") {
-//NUMERICAL TYPE
+                //NUMERICAL TYPE
                 //Zero handling
                 if (!isset($excludezeros)) {
-//If this hasn't been set, set it to on as default:
+                    //If this hasn't been set, set it to on as default:
                     $excludezeros = 1;
                 }
                 //check last character, greater/less/equals don't need special treatment


### PR DESCRIPTION
Fixed stats for ranking questions.
Also reviewed as requested and fixed the following:
- Array (Numbers): Error 500: query parameter ":scale:id" instead of ":scale_id" on 'createSGQA'
- Array (Numbers): Error 500: wrong fieldname created on 'createSGQA' (X-Scale subquestion not taken into account)
- List with Comments + Pie Chart: Error 500, "Call to a member function gT() on string": $sLanguageCode->gT("Comments")
- Ranking: 'createSGQA' returns null because it looks for subquestions instead of answer options
- Ranking: 'buildOutputList' doesn't implement l10n
- Multiple choice (M and P): 'buildOutputList' doesn't implement l10n

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
