### PR TITLE
Fixed issue #15854: Cannot open pop up editor - subquestions (an extra page refresh needed)

### DIFF
--- a/application/views/admin/survey/Question/subquestionsAndAnswers/_subquestion.twig
+++ b/application/views/admin/survey/Question/subquestionsAndAnswers/_subquestion.twig
@@ -108,7 +108,7 @@
             onkeypress=" if(event.keyCode==13) { if (event && event.preventDefault) event.preventDefault(); document.getElementById('save-button').click(); return false;}"
             />
             <span class="input-group-addon">
-                {{ getEditor("editanswer","answer_"~language~"_"~qid~"_"~scale_id, "["~gT("Subquestion:", "js")~"]("~language~")",surveyid,gid,qid,'editanswer') }}
+                {{ getEditor("editanswer","answer_"~language~"_"~qid~"_"~scale_id, "["~gT("Subquestion:", "js")~"]("~language~")",surveyid,gid,(subquestion.qid matches '/^\\d+$/') ? qid : "",'editanswer') }}
             </span>
         </div>
     </td>


### PR DESCRIPTION
For new questions qid is random. Then when sent through the URL, common action executes _addPseudoParams which performs a validation. As the new question is still not valid, 403 is gotten. So now, for new questions. we don't send the param.