### PR TITLE
Fixed issue #15819: Missing localization for group_name in add_group, set_group_properties, import_group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,9 @@ before_script:
     - cp application/config/config-sample-mysql.php application/config/config.php
     # Enable debug=2 in config file. OBS: This assumes debug is on line 61.
     # TODO: Disable, a lines was added to config file and some tests started to fail.
-    - sed -i '61s/.*/        "debug"=>2,/' application/config/config.php
-    - cat application/config/config.php
+    # NB: EmCache is always disabled when debug => 2
+    # - sed -i '61s/.*/        "debug"=>2,/' application/config/config.php
+    # - cat application/config/config.php
 
     # Install Apache.
     # Code fetched from https://docs.travis-ci.com/user/languages/php/#Apache-%2B-PHP

--- a/application/commands/ResetPasswordCommand.php
+++ b/application/commands/ResetPasswordCommand.php
@@ -21,8 +21,11 @@ class ResetPasswordCommand extends CConsoleCommand
         if (isset($sArgument) && isset($sArgument[0]) && isset($sArgument[1])) {
             $oUser = User::findByUsername($sArgument[0]);
             if ($oUser) {
+                Yii::import('application.helpers.common_helper', true);
                 $oUser->setPassword($sArgument[1]);
-                if ($oUser->save()) {
+                // Save the model validating only the password, because there may be issues with other attributes
+                // (like an invalid value for some setting), which the user cannot fix because he doesn't have access.
+                if ($oUser->save(true, ['password'])) {
                     echo "Password for user {$sArgument[0]} was set.\n";
                     return 0;
                 } else {

--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '4.4.10';
-$config['dbversionnumber'] = 437;
+$config['dbversionnumber'] = 438;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -233,6 +233,12 @@ class QuestionAdministrationController extends LSBaseController
             'core'
         );
 
+        if (App()->session['questionselectormode'] !== 'default') {
+            $selectormodeclass = App()->session['questionselectormode'];
+        } else {
+            $selectormodeclass = App()->getConfig('defaultquestionselectormode');
+        }
+
         $viewData = [
             'oSurvey'                => $question->survey,
             'oQuestion'              => $question,
@@ -242,7 +248,8 @@ class QuestionAdministrationController extends LSBaseController
             'generalSettings'        => $generalSettings,
             'showScriptField'       => $showScriptField,
             'jsVariablesHtml'       => $jsVariablesHtml,
-            'modalsHtml'            => $modalsHtml
+            'modalsHtml'            => $modalsHtml,
+            'selectormodeclass'     => $selectormodeclass,
         ];
 
         $this->aData = array_merge($this->aData, $viewData);
@@ -2543,7 +2550,13 @@ class QuestionAdministrationController extends LSBaseController
      * @todo document me
      *
      * @param Question $oQuestion
-     * @param array $dataSet
+     * @param array $dataSet these are the advancedSettings in an array like
+     *                       [display]
+     *                         [hidden]
+     *                         ...
+     *                       [logic]
+     *                       ...
+     *
      * @return boolean
      * @throws CHttpException
      */
@@ -2934,11 +2947,6 @@ class QuestionAdministrationController extends LSBaseController
     {
         $aQuestionTypeGroups = [];
 
-        if (App()->session['questionselectormode'] !== 'default') {
-            $selectormodeclass = App()->session['questionselectormode'];
-        } else {
-            $selectormodeclass = App()->getConfig('defaultquestionselectormode');
-        }
         uasort($aQuestionTypeList, "questionTitleSort");
         foreach ($aQuestionTypeList as $questionType) {
             $htmlReadyGroup = str_replace(' ', '_', strtolower($questionType['group']));

--- a/application/controllers/QuestionGroupsAdministrationController.php
+++ b/application/controllers/QuestionGroupsAdministrationController.php
@@ -735,7 +735,7 @@ class QuestionGroupsAdministrationController extends LSBaseController
 
         $landOnSideMenuTab = 'structure';
         if (empty($sScenario)) {
-            if (App()->request->getPost('save-and-close', '')) {
+            if (App()->request->getPost('close-after-save', '')) {
                 $sScenario = 'save-and-close';
             } elseif (App()->request->getPost('saveandnew', '')) {
                 $sScenario = 'save-and-new';

--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -366,8 +366,8 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
     public function newLoginForm()
     {
         $this->getEvent()->getContent($this)
-        ->addContent(CHtml::tag('span', array(), "<label for='user'>" . gT("Username") . "</label>" . CHtml::textField('user', '', array('size' => 40, 'maxlength' => 40, 'class' => "form-control"))))
-        ->addContent(CHtml::tag('span', array(), "<label for='password'>" . gT("Password") . "</label>" . CHtml::passwordField('password', '', array('size' => 40, 'maxlength' => 40, 'class' => "form-control"))));
+        ->addContent(CHtml::tag('span', array(), "<label for='user'>" . gT("Username") . "</label>" . CHtml::textField('user', '', array('size' => 240, 'maxlength' => 240, 'class' => "form-control"))))
+        ->addContent(CHtml::tag('span', array(), "<label for='password'>" . gT("Password") . "</label>" . CHtml::passwordField('password', '', array('size' => 240, 'maxlength' => 240, 'class' => "form-control"))));
     }
 
     /**

--- a/application/extensions/admin/PreviewModalWidget/assets/previewModalWidget.js
+++ b/application/extensions/admin/PreviewModalWidget/assets/previewModalWidget.js
@@ -123,7 +123,9 @@ if (typeof PreviewModalScript === 'function') {
               
               $('#in_survey_common').off('change.previewModal');
               $('#in_survey_common').on('change.previewModal', `#${this.widgetsJsName}`, (e) => {
-                  this.options.onUpdate($(e.currentTarget).val());
+                  var target = $(e.currentTarget);
+                  var option = target.find("option:selected");
+                  this.options.onUpdate(target.val(), option.data('theme'));
               });
           }
           

--- a/application/extensions/admin/PreviewModalWidget/views/simple_grouped_select.php
+++ b/application/extensions/admin/PreviewModalWidget/views/simple_grouped_select.php
@@ -8,11 +8,11 @@
     foreach ($this->groupStructureArray as $sGroupTitle => $aGroupArray) {  
         echo sprintf("<optgroup label='%s'>", $aGroupArray[$this->groupTitleKey]);
         foreach ($aGroupArray[$this->groupItemsKey] as $aItemContent) {
-            $selected = $this->value == $aItemContent['type'] ? 'selected' : '';
+            $selected = $this->value == $aItemContent['type'] && $this->theme == $aItemContent['name'] ? 'selected' : '';
             if(YII_DEBUG) {
-                echo sprintf("<option value='%s' %s>%s (%s)</option>", $aItemContent['type'], $selected, $aItemContent['title'], $aItemContent['type']);
+                echo sprintf("<option value='%s' data-theme='%s' %s>%s (%s)</option>", $aItemContent['type'], $aItemContent['name'], $selected, $aItemContent['title'], $aItemContent['type']);
             } else {
-                echo sprintf("<option value='%s' %s>%s</option>", $aItemContent['type'], $selected, $aItemContent['title']);
+                echo sprintf("<option value='%s' data-theme='%s' %s>%s</option>", $aItemContent['type'], $aItemContent['name'], $selected, $aItemContent['title']);
             }
         } 
         echo "</optgroup>";

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -2768,7 +2768,7 @@ function tsvSurveyExport($surveyid)
                 $tsv_output['type/scale'] = $group['group_order'];
                 $tsv_output['name'] = !empty($group['group_name']) ? $group['group_name'] : '';
                 $tsv_output['text'] = !empty($group['description']) ? str_replace(array("\n", "\r"), '', $group['description']) : '';
-                $tsv_output['relevance'] = !empty($group['grelevance']) ? $group['grelevance'] : '';
+                $tsv_output['relevance'] = isset($group['grelevance']) ? $group['grelevance'] : '';
                 $tsv_output['random_group'] = !empty($group['randomization_group']) ? $group['randomization_group'] : '';
                 $tsv_output['language'] = $language;
                 fputcsv($out, array_map('MaskFormula', $tsv_output), chr(9));
@@ -2782,7 +2782,7 @@ function tsvSurveyExport($surveyid)
                         $tsv_output['class'] = 'Q';
                         $tsv_output['type/scale'] = $question['type'];
                         $tsv_output['name'] = !empty($question['title']) ? $question['title'] : '';
-                        $tsv_output['relevance'] = !empty($question['relevance']) ? $question['relevance'] : '';
+                        $tsv_output['relevance'] = isset($question['relevance']) ? $question['relevance'] : '';
                         $tsv_output['text'] = !empty($question['question']) ? str_replace(array("\n", "\r"), '', $question['question']) : '';
                         $tsv_output['help'] = !empty($question['help']) ? str_replace(array("\n", "\r"), '', $question['help']) : '';
                         $tsv_output['language'] = $question['language'];

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -3622,6 +3622,83 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
             $oDB->createCommand()->update('{{settings_global}}', array('stg_value' => 437), "stg_name='DBVersion'");
             $oTransaction->commit();
         }
+        if($iOldDBVersion < 438){
+            $oTransaction = $oDB->beginTransaction();
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'hidden' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'hidden' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'statistics_showgraph' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'statistics_showgraph' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'public_statistics' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'public_statistics' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'page_break' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'page_break' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'other_numbers_only' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'other_numbers_only' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'other_comment_mandatory' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'other_comment_mandatory' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'hide_tip' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'hide_tip' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'exclude_all_others_auto' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'exclude_all_others_auto' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'commented_checkbox_auto' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'commented_checkbox_auto' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'num_value_int_only' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'num_value_int_only' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'alphasort' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'alphasort' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'use_dropdown' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'use_dropdown' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'num_value_int_only' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'num_value_int_only' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_default_set' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_default_set' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_layout' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_layout' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_middlestart' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_middlestart' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_reset' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_reset' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_reversed' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_reversed' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'slider_showminmax' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'slider_showminmax' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'value_range_allows_missing' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'value_range_allows_missing' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'multiflexible_checkbox' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'multiflexible_checkbox' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'reverse' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'reverse' and value = 'N'");
+
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '1'), "attribute = 'input_boxes' and value = 'Y'");
+            $oDB->createCommand()->update('{{question_attributes}}', array('value' => '0'), "attribute = 'input_boxes' and value = 'N'");
+
+
+            $oDB->createCommand()->update('{{settings_global}}', array('stg_value' => 438), "stg_name='DBVersion'");
+            $oTransaction->commit();
+        }
+
     } catch (Exception $e) {
         Yii::app()->setConfig('Updating', false);
         $oTransaction->rollback();

--- a/application/libraries/ExtensionInstaller/FileFetcherUploadZip.php
+++ b/application/libraries/ExtensionInstaller/FileFetcherUploadZip.php
@@ -59,8 +59,10 @@ class FileFetcherUploadZip extends FileFetcher
             throw new Exception(gT('Temporary folder does not exist.'));
         }
 
-        // NB: mkdir() always applies the set umask to 0777. See https://www.php.net/manual/en/function.mkdir
-        mkdir($destdir, 0777, true);
+        if (!file_exists($destdir)) {
+            // NB: mkdir() always applies the set umask to 0777. See https://www.php.net/manual/en/function.mkdir
+            mkdir($destdir, 0777, true);
+        }
 
         if (!is_writable(dirname($destdir))) {
             throw new Exception(gT('Cannot move files due to permission problem. ' . $destdir));

--- a/application/libraries/PluginManager/Storage/DbStorage.php
+++ b/application/libraries/PluginManager/Storage/DbStorage.php
@@ -7,6 +7,13 @@ use PluginSetting;
 class DbStorage implements iPluginStorage
 {
     /**
+     * NB: Needed even if empty.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
      * @param iPlugin $plugin
      * @param string $key Key for the setting; passing null will return all keys.
      * @param string $model Optional model name to which the data was attached.
@@ -43,7 +50,7 @@ class DbStorage implements iPluginStorage
         if ($key != null) {
             $attributes['key'] = $key;
         }
-        
+
         $records = \PluginSetting::model()->findAllByAttributes($attributes);
         if (count($records) > 1) {
             foreach ($records as $record) {
@@ -104,7 +111,7 @@ class DbStorage implements iPluginStorage
         }
         $record->value = json_encode($data);
         $result = $record->save();
-               
+
         return $result;
     }
 }

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -30,7 +30,7 @@ use LimeSurvey\Helpers\questionHelper;
  * @property integer $question_order Question order in greoup
  * @property integer $parent_qid Questions parent question ID eg for subquestions
  * @property integer $scale_id  The scale ID
- * @property integer $same_default Saves if user set to use the same default value across languages in default options dialog
+ * @property integer $same_default Saves if user set to use the same default value across languages in default options dialog ('Edit default answers')
  * @property string $relevance Questions relevane equation
  * @property string $modulename
  *

--- a/application/views/admin/token/tokenform.php
+++ b/application/views/admin/token/tokenform.php
@@ -333,13 +333,13 @@ foreach ($tokendata as $Key => $Value) {
                     <div id="remind-date-container" data-parent="#remind-switch" class="selector__date-container_hidden date-container" <?php if (!$bRemindSwitchValue){ echo "style='display:none;'"; }?> >
 
                         <div id="remind-date_datetimepicker" class="input-group date">
-                        <input class="YesNoDatePicker form-control" id="remind-date" type="text" value="<?php echo isset($remindersent) && $remindersent!='N' ? convertToGlobalSettingFormat($remindersent,true) : ''?>" name="remind-date" data-date-format="<?php echo $dateformatdetails['jsdate']; ?> HH:mm">
+                        <input class="YesNoDatePicker form-control" id="remind-date" type="text" value="<?php echo isset($remindersent) && $remindersent!='N' ? $remindersent : ''?>" name="remind-date" data-date-format="<?php echo $dateformatdetails['jsdate']; ?> HH:mm">
                         <span class="input-group-addon"><span class="fa fa-calendar"></span></span>
                         </div>
                     </div>
                 </div>
                 </div>
-                <input class='form-control hidden YesNoDateHidden' type='text' size='20' id='remindersent' name='remindersent' value="<?php if (isset($remindersent) && $remindersent!='N') {echo convertToGlobalSettingFormat($remindersent,true); } else {echo "N"; }?>" />
+                <input class='form-control hidden YesNoDateHidden' type='text' size='20' id='remindersent' name='remindersent' value="<?php if (isset($remindersent) && $remindersent!='N') {echo $remindersent; } else {echo "N"; }?>" />
             </div>
                 
             <!-- Reminder count, Uses left -->

--- a/application/views/questionAdministration/create.php
+++ b/application/views/questionAdministration/create.php
@@ -99,7 +99,8 @@
                                 'aQuestionTypeGroups' => $aQuestionTypeGroups,
                                 'questionThemeTitle'  => $questionTheme['title'],
                                 'questionThemeName'   => $questionTheme['name'],
-                                'questionThemeClass'  => ($questionTheme['settings'])->class
+                                'questionThemeClass'  => ($questionTheme['settings'])->class,
+                                'selectormodeclass'   => $selectormodeclass,
                             ]
                         ); ?>
                     </div>

--- a/application/views/survey/questions/answer/list_with_comment/config.xml
+++ b/application/views/survey/questions/answer/list_with_comment/config.xml
@@ -53,7 +53,6 @@
         <attribute>encrypted</attribute>
         <attribute>save_as_default</attribute>
         <attribute>clear_default</attribute>
-        <attribute>preg</attribute>
     </generalattributes>
 
     <!-- Question attributes -->

--- a/application/views/survey/questions/answer/listradio/config.xml
+++ b/application/views/survey/questions/answer/listradio/config.xml
@@ -202,6 +202,80 @@
             <readonly_when_active></readonly_when_active>
             <expression></expression>
         </attribute>
+        <attribute>
+            <name>fix_height</name>
+            <category>Display</category>
+            <sortorder>90</sortorder>
+            <inputtype>integer</inputtype>
+            <default>200</default>
+            <help>Fix height of the images to this value. Leave empty to not change them.</help>
+            <caption>Fixed height</caption>
+        </attribute>
+        <attribute>
+            <name>fix_width</name>
+            <category>Display</category>
+            <sortorder>90</sortorder>
+            <inputtype>integer</inputtype>
+            <help>Fix width of the images to this value. Leave empty to not change them.</help>
+            <caption>Fixed width</caption>
+        </attribute>
+        <attribute>
+            <name>crop_or_resize</name>
+            <category>Display</category>
+            <sortorder>90</sortorder>
+            <inputtype>buttongroup</inputtype>
+            <options>
+                <option>
+                    <value>0</value>
+                    <text>Resize</text>
+                </option>
+                <option>
+                    <value>1</value>
+                    <text>Crop</text>
+                </option>
+            </options>
+            <default>0</default>
+            <help>Crop images to fit into size. Needs JavaScript enabled.</help>
+            <caption>Crop or Resize</caption>
+        </attribute>
+        <attribute>
+            <name>keep_aspect</name>
+            <category>Display</category>
+            <sortorder>90</sortorder>
+            <inputtype>buttongroup</inputtype>
+            <options>
+                <option>
+                    <value>0</value>
+                    <text>No</text>
+                </option>
+                <option>
+                    <value>1</value>
+                    <text>Yes</text>
+                </option>
+            </options>
+            <default>0</default>
+            <help>Keep images aspect ratio. Can be achieved by not setting both width and height. Needs JavaScript enabled.</help>
+            <caption>Keep aspect-ratio</caption>
+        </attribute>
+        <attribute>
+            <name>horizontal_scroll</name>
+            <category>Display</category>
+            <sortorder>90</sortorder>
+            <inputtype>buttongroup</inputtype>
+            <options>
+                <option>
+                    <value>0</value>
+                    <text>No</text>
+                </option>
+                <option>
+                    <value>1</value>
+                    <text>Yes</text>
+                </option>
+            </options>
+            <default>0</default>
+            <help>Show an horizontal scroll for the images instead of a vertical list. Needs JavaScript enabled.</help>
+            <caption>Horizontal scrolling</caption>
+    </attribute>
         <!-- Display Attributes END -->
         <!-- Logic Attributes START -->
         <attribute>

--- a/application/views/survey/questions/answer/multipleshorttext/config.xml
+++ b/application/views/survey/questions/answer/multipleshorttext/config.xml
@@ -144,19 +144,6 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
-            <name>printable_help</name>
-            <category>Display</category>
-            <sortorder>201</sortorder>
-            <inputtype>text</inputtype>
-            <expression>1</expression>
-            <i18n>1</i18n>
-            <default></default>
-            <help>In the printable version the condition is being replaced with this explanation text.</help>
-            <caption>Relevance help for printable survey</caption>
-            <readonly></readonly>
-            <readonly_when_active></readonly_when_active>
-        </attribute>
-        <attribute>
             <name>text_input_columns</name>
             <category>Display</category>
             <sortorder>90</sortorder>
@@ -319,6 +306,29 @@
             <readonly_when_active></readonly_when_active>
             <expression></expression>
         </attribute>
+        <attribute>
+            <name>hide_tip</name>
+            <category>Display</category>
+            <sortorder>100</sortorder>
+            <inputtype>switch</inputtype>
+            <options>
+                <option>
+                    <value>0</value>
+                    <text>No</text>
+                </option>
+                <option>
+                    <value>1</value>
+                    <text>Yes</text>
+                </option>
+            </options>
+            <default>0</default>
+            <help>Hide the tip that is normally shown with a question</help>
+            <caption>Hide tip</caption>
+            <i18n></i18n>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+            <expression></expression>
+        </attribute>
         <!-- Display Attributes END -->
         <!-- Logic Attributes START -->
         <attribute>
@@ -431,31 +441,6 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
-            <name>other_comment_mandatory</name>
-            <category>Logic</category>
-            <sortorder>100</sortorder>
-            <inputtype>switch</inputtype>
-            <options>
-                <option>
-                    <value>0</value>
-                    <text>No</text>
-                </option>
-                <option>
-                    <value>1</value>
-                    <text>Yes</text>
-                </option>
-            </options>
-            <default>0</default>
-            <help>Make the &amp;#039;Other:&amp;#039; comment field mandatory when the &amp;#039;Other:&amp;#039;
-                option is active
-            </help>
-            <caption>&amp;#039;Other:&amp;#039; comment mandatory</caption>
-            <i18n></i18n>
-            <readonly></readonly>
-            <readonly_when_active></readonly_when_active>
-            <expression></expression>
-        </attribute>
-        <attribute>
             <name>em_validation_sq</name>
             <category>Logic</category>
             <sortorder>220</sortorder>
@@ -536,37 +521,6 @@
             <default>0</default>
             <help>Insert a page break before this question in printable view by setting this to Yes.</help>
             <caption>Insert page break in printable view</caption>
-            <i18n></i18n>
-            <readonly></readonly>
-            <readonly_when_active></readonly_when_active>
-            <expression></expression>
-        </attribute>
-        <attribute>
-            <name>scale_export</name>
-            <category>Other</category>
-            <sortorder>100</sortorder>
-            <inputtype>singleselect</inputtype>
-            <options>
-                <option>
-                    <value>0</value>
-                    <text>Default</text>
-                </option>
-                <option>
-                    <value>1</value>
-                    <text>Nominal</text>
-                </option>
-                <option>
-                    <value>2</value>
-                    <text>Ordinal</text>
-                </option>
-                <option>
-                    <value>3</value>
-                    <text>Scale</text>
-                </option>
-            </options>
-            <default>0</default>
-            <help>Set a specific SPSS export scale type for this question</help>
-            <caption>SPSS export scale type</caption>
             <i18n></i18n>
             <readonly></readonly>
             <readonly_when_active></readonly_when_active>

--- a/tests/TestBaseClassWeb.php
+++ b/tests/TestBaseClassWeb.php
@@ -19,6 +19,7 @@ use Facebook\WebDriver\WebDriverElement;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Facebook\WebDriver\Exception\TimeOutException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\UnrecognizedExceptionException;
 
 /**
  * Class TestBaseClassWeb
@@ -169,6 +170,10 @@ class TestBaseClassWeb extends TestBaseClass
 
         $submit = self::$webDriver->findElement(WebDriverBy::name('login_submit'));
         $submit->click();
+
+        self::ignoreAdminNotification();
+        self::ignoreAdminNotification();
+
         /*
         try {
             sleep(1);
@@ -219,5 +224,27 @@ class TestBaseClassWeb extends TestBaseClass
         }
 
         return $element;
+    }
+
+    /**
+     * @return void
+     */
+    protected static function ignoreAdminNotification()
+    {
+        // Ignore password warning.
+        try {
+            $button = self::$webDriver->wait(1)->until(
+                WebDriverExpectedCondition::elementToBeClickable(
+                    WebDriverBy::cssSelector('#admin-notification-modal button.btn-default')
+                )
+            );
+            $button->click();
+        } catch (TimeOutException $ex) {
+            // Do nothing.
+        } catch (NoSuchElementException $ex) {
+            // Do nothing.
+        } catch (UnrecognizedExceptionException $ex) {
+            // Do nothing.
+        }
     }
 }

--- a/tests/functional/backend/NoGreenBarTest.php
+++ b/tests/functional/backend/NoGreenBarTest.php
@@ -52,6 +52,8 @@ class NoGreenBarTest extends TestBaseClassWeb
         $input = $web->findById('firstname');
         $input->sendKeys('dummy name');
         sleep(1);
+        self::ignoreAdminNotification();
+        self::ignoreAdminNotification();
         $savebutton = $web->findById('save-button');
         $savebutton->click();
         sleep(1);

--- a/tests/unit/helpers/RemoteControlTest.php
+++ b/tests/unit/helpers/RemoteControlTest.php
@@ -346,4 +346,136 @@ class RemoteControlTest extends TestBaseClass
         self::$testSurvey->delete();
         self::$testSurvey = null;
     }
+    
+    public function testAddGroup()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        $dbo = \Yii::app()->getDb();
+
+        // Make sure the Authdb is in database (might not be the case if no browser login attempt has been made).
+        $plugin = \Plugin::model()->findByAttributes(array('name'=>'Authdb'));
+        if (!$plugin) {
+            $plugin = new \Plugin();
+            $plugin->name = 'Authdb';
+            $plugin->active = 1;
+            $plugin->save();
+        } else {
+            $plugin->active = 1;
+            $plugin->save();
+        }
+        App()->getPluginManager()->loadPlugin('Authdb', $plugin->id);
+        // Clear login attempts.
+        $query = sprintf('DELETE FROM {{failed_login_attempts}}');
+        $dbo->createCommand($query)->execute();
+
+
+        $filename = self::$surveysFolder . '/limesurvey_survey_remote_api_group_language.lss';
+        self::importSurvey($filename);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        // Add group
+        $result = $handler->add_group($sessionKey, self::$surveyId, "Test group title", "Test group description");
+        $this->assertIsNumeric($result, '$result = ' . json_encode($result));
+
+        $oGroup = \QuestionGroup::model()->findByPk($result);
+        $this->assertNotEmpty($oGroup, "Imported group not found");
+
+        $this->assertEquals("Test group title", $oGroup->questiongroupl10ns['en']->group_name);
+        $this->assertEquals("Test group description", $oGroup->questiongroupl10ns['en']->description);
+
+        // Cleanup
+        self::$testSurvey->delete();
+        self::$testSurvey = null;
+    }
+
+    public function testSetGroupProperties()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        $dbo = \Yii::app()->getDb();
+
+        // Make sure the Authdb is in database (might not be the case if no browser login attempt has been made).
+        $plugin = \Plugin::model()->findByAttributes(array('name'=>'Authdb'));
+        if (!$plugin) {
+            $plugin = new \Plugin();
+            $plugin->name = 'Authdb';
+            $plugin->active = 1;
+            $plugin->save();
+        } else {
+            $plugin->active = 1;
+            $plugin->save();
+        }
+        App()->getPluginManager()->loadPlugin('Authdb', $plugin->id);
+        // Clear login attempts.
+        $query = sprintf('DELETE FROM {{failed_login_attempts}}');
+        $dbo->createCommand($query)->execute();
+
+
+        $filename = self::$surveysFolder . '/limesurvey_survey_remote_api_group_language.lss';
+        self::importSurvey($filename);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        $survey = \Survey::model()->findByPk(self::$surveyId);
+        $oGroup = $survey->groups[0];
+
+        // Prepare group data
+        // Old style first (no separate L10n data)
+        $aGroupData = [
+            'group_name' => 'New group title',
+            'description' => 'New group description',
+            'language' => 'en',
+            'grelevance' => 1,
+        ];
+
+        // Add group
+        $result = $handler->set_group_properties($sessionKey, $oGroup->gid, $aGroupData);
+        $this->assertNotEmpty($result, "Empty results");
+        $this->assertTrue($result['questiongroupl10ns']['en']['group_name'], "Failed setting group language data (old style)");
+
+        $oGroup->refresh();
+        $this->assertEquals("New group title", $oGroup->questiongroupl10ns['en']->group_name);
+        $this->assertEquals("New group description", $oGroup->questiongroupl10ns['en']->description);
+        $this->assertEquals(1, $oGroup->grelevance);
+
+        // Prepare group data
+        // New style (separate L10n)
+        $aGroupData = [];
+        $aGroupData['questiongroupl10ns']['de'] = [
+            'group_name' => 'Der neue deutsche Titel',
+            'description' => 'Die neue deutsche Beschreibung',
+            'language' => 'de',
+        ];
+
+        // Add group
+        $result = $handler->set_group_properties($sessionKey, $oGroup->gid, $aGroupData);
+        $this->assertNotEmpty($result, "Empty results");
+        $this->assertTrue($result['questiongroupl10ns']['de']['group_name'], "Failed setting group language data (old style)");
+
+        $oGroup->refresh();
+        $this->assertEquals("Der neue deutsche Titel", $oGroup->questiongroupl10ns['de']->group_name);
+        $this->assertEquals("Die neue deutsche Beschreibung", $oGroup->questiongroupl10ns['de']->description);
+
+        // Cleanup
+        self::$testSurvey->delete();
+        self::$testSurvey = null;
+    }
 }


### PR DESCRIPTION
'import_group' was working fine.
'add_group' was updated as to save to the QuestionGroupL10n model.

'set_group_properties' was updated as to be able to receive an array on 'questiongroupl10ns' param.
The method is backward compatible. If an 'questiongroupl10ns' is not given, then it is composed from the old name, description and language parameters.

Adding test for 'add_group' y 'set_group_properties'.
