### PR TITLE
Fixed issue #17082: text display in plain italics not possible

### DIFF
--- a/assets/fonts/noto.css
+++ b/assets/fonts/noto.css
@@ -15,14 +15,14 @@
 
 @font-face {
   font-family: 'Noto Sans';
-  font-weight: 300;
+  font-weight: 400;
   font-style: italic;
   src: url('./font-src/Noto/NotoSans-Italic.ttf');
 }
 
 @font-face {
   font-family: 'Noto Sans';
-  font-weight: 400;
+  font-weight: 700;
   font-style: italic;
   src: url('./font-src/Noto/NotoSans-BoldItalic.ttf');
 }


### PR DESCRIPTION
Adjusting weight queries as to make regular italic to use the Italic.ttf font