### PR TITLE
Fixed issue #15819: Missing localization for group_name in add_group, set_group_properties, import_group

### DIFF
--- a/tests/unit/helpers/RemoteControlTest.php
+++ b/tests/unit/helpers/RemoteControlTest.php
@@ -346,4 +346,136 @@ class RemoteControlTest extends TestBaseClass
         self::$testSurvey->delete();
         self::$testSurvey = null;
     }
+    
+    public function testAddGroup()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        $dbo = \Yii::app()->getDb();
+
+        // Make sure the Authdb is in database (might not be the case if no browser login attempt has been made).
+        $plugin = \Plugin::model()->findByAttributes(array('name'=>'Authdb'));
+        if (!$plugin) {
+            $plugin = new \Plugin();
+            $plugin->name = 'Authdb';
+            $plugin->active = 1;
+            $plugin->save();
+        } else {
+            $plugin->active = 1;
+            $plugin->save();
+        }
+        App()->getPluginManager()->loadPlugin('Authdb', $plugin->id);
+        // Clear login attempts.
+        $query = sprintf('DELETE FROM {{failed_login_attempts}}');
+        $dbo->createCommand($query)->execute();
+
+
+        $filename = self::$surveysFolder . '/limesurvey_survey_remote_api_group_language.lss';
+        self::importSurvey($filename);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        // Add group
+        $result = $handler->add_group($sessionKey, self::$surveyId, "Test group title", "Test group description");
+        $this->assertIsNumeric($result, '$result = ' . json_encode($result));
+
+        $oGroup = \QuestionGroup::model()->findByPk($result);
+        $this->assertNotEmpty($oGroup, "Imported group not found");
+
+        $this->assertEquals("Test group title", $oGroup->questiongroupl10ns['en']->group_name);
+        $this->assertEquals("Test group description", $oGroup->questiongroupl10ns['en']->description);
+
+        // Cleanup
+        self::$testSurvey->delete();
+        self::$testSurvey = null;
+    }
+
+    public function testSetGroupProperties()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        $dbo = \Yii::app()->getDb();
+
+        // Make sure the Authdb is in database (might not be the case if no browser login attempt has been made).
+        $plugin = \Plugin::model()->findByAttributes(array('name'=>'Authdb'));
+        if (!$plugin) {
+            $plugin = new \Plugin();
+            $plugin->name = 'Authdb';
+            $plugin->active = 1;
+            $plugin->save();
+        } else {
+            $plugin->active = 1;
+            $plugin->save();
+        }
+        App()->getPluginManager()->loadPlugin('Authdb', $plugin->id);
+        // Clear login attempts.
+        $query = sprintf('DELETE FROM {{failed_login_attempts}}');
+        $dbo->createCommand($query)->execute();
+
+
+        $filename = self::$surveysFolder . '/limesurvey_survey_remote_api_group_language.lss';
+        self::importSurvey($filename);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        $survey = \Survey::model()->findByPk(self::$surveyId);
+        $oGroup = $survey->groups[0];
+
+        // Prepare group data
+        // Old style first (no separate L10n data)
+        $aGroupData = [
+            'group_name' => 'New group title',
+            'description' => 'New group description',
+            'language' => 'en',
+            'grelevance' => 1,
+        ];
+
+        // Add group
+        $result = $handler->set_group_properties($sessionKey, $oGroup->gid, $aGroupData);
+        $this->assertNotEmpty($result, "Empty results");
+        $this->assertTrue($result['questiongroupl10ns']['en']['group_name'], "Failed setting group language data (old style)");
+
+        $oGroup->refresh();
+        $this->assertEquals("New group title", $oGroup->questiongroupl10ns['en']->group_name);
+        $this->assertEquals("New group description", $oGroup->questiongroupl10ns['en']->description);
+        $this->assertEquals(1, $oGroup->grelevance);
+
+        // Prepare group data
+        // New style (separate L10n)
+        $aGroupData = [];
+        $aGroupData['questiongroupl10ns']['de'] = [
+            'group_name' => 'Der neue deutsche Titel',
+            'description' => 'Die neue deutsche Beschreibung',
+            'language' => 'de',
+        ];
+
+        // Add group
+        $result = $handler->set_group_properties($sessionKey, $oGroup->gid, $aGroupData);
+        $this->assertNotEmpty($result, "Empty results");
+        $this->assertTrue($result['questiongroupl10ns']['de']['group_name'], "Failed setting group language data (old style)");
+
+        $oGroup->refresh();
+        $this->assertEquals("Der neue deutsche Titel", $oGroup->questiongroupl10ns['de']->group_name);
+        $this->assertEquals("Die neue deutsche Beschreibung", $oGroup->questiongroupl10ns['de']->description);
+
+        // Cleanup
+        self::$testSurvey->delete();
+        self::$testSurvey = null;
+    }
 }


### PR DESCRIPTION
'import_group' was working fine.
'add_group' was updated as to save to the QuestionGroupL10n model.

'set_group_properties' was updated as to be able to receive an array on 'questiongroupl10ns' param.
The method is backward compatible. If an 'questiongroupl10ns' is not given, then it is composed from the old name, description and language parameters.

Adding test for 'add_group' y 'set_group_properties'.


PRevios PR (https://github.com/LimeSurvey/LimeSurvey/pull/1785) closed. This replaces it.