### PR TITLE
Fixed issue #16903: Windows server : unable to save attachements

### DIFF
--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -338,13 +338,17 @@ class RegisterController extends LSYii_Controller
         $aRelevantAttachments = array();
         if (isset($aSurveyInfo['attachments'])) {
             $aAttachments = unserialize($aSurveyInfo['attachments']);
+            $attachmentsDir =realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files');
             if (!empty($aAttachments)) {
                 if (isset($aAttachments['registration'])) {
                     LimeExpressionManager::singleton()->loadTokenInformation($aSurveyInfo['sid'], $sToken);
                     foreach ($aAttachments['registration'] as $aAttachment) {
-                        if(Yii::app()->is_file($aAttachment['url'],Yii::app()->getConfig('uploaddir').DIRECTORY_SEPARATOR."surveys".DIRECTORY_SEPARATOR.$iSurveyId,false)) {
-                            if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])) {
-                                $aRelevantAttachments[] = $aAttachment['url'];
+                        if (!empty($attachment['url'])) {
+                            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
+                            if(App()->is_file($surveyUploadDir . DIRECTORY_SEPARATOR . $baseName, $surveyUploadDir, false)) {
+                                if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])) {
+                                    $aRelevantAttachments[] = $aAttachment['url'];
+                                }
                             }
                         }
                     }

--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -345,9 +345,9 @@ class RegisterController extends LSYii_Controller
                     foreach ($aAttachments['registration'] as $aAttachment) {
                         if (!empty($attachment['url'])) {
                             $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
-                            if(App()->is_file($surveyUploadDir . DIRECTORY_SEPARATOR . $baseName, $surveyUploadDir, false)) {
+                            if(App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false)) {
                                 if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])) {
-                                    $aRelevantAttachments[] = $aAttachment['url'];
+                                    $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
                                 }
                             }
                         }

--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -343,9 +343,9 @@ class RegisterController extends LSYii_Controller
                 if (isset($aAttachments['registration'])) {
                     LimeExpressionManager::singleton()->loadTokenInformation($aSurveyInfo['sid'], $sToken);
                     foreach ($aAttachments['registration'] as $aAttachment) {
-                        if (!empty($attachment['url'])) {
-                            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
-                            if(App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false)) {
+                        if (!empty($aAttachment['url'])) {
+                            $baseName = pathinfo($aAttachment['url'], PATHINFO_BASENAME);
+                            if(App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . /** @scrutinizer ignore-type we get PATHINFO_BASENAME */ $baseName, $attachmentsDir, false)) {
                                 if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])) {
                                     $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
                                 }

--- a/application/controllers/admin/emailtemplates.php
+++ b/application/controllers/admin/emailtemplates.php
@@ -112,7 +112,7 @@ class emailtemplates extends Survey_Common_Action
                         foreach ($attachments as  $index => &$attachment) {
                             // We again take the real path.
                             $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
-                            if (App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, true)) {
+                            if (App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . /** @scrutinizer ignore-type we get PATHINFO_BASENAME */ $baseName, $attachmentsDir, true)) {
                                 $attachment['url'] = $baseName;
                                 $attachment['size'] = filesize($attachmentsDir . DIRECTORY_SEPARATOR . $baseName);
                             } else {

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1441,15 +1441,19 @@ class tokens extends Survey_Common_Action
                             $sTemplate = 'reminder';
                         }
                         $aRelevantAttachments = array();
+                        $attachmentsDir =realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files');
                         if (isset($aData['thissurvey'][$emrow['language']]['attachments'])) {
                             $aAttachments = unserialize($aData['thissurvey'][$emrow['language']]['attachments']);
                             if (!empty($aAttachments)) {
                                 if (isset($aAttachments[$sTemplate])) {
                                     LimeExpressionManager::singleton()->loadTokenInformation($aData['thissurvey']['sid'], $emrow['token']);
                                     foreach ($aAttachments[$sTemplate] as $aAttachment) {
-                                        if (Yii::app()->is_file($aAttachment['url'], Yii::app()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId)) {
-                                            if (LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])) {
-                                                $aRelevantAttachments[] = $aAttachment['url'];
+                                        if(!empty($attachment['url'])) {
+                                            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
+                                            if (App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir)
+                                                && LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])
+                                                ) {
+                                                    $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
                                             }
                                         }
                                     }

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1448,8 +1448,8 @@ class tokens extends Survey_Common_Action
                                 if (isset($aAttachments[$sTemplate])) {
                                     LimeExpressionManager::singleton()->loadTokenInformation($aData['thissurvey']['sid'], $emrow['token']);
                                     foreach ($aAttachments[$sTemplate] as $aAttachment) {
-                                        if(!empty($attachment['url'])) {
-                                            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
+                                        if(!empty($aAttachment['url'])) {
+                                            $baseName = pathinfo($aAttachment['url'], PATHINFO_BASENAME);
                                             if (App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir)
                                                 && LimeExpressionManager::singleton()->ProcessRelevance($aAttachment['relevance'])
                                                 ) {

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -500,13 +500,13 @@ function submittokens($quotaexit = false)
                  * Iterate through attachments and check them for relevance.
                  */
                 if (isset($aAttachments['confirmation'])) {
-                    $attachmentsDir = realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files');
+                    $attachmentsDir = realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $surveyid . DIRECTORY_SEPARATOR . 'files');
                     foreach ($aAttachments['confirmation'] as $aAttachment) {
                         $relevance = $aAttachment['relevance'];
                         $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
                         // If the attachment is relevant it will be added to the mail.
                         if (LimeExpressionManager::ProcessRelevance($relevance)
-                            && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false) ) {
+                            && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . /** @scrutinizer ignore-type we get PATHINFO_BASENAME */ $baseName, $attachmentsDir, false) ) {
                             $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
                         }
                     }
@@ -645,7 +645,7 @@ function sendSubmitNotifications($surveyid)
             $relevance = $aAttachment['relevance'];
             $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
             // If the attachment is relevant it will be added to the mail.
-            if (LimeExpressionManager::ProcessRelevance($relevance) && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false)) {
+            if (LimeExpressionManager::ProcessRelevance($relevance) && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . /** @scrutinizer ignore-type we get PATHINFO_BASENAME */ $baseName, $attachmentsDir, false)) {
                 $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
             }
         }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -500,11 +500,14 @@ function submittokens($quotaexit = false)
                  * Iterate through attachments and check them for relevance.
                  */
                 if (isset($aAttachments['confirmation'])) {
+                    $attachmentsDir = realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files');
                     foreach ($aAttachments['confirmation'] as $aAttachment) {
                         $relevance = $aAttachment['relevance'];
+                        $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
                         // If the attachment is relevant it will be added to the mail.
-                        if (LimeExpressionManager::ProcessRelevance($relevance) && Yii::app()->is_file($aAttachment['url'],Yii::app()->getConfig('uploaddir').DIRECTORY_SEPARATOR."surveys".DIRECTORY_SEPARATOR.$surveyid,false)) {
-                            $aRelevantAttachments[] = $aAttachment['url'];
+                        if (LimeExpressionManager::ProcessRelevance($relevance)
+                            && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false) ) {
+                            $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
                         }
                     }
                 }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -639,12 +639,14 @@ function sendSubmitNotifications($surveyid)
     /*
      * Iterate through attachments and check them for relevance.
      */
+    $attachmentsDir = realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files');
     if (isset($aAttachments['admin_notification'])) {
         foreach ($aAttachments['admin_notification'] as $aAttachment) {
             $relevance = $aAttachment['relevance'];
+            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
             // If the attachment is relevant it will be added to the mail.
-            if (LimeExpressionManager::ProcessRelevance($relevance) && Yii::app()->is_file($aAttachment['url'],Yii::app()->getConfig('uploaddir').DIRECTORY_SEPARATOR."surveys".DIRECTORY_SEPARATOR.$surveyid,false)) {
-                $aRelevantAttachments[] = $aAttachment['url'];
+            if (LimeExpressionManager::ProcessRelevance($relevance) && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false)) {
+                $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
             }
         }
     }
@@ -670,9 +672,10 @@ function sendSubmitNotifications($surveyid)
     if (isset($aAttachments['admin_detailed_notification'])) {
         foreach ($aAttachments['admin_detailed_notification'] as $aAttachment) {
             $relevance = $aAttachment['relevance'];
+            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
             // If the attachment is relevant it will be added to the mail.
-            if (LimeExpressionManager::ProcessRelevance($relevance) && Yii::app()->is_file($aAttachment['url'],Yii::app()->getConfig('uploaddir').DIRECTORY_SEPARATOR."surveys".DIRECTORY_SEPARATOR.$surveyid,false)) {
-                $aRelevantAttachments[] = $aAttachment['url'];
+            if (LimeExpressionManager::ProcessRelevance($relevance) && App()->is_file($attachmentsDir . DIRECTORY_SEPARATOR . $baseName, $attachmentsDir, false)) {
+                $aRelevantAttachments[] = $attachmentsDir . DIRECTORY_SEPARATOR . $baseName;
             }
         }
     }

--- a/application/views/admin/emailtemplates/email_language_template_tab.php
+++ b/application/views/admin/emailtemplates/email_language_template_tab.php
@@ -64,7 +64,7 @@ $script = array();
     $hideAttacehemtTable = true;
     if (isset($esrow->attachments[$tab])) {
         foreach ($esrow->attachments[$tab] as $attachment) {
-            $script[] = sprintf("prepEmailTemplates.addAttachment($('#attachments-%s-%s'), %s, %s, %s );", $grouplang, $tab, json_encode($attachment['url']), json_encode($attachment['relevance']), json_encode($attachment['size']));
+            $script[] = sprintf("prepEmailTemplates.addAttachment($('#attachments-%s-%s'), %s, %s, %s );", $grouplang, $tab, json_encode(basename($attachment['url'])), json_encode($attachment['relevance']), json_encode($attachment['size']));
         }
         $hideAttacehemtTable = false;
     }


### PR DESCRIPTION
Fixed issue #16905: Windows server : good attachment throw JS error (and broke all JS action)
Dev: save only basename : JS don't care of separator
Dev: save only basename, find files in survey upload dir (always)