### PR TITLE
Fixed issue #16903: Windows server : unable to save attachements

### DIFF
--- a/application/controllers/admin/emailtemplates.php
+++ b/application/controllers/admin/emailtemplates.php
@@ -99,20 +99,9 @@ class emailtemplates extends Survey_Common_Action
      */
     function update($iSurveyId)
     {
-        $sBaseUrl = Yii::app()->getBaseUrl();
-        $uploadUrl = Yii::app()->getConfig('uploadurl');
-        if (substr($uploadUrl, 0, strlen($sBaseUrl)) == $sBaseUrl) {
-            $uploadUrl = substr($uploadUrl, strlen($sBaseUrl));
-        }
-        $sBaseAbsoluteUrl = Yii::app()->getBaseUrl(true);
-        $sPublicUrl = Yii::app()->getConfig("publicurl");
-        $aPublicUrl = parse_url($sPublicUrl);
-        if (isset($aPublicUrl['scheme']) && isset($aPublicUrl['host'])) {
-            $sBaseAbsoluteUrl = $sPublicUrl;
-        }
-        $uploadUrl = trim($sBaseAbsoluteUrl, "/").$uploadUrl;
         // We need the real path since we check that the resolved file name starts with this path.
         $uploadDir = realpath(Yii::app()->getConfig('uploaddir'));
+        $uploadSurveyFilesDir = $uploadDir . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $iSurveyId . DIRECTORY_SEPARATOR . 'files';
         $sSaveMethod = Yii::app()->request->getPost('save', '');
         if (Permission::model()->hasSurveyPermission($iSurveyId, 'surveylocale', 'update') && $sSaveMethod != '') {
             $languagelist = Survey::model()->findByPk($iSurveyId)->additionalLanguages;
@@ -122,8 +111,10 @@ class emailtemplates extends Survey_Common_Action
                 if (isset($_POST['attachments'][$langname])) {
                     foreach ($_POST['attachments'][$langname] as $template => &$attachments) {
                         foreach ($attachments as  $index => &$attachment) {
-                            // We again take the real path.
-                            $localName = realpath(urldecode(str_replace($uploadUrl, $uploadDir, $attachment['url'])));
+                            // Take only the base name
+                            $baseName = pathinfo($attachment['url'], PATHINFO_BASENAME);
+                            // get the localName according to current $uploadSurveyFilesDir
+                            $localName = realpath($uploadSurveyFilesDir . DIRECTORY_SEPARATOR . $baseName);
                             if ($localName !== false) {
                                 if (strpos($localName, $uploadDir) === 0) {
                                     $attachment['url'] = $localName;

--- a/application/views/admin/emailtemplates/email_language_template_tab.php
+++ b/application/views/admin/emailtemplates/email_language_template_tab.php
@@ -64,7 +64,7 @@ $script = array();
     $hideAttacehemtTable = true;
     if (isset($esrow->attachments[$tab])) {
         foreach ($esrow->attachments[$tab] as $attachment) {
-            $script[] = sprintf("prepEmailTemplates.addAttachment($('#attachments-%s-%s'), %s, %s, %s );", $grouplang, $tab, json_encode($attachment['url']), json_encode($attachment['relevance']), json_encode($attachment['size']));
+            $script[] = sprintf("prepEmailTemplates.addAttachment($('#attachments-%s-%s'), %s, %s, %s );", $grouplang, $tab, json_encode(basename($attachment['url'])), json_encode($attachment['relevance']), json_encode($attachment['size']));
         }
         $hideAttacehemtTable = false;
     }


### PR DESCRIPTION
Fixed issue #16905: Windows server : good attachment throw JS error (and broke all JS action)
Dev: use only basename on view : JS don't care of separator
Dev: use only basename and survey uploaddir :
Dev: no need a complex str_replace between url and dir : we know the final dir
