### PR TITLE
Fixed issue #16904: Check attributes are escaped properly

### DIFF
--- a/application/views/questionAdministration/answerOptionRow.twig
+++ b/application/views/questionAdministration/answerOptionRow.twig
@@ -115,7 +115,7 @@
                 id='answeroptions[{{ answerOption.aid }}][{{ scale_id }}][answeroptionl10n][{{ language }}]'
                 name='answeroptions[{{ answerOption.aid }}][{{ scale_id }}][answeroptionl10n][{{ language }}]'
                 placeholder='{{ gT("Some example answer option") }}'
-                value="{{ answerOptionl10n.answer }}"
+                value="{{ answerOptionl10n.answer|escape('html_attr') }}"
             />
             <span class="input-group-addon">
                 {{ getEditor(


### PR DESCRIPTION
Answer options are escaped before render as to avoid broken html