### PR TITLE
Fixed issue #16914: Check if localization-related options are correctly imported.

### DIFF
--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -82,6 +82,7 @@ class QuestionAttribute extends LSActiveRecord
         return array(
             array('qid,attribute', 'required'),
             array('value', 'LSYii_Validators'),
+            array('language', 'LSYii_Validators', 'isLanguage' => true)
         );
     }
 


### PR DESCRIPTION
XMLImportSurvey tried to set the language for the question attributes properly, but the QuestionAttribute model didn't have a validator for 'language' field, making it "unsafe". So, the 'language' attribute was silently omitted and all question attributes ended up being saved without language.