### PR TITLE
Fixed issue #17208: avoid Column name must be … during survey taking

### DIFF
--- a/application/models/Response.php
+++ b/application/models/Response.php
@@ -36,6 +36,15 @@
             return parent::create($surveyId, $scenario);
         }
 
+        /** @inheritdoc
+         * Must be set by DB, adding by security here
+         * @see https://bugs.limesurvey.org/view.php?id=17208
+         **/
+        public function primaryKey()
+        {
+            return 'id';
+        }
+
         /**
          * Get all files related to this response and (optionally) question ID.
          *


### PR DESCRIPTION
 Fixed issue #17208: avoid olumn name must be either a string or an array during survey taking
Dev: some response table can have broken primaryKey, avoid public DB issue