### PR TITLE
Fixed issue #17210: Invalid TSV : OK on mysql/pgsql, broken on MSSQL

### DIFF
--- a/application/controllers/admin/questions.php
+++ b/application/controllers/admin/questions.php
@@ -1237,6 +1237,8 @@ class questions extends Survey_Common_Action
 
                 foreach ($questlangs as $key=>$value) {
                     if ($value != 99) {
+                        /* This language didn't exist in this survey : autofixer */
+                        switchMSSQLIdentityInsert('questions', true);
                         $arQuestion = new Question;
                         $arQuestion->qid = $qid;
                         $arQuestion->sid = $surveyid;
@@ -1251,6 +1253,7 @@ class questions extends Survey_Common_Action
                         $arQuestion->question_order = $basesettings['question_order'];
                         $arQuestion->language = $key;
                         $arQuestion->insert();
+                        switchMSSQLIdentityInsert('questions', false);
                     }
                 }
 


### PR DESCRIPTION
Dev: lack of switchMSSQLIdentityInsert
Dev: not needed by 4.X