### PR TITLE
Fixed issue #16621: In RemoteControl the parameter conditions and token for list_participants() do not allow multiple token IDs anymore

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2114,7 +2114,7 @@ class remotecontrol_handle
                     foreach ($aConditions as $columnName => $valueOrTuple) {
                         if (is_array($valueOrTuple)) {
                             /** @var string[] List of operators allowed in query. */
-                            $allowedOperators = ['<', '>', '>=', '<=', '=', '<>', 'LIKE'];
+                            $allowedOperators = ['<', '>', '>=', '<=', '=', '<>', 'LIKE', 'IN'];
                             /** @var string */
                             $operator = $valueOrTuple[0];
                             if (!in_array($operator, $allowedOperators)) {
@@ -2123,6 +2123,10 @@ class remotecontrol_handle
                                 /** @var mixed */
                                 $value = $valueOrTuple[1];
                                 $oCriteria->addSearchCondition($columnName, $value);
+                            } elseif ($operator === 'IN') {
+                                /** @var mixed */
+                                $values = array_slice($valueOrTuple, 1);
+                                $oCriteria->addInCondition($columnName, $values);
                             } else {
                                 /** @var mixed */
                                 $value = $valueOrTuple[1];

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2068,7 +2068,12 @@ class remotecontrol_handle
      *
      * If $bUnused is true, user will get the list of uncompleted tokens (token_return functionality).
      * Parameters iStart and iLimit are used to limit the number of results of this call.
-     *
+     * Starting With version 4.3.0 it is not possible anymore to query for several IDs by just service them as array - instead use the 'IN' operator
+     * Examples of conditions:
+     *     array ('tid => 'IN','1','3','26')
+     *     array('email' => 'info@example.com')
+     *     array('validuntil' => array('>', '2019-01-01 00:00:00'))
+     * 
      * By default return each participant with basic information
      * * tid : the token id
      * * token : the token for this participant
@@ -2082,7 +2087,11 @@ class remotecontrol_handle
      * @param int  $iLimit Number of participants to return
      * @param bool $bUnused If you want unused tokens, set true
      * @param bool|array $aAttributes The extented attributes that we want
-     * @param array $aConditions Optional conditions to limit the list, e.g. with array('email' => 'info@example.com') or array('validuntil' => array('>', '2019-01-01 00:00:00'))
+     * @param array $aConditions Optional conditions to limit the list, either as a key=>value array for simple comparisons
+     *              or as key=>array(operator,value[,value[...]]) using an operator. 
+     *              Valid operators are  ['<', '>', '>=', '<=', '=', '<>', 'LIKE', 'IN']
+     *              Only the IN operator allows for several values. The same key can be used several times.
+     *              All conditions are connected by AND.
      * @return array The list of tokens
      */
     public function list_participants($sSessionKey, $iSurveyID, $iStart = 0, $iLimit = 10, $bUnused = false, $aAttributes = false, $aConditions = array())

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2068,12 +2068,13 @@ class remotecontrol_handle
      *
      * If $bUnused is true, user will get the list of uncompleted tokens (token_return functionality).
      * Parameters iStart and iLimit are used to limit the number of results of this call.
-     * Starting With version 4.3.0 it is not possible anymore to query for several IDs by just service them as array - instead use the 'IN' operator
+     * Starting with version 4.3.0 it is not possible anymore to query for several IDs just using
+     * an array of values - instead you have use the 'IN' operator.
      * Examples of conditions:
      *     array ('tid => 'IN','1','3','26')
      *     array('email' => 'info@example.com')
      *     array('validuntil' => array('>', '2019-01-01 00:00:00'))
-     * 
+     *
      * By default return each participant with basic information
      * * tid : the token id
      * * token : the token for this participant
@@ -2088,7 +2089,7 @@ class remotecontrol_handle
      * @param bool $bUnused If you want unused tokens, set true
      * @param bool|array $aAttributes The extented attributes that we want
      * @param array $aConditions Optional conditions to limit the list, either as a key=>value array for simple comparisons
-     *              or as key=>array(operator,value[,value[...]]) using an operator. 
+     *              or as key=>array(operator,value[,value[...]]) using an operator.
      *              Valid operators are  ['<', '>', '>=', '<=', '=', '<>', 'LIKE', 'IN']
      *              Only the IN operator allows for several values. The same key can be used several times.
      *              All conditions are connected by AND.
@@ -2119,7 +2120,7 @@ class remotecontrol_handle
                 if (count($aConditions) > 0) {
                     $aConditionFields = array_flip(Token::model($iSurveyID)->getMetaData()->tableSchema->columnNames);
                     // NB: $valueOrTuple is either a value or tuple like [$operator, $value].
-                    $oCriteria->compare('tid', '>='.$iStart);
+                    $oCriteria->compare('tid', '>=' . $iStart);
                     foreach ($aConditions as $columnName => $valueOrTuple) {
                         if (is_array($valueOrTuple)) {
                             /** @var string[] List of operators allowed in query. */
@@ -2160,7 +2161,7 @@ class remotecontrol_handle
                 if (count($oTokens) == 0) {
                     return array('status' => 'No survey participants found.');
                 }
-                
+
                 $extendedAttributes = array();
                 if ($aAttributes) {
                     $aBasicDestinationFields = Token::model($iSurveyID)->tableSchema->columnNames;

--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -31,6 +31,10 @@ class FailedLoginAttempt extends LSActiveRecord
     {
         /** @var self $model */
         $model = parent::model($class);
+        // When running tests this might be empty
+        if (!isset($_SERVER['REMOTE_ADDR'])) {
+            $_SERVER['REMOTE_ADDR'] = '';
+        }
         return $model;
     }
 

--- a/tests/unit/helpers/RemoteControlListParticipantsTest.php
+++ b/tests/unit/helpers/RemoteControlListParticipantsTest.php
@@ -97,6 +97,59 @@ class RemoteControlListParticipantsTest extends TestBaseClass
         $this->assertEquals($expected, $list);
     }
 
+
+
+    /**
+     * Test so that validuntil works with IN operator.
+     *
+     * @return void
+     */
+    public function testConditionIn()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+        \Yii::import('application.helpers.viewHelper', true);
+        \Yii::import('application.libraries.BigData', true);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+        $this->assertNotEquals(['status' => 'Invalid user name or password'], $sessionKey);
+
+        /** @var array */
+        $list = $handler->list_participants(
+            $sessionKey,
+            self::$surveyId,
+            0,
+            999,
+            false,
+            ['validuntil', 'validfrom'],
+            ['tid' => ["1","3"]]
+        );
+
+        $expected = [
+            [
+                'tid' => "1",
+                'token' => "c",
+                'participant_info' => [
+                    'firstname' => "a",
+                    'lastname' => "b",
+                    'email' => "a@a.a"
+                ],
+                'validuntil' => "2020-04-01 15:12:00",
+                'validfrom' => "2020-03-18 15:12:00"
+            ]
+        ];
+
+        $this->assertEquals($expected, $list);
+    }
+
+
     /**
      * Test condition with empty return result.
      * 

--- a/tests/unit/helpers/RemoteControlListParticipantsTest.php
+++ b/tests/unit/helpers/RemoteControlListParticipantsTest.php
@@ -128,8 +128,8 @@ class RemoteControlListParticipantsTest extends TestBaseClass
             0,
             999,
             false,
-            ['validuntil', 'validfrom'],
-            ['tid' => ["1","3"]]
+            [],
+            ['tid' => ["IN","1","2"]]
         );
 
         $expected = [
@@ -141,9 +141,17 @@ class RemoteControlListParticipantsTest extends TestBaseClass
                     'lastname' => "b",
                     'email' => "a@a.a"
                 ],
-                'validuntil' => "2020-04-01 15:12:00",
-                'validfrom' => "2020-03-18 15:12:00"
+            ],
+            [
+                'tid' => "2",
+                'token' => "e",
+                'participant_info' => [
+                    'firstname' => "q",
+                    'lastname' => "w",
+                    'email' => "q@q.com"
+                ],
             ]
+
         ];
 
         $this->assertEquals($expected, $list);


### PR DESCRIPTION
Dev Fixed by adding an IN parameter to conditions and documenting the new way properly
See issue https://bugs.limesurvey.org/view.php?id=16621