### PR TITLE
Fixed issue #16414: Question editor is not loaded when config.xml attribute has empty string as default

### DIFF
--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -1652,6 +1652,13 @@ class questionHelper
         $additionalAttributes = array();
         // Create array of attribute with name as key
         foreach($custom_attributes['attribute'] as $customAttribute) {
+            // Empty xml nodes (ex: <default></default>) end up as empty arrays.
+            // We need a null instead
+            foreach ($customAttribute as $property => $propertyValue) {
+                if (is_array($propertyValue) && empty($propertyValue)) {
+                    $customAttribute[$property] = null;
+                }
+            }            
             // Try to translate the category title. Custom categories may not be translated, but at least if the theme tries
             // to "reuse" a core category the attribute will be displayed properly. See issue #15671
             if(!empty($customAttribute['category'])) {

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -318,6 +318,13 @@ class Question extends LSActiveRecord
                     foreach ($oQuestionTemplate->oConfig->custom_attributes->attribute as $oCustomAttribute) {
                         $sAttributeName = (string) $oCustomAttribute->name;
                         $aCustomAttribute = json_decode(json_encode((array) $oCustomAttribute), 1);
+                        // Empty xml nodes (ex: <default></default>) end up as empty arrays.
+                        // We need a null instead
+                        foreach ($aCustomAttribute as $property => $propertyValue) {
+                            if (is_array($propertyValue) && empty($propertyValue)) {
+                                $aCustomAttribute[$property] = null;
+                            }
+                        }
                         $aCustomAttribute = array_merge(
                             QuestionAttribute::getDefaultSettings(),
                             array("category"=>gT("Template")),


### PR DESCRIPTION
All empty nodes are turned into null values, instead of an empty std objec / array. (As in LS4)