### PR TITLE
Fixed issue #15051: When setting condition on Survey Participant Attributes the expression stored in DB is invalid

### DIFF
--- a/application/controllers/admin/conditionsaction.php
+++ b/application/controllers/admin/conditionsaction.php
@@ -697,7 +697,9 @@ class conditionsaction extends Survey_Common_Action
         /** @var string $editSourceTab */
         extract($args);
 
-        if (isset($p_cquestions) && $p_cquestions != '') {
+        $editSourceTab = $request->getPost('editSourceTab');
+
+        if (isset($p_cquestions) && $p_cquestions != '' && $editSourceTab == '#SRCPREVQUEST') {
             $conditionCfieldname = $p_cquestions;
         } elseif (isset($p_csrctoken) && $p_csrctoken != '') {
             $conditionCfieldname = $p_csrctoken;


### PR DESCRIPTION
Applyig same patch as on bug #16518 (3.22.29). This is an interface issue, solved now