### PR TITLE
Fixed issue #15892: use same logic for validation and unanswered for QT_O

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6235,7 +6235,14 @@ class LimeExpressionManager
                     }
                     // what about optional vs. mandatory comment and 'other' fields?
                     break;
-                    
+                case Question::QT_O_LIST_WITH_COMMENT:
+                    foreach ($unansweredSQs as $sq) {
+                        if (!preg_match("/comment$/", $sq)) {
+                            $anyUnanswered = true;
+                            break;
+                        }
+                    }
+                    break;
                 case Question::QT_COLON_ARRAY_MULTI_FLEX_NUMBERS:
                     $anyUnanswered = false;
                     $qattr = isset($LEM->qattr[$qid]) ? $LEM->qattr[$qid] : array();


### PR DESCRIPTION
Dev: Fixes a bug where type O questions are marked valid but unanswered if
an answer is chosen, but comment left empty.

Fixed issue #15892: use same logic for validation and unanswered for QT_O

This is the fix in the unanswered state logic as discussed in https://bugs.limesurvey.org/view.php?id=15892. Unfortunately I'm not experienced enough in LS development (and php in general) to provide the requested tests; I'd be glad if someone could help me out on that.
