### PR TITLE
Fixed issue #17207: When attaching using the theme editor, full path is displayed on the screen

### DIFF
--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -989,11 +989,14 @@ class themes extends Survey_Common_Action
                 break;
         }
 
+        $sFileDisplayName = ltrim(str_replace(Yii::app()->getConfig('rootdir'), '', $editfile), DIRECTORY_SEPARATOR);
+
         $editableCssFiles = $oEditedTemplate->getValidScreenFiles("css");
         $filesdir = $oEditedTemplate->filesPath;
         $aData['oEditedTemplate'] = $oEditedTemplate;
         $aData['screenname'] = $screenname;
         $aData['editfile'] = $editfile;
+        $aData['filedisplayname'] = $sFileDisplayName;
         $aData['relativePathEditfile'] = $relativePathEditfile;
         $aData['tempdir'] = $tempdir;
         $aData['templatename'] = $templatename;

--- a/application/views/admin/themes/templatesummary_view.php
+++ b/application/views/admin/themes/templatesummary_view.php
@@ -8,7 +8,7 @@ Yii::app()->getClientScript()->registerScript('editorfiletype',"editorfiletype =
     <div class="row template-sum">
         <div class="col-lg-12">
             <div class="h4">
-                <?php echo sprintf(gT("Viewing file '%s'"),$editfile); ?>
+                <?php echo sprintf(gT("Viewing file '%s'"), $filedisplayname); ?>
             </div>
 
             <?php if (!is_writable($templates[$templatename])) { ?>


### PR DESCRIPTION
Removing root dir from displayed path