### PR TITLE
Fixed issue #17120: After picking a new question theme, the settings are not properly updated

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2292,28 +2292,13 @@ class QuestionAdministrationController extends LSBaseController
         $advancedSettings = $oQuestion->getAdvancedSettingsWithValues(null, $sQuestionTheme);
 
         // Group the array in categories
-        $advancedSettings = self::groupAttributesByCategory($advancedSettings);
+        $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+        $advancedSettings = $questionAttributeHelper->groupAttributesByCategory($advancedSettings);
 
         // This category is "general setting".
         unset($advancedSettings['Attribute']);
 
         return $advancedSettings;
-    }
-
-    /**
-     * Receives an array of question attributes and groups them by category.
-     * Used by advanced settings widget.
-     *
-     * @param array $aAttributes
-     * @return array Grouped question attributes, with category as array key
-     */
-    private static function groupAttributesByCategory($aAttributes)
-    {
-        $aByCategory = [];
-        foreach ($aAttributes as $aAttribute) {
-            $aByCategory[$aAttribute['category']][] = $aAttribute;
-        }
-        return $aByCategory;
     }
 
     /**

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2278,29 +2278,42 @@ class QuestionAdministrationController extends LSBaseController
      *
      * @param int $iQuestionId
      * @param string $sQuestionType
-     * @param string $question_template
+     * @param string $sQuestionTheme
      * @return array
      * @throws CException
      * @throws Exception
      */
-    private function getAdvancedOptions($iQuestionId = null, $sQuestionType = null, $question_template = 'core')
+    private function getAdvancedOptions($iQuestionId = null, $sQuestionType = null, $sQuestionTheme = 'core')
     {
         //here we get a Question object (also if question is new --> QuestionCreate)
-
         $oQuestion = $this->getQuestionObject($iQuestionId, $sQuestionType);
-        $advancedSettings = $oQuestion->getAdvancedSettingsWithValuesByCategory(null);
-        // TODO: Why can empty array be saved as value?
-        foreach ($advancedSettings as &$category) {
-            foreach ($category as &$setting) {
-                if ($setting['value'] === []) {
-                    $setting['value'] = null;
-                }
-            }
-        }
+
+        // Get the advanced settings array
+        $advancedSettings = $oQuestion->getAdvancedSettingsWithValues(null, $sQuestionTheme);
+
+        // Group the array in categories
+        $advancedSettings = self::groupAttributesByCategory($advancedSettings);
+
         // This category is "general setting".
         unset($advancedSettings['Attribute']);
 
         return $advancedSettings;
+    }
+
+    /**
+     * Receives an array of question attributes and groups them by category.
+     * Used by advanced settings widget.
+     *
+     * @param array $aAttributes
+     * @return array Grouped question attributes, with category as array key
+     */
+    private static function groupAttributesByCategory($aAttributes)
+    {
+        $aByCategory = [];
+        foreach ($aAttributes as $aAttribute) {
+            $aByCategory[$aAttribute['category']][] = $aAttribute;
+        }
+        return $aByCategory;
     }
 
     /**

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -306,13 +306,14 @@ class Question extends LSActiveRecord
         $aThemeAttributes = QuestionTheme::getAdditionalAttrFromExtendedTheme($sQuestionTheme, $this->type);
 
         // Merge the attributes with the question theme ones
-        $aAttributes = QuestionAttribute::getMergedQuestionAttributes($aQuestionTypeAttributes, $aThemeAttributes);
+        $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+        $aAttributes = $questionAttributeHelper->mergeQuestionAttributes($aQuestionTypeAttributes, $aThemeAttributes);
 
         uasort($aAttributes, 'categorySort');
 
         // Fill attributes with values
         $aLanguages = is_null($sLanguage) ? $oSurvey->allLanguages : [$sLanguage];
-        $aAttributes = QuestionAttribute::fillAttributesWithValues($aAttributes, $aAttributeValues, $aLanguages);
+        $aAttributes = $questionAttributeHelper->fillAttributesWithValues($aAttributes, $aAttributeValues, $aLanguages);
 
         return $aAttributes;
     }
@@ -327,7 +328,7 @@ class Question extends LSActiveRecord
      * @return mixed  returns the incoming parameter $aAttributeNames or
      *
      * @deprecated use QuestionTheme::getAdditionalAttrFromExtendedTheme() to retrieve question theme attributes and
-     *             QuestionAttribute::getMergedQuestionAttributes() to merge with base attributes.
+     *             QuestionAttributeHelper->mergeQuestionAttributes() to merge with base attributes.
      */
     public static function getQuestionTemplateAttributes($aAttributeNames, $aAttributeValues, $oQuestion)
     {

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -266,6 +266,8 @@ class QuestionAttribute extends LSActiveRecord
     {
         $aQuestionAttributes = array();
         foreach ($aAttributeNames as $aAttribute) {
+            // Initializes expression. This is overwritten if no i18n definition found.
+            // Is that expected?
             $aQuestionAttributes[$aAttribute['name']]['expression'] = isset($aAttribute['expression']) ? $aAttribute['expression'] : 0;
 
             // convert empty array to empty string
@@ -340,8 +342,9 @@ class QuestionAttribute extends LSActiveRecord
             ['qid' => $oQuestion->qid, 'attribute' => 'question_template']
         );
         if ($oAttributeValue !== null) {
-            $aAttributeValueQuestionTemplate['question_template'] = $oAttributeValue->value;
-            $retAttributeNamesExtended = Question::getQuestionTemplateAttributes($retAttributeNamesExtended, $aAttributeValueQuestionTemplate, $oQuestion);
+            $sQuestionTheme = $oAttributeValue->value;
+            $aThemeAttributes = QuestionTheme::getAdditionalAttrFromExtendedTheme($sQuestionTheme, $oQuestion->type);
+            $retAttributeNamesExtended = QuestionAttribute::getMergedQuestionAttributes($retAttributeNamesExtended, $aThemeAttributes);
         }
 
         return $retAttributeNamesExtended;
@@ -549,13 +552,7 @@ class QuestionAttribute extends LSActiveRecord
         }
 
         // Filter all pesky '[]' values (empty values should be null, e.g. <default></default>).
-        foreach ($aAttributes as $attributeName => $attribute) {
-            foreach ($attribute as $fieldName => $value) {
-                if ($value === []) {
-                    $aAttributes[$attributeName][$fieldName] = null;
-                }
-            }
-        }
+        $aAttributes = self::getSanitizedQuestionAttributes($aAttributes);
 
         return $aAttributes;
     }
@@ -600,6 +597,10 @@ class QuestionAttribute extends LSActiveRecord
                 $aAttributes[$xmlAttribute]['name'] = $xmlAttribute;
             }
         }
+
+        // Filter all pesky '[]' values (empty values should be null, e.g. <default></default>).
+        $aAttributes = self::getSanitizedQuestionAttributes($aAttributes);
+
         return $aAttributes;
     }
 
@@ -629,5 +630,112 @@ class QuestionAttribute extends LSActiveRecord
         $result = App()->getPluginManager()->dispatchEvent($event);
 
         return (array) $result->get('questionAttributes');
+    }
+
+    /**
+     * Merges the 'base' attributes (ex: core question attributes) with the extended question attributes
+     * (ex: question theme attributes). It also removes all attributes where extended attribute's inputType is
+     * empty.
+     * If an extended attribute's name cannot be determined, it's omitted.
+     *
+     * @param array $aBaseAttributes    the base set of attributes
+     * @param array $aExtendedAttributes    the attributes to merge into the base set
+     *
+     * @return array the merged attributes
+     */
+    public static function getMergedQuestionAttributes($aBaseAttributes, $aExtendedAttributes)
+    {
+        $aAttributes = $aBaseAttributes;
+        foreach ($aExtendedAttributes as $key => $attribute) {
+            // TODO: move to getSanitizedQuestionAttributes()
+            // Determine the attribute name or continue with the next
+            if (!isset($attribute['name'])) {
+                if (!is_numeric($key)) {
+                    $attribute['name'] = $key;
+                } else {
+                    continue;
+                }
+            }
+
+            $sAttributeName = $attribute['name'];
+            $sInputType = $attribute['inputtype'];
+            // remove attribute if inputtype is empty
+            if (empty($sInputType)) {
+                unset($aAttributes[$sAttributeName]);
+            } else {
+                $aCustomAttribute = array_merge(
+                    QuestionAttribute::getDefaultSettings(),
+                    array("category" => gT("Template")),
+                    $attribute
+                );
+                $aAttributes[$sAttributeName] = $aCustomAttribute;
+            }
+        }
+        return $aAttributes;
+    }
+
+    /**
+     * Sanitizes an array of question attributes.
+     * Currently just replaces empty arrays (generally resulting from empty xml nodes) with null.
+     *
+     * @param array $aAttributes the array of attributes to sanitize
+     *
+     * @return array the array of sanitized attributes
+     */
+    public static function getSanitizedQuestionAttributes($aAttributes)
+    {
+        // Replace empty arrays with null
+        foreach ($aAttributes as &$aAttribute) {
+            foreach ($aAttribute as $propertyName => $propertyValue) {
+                if ($propertyValue === []) {
+                    $aAttribute[$propertyName] = null;
+                }
+            }
+        }
+        return $aAttributes;
+    }
+
+    /**
+     * Returns the received array of attributes filled with the values specified, taking into account the
+     * 'i18n' property of the attributes.
+     *
+     * Both this and rewriteQuestionAttributeArray() are helper methods and accomplish quite similar tasks,
+     * but the output is different: rewriteQuestionAttributeArray returns a name -> value array, while here
+     * we return a complete definition map and the value as a piece of information mingled into it.
+     *
+     * @param array $aAttributes the attributes to be filled
+     * @param array $aAttributeValues the values for the attributes
+     * @param array $aLanguages the languages to use for i18n attributes
+     *
+     * @return array the same source attributes with their corresponding values (when available)
+     */
+    public static function fillAttributesWithValues($aAttributes, $aAttributeValues, $aLanguages = [])
+    {
+        foreach ($aAttributes as $iKey => $aAttribute) {
+            if ($aAttribute['i18n'] == false) {
+                if (isset($aAttributeValues[$aAttribute['name']][''])) {
+                    $aAttributes[$iKey]['value'] = $aAttributeValues[$aAttribute['name']][''];
+                } else {
+                    $aAttributes[$iKey]['value'] = $aAttribute['default'];
+                }
+                // Sanitize value in case it's saved as empty array
+                if ($aAttributes[$iKey]['value'] === []) {
+                    $aAttributes[$iKey]['value'] = null;
+                }
+            } else {
+                foreach ($aLanguages as $sLanguage) {
+                    if (isset($aAttributeValues[$aAttribute['name']][$sLanguage])) {
+                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttributeValues[$aAttribute['name']][$sLanguage];
+                    } else {
+                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttribute['default'];
+                    }
+                    // Sanitize value in case it's saved as empty array
+                    if ($aAttributes[$iKey][$sLanguage]['value'] === []) {
+                        $aAttributes[$iKey][$sLanguage]['value'] = null;
+                    }
+                }
+            }
+        }
+        return $aAttributes;
     }
 }

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -344,7 +344,8 @@ class QuestionAttribute extends LSActiveRecord
         if ($oAttributeValue !== null) {
             $sQuestionTheme = $oAttributeValue->value;
             $aThemeAttributes = QuestionTheme::getAdditionalAttrFromExtendedTheme($sQuestionTheme, $oQuestion->type);
-            $retAttributeNamesExtended = QuestionAttribute::getMergedQuestionAttributes($retAttributeNamesExtended, $aThemeAttributes);
+            $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+            $retAttributeNamesExtended = $questionAttributeHelper->mergeQuestionAttributes($retAttributeNamesExtended, $aThemeAttributes);
         }
 
         return $retAttributeNamesExtended;
@@ -552,7 +553,8 @@ class QuestionAttribute extends LSActiveRecord
         }
 
         // Filter all pesky '[]' values (empty values should be null, e.g. <default></default>).
-        $aAttributes = self::getSanitizedQuestionAttributes($aAttributes);
+        $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+        $aAttributes = $questionAttributeHelper->sanitizeQuestionAttributes($aAttributes);
 
         return $aAttributes;
     }
@@ -599,7 +601,8 @@ class QuestionAttribute extends LSActiveRecord
         }
 
         // Filter all pesky '[]' values (empty values should be null, e.g. <default></default>).
-        $aAttributes = self::getSanitizedQuestionAttributes($aAttributes);
+        $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+        $aAttributes = $questionAttributeHelper->sanitizeQuestionAttributes($aAttributes);
 
         return $aAttributes;
     }
@@ -632,110 +635,4 @@ class QuestionAttribute extends LSActiveRecord
         return (array) $result->get('questionAttributes');
     }
 
-    /**
-     * Merges the 'base' attributes (ex: core question attributes) with the extended question attributes
-     * (ex: question theme attributes). It also removes all attributes where extended attribute's inputType is
-     * empty.
-     * If an extended attribute's name cannot be determined, it's omitted.
-     *
-     * @param array $aBaseAttributes    the base set of attributes
-     * @param array $aExtendedAttributes    the attributes to merge into the base set
-     *
-     * @return array the merged attributes
-     */
-    public static function getMergedQuestionAttributes($aBaseAttributes, $aExtendedAttributes)
-    {
-        $aAttributes = $aBaseAttributes;
-        foreach ($aExtendedAttributes as $key => $attribute) {
-            // TODO: move to getSanitizedQuestionAttributes()
-            // Determine the attribute name or continue with the next
-            if (!isset($attribute['name'])) {
-                if (!is_numeric($key)) {
-                    $attribute['name'] = $key;
-                } else {
-                    continue;
-                }
-            }
-
-            $sAttributeName = $attribute['name'];
-            $sInputType = $attribute['inputtype'];
-            // remove attribute if inputtype is empty
-            if (empty($sInputType)) {
-                unset($aAttributes[$sAttributeName]);
-            } else {
-                $aCustomAttribute = array_merge(
-                    QuestionAttribute::getDefaultSettings(),
-                    array("category" => gT("Template")),
-                    $attribute
-                );
-                $aAttributes[$sAttributeName] = $aCustomAttribute;
-            }
-        }
-        return $aAttributes;
-    }
-
-    /**
-     * Sanitizes an array of question attributes.
-     * Currently just replaces empty arrays (generally resulting from empty xml nodes) with null.
-     *
-     * @param array $aAttributes the array of attributes to sanitize
-     *
-     * @return array the array of sanitized attributes
-     */
-    public static function getSanitizedQuestionAttributes($aAttributes)
-    {
-        // Replace empty arrays with null
-        foreach ($aAttributes as &$aAttribute) {
-            foreach ($aAttribute as $propertyName => $propertyValue) {
-                if ($propertyValue === []) {
-                    $aAttribute[$propertyName] = null;
-                }
-            }
-        }
-        return $aAttributes;
-    }
-
-    /**
-     * Returns the received array of attributes filled with the values specified, taking into account the
-     * 'i18n' property of the attributes.
-     *
-     * Both this and rewriteQuestionAttributeArray() are helper methods and accomplish quite similar tasks,
-     * but the output is different: rewriteQuestionAttributeArray returns a name -> value array, while here
-     * we return a complete definition map and the value as a piece of information mingled into it.
-     *
-     * @param array $aAttributes the attributes to be filled
-     * @param array $aAttributeValues the values for the attributes
-     * @param array $aLanguages the languages to use for i18n attributes
-     *
-     * @return array the same source attributes with their corresponding values (when available)
-     */
-    public static function fillAttributesWithValues($aAttributes, $aAttributeValues, $aLanguages = [])
-    {
-        foreach ($aAttributes as $iKey => $aAttribute) {
-            if ($aAttribute['i18n'] == false) {
-                if (isset($aAttributeValues[$aAttribute['name']][''])) {
-                    $aAttributes[$iKey]['value'] = $aAttributeValues[$aAttribute['name']][''];
-                } else {
-                    $aAttributes[$iKey]['value'] = $aAttribute['default'];
-                }
-                // Sanitize value in case it's saved as empty array
-                if ($aAttributes[$iKey]['value'] === []) {
-                    $aAttributes[$iKey]['value'] = null;
-                }
-            } else {
-                foreach ($aLanguages as $sLanguage) {
-                    if (isset($aAttributeValues[$aAttribute['name']][$sLanguage])) {
-                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttributeValues[$aAttribute['name']][$sLanguage];
-                    } else {
-                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttribute['default'];
-                    }
-                    // Sanitize value in case it's saved as empty array
-                    if ($aAttributes[$iKey][$sLanguage]['value'] === []) {
-                        $aAttributes[$iKey][$sLanguage]['value'] = null;
-                    }
-                }
-            }
-        }
-        return $aAttributes;
-    }
 }

--- a/application/models/QuestionTheme.php
+++ b/application/models/QuestionTheme.php
@@ -1048,7 +1048,8 @@ class QuestionTheme extends LSActiveRecord
             }
         }
 
-        $additionalAttributes = QuestionAttribute::getSanitizedQuestionAttributes($additionalAttributes);
+        $questionAttributeHelper = new LimeSurvey\Models\Services\QuestionAttributeHelper();
+        $additionalAttributes = $questionAttributeHelper->sanitizeQuestionAttributes($additionalAttributes);
 
         return $additionalAttributes;
     }

--- a/application/models/QuestionTheme.php
+++ b/application/models/QuestionTheme.php
@@ -1047,6 +1047,9 @@ class QuestionTheme extends LSActiveRecord
                 }
             }
         }
+
+        $additionalAttributes = QuestionAttribute::getSanitizedQuestionAttributes($additionalAttributes);
+
         return $additionalAttributes;
     }
 

--- a/application/models/services/QuestionAttributeHelper.php
+++ b/application/models/services/QuestionAttributeHelper.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace LimeSurvey\Models\Services;
+
+class QuestionAttributeHelper
+{
+    /**
+     * Merges the 'base' attributes (ex: core question attributes) with the extended question attributes
+     * (ex: question theme attributes). It also removes all attributes where extended attribute's inputType is
+     * empty.
+     * If an extended attribute's name cannot be determined, it's omitted.
+     *
+     * @param array $aBaseAttributes    the base set of attributes
+     * @param array $aExtendedAttributes    the attributes to merge into the base set
+     *
+     * @return array the merged attributes
+     */
+    public function mergeQuestionAttributes($aBaseAttributes, $aExtendedAttributes)
+    {
+        $aAttributes = $aBaseAttributes;
+        foreach ($aExtendedAttributes as $key => $attribute) {
+            // TODO: move to sanitizeQuestionAttributes()
+            // Determine the attribute name or continue with the next
+            if (!isset($attribute['name'])) {
+                if (!is_numeric($key)) {
+                    $attribute['name'] = $key;
+                } else {
+                    continue;
+                }
+            }
+
+            $sAttributeName = $attribute['name'];
+            $sInputType = $attribute['inputtype'];
+            // remove attribute if inputtype is empty
+            if (empty($sInputType)) {
+                unset($aAttributes[$sAttributeName]);
+            } else {
+                $aCustomAttribute = array_merge(
+                    \QuestionAttribute::getDefaultSettings(),
+                    array("category" => gT("Template")),
+                    $attribute
+                );
+                $aAttributes[$sAttributeName] = $aCustomAttribute;
+            }
+        }
+        return $aAttributes;
+    }
+
+    /**
+     * Sanitizes an array of question attributes.
+     * Currently just replaces empty arrays (generally resulting from empty xml nodes) with null.
+     *
+     * @param array $aAttributes the array of attributes to sanitize
+     *
+     * @return array the array of sanitized attributes
+     */
+    public function sanitizeQuestionAttributes($aAttributes)
+    {
+        // Replace empty arrays with null
+        foreach ($aAttributes as &$aAttribute) {
+            foreach ($aAttribute as $propertyName => $propertyValue) {
+                if ($propertyValue === []) {
+                    $aAttribute[$propertyName] = null;
+                }
+            }
+        }
+        return $aAttributes;
+    }
+
+    /**
+     * Returns the received array of attributes filled with the values specified, taking into account the
+     * 'i18n' property of the attributes.
+     *
+     * Both this and rewriteQuestionAttributeArray() are helper methods and accomplish quite similar tasks,
+     * but the output is different: rewriteQuestionAttributeArray returns a name -> value array, while here
+     * we return a complete definition map and the value as a piece of information mingled into it.
+     *
+     * @param array $aAttributes the attributes to be filled
+     * @param array $aAttributeValues the values for the attributes
+     * @param array $aLanguages the languages to use for i18n attributes
+     *
+     * @return array the same source attributes with their corresponding values (when available)
+     */
+    public function fillAttributesWithValues($aAttributes, $aAttributeValues, $aLanguages = [])
+    {
+        foreach ($aAttributes as $iKey => $aAttribute) {
+            if ($aAttribute['i18n'] == false) {
+                if (isset($aAttributeValues[$aAttribute['name']][''])) {
+                    $aAttributes[$iKey]['value'] = $aAttributeValues[$aAttribute['name']][''];
+                } else {
+                    $aAttributes[$iKey]['value'] = $aAttribute['default'];
+                }
+                // Sanitize value in case it's saved as empty array
+                if ($aAttributes[$iKey]['value'] === []) {
+                    $aAttributes[$iKey]['value'] = null;
+                }
+            } else {
+                foreach ($aLanguages as $sLanguage) {
+                    if (isset($aAttributeValues[$aAttribute['name']][$sLanguage])) {
+                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttributeValues[$aAttribute['name']][$sLanguage];
+                    } else {
+                        $aAttributes[$iKey][$sLanguage]['value'] = $aAttribute['default'];
+                    }
+                    // Sanitize value in case it's saved as empty array
+                    if ($aAttributes[$iKey][$sLanguage]['value'] === []) {
+                        $aAttributes[$iKey][$sLanguage]['value'] = null;
+                    }
+                }
+            }
+        }
+        return $aAttributes;
+    }
+
+    /**
+     * Receives an array of question attributes and groups them by category.
+     * Used by advanced settings widget.
+     *
+     * @param array $aAttributes
+     * @return array Grouped question attributes, with category as array key
+     */
+    public function groupAttributesByCategory($aAttributes)
+    {
+        $aByCategory = [];
+        foreach ($aAttributes as $aAttribute) {
+            $aByCategory[$aAttribute['category']][] = $aAttribute;
+        }
+        return $aByCategory;
+    }
+}


### PR DESCRIPTION
Code reorganization.
- Added some comments.
- Have created helper functions as to be able to have a better outlook of what some function do.

Solution Summary.
The key of the solution is to be able to pickup theme attributes from a theme name and not from a the attribute set on the question. Then added a theme override parameter which will set which theme attributes should be picked up.

So now, question attributes may contain the attributes of a temp theme, which is not set on the DB.