### PR TITLE
Fixed issue #17235: Token additional attributes are blank after editing

### DIFF
--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -5063,7 +5063,7 @@ function upgradeTokens176()
         $sTokenTableName = 'tokens_' . $arSurvey['sid'];
         if (tableExists($sTokenTableName)) {
             $aColumnNames = $aColumnNamesIterator = $oDB->schema->getTable('{{' . $sTokenTableName . '}}')->columnNames;
-            $aAttributes = $arSurvey['attributedescriptions'];
+            $aAttributes = decodeTokenAttributes($arSurvey['attributedescriptions']);
             foreach ($aColumnNamesIterator as $sColumnName) {
                 // Check if an old atttribute_cpdb column exists in that token table
                 if (strpos($sColumnName, 'attribute_cpdb') !== false) {
@@ -5082,7 +5082,13 @@ function upgradeTokens176()
                     }
                 }
             }
-            $oDB->createCommand()->update('{{surveys}}', array('attributedescriptions' => serialize($aAttributes)), "sid=" . $arSurvey['sid']);
+            // Add 'cpdbmap' if missing
+            foreach ($aAttributes as &$aAttribute) {
+                if (!isset($aAttribute['cpdbmap'])) {
+                    $aAttribute['cpdbmap'] = '';
+                }
+            }
+            $oDB->createCommand()->update('{{surveys}}',array('attributedescriptions'=>json_encode($aAttributes)),"sid=".$arSurvey['sid']);
         }
     }
     unset($arSurveys);

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -5088,7 +5088,7 @@ function upgradeTokens176()
                     $aAttribute['cpdbmap'] = '';
                 }
             }
-            $oDB->createCommand()->update('{{surveys}}',array('attributedescriptions'=>json_encode($aAttributes)),"sid=".$arSurvey['sid']);
+            $oDB->createCommand()->update('{{surveys}}',array('attributedescriptions'=>serialize($aAttributes)),"sid=".$arSurvey['sid']);
         }
     }
     unset($arSurveys);

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -5088,7 +5088,7 @@ function upgradeTokens176()
                     $aAttribute['cpdbmap'] = '';
                 }
             }
-            $oDB->createCommand()->update('{{surveys}}',array('attributedescriptions'=>serialize($aAttributes)),"sid=".$arSurvey['sid']);
+            $oDB->createCommand()->update('{{surveys}}', array('attributedescriptions'=>serialize($aAttributes)),"sid=".$arSurvey['sid']);
         }
     }
     unset($arSurveys);

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -5088,7 +5088,7 @@ function upgradeTokens176()
                     $aAttribute['cpdbmap'] = '';
                 }
             }
-            $oDB->createCommand()->update('{{surveys}}', array('attributedescriptions'=>serialize($aAttributes)),"sid=".$arSurvey['sid']);
+            $oDB->createCommand()->update('{{surveys}}', array('attributedescriptions' => serialize($aAttributes)), "sid=" . $arSurvey['sid']);
         }
     }
     unset($arSurveys);

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -644,10 +644,6 @@ class Survey extends LSActiveRecord implements PermissionInterface
     public function getTokenAttributes()
     {
         $attdescriptiondata = decodeTokenAttributes($this->attributedescriptions);
-        // checked for invalid data
-        if ($attdescriptiondata == null) {
-            return array();
-        }
 
         // Catches malformed data
         if ($attdescriptiondata && strpos(key(reset($attdescriptiondata)), 'attribute_') === false) {


### PR DESCRIPTION
- Fixed upgradeTokens176() function of updatedb_helper: it was not deserializing the 'attributedescriptions' field, so all the surveys ended up without attribute descriptions. Also added a small fix to initialize the 'cpdbmap' field when missing.
- Fixed getTokenAttributes() method of Survey model: it was already merging the actual extra attributes from the token's table with the attributes defined in 'attributedescriptions' field, but only when the later wasn't empty. Now it always does the merge.