### PR TITLE
Correctly handle the case of no files having been uploaded

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8430,7 +8430,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                             if (!preg_match('/_filecount$/', $sq)) {
                                 $json = $value;
                                 $aFiles = json_decode($json);
-                                $iSize = @count($aFiles);
+                                $iSize = (is_null($aFiles)) ? 0 : @count($aFiles);
                                 // if the files have not been saved already,
                                 // move the files from tmp to the files folder
 


### PR DESCRIPTION
In a survey with optional uploads, the error "count(): Argument #1 ($var) must be of type Countable|array, null given" results if no file was uploaded.

This is fixed by checking for $aFiles being null, and setting $iSize to 0 if it is.

I am filing this bug under the "smaller internal changes" rule without a Mantis issue.

Fixed issue #NA
Dev: MAX R. P. GROSSMANN