### PR TITLE
Fixed issue #16638: EXPIRY keyword does not work in Survey description

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1891,7 +1891,7 @@ function display_first_page($thissurvey, $aSurveyInfo)
     $thissurvey                 = $aSurveyInfo;
     $thissurvey['aNavigator']   = getNavigatorDatas();
     LimeExpressionManager::StartProcessingPage();
-    LimeExpressionManager::StartProcessingGroup(-1, false, $surveyid); // start on welcome page
+    LimeExpressionManager::StartProcessingGroup(-1, false, $surveyid, true); // start on welcome page
 
     // WHY HERE ?????
     $_SESSION['survey_' . $surveyid]['LEMpostKey'] = mt_rand();


### PR DESCRIPTION
Forcing refresh at the start.