### PR TITLE
Fixed issue #16339: pluginhelper fullpagewrapper doesnt show content

### DIFF
--- a/application/controllers/admin/PluginHelper.php
+++ b/application/controllers/admin/PluginHelper.php
@@ -62,7 +62,7 @@ class PluginHelper extends Survey_Common_Action
         $content = $this->getContent(null, $plugin, $method);
 
         $aData['content'] = $content;
-        $this->_renderWrappedTemplate(null, 'super/dummy', $aData);
+        $this->_renderWrappedTemplate(null, 'super/dummy', $aData, 'layout_main.php');
     }
 
     /**


### PR DESCRIPTION
To clarify the problem: the fullpagewrapper works fine, unless one of the parameters in the URL is the survey id.

In that case the side menu appears because the layout_insurvey.php is used.

The _renderWrappedTemplate function of Survey_Common_Action.php decides that this layout should be used when the data in the view ($ aData) includes the "surveyid".

Until version 3.17.15, when you used the fullpagewrapper it worked fine even if you put a survey id in the URL. The problem is that from the commit de7707d700d1304110eca1e12fd22b3aa1d011b7 some parameters such as the survey id are included in the $ aData (it is not included by the helper plugin, but by Survey_Common_Action itself).

The solution then is for the helper plugin to explicitly specify that the layout_main.php must be used.