### PR TITLE
Fixed issue #16834: When importing a theme bigger in size than the allowed PHP.ini settings, there is no proper description of the error

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -1071,15 +1071,14 @@ class QuestionAdministrationController extends LSBaseController
         $aData['display']['menu_bars']['gid_action'] = 'viewgroup';
 
         $sFullFilepath = App()->getConfig('tempdir') . DIRECTORY_SEPARATOR . randomChars(20);
-        $sExtension = pathinfo($_FILES['the_file']['name'], PATHINFO_EXTENSION);
         $fatalerror = '';
+        
+        // Check file size and redirect on error
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl('questionAdministration/importView', array('surveyid' => $iSurveyID)));
 
-        if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-            $fatalerror = sprintf(
-                gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."),
-                getMaximumFileUploadSize() / 1024 / 1024
-            ) . '<br>';
-        } elseif (!@move_uploaded_file($_FILES['the_file']['tmp_name'], $sFullFilepath)) {
+        $sExtension = pathinfo($_FILES['the_file']['name'], PATHINFO_EXTENSION);
+        if (!@move_uploaded_file($_FILES['the_file']['tmp_name'], $sFullFilepath)) {
             $fatalerror = gT(
                 "An error occurred uploading your file."
                     . " This may be caused by incorrect permissions for the application /tmp folder."

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -1075,7 +1075,7 @@ class QuestionAdministrationController extends LSBaseController
         
         // Check file size and redirect on error
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl('questionAdministration/importView', array('surveyid' => $iSurveyID)));
+        $uploadValidator->redirectOnError('the_file', \Yii::app()->createUrl('questionAdministration/importView', array('surveyid' => $iSurveyID)));
 
         $sExtension = pathinfo($_FILES['the_file']['name'], PATHINFO_EXTENSION);
         if (!@move_uploaded_file($_FILES['the_file']['tmp_name'], $sFullFilepath)) {

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -1271,6 +1271,13 @@ class SurveyAdministrationController extends LSBaseController
      */
     public function actionUploadimagefile()
     {
+        $debug = [$_FILES];
+        // Check file size and render JSON on error.
+        // This is done before checking the survey permissions because, if the max POST size was exceeded,
+        // there is no Survey ID to check for permissions, so the error could be misleading.
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRenderJson('file', $debug);
+
         $iSurveyID = Yii::app()->request->getPost('surveyid');
         $success = false;
         $debug = [];
@@ -1284,28 +1291,6 @@ class SurveyAdministrationController extends LSBaseController
                         'debug' => $debug
                     ]
                 ),
-                false,
-                false
-            );
-        }
-        $debug[] = $_FILES;
-        if (empty($_FILES)) {
-            $uploadresult = gT("No file was uploaded.");
-            return $this->renderPartial(
-                '/admin/super/_renderJson',
-                array('data' => ['success' => $success, 'message' => $uploadresult, 'debug' => $debug]),
-                false,
-                false
-            );
-        }
-        if ($_FILES['file']['error'] == 1 || $_FILES['file']['error'] == 2) {
-            $uploadresult = sprintf(
-                gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."),
-                getMaximumFileUploadSize() / 1024 / 1024
-            );
-            return $this->renderPartial(
-                '/admin/super/_renderJson',
-                array('data' => ['success' => $success, 'message' => $uploadresult, 'debug' => $debug]),
                 false,
                 false
             );

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -1276,7 +1276,7 @@ class SurveyAdministrationController extends LSBaseController
         // This is done before checking the survey permissions because, if the max POST size was exceeded,
         // there is no Survey ID to check for permissions, so the error could be misleading.
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRenderJson('file', $debug);
+        $uploadValidator->renderJsonOnError('file', $debug);
 
         $iSurveyID = Yii::app()->request->getPost('surveyid');
         $success = false;

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -128,17 +128,16 @@ class labels extends Survey_Common_Action
         $action = returnGlobal('action');
         $aViewUrls = array();
 
+        // Check file size and redirect on error
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl("/admin/labels/sa/newlabelset"));
+
         if ($action == 'importlabels') {
             Yii::app()->loadHelper('admin/import');
 
             $sFullFilepath = Yii::app()->getConfig('tempdir') . DIRECTORY_SEPARATOR . randomChars(20);
             $aPathInfo = pathinfo($_FILES['the_file']['name']);
             $sExtension = !empty($aPathInfo['extension']) ? $aPathInfo['extension'] : '';
-
-            if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-                Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-                $this->getController()->redirect(App()->createUrl("/admin/labels/sa/newlabelset"));
-            }
 
             if (!@move_uploaded_file($_FILES['the_file']['tmp_name'], $sFullFilepath)) {
                 Yii::app()->setFlashMessage(gT("An error occurred uploading your file. This may be caused by incorrect permissions for the application /tmp folder."), 'error');

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -130,7 +130,7 @@ class labels extends Survey_Common_Action
 
         // Check file size and redirect on error
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl("/admin/labels/sa/newlabelset"));
+        $uploadValidator->redirectOnError('the_file', \Yii::app()->createUrl("/admin/labels/sa/newlabelset"));
 
         if ($action == 'importlabels') {
             Yii::app()->loadHelper('admin/import');

--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -782,7 +782,7 @@ class participantsaction extends Survey_Common_Action
 
         // Check file size and redirect on error
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', array('admin/participants/sa/importCSV'));
+        $uploadValidator->redirectOnError('the_file', array('admin/participants/sa/importCSV'));
 
         if ($_FILES['the_file']['name'] == '') {
             Yii::app()->setFlashMessage(gT('Please select a file to import!'), 'error');

--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -780,6 +780,10 @@ class participantsaction extends Survey_Common_Action
     {
         $this->checkPermission('import');
 
+        // Check file size and redirect on error
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', array('admin/participants/sa/importCSV'));
+
         if ($_FILES['the_file']['name'] == '') {
             Yii::app()->setFlashMessage(gT('Please select a file to import!'), 'error');
             Yii::app()->getController()->redirect(array('admin/participants/sa/importCSV'));
@@ -789,11 +793,7 @@ class participantsaction extends Survey_Common_Action
         $aPathinfo = pathinfo($_FILES['the_file']['name']);
         $sExtension = $aPathinfo['extension'];
         $bMoveFileResult = false;
-        if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-            Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-            Yii::app()->getController()->redirect(array('admin/participants/sa/importCSV'));
-            Yii::app()->end();
-        } elseif (strtolower($sExtension) == 'csv') {
+        if (strtolower($sExtension) == 'csv') {
             $bMoveFileResult = @move_uploaded_file($_FILES['the_file']['tmp_name'], $sFilePath);
             $filterblankemails = Yii::app()->request->getPost('filterbea');
         } else {

--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -222,7 +222,7 @@ class themes extends Survey_Common_Action
 
         // Return json at file size error.
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRenderJson('file', $debug);
+        $uploadValidator->renderJsonOnError('file', $debug);
 
         $checkImageContent = LSYii_ImageValidator::validateImage($_FILES["file"]);
         if ($checkImageContent['check'] === false) {
@@ -456,7 +456,7 @@ class themes extends Survey_Common_Action
         if (Permission::model()->hasGlobalPermission('templates', 'import')) {
             // Check file size and redirect on error
             $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-            $uploadValidator->checkUploadedFileSizeAndRedirect('upload_file', $redirectUrl);
+            $uploadValidator->redirectOnError('upload_file', $redirectUrl);
 
             $action                 = returnGlobal('action');
             $oEditedTemplate        = Template::getInstance($templatename);
@@ -1331,7 +1331,7 @@ class themes extends Survey_Common_Action
     protected function checkFileSizeError($uploadName = 'the_file')
     {
         $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-        $uploadValidator->checkUploadedFileSizeAndRedirect($uploadName, array("admin/themes/sa/upload"));
+        $uploadValidator->redirectOnError($uploadName, array("admin/themes/sa/upload"));
     }
 
     /**

--- a/application/controllers/admin/themes.php
+++ b/application/controllers/admin/themes.php
@@ -220,8 +220,9 @@ class themes extends Survey_Common_Action
 
         $debug[] = $_FILES;
 
-        // Redirect back at file size error.
-        $this->checkFileSizeError('file');
+        // Return json at file size error.
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRenderJson('file', $debug);
 
         $checkImageContent = LSYii_ImageValidator::validateImage($_FILES["file"]);
         if ($checkImageContent['check'] === false) {
@@ -443,12 +444,22 @@ class themes extends Survey_Common_Action
      */
     public function uploadfile()
     {
+        $editfile               = App()->request->getPost('editfile');
+        $templatename           = returnGlobal('templatename');
+        $screenname             = returnGlobal('screenname');
+        if (empty($screenname)) {
+            $screenname = 'welcome';
+        }
+
+        $redirectUrl = array('admin/themes', 'sa' => 'view', 'editfile' => $editfile, 'screenname' => $screenname, 'templatename' => $templatename);
+
         if (Permission::model()->hasGlobalPermission('templates', 'import')) {
+            // Check file size and redirect on error
+            $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+            $uploadValidator->checkUploadedFileSizeAndRedirect('upload_file', $redirectUrl);
+
             $action                 = returnGlobal('action');
-            $editfile               = App()->request->getPost('editfile');
-            $templatename           = returnGlobal('templatename');
             $oEditedTemplate        = Template::getInstance($templatename);
-            $screenname             = returnGlobal('screenname');
             $allowedthemeuploads    = Yii::app()->getConfig('allowedthemeuploads') . ',' . Yii::app()->getConfig('allowedthemeimageformats');
             $filename               = sanitize_filename($_FILES['upload_file']['name'], false, false, false); // Don't force lowercase or alphanumeric
             $dirfilepath            = $oEditedTemplate->filesPath;
@@ -488,7 +499,7 @@ class themes extends Survey_Common_Action
         } else {
             Yii::app()->setFlashMessage(gT("We are sorry but you don't have permissions to do this."), 'error');
         }
-        $this->getController()->redirect(array('admin/themes', 'sa' => 'view', 'editfile' => $editfile, 'screenname' => $screenname, 'templatename' => $templatename));
+        $this->getController()->redirect($redirectUrl);
     }
 
 
@@ -1319,16 +1330,8 @@ class themes extends Survey_Common_Action
      */
     protected function checkFileSizeError($uploadName = 'the_file')
     {
-        if ($_FILES[$uploadName]['error'] == 1 || $_FILES[$uploadName]['error'] == 2) {
-            Yii::app()->setFlashMessage(
-                sprintf(
-                    gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."),
-                    getMaximumFileUploadSize() / 1024 / 1024
-                ),
-                'error'
-            );
-            $this->getController()->redirect(array("admin/themes/sa/upload"));
-        }
+        $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+        $uploadValidator->checkUploadedFileSizeAndRedirect($uploadName, array("admin/themes/sa/upload"));
     }
 
     /**

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1867,12 +1867,14 @@ class tokens extends Survey_Common_Action
             $aModelErrorList = array();
             $aFirstLine = array();
 
+            // Check file size and redirect on error
+            $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
+            $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl('admin/tokens', array('sa' => 'import', 'surveyid' => $iSurveyId)));
+
             $oFile = CUploadedFile::getInstanceByName("the_file");
             $sPath = Yii::app()->getConfig('tempdir');
             $sFileName = $sPath . '/' . randomChars(20);
-            if ($_FILES['the_file']['error'] == 1 || $_FILES['the_file']['error'] == 2) {
-                Yii::app()->setFlashMessage(sprintf(gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."), getMaximumFileUploadSize() / 1024 / 1024), 'error');
-            } elseif (strtolower($oFile->getExtensionName()) != 'csv') {
+            if (strtolower($oFile->getExtensionName()) != 'csv') {
                 Yii::app()->setFlashMessage(gT("Only CSV files are allowed."), 'error');
             } elseif (!@$oFile->saveAs($sFileName)) {
                 Yii::app()->setFlashMessage(sprintf(gT("Upload file not found. Check your permissions and path (%s) for the upload directory"), $sPath), 'error');

--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1869,7 +1869,7 @@ class tokens extends Survey_Common_Action
 
             // Check file size and redirect on error
             $uploadValidator = new LimeSurvey\Models\Services\UploadValidator();
-            $uploadValidator->checkUploadedFileSizeAndRedirect('the_file', \Yii::app()->createUrl('admin/tokens', array('sa' => 'import', 'surveyid' => $iSurveyId)));
+            $uploadValidator->redirectOnError('the_file', \Yii::app()->createUrl('admin/tokens', array('sa' => 'import', 'surveyid' => $iSurveyId)));
 
             $oFile = CUploadedFile::getInstanceByName("the_file");
             $sPath = Yii::app()->getConfig('tempdir');

--- a/application/models/services/UploadValidator.php
+++ b/application/models/services/UploadValidator.php
@@ -4,6 +4,25 @@ namespace LimeSurvey\Models\Services;
 
 class UploadValidator
 {
+
+    /** @var array<string,mixed> HTTP POST variables*/
+    private $post;
+
+    /** @var array<string,mixed> HTTP File Upload variables*/
+    private $files;
+
+    /**
+     * UploadValidator constructor.
+     *
+     * @param array<string,mixed>|null  $post   HTTP POST variables. If null, $_POST is used.
+     * @param array<string,mixed>|null  $post   HTTP File Upload variables. If null, $_FILES is used.
+     */
+    public function __construct($post = null, $files = null)
+    {
+        $this->post = is_null($post) ? $_POST : $post;
+        $this->files = is_null($files) ? $_FILES : $files;
+    }
+
     /**
      * Check uploaded file size
      *
@@ -23,20 +42,20 @@ class UploadValidator
         // When 'post_max_size' is exceeded $_POST and $_FILES are empty.
         // There is no way to confirm if the superglobals are empty because 'post_max_size' was
         // exceeded, or because nothing was posted.
-        if (empty($_POST) && empty($_FILES)) {
+        if (empty($this->post) && empty($this->files)) {
             return sprintf(
                 gT("No file was uploaded or the request exceeded %01.2f MB."),
                 convertPHPSizeToBytes(ini_get('post_max_size')) / 1024 / 1024
             );
         }
 
-        if (!isset($_FILES[$fileName])) {
+        if (!isset($this->files[$fileName])) {
             return gT("File not found.");
         }
 
-        $fileSize = $_FILES[$fileName]['size'];
+        $fileSize = $this->files[$fileName]['size'];
 
-        if ($fileSize > $maximumSize || $_FILES[$fileName]['error'] == 1 || $_FILES[$fileName]['error'] == 2) {
+        if ($fileSize > $maximumSize || $this->files[$fileName]['error'] == 1 || $this->files[$fileName]['error'] == 2) {
             return sprintf(
                 gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."),
                 $maximumSize / 1024 / 1024

--- a/application/models/services/UploadValidator.php
+++ b/application/models/services/UploadValidator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace LimeSurvey\Models\Services;
+
+class UploadValidator
+{
+    /**
+     * Check uploaded file size
+     *
+     * @param string $fileName the name of the posted file
+     * @param mixed $customMaxSize maximum file upload size
+     *
+     * @throws \Exception if the file is too large or no file is found.
+     */
+    public function checkUploadedFileSize($fileName, $customMaxSize = null)
+    {
+        if (is_null($customMaxSize)) {
+            $maximumSize = getMaximumFileUploadSize();
+        } else {
+            $maximumSize = min((int) $customMaxSize, getMaximumFileUploadSize());
+        }
+
+        // When 'post_max_size' is exceeded $_POST and $_FILES are empty.
+        // There is no way to confirm if the superglobals are empty because 'post_max_size' was
+        // exceeded, or because nothing was posted.
+        if (empty($_POST) && empty($_FILES)) {
+            throw new \Exception(
+                sprintf(
+                    gT("No file was uploaded or the request exceeded %01.2f MB."),
+                    convertPHPSizeToBytes(ini_get('post_max_size')) / 1024 / 1024
+                )
+            );
+        }
+
+        if (!isset($_FILES[$fileName])) {
+            throw new \Exception(gT("File not found."));
+        }
+
+        $fileSize = $_FILES[$fileName]['size'];
+
+        if ($fileSize > $maximumSize || $_FILES[$fileName]['error'] == 1 || $_FILES[$fileName]['error'] == 2) {
+            throw new \Exception(
+                sprintf(
+                    gT("Sorry, this file is too large. Only files up to %01.2f MB are allowed."),
+                    $maximumSize / 1024 / 1024
+                )
+            );
+        }
+    }
+
+    /**
+     * Check uploaded file size. Redirects to the specified URL on failure.
+     *
+     * @param string $fileName the name of the posted file
+     * @param mixed $redirectUrl the URL to redirect on failure
+     * @param mixed $customMaxSize maximum file upload size
+     */
+    public function checkUploadedFileSizeAndRedirect($fileName, $redirectUrl, $customMaxSize = null)
+    {
+        try {
+            $this->checkUploadedFileSize($fileName, $customMaxSize);
+        } catch (\Exception $ex) {
+            \Yii::app()->setFlashMessage($ex->getMessage(), 'error');
+            \Yii::app()->getController()->redirect($redirectUrl);
+        }
+    }
+
+    /**
+     * Check uploaded file size. Renders JSON on failure.
+     *
+     * @param string $fileName the name of the posted file
+     * @param array $debugInfo the URL to redirect on failure
+     * @param mixed $customMaxSize maximum file upload size
+     */
+    public function checkUploadedFileSizeAndRenderJson($fileName, $debugInfo = [], $customMaxSize = null)
+    {
+        try {
+            $this->checkUploadedFileSize($fileName, $customMaxSize);
+        } catch (\Exception $ex) {
+            $error = $ex->getMessage();
+            return \Yii::app()->getController()->renderPartial(
+                '/admin/super/_renderJson',
+                array('data' => ['success' => 'error', 'message' => $error, 'debug' => $debugInfo]),
+                false,
+                false
+            );
+        }
+    }
+}


### PR DESCRIPTION
Created UploadValidator service helper.

Fix applied to:
- Theme import (Themes list and Theme editor)
- File upload in Theme editor (uploading files to a theme)
- Image upload (in global theme options)
- Image upload (in survey theme options
- CPDB (Import CSV)
- Labelset import
- Token import
- Question import (had to add 'action' and 'sid' to the URL)

There are few which could be pending

These are pending to be fixed:
- UploaderController
- questiongroups
- surveyadmin - Import survey - Need to split the method (used for copy and import), or move the 'action' to the URL.
- frontend_helper, checkUploadedFileValidity ?
- dataentry - Import VV file (need to split the method or assume an upload action when the request is POST)