### PR TITLE
Dev #T638a: Group Overview after create Group

### DIFF
--- a/application/controllers/QuestionGroupsAdministrationController.php
+++ b/application/controllers/QuestionGroupsAdministrationController.php
@@ -728,6 +728,7 @@ class QuestionGroupsAdministrationController extends LSBaseController
         }
 
         if ($oQuestionGroup == null) {
+            $isNewGroup = true;
             $oQuestionGroup = $this->newQuestionGroup($iSurveyId, $questionGroup);
         } else {
             $oQuestionGroup = $this->editQuestionGroup($oQuestionGroup, $questionGroup);
@@ -741,6 +742,8 @@ class QuestionGroupsAdministrationController extends LSBaseController
                 $sScenario = 'save-and-new';
             } elseif (App()->request->getPost('saveandnewquestion', '')) {
                 $sScenario = 'save-and-new-question';
+            } elseif (!empty($isNewGroup)) {
+                $sScenario = 'save-and-close';
             }
         }
         switch ($sScenario) {


### PR DESCRIPTION
When a user CREATES a question group and clicks on the SAVE button he should land on the GROUP SUMMARY page instead of EDIT GROUP so he can start adding questions