### PR TITLE
Fixed issue #17166: Survey participants button missing for View Participants permission

### DIFF
--- a/application/core/TopbarConfiguration.php
+++ b/application/core/TopbarConfiguration.php
@@ -142,6 +142,7 @@ class TopbarConfiguration
         $hasSurveyReadPermission = Permission::model()->hasSurveyPermission($sid, 'surveycontent', 'read');
         $hasSurveyTokensPermission = Permission::model()->hasSurveyPermission($sid, 'surveysettings', 'update')
             || Permission::model()->hasSurveyPermission($sid, 'tokens', 'create');
+        $hasSurveyTokensReadPermission = Permission::model()->hasSurveyPermission($sid, 'tokens', 'read');
         $hasResponsesCreatePermission = Permission::model()->hasSurveyPermission($sid, 'responses', 'create');
         $hasResponsesReadPermission = Permission::model()->hasSurveyPermission($sid, 'responses', 'read');
         $hasResponsesStatisticsReadPermission = Permission::model()->hasSurveyPermission($sid, 'statistics', 'read');
@@ -207,6 +208,7 @@ class TopbarConfiguration
             'conditionsCount' => $conditionsCount,
             'hasSurveyReadPermission' => $hasSurveyReadPermission,
             'hasSurveyTokensPermission' => $hasSurveyTokensPermission,
+            'hasSurveyTokensReadPermission' => $hasSurveyTokensReadPermission,
             'hasResponsesCreatePermission' => $hasResponsesCreatePermission,
             'hasResponsesReadPermission' => $hasResponsesReadPermission,
             'hasSurveyActivationPermission' => $hasSurveyActivationPermission,

--- a/application/extensions/TopbarWidget/views/includes/surveyTopbarLeft_view.php
+++ b/application/extensions/TopbarWidget/views/includes/surveyTopbarLeft_view.php
@@ -219,7 +219,7 @@
 <?php endif; ?>
 
 <!-- Token -->
-<?php if($hasSurveyTokensPermission):?>
+<?php if($hasSurveyTokensPermission || $hasSurveyTokensReadPermission):?>
     <a class="btn btn-default pjax btntooltip hidden-xs" href="<?php echo App()->createUrl("admin/tokens/sa/index/surveyid/$sid"); ?>" role="button">
         <span class="fa fa-user"></span>
         <?php eT("Survey participants"); ?>


### PR DESCRIPTION
Adding button to the std top bar for a survey view.