### PR TITLE
Fixed issue: Incorrect datetime value when calling remotecontrol_handle/add_response

### DIFF
--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -115,7 +115,7 @@ class SurveyDynamic extends LSActiveRecord
         foreach ($data as $k => $v) {
             $search = array('`', "'");
             $k = str_replace($search, '', $k);
-            $v = str_replace($search, '', $v);
+            $v = $v == null ? null : str_replace($search, '', $v);
             $record->$k = $v;
         }
 


### PR DESCRIPTION
When I import survey response through remote api (add_response), errors like  `CDbCommand failed to execute the SQL statement: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '' for column '319576X374X5653' at row 1`  will appear, The reason is that the null value of some fields is converted to an empty string
