### PR TITLE
Dev #T635: Land in the Suvey Builder (Structure) when creating a survey

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -82,6 +82,7 @@ $config['allowunblacklist']          = 'N'; // Allow participant to unblacklist 
 $config['userideditable']            = 'N'; // Allow editing of user IDs
 
 $config['defaulttheme']              = 'fruity'; // This setting specifys the default theme used for the 'public list' of surveys
+$config['createsample']              = true;
 $config['customassetversionnumber']  = 1;        // Used to generate the path of tmp assets (see: LSYii_AssetManager::generatePath()  )
 
 // Please be very careful if you want to allow SVG files - there are several XSS dangerous security issues

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -486,7 +486,10 @@ class SurveyAdministrationController extends LSBaseController
             // This will force the generation of the entry for survey group
             TemplateConfiguration::checkAndcreateSurveyConfig($iNewSurveyid);
 
-            $createSample = Yii::app()->getConfig('createsample');
+            $createSample = SettingsUser::getUserSettingValue('createsample');
+            if ($createSample === null || $createSample === 'default') {
+                $createSample = Yii::app()->getConfig('createsample');
+            }
 
             // Figure out destination
             if ($createSample) {

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -486,18 +486,34 @@ class SurveyAdministrationController extends LSBaseController
             // This will force the generation of the entry for survey group
             TemplateConfiguration::checkAndcreateSurveyConfig($iNewSurveyid);
 
-            // Create sample group and question
-            $iNewGroupID = $this->createSampleGroup($iNewSurveyid);
-            $iNewQuestionID = $this->createSampleQuestion($iNewSurveyid, $iNewGroupID);
+            $createSample = Yii::app()->getConfig('createsample');
 
-            Yii::app()->setFlashMessage(gT("Your new survey was created. 
-            We also created a first question group and an example question for you."), 'info');
-            $redirecturl = $this->getSurveyAndSidemenueDirectionURL(
-                $iNewSurveyid,
-                $iNewGroupID,
-                $iNewQuestionID,
-                'structure'
-            );
+            // Figure out destination
+            if ($createSample) {
+                $iNewGroupID = $this->createSampleGroup($iNewSurveyid);
+                $iNewQuestionID = $this->createSampleQuestion($iNewSurveyid, $iNewGroupID);
+
+                Yii::app()->setFlashMessage(gT("Your new survey was created. 
+                We also created a first question group and an example question for you."), 'info');
+                $redirecturl = $this->getSurveyAndSidemenueDirectionURL(
+                    $iNewSurveyid,
+                    $iNewGroupID,
+                    $iNewQuestionID,
+                    'structure'
+                );
+            } elseif (!$ownsPreviousSurveys) {
+                // SET create question and create question group as default view.
+                $redirecturl = $this->createUrl(
+                    'questionGroupsAdministration/add/',
+                    ['surveyid' => $iNewSurveyid]
+                );
+            } else {
+                $redirecturl = $this->createUrl(
+                    'surveyAdministration/view/',
+                    ['iSurveyID' => $iNewSurveyid]
+                );
+                Yii::app()->setFlashMessage(gT("Your new survey was created."), 'info');
+            }
 
             return Yii::app()->getController()->renderPartial(
                 '/admin/super/_renderJson',

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -486,36 +486,19 @@ class SurveyAdministrationController extends LSBaseController
             // This will force the generation of the entry for survey group
             TemplateConfiguration::checkAndcreateSurveyConfig($iNewSurveyid);
 
-            $createSample = App()->request->getPost('createsample');
-            $createSampleChecked = ($createSample === 'on');
+            // Create sample group and question
+            $iNewGroupID = $this->createSampleGroup($iNewSurveyid);
+            $iNewQuestionID = $this->createSampleQuestion($iNewSurveyid, $iNewGroupID);
 
-            // Figure out destination
-            if ($createSampleChecked) {
-                $iNewGroupID = $this->createSampleGroup($iNewSurveyid);
-                $iNewQuestionID = $this->createSampleQuestion($iNewSurveyid, $iNewGroupID);
+            Yii::app()->setFlashMessage(gT("Your new survey was created. 
+            We also created a first question group and an example question for you."), 'info');
+            $redirecturl = $this->getSurveyAndSidemenueDirectionURL(
+                $iNewSurveyid,
+                $iNewGroupID,
+                $iNewQuestionID,
+                'structure'
+            );
 
-                Yii::app()->setFlashMessage(gT("Your new survey was created. 
-                We also created a first question group and an example question for you."), 'info');
-                $landOnSideMenuTab = 'structure';
-                $redirecturl = $this->getSurveyAndSidemenueDirectionURL(
-                    $iNewSurveyid,
-                    $iNewGroupID,
-                    $iNewQuestionID,
-                    $landOnSideMenuTab
-                );
-            } elseif (!$ownsPreviousSurveys) {
-                // SET create question and create question group as default view.
-                $redirecturl = $this->createUrl(
-                    'questionGroupsAdministration/add/',
-                    ['surveyid' => $iNewSurveyid]
-                );
-            } else {
-                $redirecturl = $this->createUrl(
-                    'surveyAdministration/view/',
-                    ['iSurveyID' => $iNewSurveyid]
-                );
-                Yii::app()->setFlashMessage(gT("Your new survey was created."), 'info');
-            }
             return Yii::app()->getController()->renderPartial(
                 '/admin/super/_renderJson',
                 array(
@@ -2205,6 +2188,7 @@ class SurveyAdministrationController extends LSBaseController
                 $aData['aImportResults'] = $aImportResults;
                 $aData['action'] = $action;
                 if (isset($aImportResults['newsid'])) {
+                    // Set link pointing to survey administration overview. This link will be updated if the survey has groups
                     $aData['sLink'] = $this->createUrl('surveyAdministration/view/', ['iSurveyID' => $aImportResults['newsid']]);
                     $aData['sLinkApplyThemeOptions'] = 'surveyAdministration/applythemeoptions/surveyid/' . $aImportResults['newsid'];
                 }
@@ -2226,6 +2210,22 @@ class SurveyAdministrationController extends LSBaseController
                 LimeExpressionManager::FinishProcessingGroup();
             }
             LimeExpressionManager::FinishProcessingPage();
+
+            // Make the link point to the first group/question if available
+            if (!empty($aGrouplist)) {
+                $oFirstGroup = $aGrouplist[0];
+                $oFirstQuestion = Question::model()->findByAttributes(
+                    ['gid' => $oFirstGroup->gid],
+                    ['order' => 'question_order ASC']
+                );
+
+                $aData['sLink'] = $this->getSurveyAndSidemenueDirectionURL(
+                    $aImportResults['newsid'],
+                    $oFirstGroup->gid,
+                    !empty($oFirstQuestion) ? $oFirstQuestion->qid : null,
+                    'structure'
+                );
+            }
         }
 
         $this->aData = $aData;
@@ -2626,13 +2626,15 @@ class SurveyAdministrationController extends LSBaseController
      */
     public function getSurveyAndSidemenueDirectionURL($sid, $gid, $qid, $landOnSideMenuTab)
     {
-        $url = 'questionAdministration/view/';
+        $url = !empty($qid) ? 'questionAdministration/view/' : 'questionGroupsAdministration/view/';
         $params = [
             'surveyid' => $sid,
             'gid' => $gid,
-            'qid' => $qid,
-            'landOnSideMenuTab' => $landOnSideMenuTab
         ];
+        if (!empty($qid)) {
+            $params['qid'] = $qid;
+        }
+        $params['landOnSideMenuTab'] = $landOnSideMenuTab;
         return $this->createUrl($url, $params);
     }
 

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -262,6 +262,8 @@ class GlobalSettings extends Survey_Common_Action
             SettingGlobal::setSetting('allow_unstable_extension_update', sanitize_paranoid_string(Yii::app()->getRequest()->getPost('allow_unstable_extension_update', false)));
         }
 
+        SettingGlobal::setSetting('createsample', (bool) Yii::app()->getRequest()->getPost('createsample'));
+
         if (!Yii::app()->getConfig('demoMode')) {
             $sTemplate = Yii::app()->getRequest()->getPost("defaulttheme");
             if (array_key_exists($sTemplate, Template::getTemplateList())) {

--- a/application/controllers/admin/useraction.php
+++ b/application/controllers/admin/useraction.php
@@ -682,6 +682,7 @@ class UserAction extends Survey_Common_Action
                 SettingsUser::setUserSetting('answeroptionprefix', Yii::app()->request->getPost('answeroptionprefix'));
                 SettingsUser::setUserSetting('subquestionprefix', Yii::app()->request->getPost('subquestionprefix'));
                 SettingsUser::setUserSetting('lock_organizer', Yii::app()->request->getPost('lock_organizer'));
+                SettingsUser::setUserSetting('createsample', Yii::app()->request->getPost('createsample'));
 
                 Yii::app()->setFlashMessage(gT("Your personal settings were successfully saved."));
             } else {

--- a/application/views/admin/globalsettings/_general.php
+++ b/application/views/admin/globalsettings/_general.php
@@ -49,7 +49,7 @@ $dateformatdata=getDateFormatData(Yii::app()->session['dateformat']);
         <div class="row ls-space margin top-10">
             <div class="form-group col-xs-12">
                 <label class="col-sm-12 text-left control-label" for="createsample">
-                    <?php eT("Create example question group and question?");?>
+                    <?php eT("Create example question group and question:");?>
                 </label>
                 <div class="col-sm-12">
                     <?php 

--- a/application/views/admin/globalsettings/_general.php
+++ b/application/views/admin/globalsettings/_general.php
@@ -45,6 +45,27 @@ $dateformatdata=getDateFormatData(Yii::app()->session['dateformat']);
                 </div>
             </div>
         </div>
+        <!-- Autocreate group and question -->
+        <div class="row ls-space margin top-10">
+            <div class="form-group col-xs-12">
+                <label class="col-sm-12 text-left control-label" for="createsample">
+                    <?php eT("Create example question group and question?");?>
+                </label>
+                <div class="col-sm-12">
+                    <?php 
+                        $this->widget(
+                            'yiiwheels.widgets.switch.WhSwitch', [
+                                'name' => 'createsample',
+                                'id' => 'createsample',
+                                'value' => Yii::app()->getConfig('createsample'),
+                                'onLabel' => gT('On'),
+                                'offLabel' => gT('Off')
+                            ]
+                        );
+                    ?>
+                </div>
+            </div>
+        </div>
         <!-- Administrative Template -->
         <div class="row ls-space margin top-10">
             <div class="form-group col-xs-12">

--- a/application/views/admin/user/personalsettings.php
+++ b/application/views/admin/user/personalsettings.php
@@ -351,6 +351,24 @@ echo $oQuestionSelector->getModal();
                                  ?>
                                 </div>
                             </div>
+                            <!-- Create example question group and question -->
+                            <div class="col-sm-12 col-md-6">
+                                <div class="form-group">
+                                <?php echo TbHtml::label( gT("Create example question group and question:"), 'createsample', array('class'=>" control-label")); ?>
+                                    <?php
+                                        echo TbHtml::dropDownList(
+                                            'createsample',
+                                            ($aUserSettings['createsample'] ?? 'default'),
+                                            array(
+                                                'default' => gT("Default",'unescaped'),
+                                                '0' => gT("No",'unescaped'),
+                                                '1' => gT("Yes",'unescaped'),
+                                            ),
+                                            array('class' => "form-control")
+                                        );
+                                    ?>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/application/views/surveyAdministration/tabCreate_view.php
+++ b/application/views/surveyAdministration/tabCreate_view.php
@@ -63,12 +63,6 @@ App()->getClientScript()->registerScript("tabCreate-view-variables", "
                                 <label for="surveyTitle"><?= gT('Survey title')?></label>
                                 <input type="text" class="form-control" name="surveyls_title" id="surveyTitle" required="required" maxlength="200">
                             </div>
-                            <div class="form-group col-md-4 col-md-6">
-                                <label for="createsample" class="control-label"><?= gT('Create example question group and question?')?></label>
-                                <div>
-                                    <input type="checkbox" name="createsample" />
-                                </div>
-                            </div>
                         </div>
                         <div class="row">
                             <div class="form-group col-md-4 col-md-6" >


### PR DESCRIPTION
1. When a user creates a survey he should always land on the first question of the first question group in the STRUCTURE tab. If no question group exists a default one (the demo one) is created, and he lands on that first question group.
2. By doing so we don't need the option in create survey: "Create example question group and question?". Get rid of that option.