### PR TITLE
Fixed issue #12349: RTL languages not dispayed correctly in the admin editor

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -275,6 +275,7 @@ $internalConfig = array(
                 'checkPermission'         => 'LS_Twig_Extension::checkPermission',/* Not in 3.X */
                 'getAllQuestionClasses'   => 'LS_Twig_Extension::getAllQuestionClasses',
                 'getLanguageNameFromCode'    => 'getLanguageNameFromCode',/* Not in 3.X */
+                'getLanguageRTL'          => 'LS_Twig_Extension::getLanguageRTL',
 
                 'intval'                  => 'intval',
                 'empty'                   => 'empty',
@@ -360,6 +361,7 @@ $internalConfig = array(
                 ),
                 'functions' => array(
                     'getLanguageData',
+                    'getLanguageRTL',
                     'array_flip',
                     'array_intersect_key',
 

--- a/application/controllers/admin/htmleditor_pop.php
+++ b/application/controllers/admin/htmleditor_pop.php
@@ -37,6 +37,7 @@ class htmleditor_pop extends Survey_Common_Action
             $aData['sControlIdDis'] = $aData['sFieldName'] . '_popupctrldis';
             $aData['toolbarname'] = 'popup';
             $aData['htmlformatoption'] = '';
+            $aData['contentsLangDirection'] = sanitize_xss_string(App()->request->getQuery('contdir'));
             if (in_array($aData['sFieldType'], array('email-invitation', 'email-registration', 'email-confirmation', 'email-reminder'))) {
                 $aData['htmlformatoption'] = ',fullPage:true';
             }

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -678,7 +678,7 @@ class LS_Twig_Extension extends Twig_Extension
     }
 
     /**
-     * Returns true if the language uses RTL writing system
+     * Returns true if the language uses RTL writing system.
      */
     public static function getLanguageRTL($sLanguageCode)
     {

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -676,4 +676,13 @@ class LS_Twig_Extension extends Twig_Extension
 
         return $aResponses;
     }
+
+    /**
+     * Returns true if the language uses RTL writing system
+     */
+    public static function getLanguageRTL($sLanguageCode)
+    {
+        Yii::app()->loadHelper('surveytranslator');
+        return getLanguageRTL($sLanguageCode);
+    }
 }

--- a/application/helpers/admin/htmleditor_helper.php
+++ b/application/helpers/admin/htmleditor_helper.php
@@ -288,18 +288,26 @@ function getInlineEditor($fieldtype, $fieldname, $fieldtext, $surveyID = null, $
 
                 $('#" . $fieldname . "').before('$loaderHTML');
 
-                $oCKeditorVarName = CKEDITOR.replace('$fieldname', {
-                LimeReplacementFieldsType : \"" . $fieldtype . "\"
-                ,LimeReplacementFieldsSID : \"" . $surveyID . "\"
-                ,LimeReplacementFieldsGID : \"" . $gID . "\"
-                ,LimeReplacementFieldsQID : \"" . $qID . "\"
-                ,LimeReplacementFieldsAction : \"" . $action . "\"
-                ,LimeReplacementFieldsPath : \"" . Yii::app()->getController()->createUrl("limereplacementfields/index") . "\"
-                ,language:'" . sTranslateLangCode2CK(Yii::app()->session['adminlang']) . "'"
-            . $sFileBrowserAvailable
-            . $htmlformatoption
-            . $toolbaroption
-            . "});
+                var ckeConfig = {
+                    LimeReplacementFieldsType : \"" . $fieldtype . "\"
+                    ,LimeReplacementFieldsSID : \"" . $surveyID . "\"
+                    ,LimeReplacementFieldsGID : \"" . $gID . "\"
+                    ,LimeReplacementFieldsQID : \"" . $qID . "\"
+                    ,LimeReplacementFieldsAction : \"" . $action . "\"
+                    ,LimeReplacementFieldsPath : \"" . Yii::app()->getController()->createUrl("limereplacementfields/index") . "\"
+                    ,language:'" . sTranslateLangCode2CK(Yii::app()->session['adminlang']) . "'"
+                . $sFileBrowserAvailable
+                . $htmlformatoption
+                . $toolbaroption
+                . "};
+
+                // Override language direction if 'data-contents-dir' attribute is set in the target field
+                if ($('#" . $fieldname . "').get(0).hasAttribute('data-contents-dir')) {
+                    var inputLangDirection = $('#" . $fieldname . "').attr('data-contents-dir');
+                    ckeConfig.contentsLangDirection = inputLangDirection ? inputLangDirection : '';
+                }
+
+                $oCKeditorVarName = CKEDITOR.replace('$fieldname', ckeConfig);
 
                 \$('#$fieldname').parents('ul:eq(0)').addClass('editor-parent');
             }";

--- a/application/third_party/Twig/Environment.php
+++ b/application/third_party/Twig/Environment.php
@@ -1558,7 +1558,6 @@ class Environment
         foreach ($extension->getFunctions() as $name => $function) {
             if ($function instanceof TwigFunction) {
                 $name = $function->getName();
-                if ($name == 'gT') xdebug_break();
             } else {
                 @trigger_error(sprintf('Using an instance of "%s" for function "%s" is deprecated since version 1.21. Use \Twig_SimpleFunction instead.', \get_class($function), $name), E_USER_DEPRECATED);
             }

--- a/application/third_party/Twig/Environment.php
+++ b/application/third_party/Twig/Environment.php
@@ -1558,6 +1558,7 @@ class Environment
         foreach ($extension->getFunctions() as $name => $function) {
             if ($function instanceof TwigFunction) {
                 $name = $function->getName();
+                if ($name == 'gT') xdebug_break();
             } else {
                 @trigger_error(sprintf('Using an instance of "%s" for function "%s" is deprecated since version 1.21. Use \Twig_SimpleFunction instead.', \get_class($function), $name), E_USER_DEPRECATED);
             }

--- a/application/views/admin/htmleditor/pop_editor_view.php
+++ b/application/views/admin/htmleditor/pop_editor_view.php
@@ -41,6 +41,7 @@
                 */
                 if($('textarea').length > 0){
                     CKEDITOR.on('instanceReady',CKeditor_OnComplete);
+                    
                     var oCKeditor = CKEDITOR.replace( 'MyTextarea' ,  { height	: '350',
                         width	: '98%',
                         toolbarStartupExpanded : true,
@@ -53,6 +54,7 @@
                         LimeReplacementFieldsAction: "<?php echo $sAction; ?>",
                         LimeReplacementFieldsPath : "<?php echo $this->createUrl("/limereplacementfields/index"); ?>",
                         language : "<?php echo $ckLanguage ?>"
+                        <?php echo !is_null($contentsLangDirection) ? ",contentsLangDirection: '{$contentsLangDirection}'" : ''; ?>
                         <?php echo $htmlformatoption; ?> });
                 }
                 });

--- a/application/views/admin/survey/prepareEditorScript_view.php
+++ b/application/views/admin/survey/prepareEditorScript_view.php
@@ -60,10 +60,19 @@ $script.="CKEDITOR.on('instanceReady', function(event) {
 
         if (activepopup == null)
         {
-            document.getElementById(fieldname).readOnly=true;
+            var targetField = document.getElementById(fieldname);
+            targetField.readOnly=true;
             document.getElementById(controlidena).style.display='none';
             document.getElementById(controliddis).style.display='';
-            popup = window.open('".$this->createUrl('admin/htmleditor_pop/sa/index')."/name/'+fieldname+'/text/'+fieldtext+'/type/'+fieldtype+'/action/'+action+'/sid/'+sid+'/gid/'+gid+'/qid/'+qid+'/lang/".App()->language."','', 'location=no, status=yes, scrollbars=auto, menubar=no, resizable=yes, width=690, height=500');
+            var editorurl = '".$this->createUrl('admin/htmleditor_pop/sa/index')."/name/'+fieldname+'/text/'+fieldtext+'/type/'+fieldtype+'/action/'+action+'/sid/'+sid+'/gid/'+gid+'/qid/'+qid+'/lang/".App()->language."';
+            
+            // Override language direction if 'data-contents-dir' attribute is set in the target field
+            if (targetField.hasAttribute('data-contents-dir')) {
+                var inputLangDirection = targetField.getAttribute('data-contents-dir');
+                editorurl = editorurl + '/contdir/' + (inputLangDirection ? inputLangDirection : '');
+            }
+
+            popup = window.open(editorurl,'', 'location=no, status=yes, scrollbars=auto, menubar=no, resizable=yes, width=690, height=500');
 
             editorwindowsHash[fieldname] = popup;
         }

--- a/application/views/questionAdministration/answerOptionRow.twig
+++ b/application/views/questionAdministration/answerOptionRow.twig
@@ -115,6 +115,7 @@
                 id='answeroptions[{{ answerOption.aid }}][{{ scale_id }}][answeroptionl10n][{{ language }}]'
                 name='answeroptions[{{ answerOption.aid }}][{{ scale_id }}][answeroptionl10n][{{ language }}]'
                 placeholder='{{ gT("Some example answer option") }}'
+                data-contents-dir="{{ getLanguageRTL(language) ? 'rtl' : 'ltr' }}"
                 value="{{ answerOptionl10n.answer|escape('html_attr') }}"
             />
             <span class="input-group-addon">

--- a/application/views/questionAdministration/subquestionRow.twig
+++ b/application/views/questionAdministration/subquestionRow.twig
@@ -112,6 +112,7 @@
                 name='subquestions[{{ subquestion.qid }}][{{ scale_id }}][subquestionl10n][{{ language }}]'
                 placeholder='{{ gT("Some example subquestion","js") }}'
                 value="{{ subquestionl10n.question|escape('html_attr') }}"
+                data-contents-dir="{{ getLanguageRTL(language) ? 'rtl' : 'ltr' }}"
                 onkeypress=" if(event.keyCode==13) { if (event && event.preventDefault) event.preventDefault(); document.getElementById('save-button').click(); return false;}"
             />
             <span class="input-group-addon">

--- a/application/views/questionAdministration/textElements.php
+++ b/application/views/questionAdministration/textElements.php
@@ -16,7 +16,13 @@
                         <?= CHtml::textArea(
                             "questionI10N[$lang][question]",
                             $question->questionl10ns[$lang]->question ?? '',
-                            array('class'=>'form-control','cols'=>'60','rows'=>'8','id'=>"question_{$lang}")
+                            [
+                                'class' => 'form-control',
+                                'cols' => '60',
+                                'rows' => '8',
+                                'id' => "question_{$lang}",
+                                'data-contents-dir' => getLanguageRTL($lang) ? 'rtl' : 'ltr'
+                            ]
                         ); ?>
                         <?= getEditor(
                             'question-text',//"question_" . $lang, //this is important for LimereplacementfieldsController function getReplacementFields(...)!
@@ -39,7 +45,13 @@
                         <?= CHtml::textArea(
                             "questionI10N[$lang][help]",
                             $question->questionl10ns[$lang]->help ?? '',
-                            array('class'=>'form-control','cols'=>'60','rows'=>'4','id'=>"help_{$lang}")
+                            [
+                                'class' => 'form-control',
+                                'cols' => '60',
+                                'rows' => '4',
+                                'id' => "help_{$lang}",
+                                'data-contents-dir' => getLanguageRTL($lang) ? 'rtl' : 'ltr'
+                            ]
                         ); ?>
                         <?= getEditor(
                             "help_".$lang,

--- a/assets/packages/modaleditor/js/modaleditor.js
+++ b/assets/packages/modaleditor/js/modaleditor.js
@@ -45,22 +45,31 @@ var ModalEditor = function () {
         settings = ckSettings || {}; 
 
         CKEDITOR.on('instanceReady',CKeditor_OnComplete);
+
+        ckeConfig = {
+            height: '200',
+            width:  '98%',
+            toolbarStartupExpanded: true,
+            ToolbarCanCollapse: false,
+            toolbar: settings.toolbar || 'inline',
+            LimeReplacementFieldsSID : settings.sid,
+            LimeReplacementFieldsGID : settings.gid,
+            LimeReplacementFieldsQID : settings.qid,
+            //LimeReplacementFieldsType: "",
+            //LimeReplacementFieldsAction: "",
+            LimeReplacementFieldsPath : settings.replacementFieldsPath,
+            language : settings.language,
+        };
+
+        // Override language direction if 'data-contents-dir' attribute is set in the target field
+        if ($(targetField).get(0).hasAttribute('data-contents-dir')) {
+            var inputLangDirection = $(targetField).attr('data-contents-dir');
+            ckeConfig.contentsLangDirection = inputLangDirection ? inputLangDirection : '';
+        }
+
         oCKeditor = CKEDITOR.replace(
             'htmleditor-modal-textarea',
-            {
-                height: '200',
-                width:  '98%',
-                toolbarStartupExpanded: true,
-                ToolbarCanCollapse: false,
-                toolbar: settings.toolbar || 'inline',
-                LimeReplacementFieldsSID : settings.sid,
-                LimeReplacementFieldsGID : settings.gid,
-                LimeReplacementFieldsQID : settings.qid,
-                //LimeReplacementFieldsType: "",
-                //LimeReplacementFieldsAction: "",
-                LimeReplacementFieldsPath : settings.replacementFieldsPath,
-                language : settings.language,
-            }
+            ckeConfig
         );
     };
 


### PR DESCRIPTION
Corrected it for the editor of both the question and help, as well as for subquestions and answers.
We can apply the correction on other places as well.

Added a function to twig extensions as to check if the language is RTL. That function feeds the editor settings