### PR TITLE
Bug/17301  tokens  minute lock out

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -59,6 +59,8 @@ $config['adminthemeiconsize'] = 32; // This settings describes the icon size for
 // If the user enters password incorrectly
 $config['maxLoginAttempt']    = 3; // Lock them out after 3 attempts
 $config['timeOutTime']        = 60 * 10; // Lock them out for 10 minutes.
+$config['loginIpWhitelist'] = ''; // Regular expression for IPs that should be excluded from the max login attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
+$config['tokenIpWhitelist'] = ''; // Regular expression for IPs that should be excluded from the max token validation attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
 
 // Site Settings
 $config['printanswershonorsconditions'] = 1; // If set to 1, only relevant answers to questions can be printed by user. If set to 0, also questions not shown are printed

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -59,8 +59,8 @@ $config['adminthemeiconsize'] = 32; // This settings describes the icon size for
 // If the user enters password incorrectly
 $config['maxLoginAttempt']    = 3; // Lock them out after 3 attempts
 $config['timeOutTime']        = 60 * 10; // Lock them out for 10 minutes.
-$config['loginIpWhitelist'] = ''; // Regular expression for IPs that should be excluded from the max login attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
-$config['tokenIpWhitelist'] = ''; // Regular expression for IPs that should be excluded from the max token validation attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
+$config['loginIpWhitelist']   = []; // Array of regular expressions for IPs that should be excluded from the max login attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
+$config['tokenIpWhitelist']   = []; // Array of regular expressions for IPs that should be excluded from the max token validation attemps check. Ex: '192.168.0.5|192.168.0.6' or '192.168.0.\d+'
 
 // Site Settings
 $config['printanswershonorsconditions'] = 1; // If set to 1, only relevant answers to questions can be printed by user. If set to 0, also questions not shown are printed

--- a/application/core/LSUserIdentity.php
+++ b/application/core/LSUserIdentity.php
@@ -55,7 +55,7 @@ class LSUserIdentity extends CUserIdentity
         $result = new LSAuthResult(self::ERROR_NONE);
 
         // Check if the ip is locked out
-        if (FailedLoginAttempt::model()->isLockedOut()) {
+        if (FailedLoginAttempt::model()->isLockedOut(FailedLoginAttempt::TYPE_LOGIN)) {
             $message = sprintf(gT('You have exceeded the number of maximum login attempts. Please wait %d minutes before trying again.'), App()->getConfig('timeOutTime') / 60);
             $result->setError(self::ERROR_IP_LOCKED_OUT, $message);
         }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1233,7 +1233,7 @@ function finalizeRandomization($fieldmap)
 function testIfTokenIsValid(array $subscenarios, array $thissurvey, array $aEnterTokenData, $clienttoken)
 {
     $FlashError = '';
-    if (FailedLoginAttempt::model()->isLockedOut()) {
+    if (FailedLoginAttempt::model()->isLockedOut(FailedLoginAttempt::TYPE_TOKEN)) {
         $FlashError = sprintf(gT('You have exceeded the number of maximum token validation attempts. Please wait %d minutes before trying again.'), App()->getConfig('timeOutTime') / 60);
         $renderToken = 'main';
     } else {

--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -24,6 +24,9 @@
  */
 class FailedLoginAttempt extends LSActiveRecord
 {
+    const TYPE_LOGIN = 'login';
+    const TYPE_TOKEN = 'token';
+
     /**
      * @inheritdoc
      * @return FailedLoginAttempt
@@ -62,12 +65,24 @@ class FailedLoginAttempt extends LSActiveRecord
     /**
      * Check if an IP address is allowed to login or not
      *
+     * @param string $attemptType  The attempt type ('login' or 'token'). Used to check the white lists.
+     *
      * @return boolean Returns true if the user is blocked
      */
-    public function isLockedOut()
+    public function isLockedOut($attemptType = '')
     {
         $isLockedOut = false;
         $ip = substr(App()->getRequest()->getUserHostAddress(), 0, 40);
+
+        // If a valid 'attempt type' is specified, check the white list
+        if ($attemptType == self::TYPE_LOGIN || $attemptType == self::TYPE_TOKEN) {
+            $whiteList = Yii::app()->getConfig($attemptType . 'IpWhitelist');
+            if (!empty($whiteList) && preg_match('/' . str_replace('/', '\/', $whiteList) . '/', $ip, $m)) {
+                // The IP is whitelisted, so we return false
+                return false;
+            }
+        }
+
         $criteria = new CDbCriteria;
         $criteria->condition = 'number_attempts > :attempts AND ip = :ip';
         $criteria->params = array(':attempts' => Yii::app()->getConfig('maxLoginAttempt'), ':ip' => $ip);


### PR DESCRIPTION
Added a whitelist config setting as to be able to whitelist certain ips or regexs either for token or login attempts.
This is a quick solution which to solve this issue. Further discussions to the blocking feature can be added on top of this later.