### PR TITLE
Fixed issue #17309: Date question always shows error when using AR language - can't proceed at survey

### DIFF
--- a/application/core/QuestionTypes/Date/RenderDate.php
+++ b/application/core/QuestionTypes/Date/RenderDate.php
@@ -398,7 +398,7 @@ class RenderDate extends QuestionBaseRenderer
     {
         $answer = '';
         $inputnames = [];
-        $this->aDateformatDetails      = getDateFormatDataForQID($this->aQuestionAttributes, $this->oQuestion->sid);
+        $this->aDateformatDetails      = getDateFormatDataForQID($this->aQuestionAttributes, $this->oQuestion->sid, App()->language);
         $coreClass = "ls-answers answer-item date-item " . $sCoreClasses;
         $this->setMinDate();
         $this->setMaxDate();

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9595,14 +9595,14 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         $standard = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
         if ($lang == 'ar') {
-            $eastern_arabic_symbols = ["٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"];
+            $eastern_arabic_symbols = ["\u{0660}","\u{0661}","\u{0662}","\u{0663}","\u{0664}","\u{0665}","\u{0666}","\u{0667}","\u{0668}","\u{0669}"];
             $result = str_replace($eastern_arabic_symbols, $standard, $str);
         } elseif ($lang == 'fa') {
             // NOTE: NOT the same UTF-8 letters as array above (Arabic)
-            $extended_arabic_indic = ["۰", "۱", "۲", "۳", "۴", "۵", "۶", "۷", "۸", "۹"];
+            $extended_arabic_indic = ["\u{06F0}","\u{06F1}","\u{06F2}","\u{06F3}","\u{06F4}","\u{06F5}","\u{06F6}","\u{06F7}","\u{06F8}","\u{06F9}"];
             $result = str_replace($extended_arabic_indic, $standard, $str);
         } elseif ($lang == 'hi') {
-            $hindi_symbols = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
+            $hindi_symbols = ["\u{0966}","\u{0967}","\u{0968}","\u{0969}","\u{096A}","\u{096B}","\u{096C}","\u{096D}","\u{096E}","\u{096F}"];
             $result = str_replace($hindi_symbols, $standard, $str);
         }
 

--- a/application/helpers/surveytranslator_helper.php
+++ b/application/helpers/surveytranslator_helper.php
@@ -1084,7 +1084,7 @@ function getJSDateFromDateFormat($sDateformat)
      * @returns array
      *
      */
-function getDateFormatDataForQID($aQidAttributes, $mThisSurvey)
+function getDateFormatDataForQID($aQidAttributes, $mThisSurvey, $language = '')
 {
     if (isset($aQidAttributes['date_format']) && trim($aQidAttributes['date_format']) != '') {
         $aDateFormatDetails = array();
@@ -1094,7 +1094,7 @@ function getDateFormatDataForQID($aQidAttributes, $mThisSurvey)
         $aDateFormatDetails['jsdate_original'] = $aDateFormatDetails['dateformat']; // In dropdown, this is fed to Date in Javascript, not Bootstrap
     } else {
         if (!is_array($mThisSurvey)) {
-            $mThisSurvey = array('surveyls_dateformat' => getDateFormatForSID($mThisSurvey));
+            $mThisSurvey = array('surveyls_dateformat' => getDateFormatForSID($mThisSurvey, $language));
         }
         $aDateFormatDetails = getDateFormatData($mThisSurvey['surveyls_dateformat']);
     }


### PR DESCRIPTION
The sample survey has two languages: EN and AR.
At the survey level, the date format for EN is dd.mm.yyyy for AR is dd-mm-yyyy (dots vs. dashes).
At the question level it does not have a specific format.

In LS4:
When the question is rendered, it tries to use the format of the question, and if it does not have it, it uses the one of the survey. But use the base language.

In the data validation, if the question does not have a format, use the survey format, but with the corresponding language.

In this case they are different a dump is produced. 
The fix is considering the language on the rendering.