### PR TITLE
Fixed issue #17309: Date question always shows error when using AR language - can't proceed at survey

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -10218,22 +10218,17 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         {
             $result = $str;
 
-            $standard = array("0","1","2","3","4","5","6","7","8","9");
+            $standard = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
-            if ($lang == 'ar')
-            {
-                $eastern_arabic_symbols = array("Ù ","Ù¡","Ù¢","Ù£","Ù¤","Ù¥","Ù¦","Ù§","Ù¨","Ù©");
+            if ($lang == 'ar') {
+                $eastern_arabic_symbols = ["٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"];
                 $result = str_replace($eastern_arabic_symbols, $standard, $str);
-            }
-            else if ($lang == 'fa')
-            {
+            } elseif ($lang == 'fa') {
                 // NOTE: NOT the same UTF-8 letters as array above (Arabic)
-                $extended_arabic_indic = array("Û°","Û±","Û²","Û³","Û´","Ûµ","Û¶","Û·","Û¸","Û¹");
+                $extended_arabic_indic = ["۰", "۱", "۲", "۳", "۴", "۵", "۶", "۷", "۸", "۹"];
                 $result = str_replace($extended_arabic_indic, $standard, $str);
-            }
-            else if ($lang == 'hi')
-            {
-                $hindi_symbols = array("à¥¦","à¥§","à¥¨","à¥©","à¥ª","à¥«","à¥¬","à¥­","à¥®","à¥¯");
+            } elseif ($lang == 'hi') {
+                $hindi_symbols = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
                 $result = str_replace($hindi_symbols, $standard, $str);
             }
 


### PR DESCRIPTION
The sample survey has two languages: EN and AR.
At the survey level, the date format for EN is dd.mm.yyyy for AR is dd-mm-yyyy (dots vs. dashes).
At the question level it does not have a specific format.

In LS3:
The rendering part is fine.
But in validation, it fails when converting the Arabic characters. 
Ported the rutine from LS4 method and works fine now.