### PR TITLE
Fixed issue #14039: Captcha prevent panel integration. GET URL parameter not captured

### DIFF
--- a/application/core/LSHttpRequest.php
+++ b/application/core/LSHttpRequest.php
@@ -39,6 +39,9 @@ class LSHttpRequest extends CHttpRequest
     public $noCsrfValidationRoutes = array();
     public $noCsrfValidationParams = array();
 
+    /** @var array<string,mixed>|null the request query parameters (name-value pairs) */
+    private $queryParams;
+
     /**
      * Return the referal url,
      * it's used for the "close" buttons, and the "save and close" buttons
@@ -219,4 +222,29 @@ class LSHttpRequest extends CHttpRequest
         return $this->_pathInfo;
     }
 
+    /**
+     * Returns the request parameters given in the [[queryString]].
+     *
+     * This method will return the contents of `$_GET` if params where not explicitly set.
+     * @return array the request GET parameter values.
+     * @see setQueryParams()
+     */
+    public function getQueryParams()
+    {
+        if ($this->queryParams === null) {
+            return $_GET;
+        }
+
+        return $this->queryParams;
+    }
+
+    /**
+     * Sets the request [[queryString]] parameters.
+     * @param array $values the request query parameters (name-value pairs)
+     * @see getQueryParams()
+     */
+    public function setQueryParams($values)
+    {
+        $this->queryParams = $values;
+    }
 }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -2219,6 +2219,8 @@ function cookieConsentLocalization()
 /**
  * Returns an array of URL parameters that can be forwarded
  *
+ * @param LSHttpRequest $request the HTTP request
+ *
  * @return array<string,mixed>
  */
 function getForwardParameters($request)

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -884,7 +884,7 @@ function prefillFromCommandLine($surveyid)
     } else {
         $startingValues = $_SESSION['survey_'.$surveyid]['startingValues'];
     }
-    if (Yii::app()->getRequest()->getRequestType()=='GET') {
+    if (in_array(Yii::app()->getRequest()->getRequestType(), ['GET', 'POST'])) {
         $getValues = array_diff_key($_GET,array_combine($reservedGetValues, $reservedGetValues));
         if(!empty($getValues)) {
             $qcode2sgqa = array();
@@ -1320,7 +1320,7 @@ function renderRenderWayForm($renderWay, array $scenarios, $sTemplateViewPath, $
             // Rendering layout_user_forms.twig
             $thissurvey                     = $oSurvey->attributes;
             $thissurvey["aForm"]            = $aForm;
-            $thissurvey['surveyUrl']        = App()->createUrl("/survey/index", array("sid"=>$surveyid));
+            $thissurvey['surveyUrl']        = App()->createUrl("/survey/index", array_merge(["sid"=>$surveyid], getForwardParameters()));
             $thissurvey['include_content']  = 'userforms';
 
             Yii::app()->clientScript->registerScriptFile(Yii::app()->getConfig("generalscripts").'nojs.js', CClientScript::POS_HEAD);
@@ -2213,4 +2213,30 @@ function cookieConsentLocalization()
         gT('View policy'),
         gT('Please be patient until you are forwarded to the final URL.')
     );
+}
+
+/**
+ * Returns an array of URL parameters that can be forwarded
+ *
+ * @return array<string,mixed>
+ */
+function getForwardParameters()
+{
+    $reservedGetValues = array(
+        'token',
+        'sid',
+        'gid',
+        'qid',
+        'lang',
+        'newtest',
+        'action',
+        'seed',
+        'index.php',
+    );
+
+    $parameters = [];
+    if (Yii::app()->getRequest()->getRequestType() == 'GET') {
+        $parameters = array_diff_key($_GET,array_flip($reservedGetValues));
+    }
+    return $parameters;
 }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -884,8 +884,9 @@ function prefillFromCommandLine($surveyid)
     } else {
         $startingValues = $_SESSION['survey_'.$surveyid]['startingValues'];
     }
-    if (in_array(Yii::app()->getRequest()->getRequestType(), ['GET', 'POST'])) {
-        $getValues = array_diff_key($_GET,array_combine($reservedGetValues, $reservedGetValues));
+    $request = Yii::app()->getRequest();
+    if (in_array($request->getRequestType(), ['GET', 'POST'])) {
+        $getValues = array_diff_key($request->getQueryParams(), array_combine($reservedGetValues, $reservedGetValues));
         if(!empty($getValues)) {
             $qcode2sgqa = array();
             Yii::import('application.helpers.viewHelper');
@@ -2234,9 +2235,10 @@ function getForwardParameters()
         'index.php',
     );
 
+    $request = Yii::app()->getRequest();
     $parameters = [];
-    if (in_array(Yii::app()->getRequest()->getRequestType(), ['GET', 'POST'])) {
-        $parameters = array_diff_key($_GET,array_flip($reservedGetValues));
+    if (in_array($request->getRequestType(), ['GET', 'POST'])) {
+        $parameters = array_diff_key($request->getQueryParams(), array_flip($reservedGetValues));
     }
     return $parameters;
 }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1321,7 +1321,7 @@ function renderRenderWayForm($renderWay, array $scenarios, $sTemplateViewPath, $
             // Rendering layout_user_forms.twig
             $thissurvey                     = $oSurvey->attributes;
             $thissurvey["aForm"]            = $aForm;
-            $thissurvey['surveyUrl']        = App()->createUrl("/survey/index", array_merge(["sid"=>$surveyid], getForwardParameters()));
+            $thissurvey['surveyUrl']        = App()->createUrl("/survey/index", array_merge(["sid"=>$surveyid], getForwardParameters(Yii::app()->getRequest())));
             $thissurvey['include_content']  = 'userforms';
 
             Yii::app()->clientScript->registerScriptFile(Yii::app()->getConfig("generalscripts").'nojs.js', CClientScript::POS_HEAD);
@@ -2221,7 +2221,7 @@ function cookieConsentLocalization()
  *
  * @return array<string,mixed>
  */
-function getForwardParameters()
+function getForwardParameters($request)
 {
     $reservedGetValues = array(
         'token',
@@ -2235,7 +2235,6 @@ function getForwardParameters()
         'index.php',
     );
 
-    $request = Yii::app()->getRequest();
     $parameters = [];
     if (in_array($request->getRequestType(), ['GET', 'POST'])) {
         $parameters = array_diff_key($request->getQueryParams(), array_flip($reservedGetValues));

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -2235,7 +2235,7 @@ function getForwardParameters()
     );
 
     $parameters = [];
-    if (Yii::app()->getRequest()->getRequestType() == 'GET') {
+    if (in_array(Yii::app()->getRequest()->getRequestType(), ['GET', 'POST'])) {
         $parameters = array_diff_key($_GET,array_flip($reservedGetValues));
     }
     return $parameters;


### PR DESCRIPTION
Added querystring parameters to the captcha form action, so they are included in the next request.
That way, prefill values are forwarded.