### PR TITLE
Fixed issue #14897: Edit theme permissions: option 'All themes' not working

### DIFF
--- a/assets/scripts/admin/users.js
+++ b/assets/scripts/admin/users.js
@@ -38,8 +38,8 @@ function bindButtons(){
     $('.action_usercontrol_button').on('click', function(){
         runAction(this);
     });
-    $('input[name="alltemplates"]').on('switchChange.bootstrapSwitch', function(event, state) {
-        $('input[id$="_use"]').prop('checked',state).trigger('change');
+    $('input[name="alltemplates"]').on('change', function(event) {
+        $('input[id$="_use"]').prop('checked', this.checked).trigger('change');
     });
 
 }


### PR DESCRIPTION
The event being trapped is for bootstrap switch, and the controls are regular checkboxes.
Adapted the event to match regular checkboxes