### PR TITLE
Fixed issue #17360: Cannot save display theme option button size for bootstrap button question type

### DIFF
--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/config.xml
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/config.xml
@@ -63,7 +63,6 @@
             <default>default</default>
             <help>Change button size</help>
             <caption>Button size</caption>
-            <i18n>hr</i18n>
         </attribute>
         <attribute>
             <name>max_buttons_row</name>


### PR DESCRIPTION
Review definition of attribute  "button_size"