### PR TITLE
Fixed issue #17038: templateurl placeholder not being replaced

### DIFF
--- a/themes/survey/vanilla/views/layout_errors.twig
+++ b/themes/survey/vanilla/views/layout_errors.twig
@@ -48,7 +48,9 @@
             TODO: move it to a separated css file
         #}
         <meta name="generator" content="LimeSurvey http://www.limesurvey.org" />
-        <link rel="shortcut icon" href="{{ templateurl }}favicon.ico" />
+        {% if(imageSrc('./files/favicon.ico')) %}
+            <link rel="shortcut icon" href="{{ imageSrc('./files/favicon.ico') }}" />
+        {% endif %}
     </head>
 
     <body  class="{{ aSurveyInfo.class.body }} lang-{{aSurveyInfo.languagecode}} {{surveyformat}}" marginwidth="0" marginheight="0" {{ aSurveyInfo.attr.body }}>


### PR DESCRIPTION
Updating some template screens which were not migrated properly from legacy.