### PR TITLE
Add App->params to allowed Twig attributes

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -349,7 +349,7 @@ $internalConfig = array(
                 ),
                 'properties' =>  array(
                     'ETwigViewRendererYiiCoreStaticClassesProxy' => array("Html"),
-                    'LSYii_Application'                          => array("request"),
+                    'LSYii_Application'                          => array("request", "params"),
                     'TemplateConfiguration'             =>  array("sTemplateurl"),
                     'Survey' => array('sid', 'admin', 'active', 'expires', 'startdate', 'anonymized', 'format', 'savetimings', 'template', 'language', 'datestamp', 'usecookie', 'allowprev', 'printanswers', 'showxquestions', 'showgroupinfo', 'shownoanswer', 'showqnumcode', 'showwelcome', 'showprogress', 'questionindex', 'navigationdelay', 'nokeyboard', 'alloweditaftercompletion', 'hasTokensTable', 'hasResponsesTable', 'showsurveypolicynotice', 'aOptions'),
                     'SurveyLanguageSetting' => array('surveyls_description', 'surveyls_welcometext', 'surveyls_endtext', 'surveyls_policy_notice', 'surveyls_policy_error', 'surveyls_policy_notice_label'),


### PR DESCRIPTION
Dev:
Added the App->params as allowed attributes that can be fetched from twig for templating. 

Twig code has had a major upgrade with v5.0. in v4 the whole App is accessible in twig. With v5 no custom data can be pushed to twig theme. App->params does not contain any sensitive information by default LS config. This change will allow to add custom data to be pushed to params (eg via plug-ins) and then be displayed in themes via twig. 