### PR TITLE
Fixed issue #17386: The { } disappear from forced expression

### DIFF
--- a/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
+++ b/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
@@ -20,6 +20,10 @@ class AdvancedSettingWidget extends CWidget
             //echo '<pre>'; var_dump($this->setting['aFormElementOptions']['options']); echo '</pre>';
         //}
 
+        // The 'expression' property comes from the question attribute definition (either from the theme's config.xml
+        // or from newQuestionAttributes() plugin event).
+        // The value 2 indicates that the attribute must be treated as an EM expression (survey logic file and question
+        // summary automatically add the brackets before evaluation).
         if (isset($this->setting['expression']) && $this->setting['expression'] == 2) {
             $this->setting['aFormElementOptions']['inputGroup'] = ['prefix' => '{', 'suffix' => '}'];
         }

--- a/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
+++ b/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
@@ -19,6 +19,11 @@ class AdvancedSettingWidget extends CWidget
         //if ($this->setting['inputtype'] === 'singleselect') {
             //echo '<pre>'; var_dump($this->setting['aFormElementOptions']['options']); echo '</pre>';
         //}
+
+        if (isset($this->setting['expression']) && $this->setting['expression'] == 2) {
+            $this->setting['aFormElementOptions']['inputGroup'] = ['prefix' => '{', 'suffix' => '}'];
+        }
+
         $content = $this->render($this->setting['inputtype'], null, true);
         $this->render('layout', ['content' => $content]);
     }


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
