### PR TITLE
Dev #17070: Replacement Fields on Popup Editor for SubQuestions

### DIFF
--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -95,8 +95,8 @@ $(document).on('ready pjax:scriptcomplete', function () {
    */
   function updateRowProperties() {
     var sID = $('input[name=sid]').val();
-    var gID = $('input[name=gid]').val();
-    var qID = $('input[name=qid]').val();
+    var gID = $('[name=question\\[gid\\]]').val();
+    var qID = $('[name=question\\[qid\\]]').val();
     sID = $.isNumeric(sID) ? sID : '';
     gID = $.isNumeric(gID) ? gID : '';
     qID = $.isNumeric(qID) ? qID : '';


### PR DESCRIPTION
GID and QID were not sent to editor on subquestions, imapcting on replacement fields.
Issue detected while reviewing https://bugs.limesurvey.org/view.php?id=17070