### PR TITLE
Fixed issue #T919: When user clicks on Theme options icon he should be directed to Theme Options instead of a blank page

### DIFF
--- a/application/views/themeOptions/update.php
+++ b/application/views/themeOptions/update.php
@@ -259,6 +259,9 @@ echo viewHelper::getViewTestTag('surveyTemplateOptionsUpdate');
             </div>
         </div>
     </div>
+<?php if (!empty($model->sid)): // If we are in survey view, we have an additional div that we need to close ?>
+</div>
+<?php endif; ?>
 
 <!-- Form for image file upload -->
 <div class="hidden">


### PR DESCRIPTION
Missing closing tag generated on 4d88ebbf 