### PR TITLE
Disallow download of composer.json

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,6 +11,9 @@
     # deny access to hidden files and directories except .well-known
     RewriteCond %{REQUEST_URI} !^/\.well-known
     RewriteRule ^(.*/)?\.+ - [F]
+
+    # deny access to composer.json that is used for remote fingerprinting
+    RewriteRule ^composer.json - [F]
 </IfModule>
 
 # deny access to hidden files and directories without mod_rewrite


### PR DESCRIPTION
We just had some reports where composer.json was used to fingerprint the version of software are using. This PR updates .htaccess to deny the remote download of this file.