### PR TITLE
Fixed issue #T973: Javascript bug when using Condition Editor and then navigating back to Question Summary and EDITING a question

### DIFF
--- a/application/config/third_party.php
+++ b/application/config/third_party.php
@@ -283,6 +283,7 @@ return array(
         'jquery-ace' => array(
             'devBaseUrl' => 'third_party/jquery-ace',
             'basePath' => 'third_party.jquery-ace',
+            'position' => CClientScript::POS_BEGIN,
         'js' => array(
             'jquery.ace.js',
         ),


### PR DESCRIPTION
The problem is that when you go to the question summary from the condition designer (I understand that by clicking on the question in the sidemenu), the page is loaded by pjax and not the regular way (loading the full document). 

Two packages have to be loaded: 'ace' and 'jquery-ace'. 
- The first one was loaded using POS_BEGIN , so it stays at the beginning of the body, and pjax executes it. 
- The second was loaded without specifying a position so it was left in the header and was not executed when loaded through pjax.

Second package loading was updated.