### PR TITLE
Fixed issue #17427: Bug in 'Answer options' - 'Quick add'

### DIFF
--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -1483,6 +1483,20 @@ $(document).on('ready pjax:scriptcomplete', function () {
     };
   }
 
+  /**
+   * Makes the answer's table sortable
+   */
+  function makeAnswersTableSortable() /*: void */ {
+    $('.answertable tbody').sortable({
+      containment: 'parent',
+      start: startmove,
+      stop: endmove,
+      update: aftermove,
+      handle: '.move-icon',
+      distance: 3,
+    });
+  }
+
   // Public functions for LS.questionEditor module.
   LS.questionEditor = {
     /**
@@ -1552,6 +1566,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
         // TODO: Double check HTML injected here. Extra div?
         $('#advanced-options-container').replaceWith(advancedSettingsHtml);
         $('#extra-options-container').replaceWith(extraOptionsHtml);
+        makeAnswersTableSortable();
         $('.question-option-help').hide();
         $('#ls-loading').hide();
 
@@ -1856,14 +1871,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
 
   // Below, things run on pjax:scriptcomplete.
 
-    $('.answertable tbody').sortable({
-      containment: 'parent',
-      start: startmove,
-      stop: endmove,
-      update: aftermove,
-      handle: '.move-icon',
-      distance: 3,
-    });
+    makeAnswersTableSortable();
 
     $('.btnaddsubquestion').on('click.subquestions', addSubquestionInput);
     $('.btndelsubquestion').on('click.subquestions', deleteSubquestionInput);


### PR DESCRIPTION
The error only happens after switching types.
The problem was that the list of answers is supposed to be sortable, but it's only made sortable on ready/pjax:scriptcomplete.
When the list of answers is loaded by ajax (eg. when selecting a different question type), it's not made sortable.

When using quick add, one of the things done before closing the modal is refreshing the sortable list. But, since it wasn't sortable, it was silently failing and the modal never closed.

It's fixed by moving the initialization of the sortable list into a function, and calling it both on ready/pjax:scriptcomplete and after loading the ajax.