### PR TITLE
Fixed issue #17436: When editing 'General Settings' site name and pressing 'enter', a layover appears and screen freezes

### DIFF
--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -110,6 +110,7 @@
                 <button 
                     id="sendtestemailbutton"
                     class='btn btn-large btn-primary' 
+                    type="button"
                     data-href='<?= \Yii::app()->createUrl('admin/globalsettings', array("sa"=>"sendTestEmailConfirmation")) ?>'>
                     <?php eT("Send email");?>
                 </button>


### PR DESCRIPTION
Now when you press enter the submit is done. It is the behavior it had before entering the mail (13853).