### PR TITLE
Fixed issue #17480: Unable to reload with token + persistence + allow edit

### DIFF
--- a/application/models/Response.php
+++ b/application/models/Response.php
@@ -37,6 +37,15 @@ abstract class Response extends Dynamic
         return parent::create($surveyId, $scenario);
     }
 
+    /** @inheritdoc
+     * Must be set by DB, adding by security here
+     * @see https://bugs.limesurvey.org/view.php?id=17208
+     **/
+    public function primaryKey()
+    {
+        return 'id';
+    }
+
     /**
      * Get all files related to this response and (optionally) question ID.
      *


### PR DESCRIPTION
Dev: Same fix than 3.X + findByPk

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
