### PR TITLE
Fixed issue #17432: Group randomization shuffles only questions from first group

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -291,6 +291,7 @@ class SurveyRuntimeHelper
         $this->aSurveyInfo['errorHtml']['hiddenClass'] = $this->oTemplate->showpopups==1 ? "ls-js-hidden " : "";
         $this->aSurveyInfo['errorHtml']['messages']    = $aErrorHtmlMessage;
 
+        // Generate the groups data for the views ($this->aSurveyInfo['aGroups'])
         $_gseq = -1;
         foreach ($_SESSION[$this->LEMsessid]['grouplist'] as $gl) {
 
@@ -338,9 +339,16 @@ class SurveyRuntimeHelper
             $aGroup['showdescription']  = (!$this->previewquestion && trim($gl['description']) != "" && $showgroupdesc_);
             $aGroup['description']      = LimeExpressionManager::ProcessString($gl['description'], null, $aStandardsReplacementFields, 3, 1);
 
-            // one entry per QID
+            // Note: $qanda contains all questions to be shown in the screen,
+            // according to the survey's format:
+            //  - Group by Group --> Only the ones in the current group
+            //  - Question by Question --> Only the current question
+            //  - All in one --> All questions in the survey
             foreach ($qanda as $qa) {
+                // Add question to question list in group information
 
+                // For all in one, $qanda may contain questions which are not from the group
+                // currently being processed in this loop. Filter them by 'finalgroup'.
                 if ($gid == $qa['finalgroup']) {
                     $qid             = $qa[4];
                     $qinfo           = LimeExpressionManager::GetQuestionStatus($qid);

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -341,7 +341,7 @@ class SurveyRuntimeHelper
             // one entry per QID
             foreach ($qanda as $qa) {
 
-                if ($gid == $qa[6] || ( isset($_SESSION[$this->LEMsessid]['fieldmap-'.$this->iSurveyid.'-randMaster']) && $this->sSurveyMode != 'survey' ) ) {
+                if ($gid == $qa['finalgroup']) {
                     $qid             = $qa[4];
                     $qinfo           = LimeExpressionManager::GetQuestionStatus($qid);
                     $lemQuestionInfo = LimeExpressionManager::GetQuestionStatus($qid);


### PR DESCRIPTION
Reviewed how questions are filtered towards including them in the output screen