### PR TITLE
Fixed issue #17285: "Resume later" not working after "Load unfinished survey"

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5648,7 +5648,7 @@
                     }
                     elseif ($this->surveyOptions['allowsave'] && isset($_SESSION[$this->sessid]['scid']))
                     {
-                        SavedControl::model()->updateByPk($_SESSION[$this->sessid]['scid'], array('saved_thisstep'=>$thisstep));
+                        SavedControl::model()->updateByPk($_SESSION[$this->sessid]['scid'], array('saved_thisstep'=>$_SESSION[$this->sessid]['step']));
                     }
                     // Check Quotas
                     $aQuotas = checkCompletedQuota($this->sid,true);


### PR DESCRIPTION
It seems to me that there is a confusion between the "step" of the session and the value of $ thisstep.

When you are in group 2 and you save the survey for the first time, the saved table is saved_thisstep = 2. (group number, not group sequence)
That comes out of $ thisstep, which in that context has the same as the "step" of the session (the current group number).

When you save the survey for the second time (the save screen no longer appears, it is saved directly), execute _UpdateValuesInDatabase and set there $ thisstep = $ this-> currentGroupSeq (sequence, that is, 1 instead of 2) and then the SavedControl is updated with that value. At that point, $ thisstep is different from the session step.