### PR TITLE
Fixed issue #17484: After installing plugins through web interface, some files are missing

### DIFF
--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -757,10 +757,6 @@ function pluginExtractFilter($p_event, &$p_header)
         Yii::app()->getConfig('allowedpluginuploads')
     );
     $info = pathinfo($p_header['filename']);
-    // Deny files with multiple extensions in general
-    if (substr_count($info['basename'], '.') > 1) {
-        return 0;
-    }
 
     if (
         $p_header['folder']


### PR DESCRIPTION
It seems the validation was done to avoid a vulnerability (https://bugs.limesurvey.org/view.php?id=8565). According to commit 165c8353, that only applied to old PHP versions with a specific mod.
Since that check was already removed for theme's upload, we are also removing it here.
If it's really needed, maybe it could be replaced by a more specific validation (eg. checking that files don't have ".php" in the middle on the name).