### PR TITLE
Fixed issue #17333: Soft mandatory show as mandatory : produces an incomprehensible form

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6091,7 +6091,7 @@ class LimeExpressionManager
             $mandatoryTip = App()->twigRenderer->renderPartial(
                 '/survey/questions/question_help/mandatory_tip.twig',
                 [
-                    'sMandatoryText' => $LEM->gT('This question is mandatory'),
+                    'sMandatoryText' => $qInfo['mandatory'] == 'S' ? $LEM->gT("Please notice you haven't answered this question. Still, you can continue without answering.") : $LEM->gT('This question is mandatory'),
                     'part'           => 'initial',
                     'qInfo'          => $qInfo
                 ]


### PR DESCRIPTION
- Different error message for soft mandatory