### PR TITLE
Fixed issue #17334: Soft mandantory question work only with popup

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -386,6 +386,8 @@ class SurveyRuntimeHelper
         $this->aSurveyInfo['jPopup'] = json_encode($aPopup);
         $this->aSurveyInfo['mandSoft'] = array_key_exists('mandSoft', $this->aMoveResult) ? $this->aMoveResult['mandSoft'] : false;
         $this->aSurveyInfo['mandNonSoft'] = array_key_exists('mandNonSoft', $this->aMoveResult) ? $this->aMoveResult['mandNonSoft'] : false;
+        $this->aSurveyInfo['mandViolation'] = $this->aStepInfo['mandViolation'] && $this->okToShowErrors;
+        $this->aSurveyInfo['showPopups'] = $this->oTemplate != null ? $this->oTemplate->showpopups : false;
 
         $aErrorHtmlMessage                             = $this->getErrorHtmlMessage();
         $this->aSurveyInfo['errorHtml']['show']        = !empty($aErrorHtmlMessage) && $this->oTemplate->showpopups == 0;

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -804,6 +804,10 @@ class TemplateConfig extends CActiveRecord
 
         $aClassAndAttributes['attr']['alertmodal'] = $aClassAndAttributes['attr']['modaldialog'] = $aClassAndAttributes['attr']['modalcontent'] = $aClassAndAttributes['attr']['modaltitle'] = $aClassAndAttributes['attr']['modalbody'] = $aClassAndAttributes['attr']['modalfooter'] = '';
 
+        // Soft Mandatory Checkbox
+        $aClassAndAttributes['class']['mandsoftcheckbox'] = '';
+        $aClassAndAttributes['class']['mandsoftcheckboxlabel'] = '';
+
         // Assessments
         $aClassAndAttributes['class']['assessmenttable']      = ' assessment-table ';
         $aClassAndAttributes['class']['assessmentstable']     = ' assessments ';

--- a/themes/survey/vanilla/views/subviews/navigation/navigator.twig
+++ b/themes/survey/vanilla/views/subviews/navigation/navigator.twig
@@ -43,6 +43,12 @@
 
             {# On last page, Next button become submit button. #}
             {% if aNavigator.aMoveNext.value == "movesubmit" %}
+                {% if not empty(aSurveyInfo.mandViolation) and not empty(aSurveyInfo.mandSoft) and empty(aSurveyInfo.mandNonSoft) and aSurveyInfo.showPopups != 1 %}
+                <span class="checkbox-item">
+                    <input class="{{ aSurveyInfo.class.mandsoftcheckbox }}" type="checkbox" name="mandSoft" id="mandSoft" value="{{ aSurveyInfo.aNavigator.aMoveNext.value }}" />
+                    <label for="mandSoft" class="control-label {{ aSurveyInfo.class.mandsoftcheckboxlabel }}">{{ gT("Continue without answering") }}</label>&nbsp;
+                </span>
+                {% endif %}
                 <!-- Button submit -->
                 <button {{ aSurveyInfo.attr.navigatorbuttonsubmit }} accesskey="n" class=" {{ aNavigator.disabled }} {{ aSurveyInfo.class.navigatorbuttonsubmit }} btn btn-lg btn-primary">
                     {{ gT("Submit") }}


### PR DESCRIPTION
"Show popups" has three options: Popup, On Page and No.

If there is a "mandatory violation", it happens only for "soft mandatory" questions, and "Show popups" is not "Popup", then a checkbox appears next to the submit button.