### PR TITLE
Fixed issue #17453: Strings not available for translation in GlotPress

### DIFF
--- a/application/views/questionAdministration/summary.php
+++ b/application/views/questionAdministration/summary.php
@@ -211,7 +211,7 @@
                 <tr>
                     <td>
                         <strong>
-                            <?php echo $setting['caption'];?>:
+                            <?php eT($setting['caption']);?>:
                         </strong>
                     </td>
                     <td>


### PR DESCRIPTION
The question attribute names were not being translated in the summary view.