### PR TITLE
Fixed issue #17481: Error adding a large number of answer options

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -389,6 +389,20 @@ class QuestionAdministrationController extends LSBaseController
             }
         }
 
+        // Check the POST data is not truncated
+        if (!$request->getPost('bFullPOST')) {
+            $message = gT("The data received seems incomplete. This usually happens due to server limitations ( PHP setting max_input_vars) - please contact your system administrator.");
+
+            if ($calledWithAjax) {
+                echo json_encode(['message' => $message]);
+                Yii::app()->end();
+            } else {
+                $sRedirectUrl = $this->createUrl('questionAdministration/listQuestions', ['surveyid' => $iSurveyId]);
+                Yii::app()->setFlashMessage($message, 'error');
+                $this->redirect($sRedirectUrl);
+            }
+        }
+
         // Rollback at failure.
         $transaction = Yii::app()->db->beginTransaction();
         try {

--- a/application/views/questionAdministration/answerOptions.twig
+++ b/application/views/questionAdministration/answerOptions.twig
@@ -145,4 +145,3 @@
     data-qid="{{ question.qid }}"
     data-scale-id="{{ scale_id }}" {# -1 : because it's incremented via <  #}
 />
-<input type='hidden' id='bFullPOST' name='bFullPOST' value='1' />

--- a/application/views/questionAdministration/create.php
+++ b/application/views/questionAdministration/create.php
@@ -153,6 +153,8 @@
                     </div>
                 </div>
             </div>
+            <?php // Hidden field 'bFullPOST' is used to confirm the POST data is complete (it could be truncated if max_input_vars is exceeded) ?>
+            <input type='hidden' id='bFullPOST' name='bFullPOST' value='1' />
         </form>
     </div>
 

--- a/application/views/questionAdministration/subquestions.twig
+++ b/application/views/questionAdministration/subquestions.twig
@@ -137,4 +137,3 @@
     data-qid="{{ question.qid }}"
     data-scale-id="{{ scale_id }}" {# -1 : because it's incremented via <  #}
 />
-<input type='hidden' id='bFullPOST' name='bFullPOST' value='1' />


### PR DESCRIPTION
Moved and started to re-use the bFullPOST to show a warning message if some fields are not processed because of max_input options being too small.

The answerOptions.twig and subquestions.twig views had the hidden "bFullPOST" field, but was not being checked. 
Database.php used to check it, but seems that mechanism "got lost in translation".

Moved the bFullPost field to create.php following the new screen reorganization (subquestions and answers editable on the main screen)
