### PR TITLE
Fixed issue #17454: Unable to remove a user with survey permissions with friendly url enabled

### DIFF
--- a/application/controllers/admin/surveypermission.php
+++ b/application/controllers/admin/surveypermission.php
@@ -125,8 +125,8 @@ class surveypermission extends Survey_Common_Action
                 if (Permission::model()->hasSurveyPermission($iSurveyID, 'surveysecurity', 'delete')) {
                     $deleteUrl = App()->createUrl("admin/surveypermission/sa/delete/surveyid/".$iSurveyID, array(
                         'action' => 'delsurveysecurity',
-                        'user' => $PermissionRow['users_name'],
-                        'uid' => $PermissionRow['uid']
+                        'uid' => $PermissionRow['uid'],
+                        'user' => $PermissionRow['users_name']
                     ));
                     $deleteConfirmMessage = gT("Are you sure you want to delete this entry?");
                     $surveysecurity .= "<a data-target='#confirmation-modal' data-toggle='modal' data-message='{$deleteConfirmMessage}' data-href='{$deleteUrl}' type='submit' class='btn-xs btn btn-default'>


### PR DESCRIPTION
Changing the order of params, just in case the username param adds confusion to the querystring