### PR TITLE
Fixed issue #17512: Survey Logic File Syntax Error Summary Displays Incorrect Error Count

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -523,19 +523,19 @@ class ExpressionManager
      * Main entry function
      * @param string $expr
      * @param boolean $onlyparse - if true, then validate the syntax without computing an answer
-     * @param boolean $resetErrors - if true (default), EM errors will be clear before evaluation
+     * @param boolean $resetErrorsAndWarnings - if true (default), EM errors and warnings will be cleared before evaluation
      * @return boolean - true if success, false if any error occurred
      */
-    public function RDP_Evaluate($expr, $onlyparse = false, $resetErrors = true)
+    public function RDP_Evaluate($expr, $onlyparse = false, $resetErrorsAndWarnings = true)
     {
         $this->RDP_expr = $expr;
         $this->RDP_tokens = $this->RDP_Tokenize($expr);
         $this->RDP_count = count($this->RDP_tokens);
         $this->RDP_pos = -1; // starting position within array (first act will be to increment it)
-        if ($resetErrors) {
+        if ($resetErrorsAndWarnings) {
             $this->RDP_errs = array();
+            $this->RDP_warnings = array();
         }
-        $this->RDP_warnings = array();
         $this->RDP_onlyparse = $onlyparse;
         $this->RDP_stack = array();
         $this->RDP_evalStatus = false;
@@ -1839,7 +1839,7 @@ class ExpressionManager
         $stringParts = $this->asSplitStringOnExpressions($src);
         $resolvedParts = array();
         $prettyPrintParts = array();
-        $this->ResetErrors();
+        $this->ResetErrorsAndWarnings();
         foreach ($stringParts as $stringPart) {
             if ($stringPart[2] == 'STRING') {
                 $resolvedParts[] = $stringPart[0];
@@ -1847,7 +1847,7 @@ class ExpressionManager
             } else {
                 ++$this->substitutionNum;
                 $expr = $this->ExpandThisVar(substr($stringPart[0], 1, -1));
-                if ($this->RDP_Evaluate($expr, false, false)) { // We call RDP_Evaluate with $resetErrors = false because, if $src has more than one expression, error information could be lost
+                if ($this->RDP_Evaluate($expr, false, false)) { // We call RDP_Evaluate with $resetErrorsAndWarnings = false because, if $src has more than one expression, error information could be lost
                     $resolvedPart = $this->GetResult();
                 } else {
                     // show original and errors in-line only if user have the rigth to update survey content

--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -523,15 +523,18 @@ class ExpressionManager
      * Main entry function
      * @param string $expr
      * @param boolean $onlyparse - if true, then validate the syntax without computing an answer
+     * @param boolean $resetErrors - if true (default), EM errors will be clear before evaluation
      * @return boolean - true if success, false if any error occurred
      */
-    public function RDP_Evaluate($expr, $onlyparse = false)
+    public function RDP_Evaluate($expr, $onlyparse = false, $resetErrors = true)
     {
         $this->RDP_expr = $expr;
         $this->RDP_tokens = $this->RDP_Tokenize($expr);
         $this->RDP_count = count($this->RDP_tokens);
         $this->RDP_pos = -1; // starting position within array (first act will be to increment it)
-        $this->RDP_errs = array();
+        if ($resetErrors) {
+            $this->RDP_errs = array();
+        }
         $this->RDP_warnings = array();
         $this->RDP_onlyparse = $onlyparse;
         $this->RDP_stack = array();
@@ -1836,6 +1839,7 @@ class ExpressionManager
         $stringParts = $this->asSplitStringOnExpressions($src);
         $resolvedParts = array();
         $prettyPrintParts = array();
+        $this->ResetErrors();
         foreach ($stringParts as $stringPart) {
             if ($stringPart[2] == 'STRING') {
                 $resolvedParts[] = $stringPart[0];
@@ -1843,7 +1847,7 @@ class ExpressionManager
             } else {
                 ++$this->substitutionNum;
                 $expr = $this->ExpandThisVar(substr($stringPart[0], 1, -1));
-                if ($this->RDP_Evaluate($expr)) {
+                if ($this->RDP_Evaluate($expr, false, false)) { // We call RDP_Evaluate with $resetErrors = false because, if $src has more than one expression, error information could be lost
                     $resolvedPart = $this->GetResult();
                 } else {
                     // show original and errors in-line only if user have the rigth to update survey content


### PR DESCRIPTION
Basically what LimeExpressionManager :: ShowSurveyLogicFile () does is process each string and check for errors. That is, for each "field" to validate, execute $ LEM-> ProcessString (...), and then check $ LEM-> em-> HasErrors ().

The problem is that each expression contained in the chain is processed by RDP_Evaluate (), and one of the first things it does is reset the errors.

So if a string has more than one expression, and the last expression has no errors, $ LEM-> em-> HasErrors () returns false.

So HasErrors () reports only about the last execution of RDP_Evaluate (), it does not report about the entire process of ProcessString ().

On this fix we added the possibility (optional) of not reseting the errors.
That is, allow HasErrors() to report about the whole ProcessString() process.

An alternative is to create a separate flag for checking errors in the whole string.
Still, I believe that would more intrusive, involve more changes and also would be more error prone.