### PR TITLE
Fixed issue #14370: QueXML export (Print answers) of a ranking question showing name of available options instead of "Rank #"

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -1394,7 +1394,7 @@ function quexml_create_subQuestions(&$question, $qid, $varname, $iResponseID, $f
         if ($use_answers == false && $aid != false) {
             //dual scale array questions
             quexml_set_default_value($subQuestion, $iResponseID, $qid, $iSurveyID, $fieldmap, false, false, $Row['title'], $scale);
-        } if ($use_answers == true) {
+        } else if ($use_answers == true) {
             //ranking quesions
             quexml_set_default_value_rank($subQuestion, $iResponseID, $Row['qid'], $iSurveyID, $fieldmap, $Row->code);
         } else {


### PR DESCRIPTION
Fixed issue #14370: QueXML export (Print answers) of a ranking question showing name of available options instead of "Rank #"