### PR TITLE
Fix (17603): Removed language parameter from getQuestions method

### DIFF
--- a/application/libraries/PluginManager/LimesurveyApi.php
+++ b/application/libraries/PluginManager/LimesurveyApi.php
@@ -397,14 +397,12 @@ class LimesurveyApi
 
     /**
      * @param int $surveyId
-     * @param string $language
      * $param array $conditions
      * @return \Question[]
      */
-    public function getQuestions($surveyId, $language = 'en', $conditions = array())
+    public function getQuestions($surveyId, $conditions = array())
     {
         $conditions['sid'] = $surveyId;
-        $conditions['language'] = $language;
         return \Question::model()->with('subquestions')->findAllByAttributes($conditions);
     }
 


### PR DESCRIPTION
Removed language parameter from getQuestions method and query, as this column has been moved to another table (questionl10ns)

Fixed issue #17603