### PR TITLE
Fixed issue 17557: corrected erroneous error message concerning SVG file type as allowed file type for upload

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -11,10 +11,10 @@
  * See COPYRIGHT.php for copyright notices and details.
  */
 
-$config['versionnumber'] = '5.1.8';
+$config['versionnumber'] = '5.1.9';
 $config['dbversionnumber'] = 472;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;
-$config['assetsversionnumber'] = '30233';
+$config['assetsversionnumber'] = '30234';
 return $config;

--- a/docs/release_notes.txt
+++ b/docs/release_notes.txt
@@ -34,6 +34,17 @@ Thank you to everyone who helped with this new release!
 
 CHANGE LOG
 ------------------------------------------------------
+Changes from 5.1.8 (build 210910) to 5.1.9 (build 210912) September 8, 2021
+-Fixed issue: Answer text missing in ranking question when printing response (Carsten Schmitz)
+-Fixed issue: Remove url_encode for end URL (Olle Haerstedt)
+#Updated translation: German by c_schmitz, DanielZ
+#Updated translation: German by c_schmitz
+#Updated translation: Finnish by Jmantysalo
+#Updated translation: Czech by jelen1
+#Updated translation: Czech (Informal) by jelen1
+#Updated translation: Catalan by jmontane, qualitatuvic
+
+
 Changes from 5.1.7 (build 210908) to 5.1.8 (build 210910) September 7, 2021
 Fixed issue #17576: Fixed wrong string in condition for update 450
 


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #17557: 
