### PR TITLE
Fixed issue #T1380: Central Participant management - Export all participants modal

### DIFF
--- a/application/controllers/admin/participantsaction.php
+++ b/application/controllers/admin/participantsaction.php
@@ -252,7 +252,7 @@ class participantsaction extends Survey_Common_Action
         if ($count > 1) {
             return sprintf(gT("Export %s participants to CSV"), $count);
         } elseif ($count == 1) {
-            return gT("Export participant to CSV");
+            return gT("Export participants to CSV");
         } else {
             return $count;
         }

--- a/assets/scripts/admin/participantpanel.js
+++ b/assets/scripts/admin/participantpanel.js
@@ -80,6 +80,7 @@ LS.CPDB = (function() {
         $.ajax({
             url: exporttocsvcountall,
             data: postdata,
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
             method: 'POST',
 
             /**


### PR DESCRIPTION
Adding 'application/x-www-form-urlencoded' as content-type.

Seems it is the content-type that is sent also when using the same method for individual export.
But when exporting all participants, that content-type was missing.