### PR TITLE
Fixed issue: Survey participant data with quotes are not properly exported in CSV

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -2361,8 +2361,8 @@ function tokensExport($iSurveyID)
         }
 
         $tokenoutput .= '"' . trim($brow['tid']) . '",';
-        $tokenoutput .= '"' . trim($brow['firstname']) . '",';
-        $tokenoutput .= '"' . trim($brow['lastname']) . '",';
+        $tokenoutput .= '"' . str_replace('"', '""', trim($brow['firstname'])) . '",';
+        $tokenoutput .= '"' . str_replace('"', '""', trim($brow['lastname'])) . '",';
         $tokenoutput .= '"' . trim($brow['email']) . '",';
         $tokenoutput .= '"' . trim($brow['emailstatus']) . '",';
         $tokenoutput .= '"' . trim($brow['token']) . '",';
@@ -2378,7 +2378,7 @@ function tokensExport($iSurveyID)
             $tokenoutput .= '"' . trim($brow['started']) . '",';
         }
         foreach ($attrfieldnames as $attr_name) {
-            $tokenoutput .= '"' . trim($brow[$attr_name]) . '",';
+            $tokenoutput .= '"' . str_replace('"', '""', trim($brow[$attr_name])) . '",';
         }
         $tokenoutput = substr($tokenoutput, 0, -1); // remove last comma
         $tokenoutput .= "\n";

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -2382,6 +2382,7 @@ function tokensExport($iSurveyID)
         }
         $tokenoutput = substr($tokenoutput, 0, -1); // remove last comma
         $tokenoutput .= "\n";
+        // @todo: Use proper fputcsv, instead
         echo $tokenoutput;
         $tokenoutput = '';
 


### PR DESCRIPTION
Dev: Participant's name could contain quotes, for example if the participant is a company. Quotes could also be present in attribute fields. This fix allows to export quote characters in case these field contain them.

Dev: This ONLY fixes quotes, but there are also other characters like new lines, which still need to be properly escaped! The proper way to do CSV export would be to use fputcsv() and then redirect everything to php://output which automatically takes care of everything.