### PR TITLE
Fixed issue #17654: spurious error "Incorrect username and/or password!" on auth_webserver autocreating user

### DIFF
--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -261,8 +261,15 @@ class PluginManager extends \CApplicationComponent
                     !$event->isStopped()
                     && (empty($target) || in_array(get_class($subscription[0]), $target))
                 ) {
+                    // before setting event, we must save previous event
+                    // (needed if subscriber code is dispatching another event)
+                    $prev_event = $subscription[0]->getEvent();
+
                     $subscription[0]->setEvent($event);
                     call_user_func($subscription);
+
+                    // restore previous event
+                    if ($prev_event) $subscription[0]->setEvent($prev_event);
                 }
             }
         }


### PR DESCRIPTION
it fixes spurious error "Incorrect username and/or password!" on auth_webserver autocreating user

details:

When autocreating a user, Authwebserver::newUserSession:
- calls Permission::setPermissions which dispatch a new event
  => which modify $this->event
- calls $this->setAuthSuccess ... which modifies "beforeHasPermission" event instead of modifying "newUserSession" event
LSUserIdentity::authenticate which dispatched "newUserSession" event checks $authEvent->get('result') which is still null and sets $result as error.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
