### PR TITLE
Fixed issue #17641: Close button on the 'Survey participant export options' does not work

### DIFF
--- a/application/controllers/admin/tokens.php
+++ b/application/controllers/admin/tokens.php
@@ -1608,12 +1608,6 @@ class tokens extends Survey_Common_Action
                 ),
             );
 
-            // Save Button
-            $aData['showSaveButton'] = true;
-
-            // Save and Close Button
-            $aData['showSaveAndCloseButton'] = true;
-
             // White Close Button
             $aData['showWhiteCloseButton'] = true;
             $aData['closeUrl'] = Yii::app()->createUrl('admin/tokens/sa/browse/surveyid/' . $iSurveyId);


### PR DESCRIPTION
Fixed this:
>  Clicking Close from the "Survey participant export options" page should return the user back to the
participant list.