### PR TITLE
Fixed issue #14302: Easy way to get token in a anonymous survey 

### DIFF
--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -35,8 +35,13 @@ class index extends CAction
         $surveyid    = $param['sid'];
         $thisstep    = $param['thisstep'];
         $move        = getMove();
-        $clienttoken = trim($param['token']);
 
+        /* Get client token by POST or GET value */
+        $clienttoken = trim($param['token']);
+        /* If not set : get by SESSION to avoid multiple submit of same token in different navigator */
+        if(empty($clienttoken) && !empty($_SESSION['survey_' . $surveyid]['token'] ))  {
+            $clienttoken = $_SESSION['survey_' . $surveyid]['token'];
+        }
         $oSurvey = Survey::model()->findByPk($surveyid);
 
         if(empty($oSurvey)) {

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -444,7 +444,8 @@ class SurveyRuntimeHelper
             $this->aSurveyInfo['hiddenInputs']         .= \CHtml::hiddenField('start_time', time(), array('id'=>'start_time'));
             $_SESSION[$this->LEMsessid]['LEMpostKey'] = mt_rand();
             $this->aSurveyInfo['hiddenInputs']         .= \CHtml::hiddenField('LEMpostKey', $_SESSION[$this->LEMsessid]['LEMpostKey'], array('id'=>'LEMpostKey'));
-            if (!empty($_SESSION[$this->LEMsessid]['token'])) {
+            /* Reset session with multiple tabs (show Token mismatch issue) , but only for not anonymous survey */
+            if (!empty($_SESSION[$this->LEMsessid]['token']) and $this->aSurveyInfo['anonymized'] != 'Y') {
                 $this->aSurveyInfo['hiddenInputs']     .= \CHtml::hiddenField('token', $_SESSION[$this->LEMsessid]['token'], array('id'=>'token'));
             }
         }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -2041,7 +2041,7 @@ function display_first_page($thissurvey, $aSurveyInfo)
     $thissurvey['EM']['ScriptsAndHiddenInputs'] .= \CHtml::hiddenField('lastgroupname', '_WELCOME_SCREEN_', array('id'=>'lastgroupname')); //This is to ensure consistency with mandatory checks, and new group test
     $thissurvey['EM']['ScriptsAndHiddenInputs'] .= \CHtml::hiddenField('LEMpostKey', $_SESSION['survey_'.$surveyid]['LEMpostKey'], array('id'=>'LEMpostKey'));
     $thissurvey['EM']['ScriptsAndHiddenInputs'] .= \CHtml::hiddenField('thisstep', 0, array('id'=>'thisstep'));
-    if (!empty($_SESSION['survey_'.$surveyid]['token'])) {
+    if (!empty($_SESSION['survey_'.$surveyid]['token']) && $thissurvey['anonymized'] != "Y") {
         $thissurvey['EM']['ScriptsAndHiddenInputs'] .= \CHtml::hiddenField('token', $_SESSION['survey_'.$surveyid]['token'], array('id'=>'token'));
     }
 


### PR DESCRIPTION
Dev: remove token hidden input for anonymous survey
Dev: get $clienttoken by session in anonymous survey
Dev: $clienttoken usage : check token validaty on all page (time, submitted etc …)

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
