### PR TITLE
Fixing wrong sort order in statisstics output (# 17647)

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -844,8 +844,8 @@ function templateDefaultTexts($sLanguage, $mode = 'html', $sNewlines = 'text')
 */
 function groupOrderThenQuestionOrder($a, $b)
 {
-    if (isset($a['group_order']) && isset($b['group_order'])) {
-        $GroupResult = strnatcasecmp($a['group_order'], $b['group_order']);
+    if (isset($a->group['group_order']) && isset($b->group['group_order'])) {
+        $GroupResult = strnatcasecmp($a->group['group_order'], $b->group['group_order']);
     } else {
         $GroupResult = "";
     }


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #17647: Strange sort order of question groups in statistics