### PR TITLE
Fixed issue #T1328: Green bar above topbar is missing in plugin detai…

### DIFF
--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -22,6 +22,9 @@ use LimeSurvey\Menu\MenuItem;
  */
 class PluginManagerController extends Survey_Common_Action
 {
+    /**
+     * Init
+     */
     public function init()
     {
     }
@@ -164,6 +167,10 @@ class PluginManagerController extends Survey_Common_Action
         );
     }
 
+    /**
+     * Delete files
+     * @param $plugin
+     */
     public function deleteFiles($plugin)
     {
         $this->requirePostRequest();
@@ -359,14 +366,19 @@ class PluginManagerController extends Survey_Common_Action
         // Send to view plugin porperties: name and description
         $aPluginProp = App()->getPluginManager()->getPluginInfo($plugin->name);
 
+        // Fullpage Bar
         $fullPageBar = [];
         $fullPageBar['returnbutton']['url'] = 'admin/pluginmanager/sa/index';
         $fullPageBar['returnbutton']['text'] = gT('Return to plugin list');
+
+        // Green Bar with Page Title
+        $pageTitle = gT("Plugin:") . ' ' . $plugin['name'];
 
         $this->_renderWrappedTemplate(
             'pluginmanager',
             'configure',
             [
+                'pageTitle'    => $pageTitle,
                 'settings'     => $aSettings,
                 'buttons'      => $aButtons,
                 'plugin'       => $plugin,

--- a/application/views/admin/pluginmanager/configure.php
+++ b/application/views/admin/pluginmanager/configure.php
@@ -7,8 +7,6 @@ echo viewHelper::getViewTestTag('configurePlugin');
 ?>
 
 <div class="col-lg-12">
-    <div class="pagetitle h3"><?php echo gT("Plugin:") . ' ' . $plugin['name']; ?></div>
-
     <ul class="nav nav-tabs" id="settingTabs">
         <li role="presentation" class="active">
             <a role="tab" data-toggle="tab" href='#overview'><?php eT("Overview"); ?></a>


### PR DESCRIPTION
In Configuration -> Settings -> Plugins when you click on a plugin to open the detail view the green bar above the topbar is missing.

Task: Please get the green bar above the topbar in on the plugin detail view screens.