### PR TITLE
Fixed issue #17632: Basic and detailed admin notification email fails

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -53,6 +53,7 @@ class ExpressionManager
     private $RDP_result; // final result of evaluating the expression;
     private $RDP_evalStatus; // true if $RDP_result is a valid result, and  there are no serious errors
     private $varsUsed; // list of variables referenced in the equation
+    public $resetErrorsAndWarningsOnEachPart = true;
 
     // These  variables are only used by sProcessStringContainingExpressions
     private $allVarsUsed; // full list of variables used within the string, even if contains multiple expressions
@@ -1847,7 +1848,7 @@ class ExpressionManager
             } else {
                 ++$this->substitutionNum;
                 $expr = $this->ExpandThisVar(substr($stringPart[0], 1, -1));
-                if ($this->RDP_Evaluate($expr, false, false)) { // We call RDP_Evaluate with $resetErrorsAndWarnings = false because, if $src has more than one expression, error information could be lost
+                if ($this->RDP_Evaluate($expr, false, $this->resetErrorsAndWarningsOnEachPart)) {
                     $resolvedPart = $this->GetResult();
                 } else {
                     // show original and errors in-line only if user have the rigth to update survey content

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9485,6 +9485,8 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
 
             $LEM =& LimeExpressionManager::singleton();
             $LEM->sPreviewMode='logic';
+            // We set $LEM->em->resetErrorsAndWarningsOnEachPart = false because, if a string has more than one expression, error information could be lost
+            $LEM->em->resetErrorsAndWarningsOnEachPart = false;
             $aSurveyInfo=getSurveyInfo($sid,$_SESSION['LEMlang']);
             $aAttributesDefinitions=\LimeSurvey\Helpers\questionHelper::getAttributesDefinitions();
             /* All final survey string must be shown in survey language #12208 */


### PR DESCRIPTION
The problem is somehow introduced while fixing #17512.

#17512 error was about string processing errors not being shown as they errors were reset after evaluating each subexpression. 
So, when a string had 2 expressions, if the latter expression had no errors, the Survey Logic File was not showing the errors of the first expression. Fix: Stop resetting errors.

The problem we see now is that every time a subexpression is processed, the first thing done is checking for errors. If any error is found, no subexpression processing is done. 

As after the previous fix, the errors are not being reset, EM considers that after a subexpression has errors, all subexpressions that come after it have errors too.

Here, we need a deeper review on the handling of errors for subexpressions, as we are missing errors at expression level and subexpression level.

As for now, the fix we belive is ok is to:
- somehow revert prior fix
- and re apply it by narrowing down the fix to only the survey logic file process.