### PR TITLE
Fix notice "Trying to access array offset on value of type bool"

### DIFF
--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -2009,7 +2009,7 @@ class statistics_helper
         //PCHART has to be enabled and we need some data
         //
         if ($usegraph == 1) {
-            $bShowGraph = $aattr["statistics_showgraph"] == "1";
+            $bShowGraph = (isset($aattr["statistics_showgraph"]) && $aattr["statistics_showgraph"] == "1");
             $bAllowPieChart = ($outputs['qtype'] != Question::QT_M_MULTIPLE_CHOICE && $outputs['qtype'] != Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS);
             $bAllowMap = (isset($aattr["location_mapservice"]) && $aattr["location_mapservice"] == "1");
             $bShowMap = ($bAllowMap && $aattr["statistics_showmap"] == "1");


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #0: Array access on unexpected boolean variable caused notices
