### PR TITLE
New feature [PluginEvent]: Added a beforeAdminEmail event to frontend helper

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -642,9 +642,26 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_notification'], $aReplacementVars, $redata, 'admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_notification_subj'], $aReplacementVars, $redata, 'admin_notification_subj', ($thissurvey['anonymized'] == "Y"), null, array(), true);
         foreach ($aEmailNotificationTo as $sRecipient) {
-        if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, getBounceEmail($surveyid), $aRelevantAttachments)) {
-                if ($debug > 0) {
-                    echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+            $event = new PluginEvent('beforeAdminEmail');
+            $event->set('survey', $surveyid);
+            $event->set('type', 'confirm');
+            $event->set('model', 'confirm');
+            $event->set('subject', $sSubject);
+            $event->set('to', $sRecipient);
+            $event->set('body', $sMessage);
+            $event->set('from', $sFrom);
+            $event->set('bounce', getBounceEmail($surveyid));
+            App()->getPluginManager()->dispatchEvent($event);
+            $sSubject = $event->get('subject');
+            $sMessage = $event->get('body');
+            $sRecipient = $event->get('to');
+            $sFrom = $event->get('from');
+            $bounce = $event->get('bounce');
+            if ($event->get('send', true) != false) {
+                if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, $bounce, $aRelevantAttachments)) {
+                    if ($debug > 0) {
+                        echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+                    }
                 }
             }
         }
@@ -668,15 +685,30 @@ function sendSubmitNotifications($surveyid)
         $sMessage = templatereplace($thissurvey['email_admin_responses'], $aReplacementVars, $redata, 'detailed_admin_notification', $thissurvey['anonymized'] == "Y", null, array(), true);
         $sSubject = templatereplace($thissurvey['email_admin_responses_subj'], $aReplacementVars, $redata, 'detailed_admin_notification_subj', $thissurvey['anonymized'] == "Y", null, array(), true);
         foreach ($aEmailResponseTo as $sRecipient) {
-        if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, getBounceEmail($surveyid), $aRelevantAttachments)) {
-                if ($debug > 0) {
-                    echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+            $event = new PluginEvent('beforeAdminEmail');
+            $event->set('survey', $surveyid);
+            $event->set('type', 'confirm');
+            $event->set('model', 'confirm');
+            $event->set('subject', $sSubject);
+            $event->set('to', $sRecipient);
+            $event->set('body', $sMessage);
+            $event->set('from', $sFrom);
+            $event->set('bounce', getBounceEmail($surveyid));
+            App()->getPluginManager()->dispatchEvent($event);
+            $sSubject = $event->get('subject');
+            $sMessage = $event->get('body');
+            $sRecipient = $event->get('to');
+            $sFrom = $event->get('from');
+            $bounce = $event->get('bounce');
+            if ($event->get('send', true) != false) {
+                if (!SendEmailMessage($sMessage, $sSubject, $sRecipient, $sFrom, $sitename, $bIsHTML, $bounce, $aRelevantAttachments)) {
+                    if ($debug > 0) {
+                        echo '<br />Email could not be sent. Reason: '.CHtml::encode($maildebug).'<br/>';
+                    }
                 }
             }
         }
     }
-
-
 }
 
 /**


### PR DESCRIPTION
Dev: Added a beforeAdminEmail event to the frontend helper

I know that LS4+ has the beforeEmail plugin event.  Most of my customers haven't migrated to LS5 yet (-- I'm working on that).  This PR adds a "beforeAdminEmail" plugin event to sit alongside the existing beforeSurveyEmail and beforeTokenEmail events and fill in the gap, so to speak, between the range of possible email events in LS3 vs. LS4+.
