### PR TITLE
New feature [PluginEvent]: Added a beforeResumeEmail plugin event to Save library

### DIFF
--- a/application/libraries/Save.php
+++ b/application/libraries/Save.php
@@ -287,13 +287,29 @@ class Save
                 $message .= Yii::app()->getController()->createAbsoluteUrl("/survey/index/sid/{$surveyid}/loadall/reload", $aParams);
                 $from     = "{$thissurvey['adminname']} <{$thissurvey['adminemail']}>";
 
-                if (SendEmailMessage($message, $subject, $_POST['saveemail'], $from, $sitename, false, getBounceEmail($surveyid))) {
-                    $emailsent = "Y";
-                } else {
-
-                    $errormsg .= gT('Error: Email failed, this may indicate a PHP Mail Setup problem on the server. Your survey details have still been saved, however you will not get an email with the details. You should note the "name" and "password" you just used for future reference.');
-                    if (trim($thissurvey['adminemail']) == '') {
-                        $errormsg .= gT('(Reason: Administrator email address empty)');
+                $event = new PluginEvent('beforeResumeEmail');
+                $event->set('survey', $surveyid);
+                $event->set('type', 'confirm');
+                $event->set('model', 'confirm');
+                $event->set('subject', $subject);
+                $event->set('to', $_POST['saveemail']);
+                $event->set('body', $message);
+                $event->set('from', $from);
+                $event->set('bounce', getBounceEmail($surveyid));
+                App()->getPluginManager()->dispatchEvent($event);
+                $subject = $event->get('subject');
+                $message = $event->get('body');
+                $sRecipient = $event->get('to');
+                $bounce = $event->get('bounce');
+                $from = $event->get('from');
+                if ($event->get('send', true) != false) {
+                    if (SendEmailMessage($message, $subject, $_POST['saveemail'], $from, $sitename, false, $bounce)) {
+                        $emailsent = "Y";
+                    } else {
+                        $errormsg .= gT('Error: Email failed, this may indicate a PHP Mail Setup problem on the server. Your survey details have still been saved, however you will not get an email with the details. You should note the "name" and "password" you just used for future reference.');
+                        if (trim($thissurvey['adminemail']) == '') {
+                            $errormsg .= gT('(Reason: Administrator email address empty)');
+                        }
                     }
                 }
             }

--- a/application/libraries/Save.php
+++ b/application/libraries/Save.php
@@ -287,9 +287,9 @@ class Save
                 $message .= Yii::app()->getController()->createAbsoluteUrl("/survey/index/sid/{$surveyid}/loadall/reload", $aParams);
                 $from     = "{$thissurvey['adminname']} <{$thissurvey['adminemail']}>";
 
-                $event = new PluginEvent('beforeResumeEmail');
+                $event = new PluginEvent('beforeSurveyEmail');
                 $event->set('survey', $surveyid);
-                $event->set('type', 'confirm');
+                $event->set('type', 'savesurveydetails');
                 $event->set('model', 'confirm');
                 $event->set('subject', $subject);
                 $event->set('to', $_POST['saveemail']);

--- a/application/libraries/Save.php
+++ b/application/libraries/Save.php
@@ -299,11 +299,11 @@ class Save
                 App()->getPluginManager()->dispatchEvent($event);
                 $subject = $event->get('subject');
                 $message = $event->get('body');
-                $sRecipient = $event->get('to');
+                $to = $event->get('to');
                 $bounce = $event->get('bounce');
                 $from = $event->get('from');
                 if ($event->get('send', true) != false) {
-                    if (SendEmailMessage($message, $subject, $_POST['saveemail'], $from, $sitename, false, $bounce)) {
+                    if (SendEmailMessage($message, $subject, $to, $from, $sitename, false, $bounce)) {
                         $emailsent = "Y";
                     } else {
                         $errormsg .= gT('Error: Email failed, this may indicate a PHP Mail Setup problem on the server. Your survey details have still been saved, however you will not get an email with the details. You should note the "name" and "password" you just used for future reference.');


### PR DESCRIPTION
Dev: Added a beforeResumeEmail plugin event to Save library.

I should have included this with PR 2106. (This is my last PluginEvent PR related to email, honest!)

The same LS3 customer that I have who needs to be able to selectively alter the from and bounce of outgoing emails needs to intercept the emails sent when a survey is saved and the user is emailed how to resume it.


