### PR TITLE
Bug/15992  using expression manager with double quotes fails for end url field

### DIFF
--- a/application/controllers/admin/database.php
+++ b/application/controllers/admin/database.php
@@ -957,7 +957,7 @@ class database extends Survey_Common_Action
                     $data['surveyls_policy_notice_label'] = $dataseclabel;
                 }
                 if ($sURL !== null) {
-                    $data['surveyls_url'] = htmlspecialchars($sURL);
+                    $data['surveyls_url'] = $sURL;
                 }
                 if ($sURLDescription !== null) {
                     $data['surveyls_urldescription'] = htmlspecialchars($sURLDescription);

--- a/application/core/LSYii_Validators.php
+++ b/application/core/LSYii_Validators.php
@@ -58,7 +58,7 @@ class LSYii_Validators extends CValidator
         if ($this->xssfilter) {
             $object->$attribute = $this->xssFilter($object->$attribute);
             if ($this->isUrl) {
-                $object->$attribute = str_replace('javascript:', '', html_entity_decode($object->$attribute, ENT_QUOTES, "UTF-8"));
+                $object->$attribute = str_replace('javascript:', '', $object->$attribute);
             }
         }
         // Note that URL checking only checks basic URL properties. As a URL can contain EM expression there needs to be a lot of freedom.


### PR DESCRIPTION
Removed htmlspecialchars from database.php::saveSurveyLanguageSettings, and the decode in the validator.
xss will do that work.