### PR TITLE
Fixed issue #17666: Previewing a survey leads to DB error messages fr…

### DIFF
--- a/application/libraries/MersenneTwister.php
+++ b/application/libraries/MersenneTwister.php
@@ -11,7 +11,7 @@ namespace ls\mersenne;
  */
 function setSeed($surveyid)
 {
-    //traceVar(@$_SESSION['survey_' . $surveyid]['srid']);
+    /* In started survey : get seed from response table */
     if (isset($_SESSION['survey_'.$surveyid]['srid'])) {
         $oResponse = \Response::model($surveyid)->findByPk($_SESSION['survey_'.$surveyid]['srid']);
         $seed = $oResponse->seed;
@@ -23,13 +23,12 @@ function setSeed($surveyid)
         }
     } else {
         $seed = mt_rand();
-
-        // Only set seed if corresponding database column exists.
-        // This mismatch can happen if survey is activated before update to
-        // new version that uses seed.
-        $table = \Yii::app()->db->schema->getTable('{{survey_'.$surveyid.'}}');
-        if (isset($table->columns['seed'])) {
-            $_SESSION['survey_'.$surveyid]['startingValues']['seed'] = $seed;
+        /* On activated (but not started) survey : set seed in startingValues */
+        if (\Survey::model()->findByPk($surveyid)->getIsActive()) {
+            $table = \Yii::app()->db->schema->getTable('{{survey_'.$surveyid.'}}');
+            if (isset($table->columns['seed'])) {
+                $_SESSION['survey_'.$surveyid]['startingValues']['seed'] = $seed;
+            }
         }
     }
     MersenneTwister::init($seed);


### PR DESCRIPTION
Fixed issue #17666: Previewing a survey leads to DB error messages from log system
Dev: setSeed function always search activated survey
Dev: add some comments

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
