### PR TITLE
Fixed issue: Db update fails with old survey_x table

### DIFF
--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -5999,6 +5999,13 @@ function upgradeSurveyTables402($sMySQLCollation)
                     alterColumn($sTableName, 'token', "string(36) COLLATE SQL_Latin1_General_CP1_CS_AS");
                     break;
                 case 'mysql':
+                    $oDB->createCommand()->update($sTableName, ['submitdate' => null], "submitdate=0");
+                    if (in_array('datestamp', $oTableSchema->columnNames)) {
+                        $oDB->createCommand()->update($sTableName, ['datestamp' => '1970-01-01 00:00:00'], "datestamp=0");
+                    }
+                    if (in_array('startdate', $oTableSchema->columnNames)) {
+                        $oDB->createCommand()->update($sTableName, ['startdate' => '1970-01-01 00:00:00'], "startdate=0");
+                    }
                     alterColumn($sTableName, 'token', "string(36) COLLATE '{$sMySQLCollation}'");
                     break;
                 default:


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
