### PR TITLE
Fixed issue #17511: When importing a group, duplicate question codes can be generated

### DIFF
--- a/application/views/admin/survey/QuestionGroups/import_view.php
+++ b/application/views/admin/survey/QuestionGroups/import_view.php
@@ -32,6 +32,20 @@
                             <li><?php echo gT("Question attributes:") . $aImportResults['question_attributes'] ?></li>
                          </ul>                        
                     </p>
+
+                    <!-- Warnings -->
+                    <?php if (count($aImportResults['importwarnings'])>0): ?>
+                        <h2 class="warning"><?php eT("Warnings");?>:</h2>
+                        <ul  class="list-unstyled">
+                            <?php
+                                foreach ($aImportResults['importwarnings'] as $warning)
+                                { ?>
+                                <li><?php echo $warning; ?></li>
+                                <?php
+                            } ?>
+                        </ul>
+                    <?php endif; ?>
+
                     <p class="text-info"><?php eT("Question group import is complete.") ?></p>
                     
                     <!-- button -->


### PR DESCRIPTION
Copied what is done in the survey import.