### PR TITLE
Fixed issue: Show full name of a deleted user correctly

### DIFF
--- a/application/controllers/admin/useraction.php
+++ b/application/controllers/admin/useraction.php
@@ -192,7 +192,6 @@ class UserAction extends Survey_Common_Action
             $oInitialAdmin = User::model()->findByAttributes(array('parent_id' => 0));
 
             $postuserid = $this->_getPostOrParam("uid");
-            $postuser = flattenText($this->_getPostOrParam("user"));
 
             if ($oInitialAdmin && $oInitialAdmin->uid == $postuserid) {
 // it's the original superadmin !!!
@@ -239,7 +238,6 @@ class UserAction extends Survey_Common_Action
                     $this->deleteFinalUser($ownerUser, $transfer_surveys_to);
                 } else {
                     $aData['postuserid'] = $postuserid;
-                    $aData['postuser'] = $postuser;
                     $aData['current_user'] = $current_user;
 
                     $aViewUrls['deluser'][] = $aData;
@@ -273,7 +271,6 @@ class UserAction extends Survey_Common_Action
         if (!$postuserid) {
             $postuserid = (int) Yii::app()->request->getParam("uid");
         }
-        $postuser = flattenText(Yii::app()->request->getPost("user"));
         // Never delete initial admin (with findByAttributes : found the first user without parent)
         $oInitialAdmin = User::model()->findByAttributes(array('parent_id' => 0));
         if ($oInitialAdmin && $oInitialAdmin->uid == $postuserid) {
@@ -305,7 +302,7 @@ class UserAction extends Survey_Common_Action
             die();
         }
 
-        $extra = "<br />".sprintf(gT("User '%s' was successfully deleted."), $postuser)."<br /><br />\n";
+        $extra = "<br />".sprintf(gT("User '%s' was successfully deleted."), flattenText($fields['full_name']))."<br /><br />\n";
         if ($transfer_surveys_to > 0 && $iSurveysTransferred > 0) {
             $user = User::model()->findByPk($transfer_surveys_to);
             $sTransferred_to = $user->users_name;

--- a/application/controllers/admin/useraction.php
+++ b/application/controllers/admin/useraction.php
@@ -302,7 +302,7 @@ class UserAction extends Survey_Common_Action
             die();
         }
 
-        $extra = "<br />".sprintf(gT("User '%s' was successfully deleted."), flattenText($fields['full_name']))."<br /><br />\n";
+        $extra = "<br />".sprintf(gT("User '%s' was successfully deleted."), Chtml::encode($fields['full_name']))."<br /><br />\n";
         if ($transfer_surveys_to > 0 && $iSurveysTransferred > 0) {
             $user = User::model()->findByPk($transfer_surveys_to);
             $sTransferred_to = $user->users_name;

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -345,7 +345,6 @@ class User extends LSActiveRecord
         $setTemplatePermissionsUrl = Yii::app()->getController()->createUrl('admin/user/sa/setusertemplates');
         $changeOwnershipUrl = Yii::app()->getController()->createUrl('admin/user/sa/setasadminchild');
 
-        $oUser = self::model()->findByPK($this->uid);
         if ($this->uid == Yii::app()->user->getId()) {
             // Edit self
             $editUser = "<button
@@ -353,7 +352,6 @@ class User extends LSActiveRecord
             title='".gT("Edit this user")."'
             data-url='".$editUrl."'
             data-uid='".$this->uid."'
-            data-user='".htmlspecialchars($oUser['full_name'])."'
             data-action='modifyuser'
             class='btn btn-default btn-xs action_usercontrol_button'>
                 <span class='fa fa-pencil text-success'></span>
@@ -388,7 +386,7 @@ class User extends LSActiveRecord
                     && $this->parent_id == Yii::app()->session['loginID']
                 )
             ) {
-                $editUser = "<button data-toggle='tooltip' data-url='".$editUrl."' data-user='".htmlspecialchars($oUser['full_name'])."' data-uid='".$this->uid."' data-action='modifyuser' title='".gT("Edit this user")."' type='submit' class='btn btn-default btn-xs action_usercontrol_button'><span class='fa fa-pencil text-success'></span></button>";
+                $editUser = "<button data-toggle='tooltip' data-url='".$editUrl."' data-uid='".$this->uid."' data-action='modifyuser' title='".gT("Edit this user")."' type='submit' class='btn btn-default btn-xs action_usercontrol_button'><span class='fa fa-pencil text-success'></span></button>";
             }
 
             if (((Permission::model()->hasGlobalPermission('superadmin', 'read') &&
@@ -396,21 +394,20 @@ class User extends LSActiveRecord
                 (Permission::model()->hasGlobalPermission('users', 'update') &&
                 $this->parent_id == Yii::app()->session['loginID'])) && !Permission::isForcedSuperAdmin($this->uid)) {
                 //'admin/user/sa/setuserpermissions'
-                    $setPermissionsUser = "<button data-toggle='tooltip' data-user='".htmlspecialchars($this->full_name)."' data-url='".$setPermissionsUrl."' data-uid='".$this->uid."' data-action='setuserpermissions' title='".gT("Set global permissions for this user")."' type='submit' class='btn btn-default btn-xs action_usercontrol_button'><span class='icon-security text-success'></span></button>";
+                    $setPermissionsUser = "<button data-toggle='tooltip' data-url='".$setPermissionsUrl."' data-uid='".$this->uid."' data-action='setuserpermissions' title='".gT("Set global permissions for this user")."' type='submit' class='btn btn-default btn-xs action_usercontrol_button'><span class='icon-security text-success'></span></button>";
                 }
             if ((Permission::model()->hasGlobalPermission('superadmin', 'read')
                 || Permission::model()->hasGlobalPermission('templates', 'read'))
                 && !Permission::isForcedSuperAdmin($this->uid)) {
                 //'admin/user/sa/setusertemplates')
-                    $setTemplatePermissionUser = "<button type='submit' data-user='".htmlspecialchars($this->full_name)."' data-url='".$setTemplatePermissionsUrl."' data-uid='".$this->uid."' data-action='setusertemplates' data-toggle='tooltip' title='".gT("Set template permissions for this user")."' class='btn btn-default btn-xs action_usercontrol_button'><span class='icon-templatepermissions text-success'></span></button>";
+                    $setTemplatePermissionUser = "<button type='submit' data-url='".$setTemplatePermissionsUrl."' data-uid='".$this->uid."' data-action='setusertemplates' data-toggle='tooltip' title='".gT("Set template permissions for this user")."' class='btn btn-default btn-xs action_usercontrol_button'><span class='icon-templatepermissions text-success'></span></button>";
                 }
                 if ((Permission::model()->hasGlobalPermission('superadmin', 'read')
                     || (Permission::model()->hasGlobalPermission('users', 'delete')
                     && $this->parent_id == Yii::app()->session['loginID'])) && !Permission::isForcedSuperAdmin($this->uid)) {
                     $deleteUrl = Yii::app()->getController()->createUrl('admin/user/sa/deluser', array(
                         "action"=> "deluser",
-                        "uid"=>$this->uid,
-                        "user" => htmlspecialchars(Yii::app()->user->getId())
+                        "uid"=>$this->uid
                     ));
 
                         //'admin/user/sa/deluser'
@@ -433,7 +430,7 @@ class User extends LSActiveRecord
                     && $this->parent_id != Yii::app()->session['loginID']
                 ) {
                     //'admin/user/sa/setasadminchild'
-                    $changeOwnership = "<button data-toggle='tooltip' data-url='".$changeOwnershipUrl."' data-user='".htmlspecialchars($oUser['full_name'])."' data-uid='".$this->uid."' data-action='setasadminchild' title='".gT("Take ownership")."' class='btn btn-default btn-xs action_usercontrol_button' type='submit'><span class='icon-takeownership text-success'></span></button>";
+                    $changeOwnership = "<button data-toggle='tooltip' data-url='".$changeOwnershipUrl."' data-uid='".$this->uid."' data-action='setasadminchild' title='".gT("Take ownership")."' class='btn btn-default btn-xs action_usercontrol_button' type='submit'><span class='icon-takeownership text-success'></span></button>";
                 }
         }
         return "<div>"

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -372,7 +372,6 @@ class User extends LSActiveRecord
                 data-onclick='$.post(".$deleteUrl.",{
                   action: \"deluser\",
                   uid:\"".$this->uid."\",
-                  user: \"".htmlspecialchars($this->full_name)."\",
                   });'
                 data-target='#confirmation-modal'
                 data-uid='".$this->uid."'
@@ -422,7 +421,6 @@ class User extends LSActiveRecord
                         data-target='#confirmation-modal'
                         data-url='".$deleteUrl."'
                         data-uid='".$this->uid."'
-                        data-user='".htmlspecialchars($this->full_name)."'
                         data-action='deluser'
                         data-onclick='triggerRunAction($(\"#delete_user_".$this->uid."\"))'
                         data-message='".gT("Do you want to delete this user?")."'

--- a/application/views/admin/user/deluser.php
+++ b/application/views/admin/user/deluser.php
@@ -25,7 +25,6 @@
             ?>
         </select>
         <input type="hidden" name="uid" value="<?php echo $postuserid; ?>" />
-        <input type="hidden" name="user" value="<?php echo $postuser; ?>" />
         <input type="hidden" name="action" value="finaldeluser" />
         <input type="submit" value="<?php eT("Delete User"); ?>" />
     </form>

--- a/assets/scripts/admin/users.js
+++ b/assets/scripts/admin/users.js
@@ -21,14 +21,12 @@ function triggerRunAction(el){
 function runAction(el){
     var url = $(el).data('url'),
             action = $(el).data('action'),
-            user = $(el).data('user'),
             uid = $(el).data('uid');
         var form = $('<form></form>');
         form.attr('method','post');
         form.attr('action',url);
         form.append('<input type="hidden" name="uid" value="'+uid+'" />');
         form.append('<input type="hidden" name="action" value="'+action+'" />');
-        form.append('<input type="hidden" name="user" value="'+user+'" />');
         form.append('<input type="hidden" name="'+LS.data.csrfTokenName+'" value="'+LS.data.csrfToken+'" />');
         form.appendTo('body');
         form.submit();


### PR DESCRIPTION
Dev: If user's full name contain double quotes it is not displayed correctly when this user is deleted. Instead of passing full name back and forth in the session let's just use the data from the database.

Other user actions probably have the same bug, this patch is only for delete action.
