### PR TITLE
Fixed issue #14091: Filenames of uploads starting with special charac…

### DIFF
--- a/application/controllers/UploaderController.php
+++ b/application/controllers/UploaderController.php
@@ -141,8 +141,9 @@ class UploaderController extends SurveyController
                 mkdir($sTempUploadDir);
             }
             $filename = $_FILES['uploadfile']['name'];
-            // Do we filter file name ? It's used on displaying only , but not save like that.
-            //$filename = sanitize_filename($_FILES['uploadfile']['name']);// This remove all non alpha numeric characters and replaced by _ . Leave only one dot .
+            /* Fix file name : need to get only the basename url encoded for display . Avoid usage of basename : need valid UTF8 setlocale */
+            $aFilename = explode(DIRECTORY_SEPARATOR, rtrim( $filename, DIRECTORY_SEPARATOR));
+            $fixedFilename = rawurlencode(end($aFilename));
             $size = $_FILES['uploadfile']['size'] / 1024;
             $preview = Yii::app()->session['preview'];
             $aFieldMap = createFieldMap($oSurvey, 'short', false, false, $sLanguage);
@@ -246,7 +247,7 @@ class UploaderController extends SurveyController
                                 "success"       => true,
                                 "file_index"    => $filecount,
                                 "size"          => $size,
-                                "name"          => rawurlencode(basename($filename)),
+                                "name"          => $fixedFilename,
                                 "ext"           => $cleanExt,
                                 "filename"      => $randfilename,
                                 "msg"           => gT("The file has been successfully uploaded.")
@@ -274,7 +275,7 @@ class UploaderController extends SurveyController
                     $return = array(
                         "success" => true,
                         "size"    => $size,
-                        "name"    => rawurlencode(basename($filename)),
+                        "name"    => $fixedFilename,
                         "ext"     => $cleanExt,
                         "filename"      => $randfilename,
                         "msg"     => gT("The file has been successfully uploaded.")


### PR DESCRIPTION
Fixed issue #14091: Filenames of uploads starting with special characters truncated with invalid setlocale
Dev: basename according to OK, avoid usage of basename due to setlocale
