### PR TITLE
Fixed issue #17674: Impossible to add new Menu or New Menu Entry 

### DIFF
--- a/application/extensions/LimeScript/LimeScript.php
+++ b/application/extensions/LimeScript/LimeScript.php
@@ -31,16 +31,16 @@
                     // the content type is 'text/plain', which is wrong.
                     $.ajaxPrefilter(function(settings) {
                         if(!csrfSafeMethod(settings.type)) {
-                            // NB: This sometimes includes the CSRF token twice, when already added to data.
+                            // Data could be passed as string or object, so we add the token depending on the data type
                             if (typeof settings.data == 'string') {
+                                // NB: This sometimes includes the CSRF token twice, when already added to data.
                                 settings.data +=  '&" . Yii::app()->request->csrfTokenName . "=" . Yii::app()->request->csrfToken ."';
                             } else {
                                 settings.data = settings.data || {};
                                 settings.data." . Yii::app()->request->csrfTokenName . " = '" . Yii::app()->request->csrfToken . "';
                             }
                         }
-                      });
-                    ";
+                    });";
             App()->getClientScript()->registerScript('LimeScript', $script, CClientScript::POS_HEAD);
         }
     }


### PR DESCRIPTION
Recently, seems it has been changed how the token is set on AJAX calls.
Before, the ajaxSetup() methos was used.
Now, the beforeSend callback is used.

The problem of this bug is with the contentType, which is set to text/plain.
Why? Because at the time that is set, during ajaxSetup, the there was no payload, defaulting to text/plain.

Solution, is a bit wide.

Use $.ajaxPrefilter() instead of $.ajaxSetup({beforeSend: ...}) to add the CSRF token because beforeSend is
executed after the content type is determined. So, if the request had no data when beforeSend is executed,
the content type is 'text/plain', which is wrong.
