### PR TITLE
Fixed issue #17713: broken theme name in Survey general settings

### DIFF
--- a/application/views/admin/survey/subview/surveydashboard/004-generalsettingspanel.twig
+++ b/application/views/admin/survey/subview/surveydashboard/004-generalsettingspanel.twig
@@ -44,15 +44,13 @@
                             {{templateModel.title}} ( {{templateModel.name}})
                             <a href='{{sTemplateOptionsUrl}}' title="{{ gT("Edit theme options")}}" class="btn btn-default btn-xs pull-right"><i class="fa fa-paint-brush"></i></a>
                             <a href='{{sTemplateEditorUrl}}' title="{{ gT("Open theme editor in new window")}}" target="_blank" class="btn btn-default btn-xs pull-right"><i class="fa fa-object-group"></i></a>
-                            <?php
                         {% else %}
-                            {{templatename}}
+                            {{oSurvey.aOptions['template']}}
                         {% endif %}
                     {% else %}
                         {% set errorMessage = sprintf( gT('Error: Theme "%s" is not installed.'), oSurvey.aOptions['template']) %}
                         {{errorMessage}}
                     {% endif %}
-                    ?>
                 </div>
 
             </div>


### PR DESCRIPTION
Theme name was broken if user has no permissions on themes. Fixed some strange PHP code in TWIG template
and changed variable name to display actual theme name.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #17713:
