### PR TITLE
Fixed issue #17717: Saving survey group permissions fails with error 500

### DIFF
--- a/application/core/plugins/AuditLog/AuditLog.php
+++ b/application/core/plugins/AuditLog/AuditLog.php
@@ -197,7 +197,7 @@ class AuditLog extends \LimeSurvey\PluginManager\PluginBase
         $iSurveyID = $event->get('iSurveyID');
         $iUserID = $event->get('iUserID');
         $oCurrentUser = $this->api->getCurrentUser();
-        $oOldPermission = $this->api->getPermissionSet($iUserID, $iSurveyID, 'survey');
+        $oOldPermission = $this->api->getPermissionSet($iUserID, $iSurveyID, 'Survey');
         $sAction = 'update';   // Permissions are in general only updated (either you have a permission or you don't)
 
         if (count(array_diff_assoc_recursive($aNewPermissions, $oOldPermission))) {


### PR DESCRIPTION
Method getPermissionSet() expects camelcase entity name.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #17717