### PR TITLE
Fixed issue: Resend Login Data Popup Wording / Grammar Change

### DIFF
--- a/application/views/userManagement/massiveAction/_selector.php
+++ b/application/views/userManagement/massiveAction/_selector.php
@@ -38,7 +38,7 @@ $aActionsArray = array(
             'keepopen'      => 'yes',
             'showSelected'  => 'yes',
             'selectedUrl'   => App()->createUrl('userManagement/renderSelectedItems/'),
-            'sModalTitle'   => gT('Resend login data user'),
+            'sModalTitle'   => gT('Resend login data'),
             'htmlModalBody' => gT('Are you sure you want to reset and resend selected users login data?'),
         ),
         // Mass Edit


### PR DESCRIPTION
The 1st line at the top of the popup message box that appears when a user selects Resend login data needs to be corrected.

current: Resend login data user
correction/should be: Resend login data

The word user at the end needs to be removed.