### PR TITLE
Fixed issue #17790: KCFinder Image Browse Server not working due to i…

### DIFF
--- a/application/helpers/admin/htmleditor_helper.php
+++ b/application/helpers/admin/htmleditor_helper.php
@@ -27,8 +27,11 @@ function initKcfinder()
         'flash' => $sAllowedExtensions,
         'images' => $sAllowedExtensions
     );
-    if (Yii::app()->getRequest()->enableCsrfValidation && !empty(Yii::app()->getRequest()->csrfCookie->domain)) {
-        $_SESSION['KCFINDER']['cookieDomain'] = Yii::app()->getRequest()->csrfCookie->domain;
+    if (!empty(App()->getSession()->cookieParams['domain'])) {
+        $_SESSION['KCFINDER']['cookieDomain'] = App()->getSession()->cookieParams['domain'];
+    }
+    if (App()->getRequest()->enableCsrfValidation && !empty(App()->getRequest()->csrfCookie['domain'])) {
+        $_SESSION['KCFINDER']['cookieDomain'] = Yii::app()->getRequest()->csrfCookie['domain'];
     }
 
     if (


### PR DESCRIPTION
Fixed issue #17790: KCFinder Image Browse Server not working due to incorrect cookieDomain
Dev: this need to set it in config.
