### PR TITLE
Fixed issue #17711: Cannot export selected responses (only range)

### DIFF
--- a/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
+++ b/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
@@ -68,10 +68,8 @@ var onClickListAction =  function () {
     if(actionType == 'fill-session-and-redirect')
     {
         // postUrl is defined as a var in the View, if not the basic url is used
-        if(postUrl == undefined) {
-            var postUrl = $actionUrl;
-        } 
-        $(this).load(postUrl, {
+        var setSessionUrl = postUrl || $actionUrl;
+        $(this).load(setSessionUrl, {
             itemsid:$oCheckedItems},function(){
                 $(location).attr('href',$actionUrl);
             });


### PR DESCRIPTION
This was done as there was some issue of variable context when evaluating postUrl.
https://github.com/LimeSurvey/LimeSurvey/compare/master...gabrieljenik:bug/17711--Cannot-export-selected-responses---only-range?expand=1#diff-ebcc738a58028c4733ffa427dbbf7b683f9b6f6513f97ce50414c7902dd48c79L71

The global postUrl variables was ignored.
It seems, somehow JS was defining postUrl as local from the very beggining, overwritting the global one. Even if `var postUrl` wasn't evaluated yet.
