### PR TITLE
Fixed issue #17773: Code name change while we updated from Edit Quest…

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -13,7 +13,7 @@
 
 
 $config['versionnumber'] = '3.27.31';
-$config['dbversionnumber'] = 365;
+$config['dbversionnumber'] = 366;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion'] = 3;

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -2542,6 +2542,13 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
             $oTransaction->commit();
         }
 
+        // Allow label sets to contain full subquestion codes
+        if ($iOldDBVersion < 366) {
+            $oTransaction = $oDB->beginTransaction();
+            alterColumn('{{labels}}', 'code', "string(20)", false);
+            $oDB->createCommand()->update('{{settings_global}}', ['stg_value' => 366], "stg_name='DBVersion'");
+            $oTransaction->commit();
+        }
 
     } catch (Exception $e) {
         Yii::app()->setConfig('Updating', false);

--- a/application/views/admin/labels/_labelviewtabcontent_view.php
+++ b/application/views/admin/labels/_labelviewtabcontent_view.php
@@ -44,7 +44,7 @@ $codeids = '';
 
                                 <td>
                                     <input type='hidden' class='hiddencode' value='<?php echo $row['code'] ?>' />
-                                    <input type='text'  class='codeval  form-control  ' id='code_<?php echo $row['sortorder'] ?>' name='code_<?php echo $row['sortorder'] ?>' maxlength='5' size='6' value='<?php echo $row['code'] ?>'/>
+                                    <input type='text'  class='codeval  form-control  ' id='code_<?php echo $row['sortorder'] ?>' name='code_<?php echo $row['sortorder'] ?>' maxlength='20' size='20' value='<?php echo $row['code'] ?>'/>
                                 </td>
 
                                 <td>

--- a/application/views/admin/survey/Question/question_subviews/_modals.twig
+++ b/application/views/admin/survey/Question/question_subviews/_modals.twig
@@ -49,6 +49,9 @@
                             </select>
                         </div>
                         <div class="row">
+                            <div id="longcodesalert" class="col-sm-12" style="display: none;">
+                                <div class="alert alert-warning ls-space margin bottom-0 top-15">{{ gT('Warning: Some answer codes will be truncated.') }}</div>
+                            </div>
                             <div id='labelsetpreview' class="col-sm-12 ls-space margin top-15" >
 
                             </div>

--- a/assets/scripts/admin/answers.js
+++ b/assets/scripts/admin/answers.js
@@ -450,6 +450,7 @@ function lsbrowser(e)
 
     $('#labelsets').select2();
     $("#labelsetpreview").html('');
+    $('#longcodesalert').hide();
     //    e.preventDefault();
     var scale_id=window.LS.removechars($(this).attr('id'));
     var surveyid=$('input[name=sid]').val();
@@ -513,6 +514,7 @@ function lspreview(lid)
                 $tabbody=$('<div class="tab-content" style="max-height: 50vh; overflow:auto;"></div>'),
                 count=0;
 
+            var hasInvalidCodes = false;
 
             console.ls.group('LanguageParsing');
             var i=0;
@@ -548,12 +550,20 @@ function lspreview(lid)
                     $listItem.append('<div class="col-md-1"></div>');
                     $listItem.attr('data-label', JSON.stringify(label));
                     $itemList.append($listItem);
-
+                    if (label.code.length > 5) {
+                        hasInvalidCodes = true;
+                    }
                 });
                 
                 console.ls.groupEnd('ParseLabels');
                 $bodyItem.append('<h4>'+labelSet.label_name+'</h4>');
                 $itemList.appendTo($bodyItem);
+
+                if (hasInvalidCodes) {
+                    $('#longcodesalert').show();
+                } else {
+                    $('#longcodesalert').hide();
+                }
                 
                 console.ls.groupEnd('ParseLabelSet');
             });
@@ -597,6 +607,9 @@ function transferlabels(type)
                     var $row = $(row)
                     var $tr = $row.eq(4);
                     var randId = 'new'+Math.floor(Math.random()*10000);
+
+                    // Make sure codes are limited to 5 characters
+                    label.code = label.code.substr(0, 5);
 
                     // $tr.attr('data-common-id', $tr.attr('data-common-id').replace(/new[0-9]{3,6}/,randId));
                     // $tr.attr('id', $tr.attr('id').replace(/new[0-9]{3-5}/,randId));

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -143,7 +143,7 @@ function createDatabase($oDB){
         $oDB->createCommand()->createTable('{{labels}}', array(
             'id' =>  "pk",
             'lid' =>  "integer NOT NULL DEFAULT 0",
-            'code' =>  "string(5) NOT NULL default ''",
+            'code' =>  "string(20) NOT NULL default ''",
             'title' =>  "text",
             'sortorder' =>  "integer NOT NULL",
             'language' =>  "string(20) NOT NULL DEFAULT 'en'",


### PR DESCRIPTION
Made the labelsets long enough for hlding answer codes (5 chars) and subquestion codes (>= 5).
If a labelset thought for a subquestion code is imported on answer options, codes are trimed and alerts are shown