### PR TITLE
Fixed issue #16230: Reload survey (token answer persistence) don't really reload 

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -800,6 +800,16 @@ class SurveyRuntimeHelper
         //$_SESSION[$this->LEMsessid]['step'] can not be less than 0, fix it always #09772
         $_SESSION[$this->LEMsessid]['step'] = $_SESSION[$this->LEMsessid]['step'] < 0 ? 0 : $_SESSION[$this->LEMsessid]['step'];
         LimeExpressionManager::StartSurvey($this->iSurveyid, $this->sSurveyMode, $this->aSurveyOptions, false, $this->LEMdebugLevel);
+        if (isset($_SESSION[$this->LEMsessid]['LEMtokenResume'])) {
+            /* Move to max step in all condition with force */
+            if (isset($_SESSION[$this->LEMsessid]['maxstep']) && $_SESSION[$this->LEMsessid]['maxstep'] > $_SESSION[$this->LEMsessid]['step']) {
+                LimeExpressionManager::SetRelevanceTo($_SESSION[$this->LEMsessid]['maxstep']);
+                LimeExpressionManager::JumpTo($_SESSION[$this->LEMsessid]['maxstep'], false, false);
+            } else {
+                LimeExpressionManager::SetRelevanceTo($_SESSION[$this->LEMsessid]['step']);
+            }
+            unset($_SESSION[$this->LEMsessid]['LEMtokenResume']);
+        }
         LimeExpressionManager::JumpTo($_SESSION[$this->LEMsessid]['step'], false, false);
     }
 
@@ -911,14 +921,14 @@ class SurveyRuntimeHelper
         // retrieve datas from local variable
         if (isset($_SESSION[$this->LEMsessid]['LEMtokenResume'])) {
             LimeExpressionManager::StartSurvey($this->aSurveyInfo['sid'], $this->sSurveyMode, $this->aSurveyOptions, false, $this->LEMdebugLevel);
-
-            // Do it only if needed : we don't need it if we don't have index
-            if (isset($_SESSION[$this->LEMsessid]['maxstep']) && $_SESSION[$this->LEMsessid]['maxstep'] > $_SESSION[$this->LEMsessid]['step'] && $this->aSurveyInfo['questionindex']) {
+            /* Move to max step in all condition with force */
+            if (isset($_SESSION[$this->LEMsessid]['maxstep']) && $_SESSION[$this->LEMsessid]['maxstep'] > $_SESSION[$this->LEMsessid]['step']) {
+                LimeExpressionManager::SetRelevanceTo($_SESSION[$this->LEMsessid]['maxstep']);
                 LimeExpressionManager::JumpTo($_SESSION[$this->LEMsessid]['maxstep'], false, false);
+            } else {
+                LimeExpressionManager::SetRelevanceTo($_SESSION[$this->LEMsessid]['step']);
             }
-
             $this->aMoveResult = LimeExpressionManager::JumpTo($_SESSION[$this->LEMsessid]['step'], false, false); // if late in the survey, will re-validate contents, which may be overkill
-
             unset($_SESSION[$this->LEMsessid]['LEMtokenResume']);
         } elseif (!$this->LEMskipReprocessing) {
             //Move current step ###########################################################################

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4100,7 +4100,7 @@ class LimeExpressionManager
      * @param integer|null $GroupSeq
      * @return void
      */
-    public function ProcessAllNeededRelevance($onlyThisQseq = null, $GroupSeq = null)
+    public function ProcessAllNeededRelevance($onlyThisQseq = null, $groupSeq = null)
     {
         // TODO - in a running survey, only need to process the current Group.  For Admin mode, do we need to process all prior questions or not?
         //        $now = microtime(true);
@@ -4114,7 +4114,7 @@ class LimeExpressionManager
             if(
                 $gseq != $this->currentGroupSeq // ONLY validate current group
                 && !$this->allOnOnePage // except if all in one page
-                && (is_null($GroupSeq) || $gseq > $GroupSeq)
+                && (is_null($groupSeq) || $gseq > $groupSeq)
             ) {
                 continue;
             }
@@ -5258,7 +5258,6 @@ class LimeExpressionManager
      */
     public static function SetRelevanceTo($seq)
     {
-        tracevar($seq);
         $LEM =& LimeExpressionManager::singleton();
         switch ($LEM->surveyMode) {
             case 'survey':
@@ -6762,7 +6761,6 @@ class LimeExpressionManager
      */
     public static function StartProcessingGroup($gseq = null, $anonymized = false, $surveyid = null, $forceRefresh = false)
     {
-        $msg = "- ";
         $LEM =& LimeExpressionManager::singleton();
         $LEM->em->StartProcessingGroup(
             isset($surveyid) ? $surveyid : null,
@@ -8777,7 +8775,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     }
                     return $shown;
                 }
-            // NB: No break needed
+                // NB: No break needed
             case 'relevanceStatus':
                 $gseq = (isset($var['gseq'])) ? $var['gseq'] : -1;
                 $qid = (isset($var['qid'])) ? $var['qid'] : -1;
@@ -8788,22 +8786,20 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                 if (isset($args[1]) && $args[1] == 'NAOK') {
                     return 1;
                 }
-                $grel =  1;
+                $grel = 1; // Group relevance true by default
                 if(isset($_SESSION[$this->sessid]['relevanceStatus']['G' . $gseq])) {
                     $grel =  $_SESSION[$this->sessid]['relevanceStatus']['G' . $gseq];
                 }
-                $qrel =  null;
+                $qrel = 0; // Question relevance false by default since EM creation. Update it must create a major API update
                 if(isset($_SESSION[$this->sessid]['relevanceStatus'][$qid])) {
                     $qrel =  $_SESSION[$this->sessid]['relevanceStatus'][$qid];
-                } else {
-                    // TODOACTUEL
                 }
-                $sqrel =  1; // true by default - only want false if a subquestion is really irrelevant
+                $sqrel = 1; // true by default - only want false if a subquestion is really irrelevant
                 if(isset($_SESSION[$this->sessid]['relevanceStatus'][$rowdivid])) {
                     $sqrel =  $_SESSION[$this->sessid]['relevanceStatus'][$rowdivid];
                 }
                 return ($grel && $qrel && $sqrel);
-            // NB: No break needed
+                // NB: No break needed
             case 'onlynum':
                 if (isset($args[1]) && ($args[1] == 'value' || $args[1] == 'valueNAOK')) {
                     return 1;
@@ -8827,7 +8823,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
             case 'scale_id':
             default:
                 return (isset($var[$attr])) ? $var[$attr] : $default;
-            // NB: No break needed
+                // NB: No break needed
         }
     }
 

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -61,10 +61,6 @@ function loadanswers()
         $md5_code = md5($sLoadPass);
         $sha256_code = hash('sha256', $sLoadPass);
         if ($md5_code === $access_code || $sha256_code === $access_code || password_verify($sLoadPass, $access_code)) {
-            //A match has been found. Let's load the values!
-            //If this is from an email, build surveysession first
-            $_SESSION['survey_' . $surveyid]['LEMtokenResume'] = true;
-
             // If survey come from reload (GET or POST); some value need to be found on saved_control, not on survey
             if (Yii::app()->request->getParam('loadall') === "reload") {
                 // We don't need to control if we have one, because we do the test before
@@ -93,7 +89,7 @@ function loadanswers()
                 $_SESSION['survey_' . $surveyid]['step'] = ($value > 1 ? $value : 1);
                 $thisstep = $_SESSION['survey_' . $surveyid]['step'] - 1;
             } else {
-                $_SESSION['survey_' . $surveyid]['maxstep'] = ($value > 1 ? $value : 1);
+                $_SESSION['survey_' . $surveyid]['maxstep'] = $_SESSION['survey_' . $surveyid]['totalsteps'];
             }
         } elseif ($column === "datestamp") {
             $_SESSION['survey_' . $surveyid]['datestamp'] = $value;
@@ -123,6 +119,7 @@ function loadanswers()
             }  // if (in_array(
         }  // else
     } // foreach
+    $_SESSION['survey_' . $surveyid]['LEMtokenResume'] = true;
     return true;
 }
 


### PR DESCRIPTION
Dev: LEMtokenResume with reload by token too
Dev: set maxstep to totalstep if needed
Dev: Create LimeExpressionManager::SetRelevanceTo to set relevance before JumpTo in case of reload
Dev: When reload : initFirstStep function before all other: then move reloading part here.
