### PR TITLE
Fixed issue #17790: KCFinder Image Browse Server not working due to incorrect cookieDomain

### DIFF
--- a/application/helpers/admin/htmleditor_helper.php
+++ b/application/helpers/admin/htmleditor_helper.php
@@ -25,8 +25,11 @@
             'flash' => $sAllowedExtensions,
             'images' => $sAllowedExtensions
         );
-        if (Yii::app()->getRequest()->enableCsrfValidation && !empty(Yii::app()->getRequest()->csrfCookie->domain)) {
-            $_SESSION['KCFINDER']['cookieDomain'] = Yii::app()->getRequest()->csrfCookie->domain;
+        if (!empty(App()->getSession()->cookieParams['domain'])) {
+            $_SESSION['KCFINDER']['cookieDomain'] = App()->getSession()->cookieParams['domain'];
+        }
+        if (App()->getRequest()->enableCsrfValidation && !empty(App()->getRequest()->csrfCookie['domain'])) {
+            $_SESSION['KCFINDER']['cookieDomain'] = Yii::app()->getRequest()->csrfCookie['domain'];
         }
 
         if (Yii::app()->getConfig('demoMode') === false &&


### PR DESCRIPTION
Dev: this need to set it in config.
Dev: but take config to fix KCFINDER cookieDomain
Dev: same fix from master