### PR TITLE
exclude build/devel/test files from export to zip/tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,21 @@
+# exclude build/devel/test files from export to zip/tarball
+.bowerrc                export-ignore
+buildVueComponents.js   export-ignore
+composer.json           export-ignore
+CONTRIBUTING.md         export-ignore
+.editorconfig           export-ignore
+.eslint*                export-ignore
+.flowconfig             export-ignore
+.git*                   export-ignore
+.jshintrc               export-ignore
+manifest.yml            export-ignore
+package.json            export-ignore
+phpci.yml               export-ignore
+phpcs.ruleset.xml       export-ignore
+phpunit.xml             export-ignore
+tests                   export-ignore
+yarn.lock               export-ignore
+
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 


### PR DESCRIPTION
There are files exported to zip/tarball that are of no use for production. Hence they should not be exported.