### PR TITLE
Fixed issue #17873: Remote Control `delete_language` fails to remove language

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -828,7 +828,8 @@ class remotecontrol_handle
                     return array('status' => 'Cannot remove base language');
                 }
                 $aLanguages = $oSurvey->getAdditionalLanguages();
-                unset($aLanguages[$sLanguage]);
+                $iLanguageKey = array_search($sLanguage, $aLanguages, true)
+                unset($aLanguages[$iLanguageKey]);
                 $oSurvey->additional_languages = implode(' ', $aLanguages);
                 try {
                     $oSurvey->save(); // save the change to database

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -828,7 +828,7 @@ class remotecontrol_handle
                     return array('status' => 'Cannot remove base language');
                 }
                 $aLanguages = $oSurvey->getAdditionalLanguages();
-                $iLanguageKey = array_search($sLanguage, $aLanguages, true)
+                $iLanguageKey = array_search($sLanguage, $aLanguages, true);
                 unset($aLanguages[$iLanguageKey]);
                 $oSurvey->additional_languages = implode(' ', $aLanguages);
                 try {


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #17873:  Remote Control `delete_language` fails to remove language
