### PR TITLE
Fixed issue #17846: Expression manager on file upload question type don't work on same page

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -7892,12 +7892,8 @@
                         if (count($qrelgseqs) > 0) { // If some of related group are updated : must check relevance (continue)
                              $qrelJS .= "  if(" . implode(' || ', $qrelgseqs) . "){\n    ;\n  }\n  else";
                         }
-                        $qrelJS .= "  if (typeof sgqa !== 'undefined') {\n";
-                        $qrelJS .= "    var jsName = LEMalias2varName[sgqa] || 'java' + sgqa;\n";
-                        $qrelJS .= "    if (!LEMregexMatch('/ ' + jsName + ' /', UsesVars)) {\n";
-                        $qrelJS .= "      return;\n";
-                        $qrelJS .= "    }\n";
-                        $qrelJS .= "  }\n";
+                        $qrelJS .= "  if (typeof sgqa !== 'undefined' && !LEMregexMatch('/ java' + sgqa + ' /', UsesVars)) {\n";
+                        $qrelJS .= "  return;\n }\n";
                     }
 
                     $qrelJS .= implode("",$relParts);

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -7892,8 +7892,12 @@
                         if (count($qrelgseqs) > 0) { // If some of related group are updated : must check relevance (continue)
                              $qrelJS .= "  if(" . implode(' || ', $qrelgseqs) . "){\n    ;\n  }\n  else";
                         }
-                        $qrelJS .= "  if (typeof sgqa !== 'undefined' && !LEMregexMatch('/ java' + sgqa + ' /', UsesVars)) {\n";
-                        $qrelJS .= "  return;\n }\n";
+                        $qrelJS .= "  if (typeof sgqa !== 'undefined') {\n";
+                        $qrelJS .= "    var jsName = LEMalias2varName[sgqa] || 'java' + sgqa;\n";
+                        $qrelJS .= "    if (!LEMregexMatch('/ ' + jsName + ' /', UsesVars)) {\n";
+                        $qrelJS .= "      return;\n";
+                        $qrelJS .= "    }\n";
+                        $qrelJS .= "  }\n";
                     }
 
                     $qrelJS .= implode("",$relParts);

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4087,7 +4087,7 @@
                         $jsVarName_on = 'answer' . $sgqa;;
                         break;
                     case '|': //File Upload
-                        $jsVarName = $sgqa;
+                        $jsVarName = 'java' . $sgqa;
                         $jsVarName_on = $jsVarName;
                         break;
                     case 'P': //Multiple choice with comments checkbox + text

--- a/application/views/survey/questions/answer/file_upload/answer.twig
+++ b/application/views/survey/questions/answer/file_upload/answer.twig
@@ -21,8 +21,8 @@
             <span class='fa fa-upload'></span>&nbsp;{{ gT('Upload files') }}
         </a>
     </div>
-    <input type='hidden' id='{{ fileid }}' name='{{ fileid }}' value='{{ value }}' />
-    <input type='hidden' id='{{ fileid }}_filecount' name='{{ fileid }}_filecount' value="{{ filecountvalue }}" />
+    <input type='hidden' id='java{{ fileid }}' name='{{ fileid }}' value='{{ value }}' />
+    <input type='hidden' id='java{{ fileid }}_filecount' name='{{ fileid }}_filecount' value="{{ filecountvalue }}" />
     <div id='{{ fileid }}_uploadedfiles'>
 
     </div>

--- a/assets/scripts/expressions/em_javascript.js
+++ b/assets/scripts/expressions/em_javascript.js
@@ -46,9 +46,9 @@ $(document).on("change",".radio-item :radio:not([onclick]), .button-item :radio:
 $(document).on("change",".checkbox-item :checkbox:not([onclick]),.button-item :checkbox:not([onclick])",function(event){
     checkconditions($(this).val(), $(this).attr('name'), 'checkbox', 'click')
 });
-/* file upload */
-$(document).on("change",".upload-item input[id^='java']",function(event){
-    checkconditions($(this).val(), $(this).attr('name'), 'upload', 'change')
+/* hidden item */
+$(document).on("updated",".answer-item :hidden, .upload-item :hidden",function(event){
+    checkconditions($(this).val(), $(this).attr('name'), 'equation', 'updated')
 });
 
 /**

--- a/assets/scripts/expressions/em_javascript.js
+++ b/assets/scripts/expressions/em_javascript.js
@@ -46,6 +46,10 @@ $(document).on("change",".radio-item :radio:not([onclick]), .button-item :radio:
 $(document).on("change",".checkbox-item :checkbox:not([onclick]),.button-item :checkbox:not([onclick])",function(event){
     checkconditions($(this).val(), $(this).attr('name'), 'checkbox', 'click')
 });
+/* file upload */
+$(document).on("change",".upload-item input[id^='java']",function(event){
+    checkconditions($(this).val(), $(this).attr('name'), 'upload', 'change')
+});
 
 /**
  * For number

--- a/assets/scripts/modaldialog.js
+++ b/assets/scripts/modaldialog.js
@@ -135,8 +135,8 @@ function displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show
 }
 
 function copyJSON(jsonstring, filecount, fieldname, show_title, show_comment, pos) {
-    $('#'+fieldname).val(jsonstring);
-    $('#'+fieldname+'_filecount').val(filecount);
+    $('#java'+fieldname).val(jsonstring).trigger('change');
+    $('#java'+fieldname+'_filecount').val(filecount).trigger('change');
     displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show_comment, pos);
 }
 

--- a/assets/scripts/modaldialog.js
+++ b/assets/scripts/modaldialog.js
@@ -138,7 +138,6 @@ function copyJSON(jsonstring, filecount, fieldname, show_title, show_comment, po
     $('#'+fieldname).val(jsonstring);
     $('#'+fieldname+'_filecount').val(filecount);
     displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show_comment, pos);
-    checkconditions($('#'+fieldname).val(), fieldname, 'upload', 'change');
 }
 
 

--- a/assets/scripts/modaldialog.js
+++ b/assets/scripts/modaldialog.js
@@ -135,8 +135,8 @@ function displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show
 }
 
 function copyJSON(jsonstring, filecount, fieldname, show_title, show_comment, pos) {
-    $('#java'+fieldname).val(jsonstring).trigger('change');
-    $('#java'+fieldname+'_filecount').val(filecount).trigger('change');
+    $('#java'+fieldname).val(jsonstring).trigger('updated');
+    $('#java'+fieldname+'_filecount').val(filecount).trigger('updated');
     displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show_comment, pos);
 }
 

--- a/assets/scripts/modaldialog.js
+++ b/assets/scripts/modaldialog.js
@@ -138,6 +138,7 @@ function copyJSON(jsonstring, filecount, fieldname, show_title, show_comment, po
     $('#'+fieldname).val(jsonstring);
     $('#'+fieldname+'_filecount').val(filecount);
     displayUploadedFiles(jsonstring, filecount, fieldname, show_title, show_comment, pos);
+    checkconditions($('#'+fieldname).val(), fieldname, 'upload', 'change');
 }
 
 

--- a/assets/scripts/uploader.js
+++ b/assets/scripts/uploader.js
@@ -30,14 +30,14 @@ function doFileUpload()
 {
     var fieldname = $('#ia').val();
     /* Load the previously uploaded files */
-    var filecount = window.parent.window.$('#' + fieldname + '_filecount').val();
+    var filecount = window.parent.window.$('#java' + fieldname + '_filecount').val();
     $('#' + fieldname + '_filecount').val(filecount);
 
     var image_extensions = new Array("gif", "jpeg", "jpg", "png", "swf", "psd", "bmp", "tiff", "jp2", "iff", "bmp", "xbm", "ico");
 
     if (filecount > 0)
     {
-        var jsontext = window.parent.window.$('#' + fieldname).val();
+        var jsontext = window.parent.window.$('#java' + fieldname).val();
         var json = '';
         try{
             json = JSON.parse(jsontext);


### PR DESCRIPTION
When rendering file upload question types, file upload hidden fields are not following usual naming conventions as other fields.
Its processing then was skipped.

Now, looking field name on dictionary.