### PR TITLE
use different cache key for QuestionGroup model getTotalGroupsWithQue…

### DIFF
--- a/application/models/QuestionGroup.php
+++ b/application/models/QuestionGroup.php
@@ -459,7 +459,7 @@ class QuestionGroup extends LSActiveRecord
      */
     public static function getTotalGroupsWithQuestions($surveyid)
     {
-        $cacheKey = 'getTotalGroupsWithoutQuestions_' . $surveyid;
+        $cacheKey = 'getTotalGroupsWithQuestions_' . $surveyid;
         $value = EmCacheHelper::get($cacheKey);
         if ($value !== false) {
             return $value;


### PR DESCRIPTION
…stions() query

For issue:
https://bugs.limesurvey.org/view.php?id=17912

Sometimes, when emcache is enabled, an erroneous value is cached for the OptionGroup model, getTotalGroupsWithoutQuestions() function

This results in error taking the survey, when there should not be. See bug issue for more details. 
