### PR TITLE
Fixed issue #16937: Easy way to launch CDBException

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -649,6 +649,7 @@ class SurveyRuntimeHelper
             $this->setPrevStep();
             $this->checkIfFinished();
             $this->setStep();
+            $this->saveStartingValues();
 
             // CHECK UPLOADED FILES
             // TMSW - Move this into LEM::NavigateForwards?
@@ -1768,6 +1769,10 @@ class SurveyRuntimeHelper
             $this->aMoveResult = LimeExpressionManager::JumpTo($qSec + 1, 'question', false, true);
             $this->aStepInfo = LimeExpressionManager::GetStepIndexInfo($this->aMoveResult['seq']);
         }
+        
+        // "Save" starting values to response. 
+        // In the case of preview will not be "saved"", but will be incorporated in the response handled in memory.
+        LimeExpressionManager::SaveStartingValues();
     }
 
 
@@ -1887,5 +1892,16 @@ class SurveyRuntimeHelper
         }
 
         return $aQuestionClass;
+    }
+
+    /**
+     * Saves the starting values, if any is set
+     */
+    private function saveStartingValues()
+    {
+        // Don't save the starting values if on Welcome screen
+        if ($this->sSurveyMode != 'survey' && $_SESSION[$this->LEMsessid]['step'] == 0) return;
+
+        LimeExpressionManager::SaveStartingValues();
     }
 }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4623,58 +4623,9 @@ class LimeExpressionManager
         $LEM->indexGseq = [];
         $LEM->indexQseq = [];
         $LEM->qrootVarName2arrayFilter = [];
-        // set seed key if it doesn't exist to be able to pass count of startingValues check at next IF
-        if (array_key_exists('startingValues', $_SESSION[$LEM->sessid]) && !array_key_exists('seed', $_SESSION[$LEM->sessid]['startingValues'])) {
-            $_SESSION[$LEM->sessid]['startingValues']['seed'] = '';
-        }
-
-        // NOTE: now that we use a seed, count($_SESSION[$LEM->sessid]['startingValues']) start at 1
-        if (isset($_SESSION[$LEM->sessid]['startingValues']) && is_array($_SESSION[$LEM->sessid]['startingValues']) && count($_SESSION[$LEM->sessid]['startingValues']) > 1) {
-            foreach ($_SESSION[$LEM->sessid]['startingValues'] as $k => $value) {
-                if (isset($LEM->knownVars[$k])) {
-                    $knownVar = $LEM->knownVars[$k];
-                } elseif (isset($LEM->qcode2sgqa[$k])) {
-                    $knownVar = $LEM->knownVars[$LEM->qcode2sgqa[$k]];
-                } else {
-                    continue;
-                }
-                if (!isset($knownVar['jsName'])) {
-                    continue;
-                }
-                switch ($knownVar['type']) {
-                    case Question::QT_D_DATE: //DATE
-                        if (trim($value) == "") {
-                            $value = null;
-                        } else {
-                            // We don't really validate date here, anyone can send anything : forced too
-                            $dateformatdatat = getDateFormatData($LEM->surveyOptions['surveyls_dateformat']);
-                            $datetimeobj = new Date_Time_Converter($value, $dateformatdatat['phpdate']);
-                            $value = $datetimeobj->convert("Y-m-d H:i");
-                        }
-                        break;
-                    case Question::QT_N_NUMERICAL: //NUMERICAL QUESTION TYPE
-                    case Question::QT_K_MULTIPLE_NUMERICAL: //MULTIPLE NUMERICAL QUESTION
-                        if (trim($value) == "") {
-                            $value = null;
-                        } else {
-                            $value = sanitize_float($value);
-                        }
-                        break;
-                    case Question::QT_VERTICAL_FILE_UPLOAD: //File Upload
-                        $value = null;  // can't upload a file via GET
-                        break;
-                }
-                $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
-                $LEM->updatedValues[$knownVar['sgqa']] = [
-                    'type'  => $knownVar['type'],
-                    'value' => $value,
-                ];
-            }
-            $LEM->_UpdateValuesInDatabase();
-        }
 
         return [
-            'hasNext'     => true,
+            'hasNext' => true,
             'hasPrevious' => false,
         ];
     }
@@ -5070,6 +5021,7 @@ class LimeExpressionManager
                 }
             }
 
+            // Save seed data.
             if (isset($_SESSION[$this->sessid]['startingValues']['seed'])) {
                 $sdata['seed'] = $_SESSION[$this->sessid]['startingValues']['seed'];
             }
@@ -9910,6 +9862,86 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         // { and } (after &)
         $string = str_replace(["{", "}"], ["&#123;", "&#125;"], $string);
         return $string;
+    }
+
+    /**
+     * Save the starting values to the database
+     * @return boolean|void
+     */
+    public static function SaveStartingValues()
+    {
+        // Init
+        $LEM =& LimeExpressionManager::singleton();
+
+        // If not starting values, retun
+        if (!isset($_SESSION[$LEM->sessid]['startingValues'])) {
+            return false;
+        }
+        if (!is_array($_SESSION[$LEM->sessid]['startingValues'])) {
+            return false;
+        }
+
+        // set seed key if it doesn't exist to be able to pass count of startingValues check at next IF
+        // GJ: I think this is to assure that starting values always have a seed entry and then be able to check more easily
+        // If there are other starting values, besides the seed.
+        // I think this piece of code may never be reached by the execution thread. There is always a seed.
+        if (!array_key_exists('seed', $_SESSION[$LEM->sessid]['startingValues'])){        
+            $_SESSION[$LEM->sessid]['startingValues']['seed'] = '';
+        }
+
+        // Check if there are other starting values, besides the seed
+        // NOTE: now that we use a seed, count($_SESSION[$LEM->sessid]['startingValues']) start at 1
+        if (count($_SESSION[$LEM->sessid]['startingValues']) > 1) {
+            foreach ($_SESSION[$LEM->sessid]['startingValues'] as $k => $value) {
+                if (isset($LEM->knownVars[$k])) {
+                    $knownVar = $LEM->knownVars[$k];
+                } elseif (isset($LEM->qcode2sgqa[$k])) {
+                    $knownVar = $LEM->knownVars[$LEM->qcode2sgqa[$k]];
+                } else {
+                    continue;
+                }
+                if (!isset($knownVar['jsName'])) {
+                    continue;
+                }
+                switch ($knownVar['type']) {
+                    case Question::QT_D_DATE: //DATE
+                        if (trim($value) == "") {
+                            $value = null;
+                        } else {
+                            // We don't really validate date here, anyone can send anything : forced too
+                            $dateformatdatat = getDateFormatData($LEM->surveyOptions['surveyls_dateformat']);
+                            $datetimeobj = new Date_Time_Converter($value, $dateformatdatat['phpdate']);
+                            $value = $datetimeobj->convert("Y-m-d H:i");
+                        }
+                        break;
+                    case Question::QT_N_NUMERICAL: //NUMERICAL QUESTION TYPE
+                    case Question::QT_K_MULTIPLE_NUMERICAL: //MULTIPLE NUMERICAL QUESTION
+                        if (trim($value) == "") {
+                            $value = null;
+                        } else {
+                            $value = sanitize_float($value);
+                        }
+                        break;
+                    case Question::QT_VERTICAL_FILE_UPLOAD: //File Upload
+                        $value = null;  // can't upload a file via GET
+                        break;
+                }
+                /* Check validity # */
+                $qinfo = array(
+                    'qid' => $knownVar['qid'],
+                    'other' => "Y", // Not known currently, but don't broke if set
+                );
+                if (self::checkValidityAnswer($knownVar['type'],$value,$knownVar['sgqa'],$qinfo,false)) {
+                    $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
+                    $LEM->updatedValues[$knownVar['sgqa']]=array(
+                        'type'=>$knownVar['type'],
+                        'value'=>$value,
+                    );
+                }
+                unset($_SESSION[$LEM->sessid]['startingValues'][$k]);
+            }
+            $LEM->_UpdateValuesInDatabase();
+        }
     }
 
     /**


### PR DESCRIPTION
SaveStartingValues was moved from StartSurvey to InitMove. InitMove is not being called from the preview mode. So now, we call SaveStartingValues from the preview.

This is rebase of PR #1754 (https://github.com/LimeSurvey/LimeSurvey/pull/1754) to of the according to the new status of DEV env.