### PR TITLE
Fixed issue #17374: aSurveyInfo.datasecurity_notice_label does not return only the label

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -270,6 +270,7 @@ $internalConfig = array(
                 'ellipsizeString'         => 'LS_Twig_Extension::ellipsizeString',
                 'flatEllipsizeText'       => 'LS_Twig_Extension::flatEllipsizeText', /* Temporary keep it */
                 'str_replace'             => 'str_replace',
+                'strpos'                  => 'strpos',
                 'getConfig'               => 'LS_Twig_Extension::getConfig',
                 'getExpressionManagerOutput' => 'LS_Twig_Extension::getExpressionManagerOutput',/* Not in 3.X */
                 'getTextDisplayWidget'       => 'LS_Twig_Extension::getTextDisplayWidget',/* Not in 3.X */
@@ -386,6 +387,7 @@ $internalConfig = array(
                     'ellipsizeString',
                     'flatEllipsizeText',
                     'str_replace',
+                    'strpos',
                     'flattenText',
                     'getConfig',
                     'getExpressionManagerOutput',

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -2026,31 +2026,24 @@ class Survey extends LSActiveRecord implements PermissionInterface
         return $result !== false;
     }
 
+    /**
+     * Get the final label for survey id
+     * @param string $dataSecurityNoticeLabel current label
+     * @param integer $surveyId unused
+     * @return string
+     */
     public static function replacePolicyLink($dataSecurityNoticeLabel, $surveyId)
     {
-
-        $STARTPOLICYLINK = "";
-        $ENDPOLICYLINK = "";
-
-        if (self::model()->findByPk($surveyId)->showsurveypolicynotice == 2) {
-            $STARTPOLICYLINK = "<a href='#data-security-modal-" . $surveyId . "' data-toggle='collapse'>";
-            $ENDPOLICYLINK = "</a>";
-            if (!preg_match('/(\{STARTPOLICYLINK\}|\{ENDPOLICYLINK\})/', $dataSecurityNoticeLabel)) {
-                $dataSecurityNoticeLabel .= "<br/> {STARTPOLICYLINK}" . gT("Show policy") . "{ENDPOLICYLINK}";
-            }
-        }
-
-
-
-        $dataSecurityNoticeLabel =  preg_replace('/\{STARTPOLICYLINK\}/', $STARTPOLICYLINK, $dataSecurityNoticeLabel);
-
-        $countEndLabel = 0;
-        $dataSecurityNoticeLabel =  preg_replace('/\{ENDPOLICYLINK\}/', $ENDPOLICYLINK, $dataSecurityNoticeLabel, -1, $countEndLabel);
-        if ($countEndLabel == 0) {
-            $dataSecurityNoticeLabel .= '</a>';
-        }
-
-        return $dataSecurityNoticeLabel;
+        /* @var string[] to go to automatic translation */
+        $translation = [
+            gT("Show policy")
+        ];
+        return App()->twigRenderer->renderPartial(
+            '/subviews/privacy/privacy_datasecurity_notice_label.twig',
+            [
+                'dataSecurityNoticeLabel' => $dataSecurityNoticeLabel,
+            ]
+        );
     }
 
     /**

--- a/themes/survey/vanilla/views/subviews/privacy/privacy_datasecurity_notice_label.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy_datasecurity_notice_label.twig
@@ -1,0 +1,19 @@
+{# 
+    use aSurveyInfo datasecurity_notice_label
+#}
+{% set STARTPOLICYLINK = "" %}
+{% set ENDPOLICYLINK = "" %}
+{% if(aSurveyInfo.showsurveypolicynotice == 2) %}
+    {% set STARTPOLICYLINK = "<a href='#data-security-modal-" ~ aSurveyInfo.sid ~ "' data-toggle='collapse'>" %}
+    {% set ENDPOLICYLINK = "</a>" %}
+{% endif %}
+{% if( strpos( " " ~ dataSecurityNoticeLabel, '{STARTPOLICYLINK}') == false and strpos( " " ~ dataSecurityNoticeLabel, '{ENDPOLICYLINK}') == false) %}
+    {% set dataSecurityNoticeLabel = dataSecurityNoticeLabel ~ "<br/> {STARTPOLICYLINK}" ~ gT("Show policy") ~ "{ENDPOLICYLINK}" %}
+{% endif %}
+{% set haveENDPOLICYLINK = strpos( " " ~ dataSecurityNoticeLabel, '{ENDPOLICYLINK}') %}
+{% set dataSecurityNoticeLabel = str_replace('{STARTPOLICYLINK}', STARTPOLICYLINK, dataSecurityNoticeLabel) %}
+{% set dataSecurityNoticeLabel = str_replace('{ENDPOLICYLINK}', ENDPOLICYLINK, dataSecurityNoticeLabel) %}
+{% if( haveENDPOLICYLINK == false ) %}
+    {% set dataSecurityNoticeLabel = dataSecurityNoticeLabel ~ ENDPOLICYLINK %}
+{% endif %}
+{{ dataSecurityNoticeLabel }}


### PR DESCRIPTION
Dev: allow replacement of return in template twig file

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
