### PR TITLE
Fixed issue #17940: Array filter in combination with 'equals sum value' feature does not sum up values correctly

### DIFF
--- a/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
+++ b/application/core/QuestionTypes/MultipleNumericalQuestion/RenderMultipleNumerical.php
@@ -326,11 +326,16 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
         ) {
             $qinfo = LimeExpressionManager::GetQuestionStatus($this->oQuestion->qid);
 
+            $sumRemainingEqn = LimeExpressionManager::ProcessString('{'.$qinfo['sumRemainingEqn'].'}', $this->oQuestion->qid);
+            $sumEqn = LimeExpressionManager::ProcessString('{'.$qinfo['sumEqn'].'}', $this->oQuestion->qid);
+
             if (trim($this->getQuestionAttribute('equals_num_value')) != '') {
                 $equals_num_value = true;
             }
             $displaytotal = true;
         }
+
+
 
         $answer .= Yii::app()->twigRenderer->renderQuestion(
             $this->getMainView() . '/answer',
@@ -341,10 +346,10 @@ class RenderMultipleNumerical extends QuestionBaseRenderer
                 'rowTemplate' => $rowTemplate,
                 'dynamicTemplate' => $dynamicTemplate,
                 'id' => $this->oQuestion->qid,
-                'sumRemainingEqn' => $equals_num_value ? $qinfo['sumRemainingEqn'] : '',
+                'sumRemainingEqn' => $equals_num_value ? $sumRemainingEqn : '',
                 'equals_num_value' => $equals_num_value,
                 'displaytotal' => $displaytotal,
-                'sumEqn' => $displaytotal ? $qinfo['sumEqn'] : '',
+                'sumEqn' => $displaytotal ? $sumEqn : '',
                 'sLabelWidth' => $this->widthArray['sLabelWidth'],
                 'sInputContainerWidth' => $this->widthArray['sInputContainerWidth'],
                 'prefix' => $this->prefix,

--- a/application/views/survey/questions/answer/multiplenumeric/rows/dynamic.twig
+++ b/application/views/survey/questions/answer/multiplenumeric/rows/dynamic.twig
@@ -23,7 +23,7 @@
             {% endif %}
             <div id="remainingvalue_{{id}}" class="form-control-static numeric dynamic-remaining" data-number="1">
             <!-- alternative class : form-control : display like an input:text -->
-                {{ processString('{'~sumRemainingEqn~'}') }}
+                {{ sumRemainingEqn }}
             </div>
             {% if suffix  %}
                 <div class="ls-input-group-extra suffix-text suffix">
@@ -46,7 +46,7 @@
                 </div>
             {% endif %}
             <div id="totalvalue_{{id}}" class="form-control-static numeric dynamic-total" data-number="1">
-                {{ processString('{'~sumEqn~'}') }}
+                {{ sumEqn }}
             </div>
             {% if suffix  %}
                 <div class="ls-input-group-extra suffix-text suffix hidden">

--- a/application/views/survey/questions/answer/multiplenumeric/rows/dynamic_slider.twig
+++ b/application/views/survey/questions/answer/multiplenumeric/rows/dynamic_slider.twig
@@ -22,7 +22,7 @@
                 </div>
             {% endif %}
             <div id="remainingvalue_{{ id }}" class="form-control-static numeric dynamic-remaining" data-number="1"><!-- alternative class : form-control : display like an input:text -->
-                {{ processString('{'~sumRemainingEqn~'}') }}
+                {{ sumRemainingEqn }}
             </div>
             {% if suffix %}
                 <div class="suffix-text suffix">
@@ -40,7 +40,7 @@
                 {{gT('Total:')}}
             </div>
             <div id="totalvalue_{{ id }}" class="form-control-static numeric dynamic-total" data-number="1">
-                {{ processString('{'~sumEqn~'}') }}
+                {{ sumEqn }}
             </div>
         </div>
     </li>


### PR DESCRIPTION
There is a missmatch in the questionId used by the twig processString.
That missmatch produces unexpected behaviour on the EM.

The "twig processString" just assumes the current question is the last queston of the group.
So, we moved out the processString usage from the fileupload twig implementation.
Now the processString is done on PHP side.