### PR TITLE
Fixed issue #17982: Malformed DSN when using MySQL socket and DB name during installation

### DIFF
--- a/application/models/InstallerConfigForm.php
+++ b/application/models/InstallerConfigForm.php
@@ -526,8 +526,8 @@ class InstallerConfigForm extends CFormModel
         $port = $this->getDbPort();
 
         // MySQL allow unix_socket for database location, then test if $sDatabaseLocation start with "/"
-        if (substr($this->dblocation, 0, 1) == "/") {
-            $sDSN = "mysql:unix_socket={$this->dblocation}";
+        if (substr($this->dblocation, 0, 1) === "/") {
+            $sDSN = "mysql:unix_socket={$this->dblocation};";
         } else {
             $sDSN = "mysql:host={$this->dblocation};port={$port};";
         }


### PR DESCRIPTION
## How to reproduce

* create a database
* create an user@'%' identified by a password
* grant all privileges to user@'%' to that database
* install LimeSurvey and fill MySQL configuration
* remove "localhost" as MySQL server and set a valid socket like "/var/run/mysqld/mysqld.sock"
* set the database name normally
* save

What it happens:

«Database doesn't exist!»

What should happen if the database exists and if the MySQL user can see the database:

Normal installation.

## Cause of the problem

It seems that when the user selects a valid socket AND fills the database name,
then DSN is wrongly formatted, without the ';' separator between the socket path
and the database name:

    mysql:unix_socket=/var/run/mysqld/mysqld.sockdbname=foo

This should be the correct DSN instead (note the `;` before dbname):

    mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=foo

This problem existed since the feature was originally introduced
here:

* 4f97fb02e96c2526fab1ef6db5e9cc73eebc1943

The fix consists in assuring that the DSN string ends with the ';' delimiter
also in the case of an user using a socket.

Some users never encountered this problem because they left the database name
blank and put the database name directly into the sock path.

P.S.

The commit includes also a strict string comparison using `===` operator that
is more appropriate when comparing a string with another string.

<!-- Keep one of the below lines. -->

Fixed issue #17982