### PR TITLE
Fixed issue #17972: events are dispatched if the plugin is deactivated

### DIFF
--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -223,7 +223,7 @@ class PluginManagerController extends SurveyCommonAction
             }
 
             // Load the plugin:
-            App()->getPluginManager()->loadPlugin($oPlugin->name, $pluginId);
+            App()->getPluginManager()->loadPlugin($oPlugin->name, $pluginId, false);
             $result = App()->getPluginManager()->dispatchEvent(
                 new PluginEvent('beforeActivate', $this),
                 $oPlugin->name
@@ -302,7 +302,7 @@ class PluginManagerController extends SurveyCommonAction
         }
 
         $plugin      = Plugin::model()->findByPk($id);
-        $oPluginObject = App()->getPluginManager()->loadPlugin($plugin->name, $plugin->id);
+        $oPluginObject = App()->getPluginManager()->loadPlugin($plugin->name, $plugin->id, false);
 
         if (empty($oPluginObject)) {
             Yii::app()->user->setFlash('error', gT('Could not load plugin'));

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -423,10 +423,11 @@ class PluginManager extends \CApplicationComponent
      *
      * @param string $pluginName
      * @param int $id Identifier used for identifying a specific plugin instance.
+     * @param boolean $init launch init function (if exist)
      * If ommitted will return the first instantiated plugin with the given name.
      * @return iPlugin|null The plugin or null when missing
      */
-    public function loadPlugin($pluginName, $id = null)
+    public function loadPlugin($pluginName, $id = null, $init = true)
     {
         $return = null;
         $this->shutdownObject->enable();
@@ -444,7 +445,7 @@ class PluginManager extends \CApplicationComponent
                     if ($this->isWhitelisted($pluginName) && $this->getPluginInfo($pluginName) !== false) {
                         if (class_exists($pluginName)) {
                             $this->plugins[$id] = new $pluginName($this, $id);
-                            if (method_exists($this->plugins[$id], 'init')) {
+                            if ($init && method_exists($this->plugins[$id], 'init')) {
                                 $this->plugins[$id]->init();
                             }
                         } else {

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -83,7 +83,7 @@ class PluginManager extends \CApplicationComponent
     }
     /**
      * Return a list of installed plugins, but only if the files are still there
-     *
+     * @deprecated unused in 5.3.8
      * This prevents errors when a plugin was installed but the files were removed
      * from the server.
      *
@@ -98,7 +98,7 @@ class PluginManager extends \CApplicationComponent
 
         foreach ($records as $record) {
             // Only add plugins we can find
-            if ($this->loadPlugin($record->name) !== false) {
+            if ($this->loadPlugin($record->name, $record->id, $record->active) !== false) {
                 $plugins[$record->id] = $record;
             }
         }
@@ -523,7 +523,7 @@ class PluginManager extends \CApplicationComponent
         $records = Plugin::model()->findAll();
         foreach ($records as $record) {
             if ($record->load_error == 0) {
-                $this->loadPlugin($record->name, $record->id);
+                $this->loadPlugin($record->name, $record->id, $record->active);
             }
         }
     }


### PR DESCRIPTION
Dev: Add param to load init
Dev: set it to false in PluginManagerController in all case
Dev: active plugin are loaded via PluginManager->loadPlugins
