### PR TITLE
Fixed issue #17972: events are dispatched if the plugin is deactivated

### DIFF
--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -49,7 +49,7 @@ class PluginManagerController extends Survey_Common_Action
         foreach ($aoPlugins as $oPlugin) {
             /* @var $plugin Plugin */
             if (array_key_exists($oPlugin->name, $aDiscoveredPlugins)) {
-                $plugin = App()->getPluginManager()->loadPlugin($oPlugin->name, $oPlugin->id);
+                $plugin = App()->getPluginManager()->loadPlugin($oPlugin->name, $oPlugin->id, false);
                 if ($plugin) {
                     $aPluginSettings = $plugin->getPluginSettings(false);
                     $data[]          = array(
@@ -114,7 +114,7 @@ class PluginManagerController extends Survey_Common_Action
             $iStatus = $oPlugin->active;
             if ($iStatus == 0) {
                 // Load the plugin:
-                App()->getPluginManager()->loadPlugin($oPlugin->name, $id);
+                App()->getPluginManager()->loadPlugin($oPlugin->name, $id, false);
                 $result = App()->getPluginManager()->dispatchEvent(new PluginEvent('beforeActivate', $this), $oPlugin->name);
                 if ($result->get('success', true)) {
                     $iStatus = 1;
@@ -184,7 +184,7 @@ class PluginManagerController extends Survey_Common_Action
         }
 
         $arPlugin      = Plugin::model()->findByPk($id)->attributes;
-        $oPluginObject = App()->getPluginManager()->loadPlugin($arPlugin['name'], $arPlugin['id']);
+        $oPluginObject = App()->getPluginManager()->loadPlugin($arPlugin['name'], $arPlugin['id'], false);
 
         if ($arPlugin === null) {
             Yii::app()->user->setFlash('error', gT('The plugin was not found.'));

--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -113,8 +113,8 @@ class PluginManagerController extends Survey_Common_Action
         if (!is_null($oPlugin)) {
             $iStatus = $oPlugin->active;
             if ($iStatus == 0) {
-                // Load the plugin:
-                App()->getPluginManager()->loadPlugin($oPlugin->name, $id, false);
+                // Load the plugin (and init)
+                App()->getPluginManager()->loadPlugin($oPlugin->name, $id, true); 
                 $result = App()->getPluginManager()->dispatchEvent(new PluginEvent('beforeActivate', $this), $oPlugin->name);
                 if ($result->get('success', true)) {
                     $iStatus = 1;

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -69,7 +69,7 @@ class PluginManager extends \CApplicationComponent
 
         foreach ($records as $record) {
             // Only add plugins we can find
-            if ($this->loadPlugin($record->name) !== false) {
+            if ($this->loadPlugin($record->name, $record->id, $record->active) !== false) {
                 $plugins[$record->id] = $record;
             }
         }
@@ -268,10 +268,11 @@ class PluginManager extends \CApplicationComponent
      *
      * @param string $pluginName
      * @param int $id Identifier used for identifying a specific plugin instance.
+     * @param boolean $init init plugin if method is available
      * If ommitted will return the first instantiated plugin with the given name.
      * @return iPlugin|null The plugin or null when missing
      */
-    public function loadPlugin($pluginName, $id = null)
+    public function loadPlugin($pluginName, $id = null, $init = true)
     {
         // If the id is not set we search for the plugin.
         if (!isset($id)) {
@@ -285,8 +286,7 @@ class PluginManager extends \CApplicationComponent
                 if ($this->getPluginInfo($pluginName) !== false) {
                     if (class_exists($pluginName)) {
                         $this->plugins[$id] = new $pluginName($this, $id);
-
-                        if (method_exists($this->plugins[$id], 'init')) {
+                        if ($init && method_exists($this->plugins[$id], 'init')) {
                             $this->plugins[$id]->init();
                         }
                     } else {
@@ -332,7 +332,7 @@ class PluginManager extends \CApplicationComponent
     {
         $records = Plugin::model()->findAll();
         foreach ($records as $record) {
-            $this->loadPlugin($record->name, $record->id);
+            $this->loadPlugin($record->name, $record->id, $record->active);
         }
     }
 


### PR DESCRIPTION
Dev: Add param to load init
Dev: set it to false in PluginManagerController in all case
Dev: active plugin are loaded via PluginManager->loadPlugins
Dev: use plugin model active status in PluginManager