### PR TITLE
Fixed issue #17811: Theme options for logo and background images are not saved

### DIFF
--- a/application/helpers/SurveyThemeHelper.php
+++ b/application/helpers/SurveyThemeHelper.php
@@ -154,7 +154,7 @@ class SurveyThemeHelper
                 if (empty($categoryPath)) {
                     continue;
                 }
-                $categoryPath = $categoryPath . '/';
+                $categoryPath = $categoryPath . DIRECTORY_SEPARATOR;
                 if (strpos($absolutePath, $categoryPath) === 0) {
                     $virtualPath = str_replace($categoryPath, $category->pathPrefix, $absolutePath);
                     return new ThemeFileInfo($absolutePath, $virtualPath, $category);
@@ -181,7 +181,7 @@ class SurveyThemeHelper
             if (empty($categoryPath)) {
                 continue;
             }
-            $categoryPath = $categoryPath . '/';
+            $categoryPath = $categoryPath . DIRECTORY_SEPARATOR;
 
             // Get the realpath for the file.
             $realPath = realpath($categoryPath . $path);
@@ -278,7 +278,7 @@ class SurveyThemeHelper
                 return null;    // No category matched the path's prefix
             }
             $category = reset($filteredCategories);
-            $categoryPath = realpath($category->path) . '/';
+            $categoryPath = realpath($category->path) . DIRECTORY_SEPARATOR;
 
             // Validate that the file exists
             $realPath = realpath($categoryPath . '/' . substr($path, strlen($prefix)));

--- a/themes/survey/bootswatch/config.xml
+++ b/themes/survey/bootswatch/config.xml
@@ -68,7 +68,7 @@
         <fixnumauto type="buttons" category="Simple options" width="4" title="Fix automatically numeric value" options="enable|partial|disable" optionlabels="Yes|For expression|No">off</fixnumauto>
         <!-- images -->
         <brandlogo type="buttons" category="Images" width="4" title="Logo" options="on|off" optionlabels="Yes|No">on</brandlogo>
-        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">themes/survey/bootswatch/files/logo.png</brandlogofile>
+        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">./files/logo.png</brandlogofile>
         <hideprivacyinfo type="buttons" category="Simple options" width="4" title="Hide privacy info" options="on|off" optionlabels="Yes|No">off</hideprivacyinfo>
         <cssframework type="dropdown" category="Simple options" title="Variations" parent="cssframework">
             <dropdownoptions>

--- a/themes/survey/fruity/config.xml
+++ b/themes/survey/fruity/config.xml
@@ -105,7 +105,7 @@
         <backgroundimage type="buttons" category="Images" width="4" title="Background image" options="on|off" optionlabels="Yes|No">off</backgroundimage>
         <backgroundimagefile type="dropdown" category="Images" width="6" title="Background image file" parent="backgroundimage">./files/pattern.png</backgroundimagefile>
         <brandlogo type="buttons" category="Images" width="4" title="Logo" options="on|off" optionlabels="Yes|No">on</brandlogo>
-        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">themes/survey/fruity/files/logo.png</brandlogofile>
+        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">./files/logo.png</brandlogofile>
         <!-- animations -->
         <animatebody type="buttons" category="Animations" width="4" title="Animate body" options="on|off" optionlabels="Yes|No">off</animatebody>
         <bodyanimation type="dropdown" category="Animations" width="6" title="Body animation" parent="animatebody">fadeInRight

--- a/themes/survey/vanilla/config.xml
+++ b/themes/survey/vanilla/config.xml
@@ -66,7 +66,7 @@
         <fixnumauto type="buttons" category="Simple options" width="4" title="Fix automatically numeric value" options="enable|partial|disable" optionlabels="Yes|For expression|No">off</fixnumauto>
         <!-- images -->
         <brandlogo type="buttons" category="Images" width="4" title="Logo" options="on|off" optionlabels="Yes|No">on</brandlogo>
-        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">themes/survey/vanilla/files/logo.png</brandlogofile>
+        <brandlogofile type="dropdown" category="Images" width="6" title="Logo file" parent="brandlogo">./files/logo.png</brandlogofile>
         <!-- fonts -->
         <font type="dropdown" category="Fonts" width="12" title="Fonts" parent="font">noto
             <dropdownoptions>


### PR DESCRIPTION
- Using DIRECTORY_SEPARATOR.
- Making logo paths on base theme config.xml file to be local, instead of relative to the LS root