### PR TITLE
Fixed issue #17991: Importing a question from the "List questions" menu fails with 400 error

### DIFF
--- a/application/controllers/admin/questions.php
+++ b/application/controllers/admin/questions.php
@@ -141,7 +141,7 @@ class questions extends Survey_Common_Action
     /**
      * Display import view
      */
-    public function importView($groupid , $surveyid)
+    public function importView($surveyid, $groupid = null)
     {
         $iSurveyID = (int) $surveyid;
         if (!Permission::model()->hasSurveyPermission($iSurveyID, 'surveycontent', 'import')) {

--- a/application/views/admin/survey/surveybar_addgroupquestion.php
+++ b/application/views/admin/survey/surveybar_addgroupquestion.php
@@ -54,7 +54,7 @@
                 <span class="icon-add"></span>
                 <?php eT("Add new question"); ?>
             </a>
-            <a class="btn btn-default" href='<?php echo $this->createUrl("admin/questions/sa/importview/surveyid/" . $oSurvey->sid . "/groupid"); ?>' role="button">
+            <a class="btn btn-default" href='<?php echo $this->createUrl("admin/questions/sa/importview", ['surveyid' => $oSurvey->sid]); ?>' role="button">
                 <span class="icon-import"></span>
                 <?php eT("Import a question"); ?>
             </a>

--- a/application/views/admin/survey/surveybar_addgroupquestion.php
+++ b/application/views/admin/survey/surveybar_addgroupquestion.php
@@ -54,7 +54,7 @@
                 <span class="icon-add"></span>
                 <?php eT("Add new question"); ?>
             </a>
-            <a class="btn btn-default" href='<?php echo $this->createUrl("admin/questions/sa/importview/surveyid/".$oSurvey->sid); ?>' role="button">
+            <a class="btn btn-default" href='<?php echo $this->createUrl("admin/questions/sa/importview/surveyid/" . $oSurvey->sid . "/groupid"); ?>' role="button">
                 <span class="icon-import"></span>
                 <?php eT("Import a question"); ?>
             </a>


### PR DESCRIPTION
This is just a workaround.

We still need to review if the change below (making the groupid mandatory) is still necesarry to review a more integral approach. https://github.com/LimeSurvey/LimeSurvey/commit/e877a504bcad71dbc0266d830acb0752f168f477#diff-8ba52d76c0ab5c25746214e40fd926cfdb0ae2024bd7bcdd90f1035014f5be12R141

If not necessary, the urls that point to the screen may need some reviewal in the order of the parameters and the ones being sent.