### PR TITLE
Fixed issue #18047: Conditional filters attachments for confirmation mail doesn't work

### DIFF
--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -715,7 +715,7 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
                     LimeExpressionManager::singleton()->loadTokenInformation($this->surveyId, $this->oToken->token);
                 }
                 foreach ($aAttachments[$attachementType] as $aAttachment) {
-                    if ($this->attachementExists($aAttachment)) {
+                    if ($this->attachementExists($aAttachment) && LimeExpressionManager::ProcessRelevance($aAttachment['relevance'])) {
                         $this->addAttachment($aAttachment['url']);
                     }
                 }

--- a/application/views/admin/emailtemplates/emailtemplates_view.php
+++ b/application/views/admin/emailtemplates/emailtemplates_view.php
@@ -92,11 +92,13 @@ var LS = LS || {};  // namespace
         <div class='modal-content'>
             <div class='modal-header'>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span>&times;</span></button>
-                <h4 class="modal-title"><?php eT("Condition");?></h4>
+                <label for='attachment-relevance-condition' class="h4 modal-title"><?php eT("Condition");?></label>
             </div>
             <div class='modal-body'>
-                <div class='form-group'>
-                    <textarea class='form-control'></textarea>
+                <div class='input-group'>
+                    <div class="input-group-addon">{</div>
+                    <textarea class='form-control' id='attachment-relevance-condition'></textarea>
+                    <div class="input-group-addon">}</div>
                 </div>
             </div>
             <div class='modal-footer'>


### PR DESCRIPTION
Dev: adding lost checking of relevance …
Dev: clearly view condition don't need {}