### PR TITLE
Fixed issue #18066: RPC method `upload_file` does not honor `$sFileName` argument in response

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -3131,8 +3131,7 @@ class remotecontrol_handle
         return array(
             "success"   => true,
             "size"      => $size,
-            //FIXME $filename not defined!!!
-            "name"      => rawurlencode(basename($filename)),
+            "name"      => rawurlencode(basename($sFileName)),
             "ext"       => $ext,
             "filename"  => $randfilename,
             "msg"       => gT("The file has been successfully uploaded.")


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue [#18066](https://bugs.limesurvey.org/view.php?id=18066): Method upload_file does not honor $FileName argument in response
