### PR TITLE
Fixed issue #18060: 'Save as default values' question setting not working properly

### DIFF
--- a/application/extensions/GeneralOptionWidget/settings/SaveAsDefaultGeneralOption.php
+++ b/application/extensions/GeneralOptionWidget/settings/SaveAsDefaultGeneralOption.php
@@ -19,7 +19,7 @@ class SaveAsDefaultGeneralOption extends GeneralOption
             'save_as_default',
             null,
             gT('All attribute values for this question type will be saved as default'),
-            $question->same_default == 1 ? 'Y' : 'N',
+            'N',
             [
                 'classes' => [],
                 'options' => [

--- a/application/models/services/QuestionAttributeFetcher.php
+++ b/application/models/services/QuestionAttributeFetcher.php
@@ -91,7 +91,11 @@ class QuestionAttributeFetcher
         $questionAttributeHelper = new QuestionAttributeHelper();
 
         // Get attribute values
-        $attributeValues = \QuestionAttribute::model()->getAttributesAsArrayFromDB($this->question->qid);
+        if (!empty($this->question->qid)) {
+            $attributeValues = \QuestionAttribute::model()->getAttributesAsArrayFromDB($this->question->qid);
+        } else {
+            $attributeValues = $questionAttributeHelper->getUserDefaultsForQuestionType($this->question->type);
+        }
 
         // Fill attributes with values
         $languages = is_null($language) ? $survey->allLanguages : [$language];

--- a/application/models/services/QuestionAttributeHelper.php
+++ b/application/models/services/QuestionAttributeHelper.php
@@ -277,4 +277,27 @@ class QuestionAttributeHelper
         uasort($attributesCopy, [$this, 'categorySort']);
         return $attributesCopy;
     }
+
+    /**
+     * Returns the user's default values for the specified question type
+     * @param string $questionType
+     * @return array<string,mixed>
+     */
+    public function getUserDefaultsForQuestionType($questionType)
+    {
+        $defaultValues = [];
+        $userDefaultQuestionAttributes = \SettingsUser::getUserSettingValue('question_default_values_' . $questionType);
+        if ($userDefaultQuestionAttributes !== null) {
+            $defaultValuesByCategory = json_decode($userDefaultQuestionAttributes, true);
+            foreach ($defaultValuesByCategory as $attributes) {
+                foreach ($attributes as $attribute => $value) {
+                    if (!is_array($value)) {
+                        $value = ['' => $value];
+                    }
+                    $defaultValues[$attribute] = $value;
+                }
+            }
+        }
+        return $defaultValues;
+    }
 }


### PR DESCRIPTION
1) The value of the front_end switch depended on use_defaults, which has nothing to do with it. Now it always appears disabled, as this a one way switch: You can only set it to true and then defaults will be snapshot and saved. There is no link in between the default values sanpshot and the current question attributes. Question attributes can later be changed, and the default wouldn't be impacted.

2) Defaults were saved but not used for populating new questions. Now they do.