### PR TITLE
Fixed issue #16907: Importing Question through Remote Control doesn't set new title for all languages

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1457,7 +1457,7 @@ class remotecontrol_handle
                     fixLanguageConsistency($iSurveyID);
                     $iNewqid = $aImportResults['newqid'];
 
-                    $oQuestion = Question::model()->findByAttributes(array('sid' => $iSurveyID, 'gid' => $iGroupID, 'qid' => $iNewqid));
+                    $oQuestion = Question::model()->findByAttributes(array('sid' => $iSurveyID, 'gid' => $iGroupID, 'qid' => $iNewqid, 'language' => $oSurvey->language));
                     if ($sNewQuestionTitle != null) {
                                             $oQuestion->setAttribute('title', $sNewQuestionTitle);
                     }
@@ -1482,6 +1482,17 @@ class remotecontrol_handle
                     } catch (Exception $e) {
                         // no need to throw exception
                     }
+
+                    // Set title for other languages
+                    $additionalLanguages = $oSurvey->getAdditionalLanguages();
+                    if ($sNewQuestionTitle != null && !empty($additionalLanguages)) {
+                        foreach ($additionalLanguages as $language) {
+                            $oQuestion = Question::model()->findByAttributes(array('sid' => $iSurveyID, 'gid' => $iGroupID, 'qid' => $iNewqid, 'language' => $language));
+                            $oQuestion->setAttribute('title', $sNewQuestionTitle);
+                            $oQuestion->save();
+                        }
+                    }
+
                     return (int) $aImportResults['newqid'];
                 }
             } else {


### PR DESCRIPTION
There are several problems with importing questions.

1) The new "title" is only set in the first language (it is the problem of the ticket).
2) The new question text is also set to the first language only.
3) The new "title" is set after importing. In other words, if you want to import a question, whose title already exists, but set it at the moment (through the API call), you can't, because before setting the new one, the process will fail because of the duplication.

This particular ticket is simple, because the title has to always be the same. The text of the question is more complicated because setting the same text in all languages does not make sense. This ticket is only limited to item 1.