### PR TITLE
Fixed issue #18029: Removed html tags in emails

### DIFF
--- a/application/views/admin/emailtemplates/email_language_template_tab.php
+++ b/application/views/admin/emailtemplates/email_language_template_tab.php
@@ -126,14 +126,3 @@ App()->getClientScript()->registerScript("ScriptEmailTemplateLanguageTemplate_<?
     {close: '".gT('Close')."', save: '".gT('Save')."'}, '".App()->getController()->createUrl('admin/emailtemplates/getTemplateOfType', array('type' => $tab, 'language' => $grouplang, 'survey' => $surveyid ))."');\n
     ".implode("\n", $script), LSYii_ClientScript::POS_POSTSCRIPT);
 ?>
-
-
-
-    <script >
-        $(document).ready(function(){
-            // Change fullPage configuration for each CKEDITOR instance loaded in this view.
-            $.each(CKEDITOR.instances, function(index, editor){
-                editor.config.fullPage = true;
-            });
-        })
-    </script>

--- a/application/views/admin/emailtemplates/email_language_template_tab.php
+++ b/application/views/admin/emailtemplates/email_language_template_tab.php
@@ -126,3 +126,14 @@ App()->getClientScript()->registerScript("ScriptEmailTemplateLanguageTemplate_<?
     {close: '".gT('Close')."', save: '".gT('Save')."'}, '".App()->getController()->createUrl('admin/emailtemplates/getTemplateOfType', array('type' => $tab, 'language' => $grouplang, 'survey' => $surveyid ))."');\n
     ".implode("\n", $script), LSYii_ClientScript::POS_POSTSCRIPT);
 ?>
+
+
+
+    <script >
+        $(document).ready(function(){
+            // Change fullPage configuration for each CKEDITOR instance loaded in this view.
+            $.each(CKEDITOR.instances, function(index, editor){
+                editor.config.fullPage = true;
+            });
+        })
+    </script>

--- a/application/views/admin/survey/prepareEditorScript_view.php
+++ b/application/views/admin/survey/prepareEditorScript_view.php
@@ -1,10 +1,10 @@
 <!--<script type="text/javascript" src="<?php echo Yii::app()->getConfig('sCKEditorURL'); ?>/ckeditor.js"></script>-->
-<?php 
+<?php
 $script = "
     CKEDITOR.on('dialogDefinition', function (ev) {
         var dialogName = ev.data.name;
         var dialogDefinition = ev.data.definition;
-
+        console.log(ev);
         // Remove upload tab from Link and Image dialog as it interferes with
         // CSRF protection and upload can be reached using the browse server tab
         if ( dialogName == 'link')
@@ -21,12 +21,12 @@ $script = "
     ";
 
 /**
-* @todo This following three JS lines are a hack to keep the most common usage of <br> in ExpressionScript from breaking the expression,
-* because the HTML editor will insert linebreaks after every <br>, even if it is inside a ExpressionScript tag {}
-* The proper way to fix this would be to merge a plugin like ShowProtected (https://github.com/IGx89/CKEditor-ShowProtected-Plugin) 
-* with LimeReplacementFields and in general use ProtectSource for ExpressionScript
-* See https://stackoverflow.com/questions/2851068/prevent-ckeditor-from-formatting-code-in-source-mode
-*/ 
+ * @todo This following three JS lines are a hack to keep the most common usage of <br> in ExpressionScript from breaking the expression,
+ * because the HTML editor will insert linebreaks after every <br>, even if it is inside a ExpressionScript tag {}
+ * The proper way to fix this would be to merge a plugin like ShowProtected (https://github.com/IGx89/CKEditor-ShowProtected-Plugin)
+ * with LimeReplacementFields and in general use ProtectSource for ExpressionScript
+ * See https://stackoverflow.com/questions/2851068/prevent-ckeditor-from-formatting-code-in-source-mode
+ */
 $script.="CKEDITOR.on('instanceReady', function(event) {
 
         // Change config. for editors with name like email_*
@@ -70,22 +70,38 @@ $script.="CKEDITOR.on('instanceReady', function(event) {
             document.getElementById(controlidena).style.display='none';
             document.getElementById(controliddis).style.display='';
             popup = window.open('".$this->createUrl('admin/htmleditor_pop/sa/index')."/name/'+fieldname+'/text/'+fieldtext+'/type/'+fieldtype+'/action/'+action+'/sid/'+sid+'/gid/'+gid+'/qid/'+qid+'/lang/".App()->language."','', 'location=no, status=yes, scrollbars=auto, menubar=no, resizable=yes, width=690, height=500');
-
+            
+            // Check if action is related to email templates.
+            if(action === 'editemailtemplates'){
+                // Add a listener to load event, change config once the popup has finish loaded.
+                popup.addEventListener('load', enableFullPageConfigForEditor, false);
+            }
+           
             editorwindowsHash[fieldname] = popup;
         }
         else
         {
             activepopup.focus();
-        }
+        }  
+
+    }
+    
+    // Used for the popup editor in email templates.
+    function enableFullPageConfigForEditor()
+    {
+        this.CKEDITOR.config.fullPage = true;
     }
 
     function updateCKeditor(fieldname,value)
     {
+    
         var mypopup= editorwindowsHash[fieldname];
+        
         if (mypopup)
         {
             var oMyEditor = mypopup.CKEDITOR.instances['MyTextarea'];
             if (oMyEditor) {oMyEditor.setData(value);}
+            
             mypopup.focus();
         }
         else
@@ -94,7 +110,6 @@ $script.="CKEDITOR.on('instanceReady', function(event) {
             oMyEditor.setData(value);
         }
     }
-
 ";
 
 Yii::app()->getClientScript()->registerScript('ckEditorPreparingSettings', $script, LSYii_ClientScript::POS_BEGIN);

--- a/application/views/admin/survey/prepareEditorScript_view.php
+++ b/application/views/admin/survey/prepareEditorScript_view.php
@@ -28,6 +28,14 @@ $script = "
 * See https://stackoverflow.com/questions/2851068/prevent-ckeditor-from-formatting-code-in-source-mode
 */ 
 $script.="CKEDITOR.on('instanceReady', function(event) {
+
+        // Change config. for editors with name like email_*
+        // Those editors are initialized for email templates.
+        // It doesn't have effects on popup Editors.
+        if(event.editor.name.startsWith('email_')){
+            event.editor.config.fullPage = true;
+        }
+        
         event.editor.dataProcessor.writer.setRules( 'br', { breakAfterOpen: 0 } );
     });    
 


### PR DESCRIPTION

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #18029: Removed html tags in emails
Dev: Add js script to change configuration of loaded instances of CKEDITOR in the email templates view to prevent losing html tags when switching from wysiwyg to source mode. The fullpage config: "With these settings in place, CKEditor 4 will output the entire HTML page, including the elements outside the <body> section."
