### PR TITLE
Fixed issue #18085: Renamed custom theme not updated in global survey settings

### DIFF
--- a/application/models/Template.php
+++ b/application/models/Template.php
@@ -656,6 +656,7 @@ class Template extends LSActiveRecord
         Yii::import('application.helpers.sanitize_helper', true);
         $this->deleteAssetVersion();
         Survey::model()->updateAll(array('template' => $sNewName), "template = :oldname", array(':oldname' => $this->name));
+        SurveysGroupsettings::model()->updateAll(['template' => $sNewName], "template = :oldname", [':oldname' => $this->name]);
         Template::model()->updateAll(array('name' => $sNewName, 'folder' => $sNewName), "name = :oldname", array(':oldname' => $this->name));
         Template::model()->updateAll(array('extends' => $sNewName), "extends = :oldname", array(':oldname' => $this->name));
         TemplateConfiguration::rename($this->name, $sNewName);


### PR DESCRIPTION
When renaming a theme, the surveys are updated, and the defaults (the default at the global settings level). 
But the groups are not updated (neither the normal ones nor the 0, which is the one in the global survey settings). That is fixed here.