### PR TITLE
Fixed issue #17837: Directly show edit mode: some quirks

### DIFF
--- a/application/controllers/QuestionGroupsAdministrationController.php
+++ b/application/controllers/QuestionGroupsAdministrationController.php
@@ -585,7 +585,8 @@ class QuestionGroupsAdministrationController extends LSBaseController
 
         LimeExpressionManager::UpgradeConditionsToRelevance($iSurveyId);
         $survey = Survey::model()->findByPk($iSurveyId);
-        if (!empty($survey->groups)) {
+        $landOnSideMenuTab = Yii::app()->request->getPost('landOnSideMenuTab');
+        if ($landOnSideMenuTab == 'structure' && !empty($survey->groups)) {
             $this->redirect(
                 Yii::app()->createUrl(
                     'questionGroupsAdministration/view/',

--- a/application/extensions/TopbarWidget/views/includes/groupToolsDropdownItems.php
+++ b/application/extensions/TopbarWidget/views/includes/groupToolsDropdownItems.php
@@ -27,7 +27,17 @@
                 <a href="#" onclick="return false;"
                     data-toggle="modal"
                     data-target="#confirmation-modal"
-                    data-onclick='(function() { <?php echo convertGETtoPOST(Yii::app()->createUrl("questionGroupsAdministration/delete/", ["asJson" => true, "surveyid" => $surveyid, "gid"=>$gid])); ?> })'
+                    data-onclick='(function() { <?php echo convertGETtoPOST(
+                        Yii::app()->createUrl(
+                            "questionGroupsAdministration/delete/",
+                            [
+                                "asJson" => true,
+                                "surveyid" => $surveyid,
+                                "gid" => $gid,
+                                "landOnSideMenuTab" => 'structure'
+                            ]
+                        )
+                    ); ?> })'
                     data-message="<?php eT("Deleting this group will also delete any questions and answers it contains. Are you sure you want to continue?","js"); ?>"
                 >
                     <span class="fa fa-trash text-danger"></span>


### PR DESCRIPTION
Fixing the following: When you delete a group using the groups list, after deleting the specific group, you end up in the edit mode of a group, while I hope to end up in the group list.