### PR TITLE
Fixed issue #18146: Unable to use "other" as subquestion code

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -1976,13 +1976,8 @@ class QuestionAdministrationController extends LSBaseController
         foreach ($aQids as $sQid) {
             $iQid = (int)$sQid;
             $oQuestion = Question::model()->findByPk(["qid" => $iQid], 'sid=:sid', [':sid' => $iSid]);
-            // Only set the other state for question types that have this attribute
-            if (
-                ($oQuestion->type == Question::QT_L_LIST)
-                || ($oQuestion->type == Question::QT_EXCLAMATION_LIST_DROPDOWN)
-                || ($oQuestion->type == Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS)
-                || ($oQuestion->type == Question::QT_M_MULTIPLE_CHOICE)
-            ) {
+            // Only set the other state for question types that have this attribute (and no parent_qid)
+            if ($oQuestion->getAllowOther()) {
                 $oQuestion->other = $sOther;
                 $oQuestion->save();
             }

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -1512,10 +1512,11 @@ class Question extends LSActiveRecord
 
     /**
      * Remove subquestion if needed when update question type
+     * @return void
      */
     protected function removeInvalidSubquestions()
     {
-        if (!$this->getAllowSubquestions()) {
+        if ($this->getAllowSubquestions()) {
             return;
         }
 

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -853,12 +853,7 @@ class Question extends LSActiveRecord
     {
         return (
             !$this->parent_qid
-            && (
-                $this->type == self::QT_L_LIST
-                || $this->type == self::QT_EXCLAMATION_LIST_DROPDOWN
-                || $this->type == self::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
-                || $this->type == self::QT_M_MULTIPLE_CHOICE
-            )
+            && $this->getQuestionType()->other
         );
     }
 
@@ -871,21 +866,7 @@ class Question extends LSActiveRecord
     {
         return (
             !$this->parent_qid
-            && (
-                $this->type == self::QT_1_ARRAY_DUAL
-                || $this->type == self::QT_A_ARRAY_5_POINT
-                || $this->type == self::QT_B_ARRAY_10_CHOICE_QUESTIONS
-                || $this->type == self::QT_C_ARRAY_YES_UNCERTAIN_NO
-                || $this->type == self::QT_E_ARRAY_INC_SAME_DEC
-                || $this->type == self::QT_F_ARRAY
-                || $this->type == self::QT_H_ARRAY_COLUMN
-                || $this->type == self::QT_K_MULTIPLE_NUMERICAL
-                || $this->type == self::QT_M_MULTIPLE_CHOICE
-                || $this->type == self::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
-                || $this->type == self::QT_Q_MULTIPLE_SHORT_TEXT
-                || $this->type == self::QT_COLON_ARRAY_NUMBERS
-                || $this->type == self::QT_SEMICOLON_ARRAY_TEXT
-            )
+            && $this->getQuestionType()->subquestions
         );
     }
 

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -182,7 +182,7 @@ class Question extends LSActiveRecord
                 $aRules[] = array('title', 'match', 'pattern' => '/comment$/', 'not' => true, 'message' => gT("'comment' suffix can not be used with multiple choice with comments."));
             }
         } else {
-            if($this->getAsSubquestions()) {
+            if ($this->getAsSubquestions()) {
                 // Disallow other if sub question have 'other' for title
                 $oSubquestionOther = Question::model()->find("parent_qid=:parent_qid and LOWER(title)='other'", array("parent_qid" => $this->qid));
                 if ($oSubquestionOther) {

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -854,10 +854,10 @@ class Question extends LSActiveRecord
         return (
             !$this->parent_qid
             && (
-                $this->type == Question::QT_L_LIST
-                || $this->type == Question::QT_EXCLAMATION_LIST_DROPDOWN
-                || $this->type == Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
-                || $this->type == Question::QT_M_MULTIPLE_CHOICE
+                $this->type == self::QT_L_LIST
+                || $this->type == self::QT_EXCLAMATION_LIST_DROPDOWN
+                || $this->type == self::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
+                || $this->type == self::QT_M_MULTIPLE_CHOICE
             )
         );
     }
@@ -872,19 +872,19 @@ class Question extends LSActiveRecord
         return (
             !$this->parent_qid
             && (
-                $this->type == QT_1_ARRAY_DUAL
-                || $this->type == QT_A_ARRAY_5_POINT
-                || $this->type == QT_B_ARRAY_10_CHOICE_QUESTIONS
-                || $this->type == QT_C_ARRAY_YES_UNCERTAIN_NO
-                || $this->type == QT_E_ARRAY_INC_SAME_DEC
-                || $this->type == QT_F_ARRAY
-                || $this->type == QT_H_ARRAY_COLUMN
-                || $this->type == QT_K_MULTIPLE_NUMERICAL
-                || $this->type == QT_M_MULTIPLE_CHOICE
-                || $this->type == QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
-                || $this->type == QT_Q_MULTIPLE_SHORT_TEXT
-                || $this->type == QT_COLON_ARRAY_NUMBERS
-                || $this->type == QT_SEMICOLON_ARRAY_TEXT
+                $this->type == self::QT_1_ARRAY_DUAL
+                || $this->type == self::QT_A_ARRAY_5_POINT
+                || $this->type == self::QT_B_ARRAY_10_CHOICE_QUESTIONS
+                || $this->type == self::QT_C_ARRAY_YES_UNCERTAIN_NO
+                || $this->type == self::QT_E_ARRAY_INC_SAME_DEC
+                || $this->type == self::QT_F_ARRAY
+                || $this->type == self::QT_H_ARRAY_COLUMN
+                || $this->type == self::QT_K_MULTIPLE_NUMERICAL
+                || $this->type == self::QT_M_MULTIPLE_CHOICE
+                || $this->type == self::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS
+                || $this->type == self::QT_Q_MULTIPLE_SHORT_TEXT
+                || $this->type == self::QT_COLON_ARRAY_NUMBERS
+                || $this->type == self::QT_SEMICOLON_ARRAY_TEXT
             )
         );
     }

--- a/application/models/QuestionTheme.php
+++ b/application/models/QuestionTheme.php
@@ -415,6 +415,7 @@ class QuestionTheme extends LSActiveRecord
         // set settings as json
         $questionMetaData['settings'] = json_encode([
             'subquestions'     => $questionMetaData['subquestions'] ?? 0,
+            'other'            => $questionMetaData['other'] ?? false,
             'answerscales'     => $questionMetaData['answerscales'] ?? 0,
             'hasdefaultvalues' => $questionMetaData['hasdefaultvalues'] ?? 0,
             'assessable'       => $questionMetaData['assessable'] ?? 0,

--- a/application/models/QuestionType.php
+++ b/application/models/QuestionType.php
@@ -77,6 +77,9 @@ class QuestionType extends StaticModel
     /** @var integer $subquestions whether has subquestions //TODO make it boolean instead */
     public $subquestions;
 
+    /** @var boolean $other allow other (and add subquetsion title other if Y)*/
+    public $other = false;
+
     /** @var integer $assessable whether it can be used inside Assessments / Quizmode */
     public $assessable;
 
@@ -96,8 +99,17 @@ class QuestionType extends StaticModel
      */
     public function attributeNames()
     {
-        return ['code', 'description', 'group', 'subquestions', 'assessable',
-            'hasdefaultvalues', 'answerscales', 'class'];
+        return [
+            'code',
+            'description',
+            'group',
+            'subquestions',
+            'other',
+            'assessable',
+            'hasdefaultvalues',
+            'answerscales',
+            'class'
+        ];
     }
 
     /**
@@ -124,9 +136,9 @@ class QuestionType extends StaticModel
     /**
      * @param string $language
      * @return array
+     * Still used in QuestionAdministrationController
      *
-     * @deprecated use the new xml-version implemented in function findQuestionMetaData($type) in QuestionTheme
-     *
+     * TODO choose between self::modelsAttributes and QuestionTheme::findQuestionMetaData or QuestionTheme::getAllQuestionMetaData
      * TODO QuestionTheme 1591616914305: Needs to be replaced by @link QuestionTheme::getAllQuestionMetaData() however translations inside the xml need to be inserted first
      */
 
@@ -138,6 +150,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array dual scale", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'assessable' => 1,
                 'hasdefaultvalues' => 0,
                 'answerscales' => 2,
@@ -148,6 +161,7 @@ class QuestionType extends StaticModel
                 'description' => gT("5 point choice", "html", $language),
                 'group' => gT("Single choice questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -158,6 +172,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (5 point choice)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -168,6 +183,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (10 point choice)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -178,6 +194,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (Yes/No/Uncertain)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -188,6 +205,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Date/Time", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -198,6 +216,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (Increase/Same/Decrease)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -208,6 +227,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 1,
@@ -218,6 +238,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Gender", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -229,6 +250,7 @@ class QuestionType extends StaticModel
                 'group' => gT('Arrays'),
                 'hasdefaultvalues' => 0,
                 'subquestions' => 1,
+                'other' => false,
                 'assessable' => 1,
                 'answerscales' => 1,
                 'class' => 'array-flexible-column'
@@ -239,6 +261,7 @@ class QuestionType extends StaticModel
                 'group' => gT("Mask questions"),
                 'hasdefaultvalues' => 0,
                 'subquestions' => 0,
+                'other' => false,
                 'assessable' => 0,
                 'answerscales' => 0,
                 'class' => 'language'
@@ -249,6 +272,7 @@ class QuestionType extends StaticModel
                 'group' => gT("Mask questions"),
                 'hasdefaultvalues' => 1,
                 'subquestions' => 1,
+                'other' => false,
                 'assessable' => 1,
                 'answerscales' => 0,
                 'class' => 'numeric-multi'
@@ -258,6 +282,7 @@ class QuestionType extends StaticModel
                 'description' => gT("List (Radio)", "html", $language),
                 'group' => gT("Single choice questions"),
                 'subquestions' => 0,
+                'other' => true,
                 'hasdefaultvalues' => 1,
                 'assessable' => 1,
                 'answerscales' => 1,
@@ -268,6 +293,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Multiple choice", "html", $language),
                 'group' => gT("Multiple choice questions"),
                 'subquestions' => 1,
+                'other' => true,
                 'hasdefaultvalues' => 1,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -278,6 +304,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Numerical input", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -288,6 +315,7 @@ class QuestionType extends StaticModel
                 'description' => gT("List with comment", "html", $language),
                 'group' => gT("Single choice questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 1,
                 'answerscales' => 1,
@@ -298,6 +326,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Multiple choice with comments", "html", $language),
                 'group' => gT("Multiple choice questions"),
                 'subquestions' => 1,
+                'other' => true,
                 'hasdefaultvalues' => 1,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -308,6 +337,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Multiple short text", "html", $language),
                 'group' => gT("Text questions"),
                 'subquestions' => 1,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -318,6 +348,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Ranking", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 1,
@@ -328,6 +359,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Short free text", "html", $language),
                 'group' => gT("Text questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -338,6 +370,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Long free text", "html", $language),
                 'group' => gT("Text questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -348,6 +381,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Huge free text", "html", $language),
                 'group' => gT("Text questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -358,6 +392,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Text display", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -368,6 +403,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Yes/No", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 1,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -378,6 +414,7 @@ class QuestionType extends StaticModel
                 'description' => gT("List (Dropdown)", "html", $language),
                 'group' => gT("Single choice questions"),
                 'subquestions' => 0,
+                'other' => true,
                 'hasdefaultvalues' => 1,
                 'assessable' => 1,
                 'answerscales' => 1,
@@ -388,6 +425,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (Numbers)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 2,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 1,
                 'answerscales' => 0,
@@ -398,6 +436,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Array (Texts)", "html", $language),
                 'group' => gT('Arrays'),
                 'subquestions' => 2,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -408,6 +447,7 @@ class QuestionType extends StaticModel
                 'description' => gT("File upload", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,
@@ -418,6 +458,7 @@ class QuestionType extends StaticModel
                 'description' => gT("Equation", "html", $language),
                 'group' => gT("Mask questions"),
                 'subquestions' => 0,
+                'other' => false,
                 'hasdefaultvalues' => 0,
                 'assessable' => 0,
                 'answerscales' => 0,

--- a/application/views/survey/questions/answer/list_dropdown/config.xml
+++ b/application/views/survey/questions/answer/list_dropdown/config.xml
@@ -18,6 +18,7 @@
         <questionType>!</questionType>
         <group>Single choice questions</group>
         <subquestions>0</subquestions>
+        <other>1</other>
         <answerscales>1</answerscales>
         <hasdefaultvalues>1</hasdefaultvalues>
         <assessable>1</assessable>

--- a/application/views/survey/questions/answer/listradio/config.xml
+++ b/application/views/survey/questions/answer/listradio/config.xml
@@ -18,6 +18,7 @@
         <questionType>L</questionType>
         <group>Single choice questions</group>
         <subquestions>0</subquestions>
+        <other>1</other>
         <answerscales>1</answerscales>
         <hasdefaultvalues>1</hasdefaultvalues>
         <assessable>1</assessable>

--- a/application/views/survey/questions/answer/multiplechoice/config.xml
+++ b/application/views/survey/questions/answer/multiplechoice/config.xml
@@ -18,6 +18,7 @@
         <questionType>M</questionType>
         <group>Multiple choice questions</group>
         <subquestions>1</subquestions>
+        <other>1</other>
         <answerscales>0</answerscales>
         <hasdefaultvalues>1</hasdefaultvalues>
         <assessable>1</assessable>

--- a/application/views/survey/questions/answer/multiplechoice_with_comments/config.xml
+++ b/application/views/survey/questions/answer/multiplechoice_with_comments/config.xml
@@ -18,6 +18,7 @@
         <questionType>P</questionType>
         <group>Multiple choice questions</group>
         <subquestions>1</subquestions>
+        <other>1</other>
         <answerscales>0</answerscales>
         <hasdefaultvalues>1</hasdefaultvalues>
         <assessable>1</assessable>


### PR DESCRIPTION
Dev: reset other to N when save by rules
Dev: in 3.X : done in database, getPost is empty when not submitted
Dev: inverse must be done too when try to update to single choice with other