### PR TITLE
Fixed issue: #18029 - Removed html tags in emails for v5

### DIFF
--- a/application/views/admin/survey/prepareEditorScript_view.php
+++ b/application/views/admin/survey/prepareEditorScript_view.php
@@ -30,6 +30,14 @@ $script = "
 $script.="CKEDITOR.on('instanceReady', function(event) {
         var textareaId = event.editor.element.getId();
         $('#'+textareaId+'_htmleditor_loader').remove();
+        
+        // Change config. for editors with name like email_*
+        // Those editors are initialized for email templates.
+        // It doesn't have effects on popup Editors.
+        if(event.editor.name.startsWith('email_')){
+            event.editor.config.fullPage = true;
+        }
+        
         event.editor.dataProcessor.writer.setRules( 'br', { breakAfterOpen: 0 } );
     });    
 
@@ -75,7 +83,13 @@ $script.="CKEDITOR.on('instanceReady', function(event) {
             }
 
             popup = window.open(editorurl,'', 'location=no, status=yes, scrollbars=auto, menubar=no, resizable=yes, width=690, height=500');
-
+            
+            // Check if action is related to email templates.
+            if(action === 'editemailtemplates'){
+                // Add a listener to load event, change config once the popup has finish loaded.
+                popup.addEventListener('load', enableFullPageConfigForEditor, false);
+            }
+            
             editorwindowsHash[fieldname] = popup;
         }
         else
@@ -84,6 +98,12 @@ $script.="CKEDITOR.on('instanceReady', function(event) {
         }
     }
 
+    // Used for the popup editor in email templates.
+    function enableFullPageConfigForEditor()
+    {
+        this.CKEDITOR.config.fullPage = true;
+    }
+    
     function updateCKeditor(fieldname,value)
     {
         var mypopup= editorwindowsHash[fieldname];


### PR DESCRIPTION
Fixed issue #18029:
Dev:  Add js script to change configuration of loaded instances of CKEDITOR in the email templates view to prevent losing html tags when switching from wysiwyg to source mode. The fullpage config: "With these settings in place, CKEditor 4 will output the entire HTML page, including the elements outside the section.". This patch was previously merged in 3.x LTS, this PR is for v5.