### PR TITLE
Fixed issue #17700: Custom logo disappears in extended themes

### DIFF
--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -414,7 +414,7 @@ class TemplateConfiguration extends TemplateConfig
             $oTemplateConfigurationModel = TemplateConfiguration::getInstanceFromSurveyGroup(
                 $iSurveyGroupId,
                 $sTemplateName,
-                $abstractInstance
+                true
             );
         }
 
@@ -422,7 +422,7 @@ class TemplateConfiguration extends TemplateConfig
             $oTemplateConfigurationModel = TemplateConfiguration::getInstanceFromSurveyId(
                 $iSurveyId,
                 $sTemplateName,
-                $abstractInstance
+                true
             );
         }
 

--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -205,9 +205,11 @@ var ThemeOptions = function () {
                 console.error('No valid monochrom theme field!');
             }
 
-            $('#simple_edit_add_css').val(currentThemeObject.add.filter(function (item, i) {
-                return /^css\/variations\/.*$/.test(item);
-            }));
+            if (currentThemeObject.add) {
+                $('#simple_edit_add_css').val(currentThemeObject.add.filter(function (item, i) {
+                    return /^css\/variations\/.*$/.test(item);
+                }));
+            }
         }
 
     };


### PR DESCRIPTION
Fixing:
- Settings at global level are not sticking (not saving).
- Need to enter multiple times to theme options or to a survey (participant mode) to have settings being picked up correctly.