### PR TITLE
Fixed issue #18203: Return arrays instead of strings from `update_response`

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -2919,36 +2919,36 @@ class remotecontrol_handle
      * @param string $sSessionKey Auth credentials
      * @param int $iSurveyID Id of the Survey to update response
      * @param array $aResponseData The actual response
-     * @return string|boolean TRUE(bool) on success. errormessage on error
+     * @return array|boolean TRUE(bool) on success. Array with error status on failure.
      */
     public function update_response($sSessionKey, $iSurveyID, $aResponseData)
     {
         if (!$this->_checkSessionKey($sSessionKey)) {
-            return self::INVALID_SESSION_KEY;
+            return array('status' => self::INVALID_SESSION_KEY);
         }
         $iSurveyID = (int) $iSurveyID;
         $oSurvey = Survey::model()->findByPk($iSurveyID);
         if (is_null($oSurvey)) {
-            return 'Error: Invalid survey ID';
+            return array('status' => 'Invalid survey ID');
         }
         if (!$oSurvey->isActive) {
-            return 'Error: Survey is not active.';
+            return array('status' => 'Survey is not active');
         }
 
         if (!$oSurvey->isAllowEditAfterCompletion) {
-            return 'Error: Survey does not allow edit after completion.';
+            return array('status' => 'Survey does not allow edit after completion');
         }
 
         if (Permission::model()->hasSurveyPermission($iSurveyID, 'responses', 'update')) {
             if (!Yii::app()->db->schema->getTable($oSurvey->responsesTableName)) {
-                            return 'Error: No survey response table';
+                return array('status' => 'No survey response table');
             }
 
             if (
                 !isset($aResponseData['id'])
                 && !isset($aResponseData['token'])
             ) {
-                return 'Error: Missing response identifier (id|token).';
+                return array('status' => 'Missing response identifier (id|token)');
             }
 
             SurveyDynamic::sid($iSurveyID);
@@ -2961,16 +2961,16 @@ class remotecontrol_handle
             }
 
             if (empty($aResponses)) {
-                            return 'Error: No matching Response.';
+                return array('status' => 'No matching Response');
             }
             if (count($aResponses) > 1) {
-                            return 'Error: More then one matching response, updateing multiple responses at once is not supported.';
+                return array('status' => 'More then one matching response, updateing multiple responses at once is not supported');
             }
 
             $aBasicDestinationFields = $oSurveyDynamic->tableSchema->columnNames;
             $aInvalidFields = array_diff_key($aResponseData, array_flip($aBasicDestinationFields));
             if (count($aInvalidFields) > 0) {
-                            return 'Error: Invalid Column names supplied: ' . implode(', ', array_keys($aInvalidFields));
+                return array('status' => 'Invalid Column names supplied: ' . implode(', ', array_keys($aInvalidFields)));
             }
 
             unset($aResponseData['token']);
@@ -2984,10 +2984,10 @@ class remotecontrol_handle
             if ($bResult) {
                 return $bResult;
             } else {
-                return 'Unable to edit response';
+                return array('status' => 'Unable to edit response');
             }
         } else {
-            return 'No permission';
+            return array('status' => 'No permission');
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #18203: https://bugs.limesurvey.org/view.php?id=18203
