### PR TITLE
Fixed issue #18183: Date filter at statistics is not applied correctly

### DIFF
--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -318,6 +318,7 @@ function buildSelects($allfields, $surveyid, $language)
     $selects = array();
     $aQuestionMap = array();
     $survey = Survey::model()->findByPk($surveyid);
+    $formatdata = getDateFormatData(Yii::app()->session['dateformat']);
 
     $fieldmap = createFieldMap($survey, "full", false, false, $language);
     foreach ($fieldmap as $field) {
@@ -463,7 +464,10 @@ function buildSelects($allfields, $surveyid, $language)
                 elseif ($firstletter == "D" && $_POST[$pv] != "") {
                     //Date equals
                     if (substr($pv, -2) == "eq") {
-                        $selects[] = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 3))." = ".App()->db->quoteValue($_POST[$pv]);
+                        $datetimeobj = new Date_Time_Converter($_POST[$pv], $formatdata['phpdate'] . ' H:i');
+                        $dateValue = $datetimeobj->convert("Y-m-d");
+                        $columnName = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 3));
+                        $selects[] = $columnName . " >= " . Yii::app()->db->quoteValue($dateValue . " 00:00:00") . " and " . $columnName . " <= " . Yii::app()->db->quoteValue($dateValue . " 23:59:59");
                     } else {
                         //date less than
                         if (substr($pv, -4) == "less") {
@@ -480,7 +484,6 @@ function buildSelects($allfields, $surveyid, $language)
                 //check for datestamp of given answer
                 elseif (substr($pv, 0, 9) == "datestamp") {
                     //timestamp equals
-                    $formatdata = getDateFormatData(Yii::app()->session['dateformat']);
                     if (substr($pv, -1, 1) == "E" && !empty($_POST[$pv])) {
                         $datetimeobj = new Date_Time_Converter($_POST[$pv], $formatdata['phpdate'].' H:i');
                         $sDateValue = $datetimeobj->convert("Y-m-d");

--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -462,21 +462,23 @@ function buildSelects($allfields, $surveyid, $language)
 
                 //D - Date
                 elseif ($firstletter == "D" && $_POST[$pv] != "") {
+                    $datetimeobj = new Date_Time_Converter($_POST[$pv], $formatdata['phpdate'] . ' H:i');
                     //Date equals
                     if (substr($pv, -2) == "eq") {
-                        $datetimeobj = new Date_Time_Converter($_POST[$pv], $formatdata['phpdate'] . ' H:i');
                         $dateValue = $datetimeobj->convert("Y-m-d");
                         $columnName = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 3));
                         $selects[] = $columnName . " >= " . Yii::app()->db->quoteValue($dateValue . " 00:00:00") . " and " . $columnName . " <= " . Yii::app()->db->quoteValue($dateValue . " 23:59:59");
                     } else {
+                        $dateValue = $datetimeobj->convert("Y-m-d H:i");
+
                         //date less than
                         if (substr($pv, -4) == "less") {
-                            $selects[] = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 5))." >= ".App()->db->quoteValue($_POST[$pv]);
+                            $selects[] = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 5))." >= ".App()->db->quoteValue($dateValue);
                         }
 
                         //date greater than
                         if (substr($pv, -4) == "more") {
-                            $selects[] = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 5))." <= ".App()->db->quoteValue($_POST[$pv]);
+                            $selects[] = Yii::app()->db->quoteColumnName(substr($pv, 1, strlen($pv) - 5))." <= ".App()->db->quoteValue($dateValue);
                         }
                     }
                 }

--- a/application/views/admin/export/statistics_subviews/_question.php
+++ b/application/views/admin/export/statistics_subviews/_question.php
@@ -277,7 +277,7 @@
                     'id' => $myfield3,
                     'value' => isset($_POST[$myfield3]) ? $_POST[$myfield3] : '',
                     'pluginOptions' => array(
-                        'format' => $dateformatdetails['jsdate'] . " HH:mm",
+                        'format' => $dateformatdetails['jsdate'],
                         'allowInputToggle' =>true,
                         'showClear' => true,
                         'tooltips' => array(


### PR DESCRIPTION
Making the equal filter to use a date picker (just date).
Later on the PHP side, we query by columnanme in between the start and midnight of the filter date.