### PR TITLE
Fixed issue #18246: The setting in the theme variation field (global level) is not shown

### DIFF
--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -1593,12 +1593,18 @@ class TemplateConfiguration extends TemplateConfig
      */
     public function sanitizeImagePathsOnJson($attribute, $params)
     {
+        $excludedOptions = [
+            'cssframework'
+        ];
         // Validates all options of the theme. Not only classic ones which are expected to hold a path,
         // as other options may hold a path as well (eg. custom theme options)
         $decodedOptions = json_decode($this->$attribute, true);
         if (is_array($decodedOptions)) {
             Yii::import('application.helpers.SurveyThemeHelper');
-            foreach ($decodedOptions as &$value) {
+            foreach ($decodedOptions as $option => &$value) {
+                if (in_array($option, $excludedOptions)) {
+                    continue;
+                }
                 $value = SurveyThemeHelper::sanitizePathInOption($value, $this->template_name, $this->sid);
             }
             $this->$attribute = json_encode($decodedOptions);


### PR DESCRIPTION
The dropdown value was blank because the selected value had a prefix and the options did not.
Removes the prefix to the saved value.

cssframework (variation) shouldn't be prefixed as logos do, for example.
They are always relative to the theme.