### PR TITLE
Fixed model relations referring to in-existing objects, add unit test…

### DIFF
--- a/application/models/QuestionGroupL10n.php
+++ b/application/models/QuestionGroupL10n.php
@@ -50,7 +50,7 @@ class QuestionGroupL10n extends LSActiveRecord
     {
         $alias = $this->getTableAlias();
         return array(
-            'group' => array(self::BELONGS_TO, 'group', '', 'on' => "$alias.gid = group.gid"),
+            'group' => array(self::BELONGS_TO, QuestionGroup::class, '', 'on' => "$alias.gid = group.gid"),
         );
     }
 

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -443,7 +443,7 @@ class Survey extends LSActiveRecord implements PermissionInterface
             'quotas' => array(self::HAS_MANY, 'Quota', 'sid', 'order' => 'name ASC'),
             'surveymenus' => array(self::HAS_MANY, 'Surveymenu', array('survey_id' => 'sid')),
             'surveygroup' => array(self::BELONGS_TO, 'SurveysGroups', array('gsid' => 'gsid')),
-            'surveysettings' => array(self::BELONGS_TO, 'SurveysGroupSettings', array('gsid' => 'gsid')),
+            'surveysettings' => array(self::BELONGS_TO, SurveysGroupsettings::class, array('gsid' => 'gsid')),
             'templateModel' => array(self::HAS_ONE, 'Template', array('name' => 'template')),
             'templateConfiguration' => array(self::HAS_ONE, 'TemplateConfiguration', array('sid' => 'sid'))
         );

--- a/application/models/SurveyLink.php
+++ b/application/models/SurveyLink.php
@@ -64,7 +64,7 @@ class SurveyLink extends LSActiveRecord
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
         return array(
-            'participant' => array(self::HAS_ONE, 'Particiant', 'participant_id'),
+            'participant' => array(self::HAS_ONE, Participant::class, 'participant_id'),
             'survey' => array(self::HAS_ONE, 'Survey', array('sid' => 'survey_id'))
         );
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -231,6 +231,7 @@ require_once __DIR__ . '/TestBaseClassWeb.php';
 require_once __DIR__ . '/TestBaseClassView.php';
 require_once __DIR__ . '/DummyController.php';
 require_once __DIR__ . '/unit/helpers/remotecontrol/BaseTest.php';
+require_once __DIR__ . '/unit/models/BaseModelTestCase.php';
 
 define('PHP_ENV', 'test');
 // TODO: Move this logic to installater test.

--- a/tests/unit/models/AnswerL10nTest.php
+++ b/tests/unit/models/AnswerL10nTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class AnswerL10nTest extends BaseModelTestCase
+{
+    protected $modelClassName = \AnswerL10n::class;
+}

--- a/tests/unit/models/AnswerTest.php
+++ b/tests/unit/models/AnswerTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class AnswerTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Answer::class;
+}

--- a/tests/unit/models/BaseModelTestCase.php
+++ b/tests/unit/models/BaseModelTestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace ls\tests;
+
+
+use LimeSurvey\Datavalueobjects\SimpleSurveyValues;
+use LimeSurvey\Models\Services\CreateSurvey;
+use PHPUnit\Framework\TestCase;
+
+
+
+class BaseModelTestCase extends TestCase
+{
+    /** @var string $modelClassName */
+    protected $modelClassName;
+
+    public function testRelationsUseExistingClasses()
+    {
+        /** @var \CActiveRecord $model */
+        $model = new $this->modelClassName();
+        $relations = $model->relations();
+        if (empty($relations)) {
+            // make a dummy test not to be marked as "risky"
+            $this->assertTrue(true);
+            return;
+        }
+        foreach ($relations as $relation) {
+            $this->assertTrue(class_exists($relation[1]), "Relation class {$relation[1]} does not exist");
+        }
+    }
+
+}

--- a/tests/unit/models/ConditionTest.php
+++ b/tests/unit/models/ConditionTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class ConditionTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Condition::class;
+}

--- a/tests/unit/models/DefaultValueTest.php
+++ b/tests/unit/models/DefaultValueTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class DefaultValueTest extends BaseModelTestCase
+{
+    protected $modelClassName = \DefaultValue::class;
+}

--- a/tests/unit/models/Label10nTest.php
+++ b/tests/unit/models/Label10nTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class Label10nTest extends BaseModelTestCase
+{
+    protected $modelClassName = \LabelL10n::class;
+}

--- a/tests/unit/models/LabelSetTest.php
+++ b/tests/unit/models/LabelSetTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class LabelSetTest extends BaseModelTestCase
+{
+    protected $modelClassName = \LabelSet::class;
+}

--- a/tests/unit/models/LabelTest.php
+++ b/tests/unit/models/LabelTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class LabelTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Label::class;
+}

--- a/tests/unit/models/ParticipantAttributeNameTest.php
+++ b/tests/unit/models/ParticipantAttributeNameTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class ParticipantAttributeNameTest extends BaseModelTestCase
+{
+    protected $modelClassName = \ParticipantAttributeName::class;
+}

--- a/tests/unit/models/ParticipantAttributeTest.php
+++ b/tests/unit/models/ParticipantAttributeTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class ParticipantAttributeTest extends BaseModelTestCase
+{
+    protected $modelClassName = \ParticipantAttribute::class;
+}

--- a/tests/unit/models/ParticipantTest.php
+++ b/tests/unit/models/ParticipantTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class ParticipantTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Participant::class;
+}

--- a/tests/unit/models/PermissionTest.php
+++ b/tests/unit/models/PermissionTest.php
@@ -6,8 +6,10 @@ use Permission;
 use SurveysGroups;
 use PHPUnit\Framework\TestCase;
 
-class PermissionTest extends TestCase
+class PermissionTest extends BaseModelTestCase
 {
+    protected $modelClassName = Permission::class;
+
     public static function setupBeforeClass(): void
     {
         \Yii::import('application.helpers.common_helper', true);

--- a/tests/unit/models/QuestionAttributeTest.php
+++ b/tests/unit/models/QuestionAttributeTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuestionAttributeTest extends BaseModelTestCase
+{
+    protected $modelClassName = \QuestionAttribute::class;
+}

--- a/tests/unit/models/QuestionGroupL10nTest.php
+++ b/tests/unit/models/QuestionGroupL10nTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuestionGroupL10nTest extends BaseModelTestCase
+{
+    protected $modelClassName = \QuestionGroupL10n::class;
+
+}

--- a/tests/unit/models/QuestionGroupTest.php
+++ b/tests/unit/models/QuestionGroupTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ls\tests;
+
+
+use QuestionGroup;
+
+class QuestionGroupTest extends BaseModelTestCase
+{
+    protected $modelClassName = QuestionGroup::class;
+}

--- a/tests/unit/models/QuestionL10nTest.php
+++ b/tests/unit/models/QuestionL10nTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuestionL10nTest extends BaseModelTestCase
+{
+    protected $modelClassName = \QuestionL10n::class;
+}

--- a/tests/unit/models/QuestionTest.php
+++ b/tests/unit/models/QuestionTest.php
@@ -5,8 +5,10 @@ namespace ls\tests;
 use Question;
 use PHPUnit\Framework\TestCase;
 
-class QuestionTest extends TestCase
+class QuestionTest extends BaseModelTestCase
 {
+    protected $modelClassName = Question::class;
+
     public static function setupBeforeClass(): void
     {
         \Yii::import('application.helpers.common_helper', true);

--- a/tests/unit/models/QuotaLanguageSettingTest.php
+++ b/tests/unit/models/QuotaLanguageSettingTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuotaLanguageSettingTest extends BaseModelTestCase
+{
+    protected $modelClassName = \QuotaLanguageSetting::class;
+}

--- a/tests/unit/models/QuotaMemberTest.php
+++ b/tests/unit/models/QuotaMemberTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuotaMemberTest extends BaseModelTestCase
+{
+    protected $modelClassName = \QuotaMember::class;
+}

--- a/tests/unit/models/QuotaTest.php
+++ b/tests/unit/models/QuotaTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class QuotaTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Quota::class;
+}

--- a/tests/unit/models/SurveyLanguageSettingTest.php
+++ b/tests/unit/models/SurveyLanguageSettingTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyLanguageSettingTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveyLanguageSetting::class;
+}

--- a/tests/unit/models/SurveyLinkTest.php
+++ b/tests/unit/models/SurveyLinkTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyLinkTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveyLink::class;
+}

--- a/tests/unit/models/SurveyMenuEntriesTest.php
+++ b/tests/unit/models/SurveyMenuEntriesTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyMenuEntriesTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveymenuEntries::class;
+}

--- a/tests/unit/models/SurveyMenuTest.php
+++ b/tests/unit/models/SurveyMenuTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyMenuTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Surveymenu::class;
+}

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Survey::class;
+}

--- a/tests/unit/models/SurveyUrlParameterTest.php
+++ b/tests/unit/models/SurveyUrlParameterTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveyUrlParameterTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveyURLParameter::class;
+}

--- a/tests/unit/models/SurveysGroupSettingsTest.php
+++ b/tests/unit/models/SurveysGroupSettingsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveysGroupSettingsTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveysGroupsettings::class;
+}

--- a/tests/unit/models/SurveysGroupsTest.php
+++ b/tests/unit/models/SurveysGroupsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class SurveysGroupsTest extends BaseModelTestCase
+{
+    protected $modelClassName = \SurveysGroups::class;
+}

--- a/tests/unit/models/TutorialTest.php
+++ b/tests/unit/models/TutorialTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class TutorialTest extends BaseModelTestCase
+{
+    protected $modelClassName = \Tutorial::class;
+}

--- a/tests/unit/models/UserGroupTest.php
+++ b/tests/unit/models/UserGroupTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class UserGroupTest extends BaseModelTestCase
+{
+    protected $modelClassName = \UserGroup::class;
+}

--- a/tests/unit/models/UserInPermissionRoleTest.php
+++ b/tests/unit/models/UserInPermissionRoleTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class UserInPermissionRoleTest extends BaseModelTestCase
+{
+    protected $modelClassName = \UserInPermissionrole::class;
+}

--- a/tests/unit/models/UserTest.php
+++ b/tests/unit/models/UserTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ls\tests;
+
+
+class UserTest extends BaseModelTestCase
+{
+    protected $modelClassName = \User::class;
+}


### PR DESCRIPTION
…s to check that

Fixed issue: 3 models had a broken relation referring to a class that did not exist

also added unit tests for a bunch of models to check that. 

The base BaseModelTestCase also allows some additional checks to be added easily for all models in the future