### PR TITLE
Fixed issue #18242: Quick translation: end note not shown

### DIFF
--- a/application/controllers/admin/Translate.php
+++ b/application/controllers/admin/Translate.php
@@ -247,7 +247,9 @@ class Translate extends SurveyCommonAction
                 $textfrom_length = strlen(trim($textfrom));
                 $textfrom2_length = $associated ? strlen(trim($textfrom2)) : 0;
 
-                $all_fields_empty = !($textfrom_length > 0) && !($textfrom2_length > 0);
+                if ($textfrom_length > 0 || $textfrom2_length > 0) {
+                    $all_fields_empty = false;
+                }
 
                 $aData = array_merge($aData, array(
                                 'textfrom' => $this->cleanup($textfrom, array()),

--- a/application/controllers/admin/Translate.php
+++ b/application/controllers/admin/Translate.php
@@ -244,9 +244,10 @@ class Translate extends SurveyCommonAction
                 $gid = ($amTypeOptions["gid"] == true) ? $gid = $aRowfrom['gid'] : null;
                 $qid = ($amTypeOptions["qid"] == true) ? $qid = $aRowfrom['qid'] : null;
 
-                $textform_length = strlen(trim($textfrom));
+                $textfrom_length = strlen(trim($textfrom));
+                $textfrom2_length = $associated ? strlen(trim($textfrom2)) : 0;
 
-                $all_fields_empty = !($textform_length > 0);
+                $all_fields_empty = !($textfrom_length > 0) && !($textfrom2_length > 0);
 
                 $aData = array_merge($aData, array(
                                 'textfrom' => $this->cleanup($textfrom, array()),

--- a/application/views/admin/translate/translatefields_view.php
+++ b/application/views/admin/translate/translatefields_view.php
@@ -1,4 +1,4 @@
-<?php if (strlen(trim((string)$textfrom)) > 0) : ?>
+<?php if (strlen(trim((string)$textfrom)) > 0 || strlen(trim((string)$textfrom2)) > 0) : ?>
     <?php if (extension_loaded('tidy')) : ?>
         <?=tidy_repair_string($translateFields,array(),'utf8')?>
     <?php else:?>


### PR DESCRIPTION
"nothing to translate" message will only appear if all elements' text are empty (not just main).