### PR TITLE
Fixed issue #18298: Saving in question organizer always prompts

### DIFF
--- a/assets/scripts/admin/organize.js
+++ b/assets/scripts/admin/organize.js
@@ -73,7 +73,9 @@ $(document).on('ready  pjax:scriptcomplete', function(){
 /**
  * Show confirmation message when user leaves without saving
  */
-window.onload = function() {
+// Don't show the confirmation prompt for now. It doesn't work when "leaving" through PJAX,
+// and it interferes with save.
+/*window.onload = function() {
     window.addEventListener("beforeunload", function (e) {
         if (formSubmitting) {
             return undefined;
@@ -86,7 +88,7 @@ window.onload = function() {
             return confirmationMessage; //Gecko + Webkit, Safari, Chrome etc.
         }
     });
-}
+}*/
 
 /**
  * Fix big question part


### PR DESCRIPTION
Removing confirmation prompt as it is not working well with pjax (ignored).