### PR TITLE
Fixed issue #18134: Present subquestions/answer options in random order has no clue about current state

### DIFF
--- a/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
+++ b/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
@@ -153,6 +153,12 @@ var onClickListAction =  function () {
     /* Define what should be done when user confirm the mass action */
     /* remove all existing action before adding the new one */
     $modalButton.off('click').on('click', function(){
+        var $form = $modal.find('form');
+        if ($form.data('trigger-validation')) {
+            if (!$form[0].reportValidity()) {
+                return;
+            }
+        }
 
         // Custom datas comming from the modal (like sid)
         var $postDatas  = {sItems:$oCheckedItems};

--- a/application/views/admin/survey/Question/massive_actions/_set_subquestansw_order.php
+++ b/application/views/admin/survey/Question/massive_actions/_set_subquestansw_order.php
@@ -4,12 +4,13 @@
  */
 $surveyid = App()->request->getParam('surveyid', 0);
 ?>
-<form class="custom-modal-datas form-horizontal">
+<form class="custom-modal-datas form-horizontal" data-trigger-validation="true">
     <div  class="form-group" id="CssClass">
         <label class="col-sm-4 control-label"><?php eT("Random order:"); ?></label>
         <div class="col-sm-8">
-            <select class="form-control custom-data attributes-to-update" id="random_order" name="random_order">
-                <option value="0" selected="selected"><?php eT('Off');?></option>
+            <select class="form-control custom-data attributes-to-update" id="random_order" name="random_order" required>
+                <option value="" selected="selected"><?php eT('Please select and option');?></option>
+                <option value="0"><?php eT('Off');?></option>
                 <option value="1"><?php eT('Randomize on each page load');?></option>
             </select>
         </div>


### PR DESCRIPTION
Turning control into a dropdown which doesn't preset any value form the selected items.