### PR TITLE
Fixed issue #18133: Set 'Other' state has no clue about current state

### DIFF
--- a/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
+++ b/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
@@ -155,6 +155,12 @@ var onClickListAction =  function () {
     /* Define what should be done when user confirm the mass action */
     /* remove all existing action before adding the new one */
     $modalButton.off('click').on('click', function(){
+        var $form = $modal.find('form');
+        if ($form.data('trigger-validation')) {
+            if (!$form[0].reportValidity()) {
+                return;
+            }
+        }
 
         // Custom datas comming from the modal (like sid)
         var $postDatas  = {sItems:$oCheckedItems};

--- a/application/views/admin/survey/Question/massive_actions/_set_questions_other.php
+++ b/application/views/admin/survey/Question/massive_actions/_set_questions_other.php
@@ -7,11 +7,15 @@
 /** @var Question $model */
 
 ?>
-<form class="custom-modal-datas form-horizontal">
+<form class="custom-modal-datas form-horizontal" data-trigger-validation="true">
     <div  class="form-group" id="OtherSelection">
         <label class="col-sm-4 control-label"><?php eT("Option 'Other':"); ?></label>
         <div class="col-sm-8">
-            <?php $this->widget('yiiwheels.widgets.switch.WhSwitch', array('name' => 'other', 'value'=> '', 'htmlOptions'=>array('class'=>'custom-data  bootstrap-switch-boolean', 'data-gridid'=>'question-grid'), 'onLabel'=>gT('On'),'offLabel'=>gT('Off')));?>
+            <select class="form-control custom-data attributes-to-update" id="other" name="other" required>
+                <option value="" selected="selected"><?php eT('Please select and option');?></option>
+                <option value="false"><?php eT('Off');?></option>
+                <option value="true"><?php eT('On');?></option>
+            </select>
         </div>
         <input type="hidden" name="sid" value="<?php echo (int) Yii::app()->request->getParam('surveyid',0); ?>" class="custom-data"/>
     </div>


### PR DESCRIPTION
Turning control into a dropdown which doesn't preset any value form the selected items.