### PR TITLE
Fixed issue #15195: Expiration date can be set before start date

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -1920,7 +1920,7 @@ class SurveyAdministrationController extends LSBaseController
             $aData['moreInfo'] = $temp;
         }
 
-        App()->getClientScript()->registerScriptFile(App()->getConfig('adminscripts') . 'surveysettings.js');
+        App()->getClientScript()->registerScriptFile(App()->getConfig('adminscripts') . 'surveysettings.js', LSYii_ClientScript::POS_BEGIN);
         App()->getClientScript()->registerPackage('jquery-json');
         App()->getClientScript()->registerPackage('bootstrap-switch');
 

--- a/application/views/surveyAdministration/editLocalSettings_main_view.php
+++ b/application/views/surveyAdministration/editLocalSettings_main_view.php
@@ -72,9 +72,9 @@ $('#".$entryData['name']."').off('.editLocalsettings');
 
 $('#".$entryData['name']."').on('submit.editLocalsettings', function(e){
     e.preventDefault();
-    //if (!validateSettingsForm($(this))) {
-      //return false;
-    //}
+    if (!validateSettingsForm($(this))) {
+      return false;
+    }
     var data = $(this).serializeArray();
     var uri = $(this).attr('action');
     $.ajax({


### PR DESCRIPTION
- Fix how surveysettings.js is loaded (to avoid the bug in ticket #18314)
- Uncommenting the original PR, which was reverted for solving #18314