### PR TITLE
New feature #18321: Add `get_available_site_settings` RPC method

### DIFF
--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -285,6 +285,16 @@ class LSYii_Application extends CWebApplication
         return isset($this->config[$name]) ? $this->config[$name] : $default;
     }
 
+    /**
+     * Returns the array of available configurations
+     *
+     * @access public
+     * @return array
+     */
+    public function getAvailableConfigs()
+    {
+        return $this->config;
+    }
 
     /**
      * For future use, cache the language app wise as well.

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -85,6 +85,29 @@ class remotecontrol_handle
     }
 
     /**
+     * Get the available site settings
+     *
+     * Using this function you can get the available site settings.
+     *
+     * @access public
+     * @param string $sSessionKey the session key
+     * @return array
+     */
+    public function get_available_site_settings($sSessionKey)
+    {
+        $sSessionKey = (string) $sSessionKey;
+        if (!$this->_checkSessionKey($sSessionKey)) {
+            return array('status' => self::INVALID_SESSION_KEY);
+        }
+
+        if (!Permission::model()->hasGlobalPermission('superadmin', 'read')) {
+            return array('status' => 'User is not allowed to read the available site settings');
+        }
+
+        return Yii::app()->getAvailableConfigs();
+    }
+
+    /**
      * Get a global setting
      *
      * Function to query site settings. Can only be used by super administrators.

--- a/tests/unit/helpers/RemoteControlTest.php
+++ b/tests/unit/helpers/RemoteControlTest.php
@@ -589,4 +589,27 @@ class RemoteControlTest extends TestBaseClass
         $result = $handler->get_fieldmap($sessionKey, self::$surveyId, 'es');
         $this->assertEquals('Pregunta de ejemplo', $result[$sgq]['question']);
     }
+
+    /**
+     * Test the get_available_site_settings API call
+     */
+    public function testGetAvailableSiteSettings()
+    {
+        \Yii::import('application.helpers.remotecontrol.remotecontrol_handle', true);
+
+        // Create handler.
+        $admin   = new \AdminController('dummyid');
+        $handler = new \remotecontrol_handle($admin);
+
+        // Get session key.
+        $sessionKey = $handler->get_session_key(
+            self::$username,
+            self::$password
+        );
+
+        $settings = $handler->get_available_site_settings($sessionKey);
+        $this->assertNotEmpty($settings);
+        $this->assertArrayHasKey('sitename', $settings);
+        $this->assertArrayHasKey('defaultlang', $settings);
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

New feature [#18321](https://bugs.limesurvey.org/view.php?id=18321): "New method: get_available_site_settings"
