### PR TITLE
Dev: Fix a property name typo (`Question::$questionAttributes`)

### DIFF
--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -39,7 +39,7 @@ use LimeSurvey\Helpers\questionHelper;
  * @property QuestionGroup $groups  //@TODO should be singular
  * @property Question $parents      //@TODO should be singular
  * @property Question[] $subquestions
- * @property QuestionAttribute[] $questionAttributes NB! returns all QuestionArrtibute Models fot this QID regardless of the specified language
+ * @property QuestionAttribute[] $questionattributes NB! returns all QuestionArrtibute Models fot this QID regardless of the specified language
  * @property QuestionL10n[] $questionl10ns Question Languagesettings indexd by language code
  * @property string[] $quotableTypes Question types that can be used for quotas
  * @property Answer[] $answers


### PR DESCRIPTION
[Example line of correct usage](https://github.com/LimeSurvey/LimeSurvey/blob/master/application/controllers/SurveyAdministrationController.php#L919).