### PR TITLE
updated "generate tokens" button text to "access code" to keep the wo…

### DIFF
--- a/application/extensions/TopbarWidget/views/includes/tokensTopbarLeft_view.php
+++ b/application/extensions/TopbarWidget/views/includes/tokensTopbarLeft_view.php
@@ -159,7 +159,7 @@
     <!-- Generate tokens -->
     <a class="btn btn-default" href="<?php echo Yii::App()->createUrl("admin/tokens/sa/tokenify/surveyid/$oSurvey->sid"); ?>" role="button">
         <span class="icon-do text-success"></span>
-        <?php eT("Generate tokens"); ?>
+        <?php eT("Generate Access Codes"); ?>
     </a>
 
     <!-- View participants of this survey in CPDB -->


### PR DESCRIPTION


Fixed issue NA: unsure if it needs a mantis ID as it's a minor text change,

Updated the button text for the button used to generate access codes for a close access survey. 


It used to say "Generate Tokens" which is non-obvious to a non-technical user. 
Who wouldn't realize what the issue is by looking at the warning message when sending out invitation emails, which read "....having an access code"

