### PR TITLE
Fixed issue #17825: Strings “LimeSurvey internal database” not available for translation in GlotPress

### DIFF
--- a/application/core/plugins/Authdb/Authdb.php
+++ b/application/core/plugins/Authdb/Authdb.php
@@ -282,4 +282,13 @@ class Authdb extends AuthPluginBase
 
         $event->set('writer', $writer);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getAuthMethodName()
+    {
+        // Using string literal here so it can be picked by translation bot
+        return gT('LimeSurvey internal database');
+    }
 }

--- a/application/libraries/PluginManager/AuthPluginBase.php
+++ b/application/libraries/PluginManager/AuthPluginBase.php
@@ -166,4 +166,14 @@ abstract class AuthPluginBase extends PluginBase
 
         return $this;
     }
+
+    /**
+     * Returns the authentication method's name
+     *
+     * @return string
+     */
+    public static function getAuthMethodName()
+    {
+        return self::$name;
+    }
 }

--- a/application/views/admin/authentication/login.php
+++ b/application/views/admin/authentication/login.php
@@ -55,7 +55,8 @@ echo viewHelper::getViewTestTag('login');
                                     foreach($pluginNames as $plugin)
                                     {
                                         $info = App()->getPluginManager()->getPluginInfo($plugin);
-                                        $possibleAuthMethods[$plugin] = $info['pluginName'];
+                                        $methodName = call_user_func([$info['pluginClass'], 'getAuthMethodName']);
+                                        $possibleAuthMethods[$plugin] = !empty($methodName) ? $methodName : $info['pluginName'];
                                     }
                                     //print_r($possibleAuthMethods); die();
 


### PR DESCRIPTION
New function `getAuthMethodName` for auth plugins