### PR TITLE
Fixed issue #14310: Google Analytics functionality doesn't work

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -264,6 +264,7 @@ $internalConfig = array(
                 'darkencss'               => 'LS_Twig_Extension::darkencss',
                 'lightencss'              => 'LS_Twig_Extension::lightencss',
                 'getAllTokenAnswers'      => 'LS_Twig_Extension::getAllTokenAnswers',
+                'getGoogleAnalyticsTrackingUrl'      => 'LS_Twig_Extension::getGoogleAnalyticsTrackingUrl',
             ),
             'filters' => array(
                 'jencode' => 'CJSON::encode',
@@ -372,6 +373,7 @@ $internalConfig = array(
                     'darkencss',
                     'lightencss',
                     'getAllTokenAnswers',
+                    'getGoogleAnalyticsTrackingUrl',
                 ),
             ),
 

--- a/application/controllers/PrintanswersController.php
+++ b/application/controllers/PrintanswersController.php
@@ -143,6 +143,7 @@ class PrintanswersController extends LSYii_Controller
         if (empty($sExportType)) {
             Yii::app()->setLanguage($sLanguage);
             $aData['aSurveyInfo']['include_content'] = 'printanswers';
+            $aData['aSurveyInfo']['trackUrlPageName'] = 'printanswers';
             Yii::app()->twigRenderer->renderTemplateFromFile('layout_printanswers.twig', $aData, false);
 
         } else if ($sExportType == 'pdf') {

--- a/application/controllers/Statistics_userController.php
+++ b/application/controllers/Statistics_userController.php
@@ -301,6 +301,7 @@ class Statistics_userController extends SurveyController
         //$this->layout = "public";
         //$this->render('/statistics_user_view', $data);
         $data['aSurveyInfo']['include_content'] = 'statistics_user';
+        $aData['aSurveyInfo']['trackUrlPageName'] = 'statistics_user';
         // Set template into last instance. Will be picked up later by the renderer
         $oTemplate = Template::model()->getInstance('', $iSurveyID);
         Yii::app()->twigRenderer->renderTemplateFromFile('layout_statistics_user.twig', $data, false);

--- a/application/controllers/survey/index.php
+++ b/application/controllers/survey/index.php
@@ -456,6 +456,7 @@ class index extends CAction
             $thissurvey['aLoadForm'] = $aLoadForm;
             //$oTemplate->registerAssets();
             $thissurvey['include_content'] = 'load';
+            $thissurvey['trackUrlPageName'] = 'load';
             Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey'=>Survey::model()->findByPk($surveyid), 'aSurveyInfo'=>$thissurvey), false);
         }
 

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1022,6 +1022,7 @@ class SurveyRuntimeHelper
                 $this->aSurveyInfo['aSaveForm'] = $cSave->getSaveFormDatas($this->aSurveyInfo['sid']);
 
                 $this->aSurveyInfo['include_content'] = 'save';
+                $this->aSurveyInfo['trackUrlPageName'] = 'save';
                 Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey'=> Survey::model()->findByPk($this->iSurveyid), 'aSurveyInfo'=>$this->aSurveyInfo), false);
             } else {
                 // Intentional retest of all conditions to be true, to make sure we do have tokens and surveyid

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -909,9 +909,7 @@ function getSurveyInfo($surveyid, $languagecode = '')
             if (!isset($thissurvey['adminname'])) {$thissurvey['adminname'] = Yii::app()->getConfig('siteadminemail'); }
             if (!isset($thissurvey['adminemail'])) {$thissurvey['adminemail'] = Yii::app()->getConfig('siteadminname'); }
             if (!isset($thissurvey['urldescrip']) || $thissurvey['urldescrip'] == '') {$thissurvey['urldescrip'] = $thissurvey['surveyls_url']; }
-            if (isset($thissurvey['googleanalyticsapikey']) && $thissurvey['googleanalyticsapikey'] === "9999useGlobal9999") {
-                $thissurvey['googleanalyticsapikey'] = trim(Yii::app()->getConfig('googleanalyticsapikey'));
-            }
+            $thissurvey['googleanalyticsapikey'] = $oSurvey->getGoogleanalyticsapikey();
 
             $thissurvey['owner_username'] = $result->survey->ownerUserName;
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -909,6 +909,9 @@ function getSurveyInfo($surveyid, $languagecode = '')
             if (!isset($thissurvey['adminname'])) {$thissurvey['adminname'] = Yii::app()->getConfig('siteadminemail'); }
             if (!isset($thissurvey['adminemail'])) {$thissurvey['adminemail'] = Yii::app()->getConfig('siteadminname'); }
             if (!isset($thissurvey['urldescrip']) || $thissurvey['urldescrip'] == '') {$thissurvey['urldescrip'] = $thissurvey['surveyls_url']; }
+            if (isset($thissurvey['googleanalyticsapikey']) && $thissurvey['googleanalyticsapikey'] === "9999useGlobal9999") {
+                $thissurvey['googleanalyticsapikey'] = trim(Yii::app()->getConfig('googleanalyticsapikey'));
+            }
 
             $thissurvey['owner_username'] = $result->survey->ownerUserName;
 

--- a/application/helpers/replacements_helper.php
+++ b/application/helpers/replacements_helper.php
@@ -235,35 +235,6 @@ function templatereplace($line, $replacements = array(), &$redata = array(), $de
     $_restart = "";
     $_return_to_survey = "";
 
-    if (isset($thissurvey['googleanalyticsapikey']) && $thissurvey['googleanalyticsapikey'] === "9999useGlobal9999") {
-        $_googleAnalyticsAPIKey = trim(App()->getConfig('googleanalyticsapikey'));
-    } else if (isset($thissurvey['googleanalyticsapikey']) && trim($thissurvey['googleanalyticsapikey']) != '') {
-        $_googleAnalyticsAPIKey = trim($thissurvey['googleanalyticsapikey']);
-    } else {
-        $_googleAnalyticsAPIKey = "";
-    }
-
-    $thissurvey['googleanalyticsapikey'] = $_googleAnalyticsAPIKey;
-
-    $_googleAnalyticsStyle = (isset($thissurvey['googleanalyticsstyle']) ? $thissurvey['googleanalyticsstyle'] : '1');
-
-    if ($_googleAnalyticsAPIKey != '' && $_googleAnalyticsStyle == 2) {
-        // SurveyName-[SID]/[GSEQ]-GroupName - create custom GSEQ based upon page step
-        $moveInfo = LimeExpressionManager::GetLastMoveResult();
-        if (is_null($moveInfo)) {
-            $gseq = 'welcome';
-        } else if ($moveInfo['finished']) {
-            $gseq = 'finished';
-        } else if (isset($moveInfo['at_start']) && $moveInfo['at_start']) {
-            $gseq = 'welcome';
-        } else if (is_null($_groupname)) {
-            $gseq = 'printanswers';
-        } else {
-            $gseq = $moveInfo['gseq'] + 1;
-        }
-
-    }
-
     $_endtext = '';
     if (isset($thissurvey['surveyls_endtext']) && trim($thissurvey['surveyls_endtext']) != '') {
         $_endtext = $thissurvey['surveyls_endtext'];

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -785,9 +785,9 @@ class Survey extends LSActiveRecord
     public function getGoogleanalyticsapikey()
     {
         if ($this->googleanalyticsapikey === "9999useGlobal9999") {
-            return getGlobalSetting('googleanalyticsapikey');
+            return trim(Yii::app()->getConfig('googleanalyticsapikey'));
         } else {
-            return $this->googleanalyticsapikey;
+            return trim($this->googleanalyticsapikey);
         }
     }
 

--- a/themes/survey/vanilla/views/subviews/header/google_analytics.twig
+++ b/themes/survey/vanilla/views/subviews/header/google_analytics.twig
@@ -26,7 +26,7 @@
         ga('send', 'pageview');
         </script>
     {% else %}
-        {% set trackUrl = getGoogleAnalyticsTrackingUrl(aSurveyInfo.sid) %}
+        {% set trackUrl = getGoogleAnalyticsTrackingUrl(aSurveyInfo.sid, aSurveyInfo.trackUrlPageName ?? '') %}
         <script>
         (function(i,s,o,g,r,a,m){ i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){ (i[r].q=i[r].q||[]).push(arguments) }
         ,i[r].l=1*new Date();a=s.createElement(o), m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/themes/survey/vanilla/views/subviews/header/google_analytics.twig
+++ b/themes/survey/vanilla/views/subviews/header/google_analytics.twig
@@ -26,6 +26,7 @@
         ga('send', 'pageview');
         </script>
     {% else %}
+        {% set trackUrl = getGoogleAnalyticsTrackingUrl(aSurveyInfo.sid) %}
         <script>
         (function(i,s,o,g,r,a,m){ i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){ (i[r].q=i[r].q||[]).push(arguments) }
         ,i[r].l=1*new Date();a=s.createElement(o), m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -33,7 +34,7 @@
 
         ga('create', '{{ aSurveyInfo.googleanalyticsapikey }}', 'auto');
         ga('send', 'pageview');
-        ga('send', 'pageview', '{{ aSurveyInfo.trackURL }}');
+        ga('send', 'pageview', '{{ trackUrl }}');
         </script>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
- Porting logic from 2.06_sp_1.6.0
- Implementing google tracking by surveyId & group number/name
- Added the possibility of setting the "group number/name" from the controller. Used for Print Answers, Public Stats, Registration, Load Survey y Resume Later.

For reference, in LS 2.06:
- Registration and Load Survey pages came out as Welcome
- Print Answers, Public Stats and Resume Later pages came out with the group number, and without the group name (wrongly I think, as there is not group number for those). I mean, it didn't say print answer or anything like that, even though the code seemed to try to do that.


