### PR TITLE
Fixed issue #18323: When copying a question with sub-questions, the sub-questions are not copied

### DIFF
--- a/application/models/services/CopyQuestion.php
+++ b/application/models/services/CopyQuestion.php
@@ -93,10 +93,10 @@ class CopyQuestion
     public function createNewCopiedQuestion($questionCode, $groupId, $questionToCopy)
     {
         $this->newQuestion = new \Question();
-        // We need to use setAttributes here with $safeOnly=false to avoid issue #18323, because otherwise the
-        // validators are loaded before setting the attributes, and that means the wrong rules are applied.
-        // By setting $safeOnly=false here, we let the proper validators to be determined while saving, when the
-        // attributes already have their values.
+        // We need to use setAttributes here with $safeOnly=false to avoid issue #18323.
+        // Otherwise validators are loaded before setting the attributes. 
+        // Right now, probably a bug, some rules are added as validators conditionally, depending on the attribute values.
+        // Then the rules set (final validators loaded) may not match the attributes which are later set.
         $this->newQuestion->setAttributes($questionToCopy->attributes, false);
         $this->newQuestion->title = $questionCode;
         $this->newQuestion->gid = $groupId;
@@ -155,10 +155,10 @@ class CopyQuestion
 
         foreach ($subquestions as $subquestion) {
             $copiedSubquestion = new \Question();
-            // We need to use setAttributes here with $safeOnly=false to avoid issue #18323, because otherwise the
-            // validators are loaded before setting the attributes, and that means the wrong rules are applied.
-            // By setting $safeOnly=false here, we let the proper validators to be determined while saving, when the
-            // attributes already have their values.
+            // We need to use setAttributes here with $safeOnly=false to avoid issue #18323.
+            // Otherwise validators are loaded before setting the attributes. 
+            // Right now, probably a bug, some rules are added as validators conditionally, depending on the attribute values.
+            // Then the rules set (final validators loaded) may not match the attributes which are later set.
             $copiedSubquestion->setAttributes($subquestion->attributes, false);
             $copiedSubquestion->parent_qid = $this->newQuestion->qid;
             $copiedSubquestion->qid = null; //new question id needed ...

--- a/application/models/services/CopyQuestion.php
+++ b/application/models/services/CopyQuestion.php
@@ -94,7 +94,7 @@ class CopyQuestion
     {
         $this->newQuestion = new \Question();
         // We need to use setAttributes here with $safeOnly=false to avoid issue #18323.
-        // Otherwise validators are loaded before setting the attributes. 
+        // Otherwise validators are loaded before setting the attributes.
         // Right now, probably a bug, some rules are added as validators conditionally, depending on the attribute values.
         // Then the rules set (final validators loaded) may not match the attributes which are later set.
         $this->newQuestion->setAttributes($questionToCopy->attributes, false);
@@ -156,7 +156,7 @@ class CopyQuestion
         foreach ($subquestions as $subquestion) {
             $copiedSubquestion = new \Question();
             // We need to use setAttributes here with $safeOnly=false to avoid issue #18323.
-            // Otherwise validators are loaded before setting the attributes. 
+            // Otherwise validators are loaded before setting the attributes.
             // Right now, probably a bug, some rules are added as validators conditionally, depending on the attribute values.
             // Then the rules set (final validators loaded) may not match the attributes which are later set.
             $copiedSubquestion->setAttributes($subquestion->attributes, false);

--- a/application/models/services/CopyQuestion.php
+++ b/application/models/services/CopyQuestion.php
@@ -93,7 +93,11 @@ class CopyQuestion
     public function createNewCopiedQuestion($questionCode, $groupId, $questionToCopy)
     {
         $this->newQuestion = new \Question();
-        $this->newQuestion->attributes = $questionToCopy->attributes;
+        // We need to use setAttributes here with $safeOnly=false to avoid issue #18323, because otherwise the
+        // validators are loaded before setting the attributes, and that means the wrong rules are applied.
+        // By setting $safeOnly=false here, we let the proper validators to be determined while saving, when the
+        // attributes already have their values.
+        $this->newQuestion->setAttributes($questionToCopy->attributes, false);
         $this->newQuestion->title = $questionCode;
         $this->newQuestion->gid = $groupId;
         $this->newQuestion->question_order = $this->copyQuestionValues->getQuestionPositionInGroup();
@@ -151,7 +155,11 @@ class CopyQuestion
 
         foreach ($subquestions as $subquestion) {
             $copiedSubquestion = new \Question();
-            $copiedSubquestion->attributes = $subquestion->attributes;
+            // We need to use setAttributes here with $safeOnly=false to avoid issue #18323, because otherwise the
+            // validators are loaded before setting the attributes, and that means the wrong rules are applied.
+            // By setting $safeOnly=false here, we let the proper validators to be determined while saving, when the
+            // attributes already have their values.
+            $copiedSubquestion->setAttributes($subquestion->attributes, false);
             $copiedSubquestion->parent_qid = $this->newQuestion->qid;
             $copiedSubquestion->qid = null; //new question id needed ...
             $areSubquestionsCopied = $areSubquestionsCopied && $copiedSubquestion->save();


### PR DESCRIPTION
Setting attributes using setAttributes($safeOnly=false), as to not trigger the process of creating the validators.