### PR TITLE
Fixed issue #16187: No proper error message when copying survey and ID already exists

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1285,6 +1285,9 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
         if ($newSurvey->sid) {
             $iNewSID = $results['newsid'] = $newSurvey->sid;
             $results['surveys']++;
+            if (!empty($iDesiredSurveyId) && $iNewSID != $iDesiredSurveyId) {
+                $results['importwarnings'][] = gT("The desired survey ID was invalid and could not be assigned to the new survey.");
+            }
         } else {
             $results['error'] = CHtml::errorSummary($newSurvey, gT("Unable to import survey."));
             return $results;

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1286,7 +1286,7 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
             $iNewSID = $results['newsid'] = $newSurvey->sid;
             $results['surveys']++;
             if (!empty($iDesiredSurveyId) && $iNewSID != $iDesiredSurveyId) {
-                $results['importwarnings'][] = gT("The desired survey ID was invalid and could not be assigned to the new survey.");
+                $results['importwarnings'][] = gT("The desired survey ID was already in use, therefore a random one was assigned.");
             }
         } else {
             $results['error'] = CHtml::errorSummary($newSurvey, gT("Unable to import survey."));

--- a/application/views/surveyAdministration/tabCopy_view.php
+++ b/application/views/surveyAdministration/tabCopy_view.php
@@ -42,10 +42,10 @@
                         <div class="">
                             <input type='number' step="1" min="1" max="999999" id='copysurveyid' size='82' name='copysurveyid' value='' class="form-control" />
                         </div>
-                        <div class="">
-                          <p class="form-control-static">
+                        <div class="help-block">
                             <span class='annotation text-info'><?php echo  gT("Optional"); ?> </span>
-                          </p>
+                            -
+                            <?= gT("If ID is taken, a random one will be assigned."); ?> </span>
                         </div>
                     </div>
                     <div class="form-group">

--- a/application/views/surveyAdministration/tabCopy_view.php
+++ b/application/views/surveyAdministration/tabCopy_view.php
@@ -45,7 +45,7 @@
                         <div class="help-block">
                             <span class='annotation text-info'><?php echo  gT("Optional"); ?> </span>
                             -
-                            <?= gT("If ID is taken, a random one will be assigned."); ?> </span>
+                            <?= gT("If the new survey ID is already used, a random one will be assigned."); ?> </span>
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
Added warning about "custom survey ID is taken"
Reviewed help text of the custom survey id field