### PR TITLE
Fixed issue #18413: Cannot authenticate with LDAP when using PHP 8.1

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -480,7 +480,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
 
         // Try to connect
         $ldapconn = $this->createConnection();
-        if (!is_resource($ldapconn)) {
+        if ($ldapconn === false) {
             $this->setAuthFailure($ldapconn['errorCode'], gT($ldapconn['errorMessage']));
             return;
         }


### PR DESCRIPTION
After upgrading to PHP 8.1 the login via LDAP isn't possible.

Error message: Cannot use object of type LDAP\Connection as array

This is a fix for it.

Fixed issue #18413 (https://bugs.limesurvey.org/view.php?id=18413)