### PR TITLE
Condition for MenuEntries - when item is active

### DIFF
--- a/application/models/Surveymenu.php
+++ b/application/models/Surveymenu.php
@@ -60,7 +60,7 @@ class Surveymenu extends LSActiveRecord
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
         return array(
-            'surveymenuEntries' => array(self::HAS_MANY, 'SurveymenuEntries', 'menu_id'),
+            'surveymenuEntries' => array(self::HAS_MANY, 'SurveymenuEntries', 'menu_id','condition' => 'surveymenuEntries.active = 1 '),
             'survey' => array(self::BELONGS_TO, 'Survey', ['survey_id' => 'sid']),
             'user' => array(self::BELONGS_TO, 'User', 'user_id'),
             'parent' => array(self::BELONGS_TO, 'Surveymenu', 'parent_id'),


### PR DESCRIPTION
previously all Menu Entries regardless of active value (0 or 1) loaded, new condition added.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
