### PR TITLE
Fixed issue #18431: call to undefined function url_encode()

### DIFF
--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -963,7 +963,7 @@ class UpdateForm extends CFormModel
     {
         if ((extension_loaded("curl"))) {
             if (isset($_REQUEST['access_token'])) {
-                $getters .= "&access_token=" . url_encode($_REQUEST['access_token']);
+                $getters .= "&access_token=" . urlencode($_REQUEST['access_token']);
             }
 
             $ch = curl_init($this->getProtocol() . Yii::app()->getConfig("comfort_update_server_url") . $getters);


### PR DESCRIPTION
url_encode doesn't exist in php. The correct function is urlencode: https://www.php.net/manual/en/function.urlencode.php

Fixed issue #18431:
Dev:
