### PR TITLE
Fixed issue #18488: Conditions are not properly highlighted if they have additional spaces

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3750,9 +3750,9 @@
                 if($this->sPreviewMode=='group' || $this->sPreviewMode=='question') $fielddata['grelevance']=1;
 
                 $questionNum = $fielddata['qid'];
-                $relevance = (isset($fielddata['relevance'])) ? $fielddata['relevance'] : 1;
-                $SQrelevance = (isset($fielddata['SQrelevance'])) ? $fielddata['SQrelevance'] : 1;
-                $grelevance = (isset($fielddata['grelevance'])) ? $fielddata['grelevance'] : 1;
+                $relevance = (isset($fielddata['relevance'])) ? trim($fielddata['relevance']) : 1;
+                $SQrelevance = (isset($fielddata['SQrelevance'])) ? trim($fielddata['SQrelevance']) : 1;
+                $grelevance = (isset($fielddata['grelevance'])) ? trim($fielddata['grelevance']) : 1;
                 $hidden = (isset($qattr[$questionNum]['hidden'])) ? ($qattr[$questionNum]['hidden'] == '1') : false;
                 $scale_id = (isset($fielddata['scale_id'])) ? $fielddata['scale_id'] : '0';
                 $preg = (isset($fielddata['preg'])) ? $fielddata['preg'] : NULL; // a perl regular exrpession validation function

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -112,7 +112,8 @@ class Question extends LSActiveRecord
                     array('scale_id', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>true),
                     array('same_default', 'numerical', 'integerOnly'=>true, 'allowEmpty'=>true),
                     array('type', 'length', 'min' => 1, 'max'=>1),
-                    array('preg,relevance', 'safe'),
+                    array('relevance', 'filter', 'filter' => 'trim'),
+                    array('preg', 'safe'),
                     array('modulename', 'length', 'max'=>255),
                 );
         // Always enforce unicity on Sub question code (DB issue).

--- a/application/models/QuestionGroup.php
+++ b/application/models/QuestionGroup.php
@@ -66,6 +66,7 @@ class QuestionGroup extends LSActiveRecord
                 'params'=>array(':language'=>$this->language)
                 ),
                 'message'=>'{attribute} "{value}" is already in use.'),
+            array('relevance', 'filter', 'filter' => 'trim'),
             array('language', 'length', 'min' => 2, 'max'=>20), // in array languages ?
             array('group_name,description', 'LSYii_Validators'),
             array('group_name', 'length', 'min' => 0, 'max'=>100),

--- a/application/models/QuestionGroup.php
+++ b/application/models/QuestionGroup.php
@@ -66,7 +66,7 @@ class QuestionGroup extends LSActiveRecord
                 'params'=>array(':language'=>$this->language)
                 ),
                 'message'=>'{attribute} "{value}" is already in use.'),
-            array('relevance', 'filter', 'filter' => 'trim'),
+            array('grelevance', 'filter', 'filter' => 'trim'),
             array('language', 'length', 'min' => 2, 'max'=>20), // in array languages ?
             array('group_name,description', 'LSYii_Validators'),
             array('group_name', 'length', 'min' => 0, 'max'=>100),

--- a/application/views/admin/survey/Question/question_view.php
+++ b/application/views/admin/survey/Question/question_view.php
@@ -170,7 +170,10 @@
                         <td><?php eT("Relevance equation:"); ?></td>
                         <td>
                             <?php
-                            LimeExpressionManager::ProcessString("{" . trim($qrrow['relevance']) . "}", $qid);    // tests Relevance equation so can pretty-print it
+                            LimeExpressionManager::ProcessString(
+                                "{" . trim($qrrow['relevance']) . "}",
+                                $qid
+                            );
                             echo viewHelper::stripTagsEM(LimeExpressionManager::GetLastPrettyPrintExpression());
                             ?>
                         </td>
@@ -183,7 +186,10 @@
                         <td><?php eT("Group relevance:"); ?></td>
                         <td>
                             <?php
-                            LimeExpressionManager::ProcessString("{" . trim($oQuestion->groups->grelevance) . "}", $qid);
+                            LimeExpressionManager::ProcessString(
+                                "{" . trim($oQuestion->groups->grelevance) . "}",
+                                $qid
+                            );
                             echo viewHelper::stripTagsEM(LimeExpressionManager::GetLastPrettyPrintExpression());
                             ?>
                         </td>

--- a/application/views/admin/survey/Question/question_view.php
+++ b/application/views/admin/survey/Question/question_view.php
@@ -165,12 +165,12 @@
                 <?php endif; ?>
 
                 <!-- Relevance equation -->
-                <?php if (trim($qrrow['relevance']) != ''): ?>
+                <?php if (trim($qrrow['relevance']) != '') : ?>
                     <tr>
                         <td><?php eT("Relevance equation:"); ?></td>
                         <td>
                             <?php
-                            LimeExpressionManager::ProcessString("{" . $qrrow['relevance'] . "}", $qid);    // tests Relevance equation so can pretty-print it
+                            LimeExpressionManager::ProcessString("{" . trim($qrrow['relevance']) . "}", $qid);    // tests Relevance equation so can pretty-print it
                             echo viewHelper::stripTagsEM(LimeExpressionManager::GetLastPrettyPrintExpression());
                             ?>
                         </td>
@@ -178,12 +178,12 @@
                 <?php endif; ?>
 
                 <!-- Group Relevance equation -->
-                <?php if (trim($oQuestion->groups->grelevance)!=''): ?>
+                <?php if (trim($oQuestion->groups->grelevance) != '') : ?>
                     <tr>
                         <td><?php eT("Group relevance:"); ?></td>
                         <td>
                             <?php
-                            LimeExpressionManager::ProcessString("{" . $oQuestion->groups->grelevance . "}", $qid);
+                            LimeExpressionManager::ProcessString("{" . trim($oQuestion->groups->grelevance) . "}", $qid);
                             echo viewHelper::stripTagsEM(LimeExpressionManager::GetLastPrettyPrintExpression());
                             ?>
                         </td>


### PR DESCRIPTION
Dev: trim when view
Dev: trim when save
Dev: uneeded trim in expression (but more clear)
