### PR TITLE
Fixed issue #18336: Placeholder fields VALIDFROM and VALIDUNTIL not listed at email templates

### DIFF
--- a/application/controllers/LimereplacementfieldsController.php
+++ b/application/controllers/LimereplacementfieldsController.php
@@ -325,6 +325,8 @@ class LimeReplacementFieldsController extends LSBaseController
             $replFields['GLOBALOPTINURL'] = gT("Participant - Central participant DB opt-in URL");
             $replFields['FIRSTNAME'] = gT("Participant - First name");
             $replFields['LASTNAME'] = gT("Participant - Last name");
+            $replFields['VALIDFROM'] = gT("Participant - The date the token is valid from");
+            $replFields['VALIDUNTIL'] = gT("Participant - The date the token is valid until");
             $replFields['SURVEYNAME'] = gT("Survey title");
             $replFields['SID'] = gT("Survey ID");
             $replFields['SURVEYDESCRIPTION'] = gT("Survey description");


### PR DESCRIPTION
- Descriptions taken from the manual