### PR TITLE
New feature #18565: Provide more descriptive log about exceptions hap…

### DIFF
--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -385,12 +385,15 @@ class LSYii_Application extends CWebApplication
      */
     public function onException($event)
     {
+        /* Always log Yii Exception on error_log */
+        error_log(sprintf("Exception: %s, stack trace: %s", $event->exception->getMessage(), $event->exception->getTraceAsString()));
+
         if (!Yii::app() instanceof CWebApplication) {
-            /* Don't update for CLI */
+            /* Don't do anything more with CLI */
             return;
         }
         if (defined('PHP_ENV') && PHP_ENV == 'test') {
-            // If run from phpunit, die with exception message.
+            /* If run from phpunit, die with exception message. */
             die($event->exception->getMessage());
         }
         if (!$this->dbVersion) {


### PR DESCRIPTION
New feature #18565: Provide more descriptive log about exceptions happen during running LimeSurvey
Dev: use Yii::app()->onException, PHP Parse error and other already goes to error_log


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exception logging to automatically capture all errors with complete stack traces for improved debugging and error tracking. This enables faster issue resolution and strengthened diagnostic capabilities across development and support teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->