### PR TITLE
Fixed Issue #18581: Blocking users after X failed attempts counts incorrectly (off by 1)

### DIFF
--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -104,7 +104,7 @@ class FailedLoginAttempt extends LSActiveRecord
 
         if (Yii::app()->getConfig('DBVersion') <= 480) {
             $criteria = new CDbCriteria();
-            $criteria->condition = 'number_attempts > :attempts AND ip = :ip';
+            $criteria->condition = 'number_attempts >= :attempts AND ip = :ip';
             $criteria->params = array(
                 ':attempts' => $maxLoginAttempt,
                 ':ip' => $ip,
@@ -112,7 +112,7 @@ class FailedLoginAttempt extends LSActiveRecord
             $row = $this->find($criteria);
         } else {
             $criteria = new CDbCriteria();
-            $criteria->condition = 'number_attempts > :attempts AND ip = :ip AND is_frontend = :is_frontend';
+            $criteria->condition = 'number_attempts > :attempts AND ip >= :ip AND is_frontend = :is_frontend';
             $criteria->params = array(
                 ':attempts' => $maxLoginAttempt,
                 ':ip' => $ip,

--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -112,7 +112,7 @@ class FailedLoginAttempt extends LSActiveRecord
             $row = $this->find($criteria);
         } else {
             $criteria = new CDbCriteria();
-            $criteria->condition = 'number_attempts > :attempts AND ip >= :ip AND is_frontend = :is_frontend';
+            $criteria->condition = 'number_attempts >= :attempts AND ip = :ip AND is_frontend = :is_frontend';
             $criteria->params = array(
                 ':attempts' => $maxLoginAttempt,
                 ':ip' => $ip,

--- a/tests/unit/models/FailedLoginAttemptTest.php
+++ b/tests/unit/models/FailedLoginAttemptTest.php
@@ -45,4 +45,14 @@ class FailedLoginAttempTest extends TestBaseClass
         FailedLoginAttempt::model()->addAttempt();  
         $this->assertTrue(FailedLoginAttempt::model()->isLockedOut(FailedLoginAttempt::TYPE_LOGIN));
     }
+
+    /**
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        FailedLoginAttempt::model()->deleteAttempts(FailedLoginAttempt::TYPE_LOGIN);
+
+        parent::tearDownAfterClass();
+    }    
 }

--- a/tests/unit/models/FailedLoginAttemptTest.php
+++ b/tests/unit/models/FailedLoginAttemptTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ls\tests;
+
+use FailedLoginAttempt;
+
+class FailedLoginAttempTest extends TestBaseClass
+{
+    public function testAddDeleteAttemp()
+    {
+        // Save Ip
+        $ip = substr(getIPAddress(), 0, 40);
+
+        // Make sure there are no records for the ip
+        FailedLoginAttempt::model()->deleteAttempts(FailedLoginAttempt::TYPE_LOGIN);
+        $this->assertNull(FailedLoginAttempt::model()->findByAttributes((array('ip' => $ip))));
+
+        // Verify that the try counter increases by one
+        FailedLoginAttempt::model()->addAttempt();
+        $data = FailedLoginAttempt::model()->findByAttributes((array('ip' => $ip)));
+        $this->assertEquals(1, $data->number_attempts);
+
+        // Verify that the try counter increases by one
+        FailedLoginAttempt::model()->addAttempt();
+        $data = FailedLoginAttempt::model()->findByAttributes((array('ip' => $ip)));
+        $this->assertEquals(2, $data->number_attempts);
+
+        // Verify that all records are deleted
+        FailedLoginAttempt::model()->deleteAttempts(FailedLoginAttempt::TYPE_LOGIN);
+        $this->assertNull(FailedLoginAttempt::model()->findByAttributes((array('ip' => $ip))));
+    }
+
+    public function testIsLockedOut()
+    {
+        $maxLoginAttempt = \Yii::app()->getConfig('maxLoginAttempt');
+
+        // Verify that the user has attempts available
+        FailedLoginAttempt::model()->deleteAttempts(FailedLoginAttempt::TYPE_LOGIN);
+        for ($i = 0; $i < $maxLoginAttempt - 1; $i++) {
+            FailedLoginAttempt::model()->addAttempt();
+            $this->assertFalse(FailedLoginAttempt::model()->isLockedOut(FailedLoginAttempt::TYPE_LOGIN));
+        }
+
+        // Verify that the user has no attempts available
+        FailedLoginAttempt::model()->addAttempt();  
+        $this->assertTrue(FailedLoginAttempt::model()->isLockedOut(FailedLoginAttempt::TYPE_LOGIN));
+    }
+}


### PR DESCRIPTION
- Fix
- Test

Re taken from https://github.com/LimeSurvey/LimeSurvey/pull/2846

As to troubleshoot the CI problem, we just pushed the contents in a new branch and it worked. ...

Still, it wasn;t about changing PR.
The problem was that the FailedLoginAttempt Unit Test was leaving the login attempts table dirty for the integrity tests.

