### PR TITLE
DEV: Update GitHub actions to make screenshots available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,3 +153,11 @@ jobs:
         env:
             DOMAIN: localhost
         run: php vendor/bin/phpunit --testdox --stop-on-failure tests/functional
+
+      - name: Upload Screenshots
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: screenshots
+          path: tests/tmp/screenshots/
+          retention-days: 5


### PR DESCRIPTION
- If the tests fail, the contents of 'tests/tmp/screenshots/' are uploaded as a workflow artifact.

Later can be found here.
![image](https://user-images.githubusercontent.com/4942495/218558039-38488b7b-0149-4904-8cda-5df1b2d78c62.png)
