### PR TITLE
Update getSurveyList() from common_helper.php to lazy load survey lan…

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -181,7 +181,6 @@ function getSurveyList($bReturnArray = false)
     if (is_null($cached)) {
         $surveyidresult = Survey::model()
             ->permission(Yii::app()->user->getId())
-            ->with('languagesettings')
             ->findAll();
         foreach ($surveyidresult as $result) {
             $surveynames[] = array_merge($result->attributes, $result->languagesettings[$result->language]->attributes);
@@ -347,7 +346,7 @@ function convertGETtoPOST($url)
             function ($v, $k) {
                 return $k.'='.$v;
             },
-            $getArray, 
+            $getArray,
             array_keys($getArray)
         ));
     }
@@ -968,11 +967,11 @@ function groupOrderThenQuestionOrder($a, $b)
 /**
  * Shifts the sortorder for questions, creating extra spaces at the start of the group
  * This is an alias for updateQuestionOrder()
- * 
+ *
  * @param integer $sid SID is not needed anymore, but is left here for backward compatibility
  * @param integer $gid
  * @param integer $shiftvalue
- * 
+ *
  * @return void
  */
 function shiftOrderQuestions($sid, $gid, $shiftvalue)
@@ -985,9 +984,9 @@ function shiftOrderQuestions($sid, $gid, $shiftvalue)
 
 /**
  * Rewrites the sortorder for groups
- * 
+ *
  * @param integer $surveyid
- * 
+ *
  * @return void
  */
 function fixSortOrderGroups($surveyid)
@@ -3256,13 +3255,13 @@ function SSLRedirect($enforceSSLMode)
 */
 function enforceSSLMode()
 {
-    $bForceSSL = ''; // off 
+    $bForceSSL = ''; // off
     $bSSLActive = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "off") ||
     (isset($_SERVER['HTTP_FORWARDED_PROTO']) && $_SERVER['HTTP_FORWARDED_PROTO'] == "https") ||
     (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == "https"));
     if (Yii::app()->getConfig('ssl_emergency_override') !== true) {
         $bForceSSL = strtolower(getGlobalSetting('force_ssl'));
-    } 
+    }
     if ($bForceSSL == 'on' && !$bSSLActive) {
         SSLRedirect('s');
     }
@@ -3799,11 +3798,11 @@ function fixLanguageConsistency($sid, $availlangs = '')
     $result = Yii::app()->db->createCommand($query)->queryColumn();
     foreach ($result as $questionID) {
         // Get the question in base language
-        $oQuestion=Question::model()->findByAttributes(array('qid'=>$questionID,'language'=>$baselang)); 
+        $oQuestion=Question::model()->findByAttributes(array('qid'=>$questionID,'language'=>$baselang));
         // Update the scale ID according to language
-        Yii::app()->db->createCommand()->update('{{questions}}',array('scale_id'=>$oQuestion->scale_id),'qid='.$questionID);   
+        Yii::app()->db->createCommand()->update('{{questions}}',array('scale_id'=>$oQuestion->scale_id),'qid='.$questionID);
     }
-    
+
     $quests = array();
     $query = "SELECT * FROM {{questions}} WHERE sid='{$sid}' AND language='{$baselang}' ORDER BY question_order";
     $result = Yii::app()->db->createCommand($query)->query()->readAll();
@@ -5079,14 +5078,14 @@ function isZipBomb($zip_filename)
     $totalSize = 0;
     $zip = new ZipArchive();
     if ($zip->open($zip_filename) === true) {
-        
+
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $fileStats = $zip->statIndex($i);
             $totalSize += $fileStats['size'];
         }
-           
+
         $zip->close();
-    }        
+    }
     return ( $totalSize >  Yii::app()->getConfig('maximum_unzipped_size'));
 }
 
@@ -5122,7 +5121,7 @@ function get_zip_originalsize($filename)
 /**
  * PHP7 has created a little nasty bomb with count throwing erroros on uncountables
  * This is to "fix" this problem
- * 
+ *
  * @param mixed $element
  * @return integer counted element
  * @author


### PR DESCRIPTION
Update getSurveyList() from common_helper.php to lazy load survey language settings

When the site has many surveys this method was consuming allot of memory in loading all of the survey language settings data into memory. This was found after a complaint from phsinterface.limequery.com.