### PR TITLE
ucfirst(null) depreactated in PHP8.X

### DIFF
--- a/application/libraries/PluginManager/Storage/DbStorage.php
+++ b/application/libraries/PluginManager/Storage/DbStorage.php
@@ -24,7 +24,10 @@ class DbStorage implements iPluginStorage
      */
     public function get(iPlugin $plugin, $key = null, $model = null, $id = null, $default = null, $language = null)
     {
-        $functionName = 'get' . ucfirst($model);
+        $functionName = 'get';
+        if ($model != null) {
+            $functionName .= ucfirst($model);
+        }
         if ($model == null || !method_exists($this, $functionName)) {
             return $this->getGeneric($plugin, $key, $model, $id, $default);
         } else {


### PR DESCRIPTION
Verify $model contains a value before calling ucfirst($model)

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
