### PR TITLE
CT-41_CT-43: Apply original  value if no value in POST array on update

### DIFF
--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -1450,7 +1450,10 @@ class DataEntry extends SurveyCommonAction
             if ($fieldname == 'id') {
                 continue;
             }
-            $thisvalue = Yii::app()->request->getPost($fieldname);
+            $thisvalue = Yii::app()->request->getPost(
+                $fieldname,
+                $oResponse->$fieldname ?? null
+            );
             switch ($irow['type']) {
                 case 'lastpage':
                     // Last page not updated : not in view


### PR DESCRIPTION
Multiple choice question are presented as a list of checkboxes. If a value is checked it is stored as "Y" in the DB. If the value not checked it is stored as an empty string in the DB. On export its possible to convert Y and "" responses to 1 and 2 respectively. The customer reported that after editing a response the data exported contains an empty string instead of the expect value "2".

The problem is that the response update functionality was updating the response value with data found in $_POST. If no data was found in post it set the value to null. Checkboxes, only appear in $_POST if they have a value which means they were being set to null when they previously had an empty string value.

To solve this I changed the code so that the value is set to the original value of the response when not found in $_POST rather than setting it to null.