### PR TITLE
Propagate survey context to submenus

### DIFF
--- a/application/models/Surveymenu.php
+++ b/application/models/Surveymenu.php
@@ -138,7 +138,7 @@ class Surveymenu extends LSActiveRecord
         foreach ($oSurveyMenuObjects as $oSurveyMenuObject) {
             $entries = [];
             $aMenuEntries = $oSurveyMenuObject->surveymenuEntries;
-            $submenus = $this->getSurveymenuSubmenus($oSurveyMenuObject, $collapsed);
+            $submenus = $this->getSurveymenuSubmenus($oSurveyMenuObject, $collapsed, $oSurvey);
             foreach ($aMenuEntries as $menuEntry) {
                 $aEntry = $menuEntry->attributes;
                 //Skip menuentry if not activated in collapsed mode
@@ -206,7 +206,7 @@ class Surveymenu extends LSActiveRecord
         return $aResultCollected;
     }
 
-    public function getSurveymenuSubmenus($oParentSurveymenu, $collapsed = false)
+    public function getSurveymenuSubmenus($oParentSurveymenu, $collapsed = false, $oSurvey = null)
     {
         $criteria = new CDbCriteria();
         $criteria->addCondition('survey_id=:surveyid OR survey_id IS NULL');
@@ -225,7 +225,7 @@ class Surveymenu extends LSActiveRecord
 
         $oMenus = Surveymenu::model()->findAll($criteria);
 
-        $aResultCollected = $this->createSurveymenuArray($oMenus, $collapsed);
+        $aResultCollected = $this->createSurveymenuArray($oMenus, $collapsed, $oSurvey);
         return $aResultCollected;
     }
 


### PR DESCRIPTION
Fixes broken "Simple plugins" survey menu item link

On survey admin, open up the plugin menu in the sidebar, the link on the "Simple plugins" item is broken, it is missing value for the "surveyid" parameter, this is because the survey context was not passed from Surveymenu::createSurveymenuArray to Surveymenu::getSurveymenuSubmenus

Fixed issue # cannot log into mantis with account I just created
