### PR TITLE
CT-41: Response editor value defaults to empty space

### DIFF
--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -1450,10 +1450,7 @@ class DataEntry extends SurveyCommonAction
             if ($fieldname == 'id') {
                 continue;
             }
-            $thisvalue = Yii::app()->request->getPost(
-                $fieldname,
-                $oResponse->$fieldname ?? null
-            );
+            $thisvalue = Yii::app()->request->getPost($fieldname, '');
             switch ($irow['type']) {
                 case 'lastpage':
                     // Last page not updated : not in view


### PR DESCRIPTION
I just noticed that my previous "fix" breaks when updating checkboxes. Defaulting to the previous value for checkboxes makes it impossible to uncheck previously checked checkboxes.

The only solution is to default to empty string. Checkboxes that are not checked as stored as an empty space. So they should default to an empty space.

As pointed out by Olle, NULL valued is used to indicate that a given question has not been answered and defaulting to an empty space will cause that information to be lost. This makes no difference when updating responses using the response editor however, since values for all questions are submitted and those questions without a value will get whatever the default value is (NULL or empty space). So its a case of either losing the correct empty space value which indicates No Answer for arrays and Not Checked for checkboxes or loosing the information that the original response did not have an answer for the question. So I conclude that until we have a better solution empty space default is preferable to a null default in the response editor.

