### PR TITLE
Fixed #17845: Label set preview only shows last item, other items are missing

### DIFF
--- a/application/helpers/admin/label_helper.php
+++ b/application/helpers/admin/label_helper.php
@@ -144,8 +144,7 @@ function modlabelsetanswers($lid)
             $assessmentvalue = (int) ($oLabelData['assessmentvalue']);
             $sortorder = $index;
 
-            $oLabel = Label::model()->findByPk($lid);
-            $oLabel = $oLabel == null ? (new Label()) : $oLabel;
+            $oLabel = new Label();
             $oLabel->lid = $lid;
             $oLabel->code = $actualcode;
             $oLabel->sortorder = $sortorder;


### PR DESCRIPTION
Create a new Label instead of trying to get one which does not exists since every label is deleted at the start of 'modlabelsetanswers'. Besides, Label search was using LabelSet id (lid) which led to labels corruption.