### PR TITLE
Fixed issue #17897: Build of statistics fails with DivisionByZero

### DIFF
--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -2639,7 +2639,11 @@ class statistics_helper
                         // or at least I don't know how !!! (lemeur)
                     } else {
                         //we want to have some "real" data here
-                        if ($gdata[$i] != "N/A") {
+                        if (
+                            $gdata[$i] != "N/A"
+                            && $gdata[$i] !== 0         // To keep it working like it did before PHP 8
+                            && $TotalCompleted != 0     // Just to be sure we avoid a division by zero
+                        ) {
                             //calculate percentage
                             $gdata[$i] = ($grawdata[$i] / $TotalCompleted) * 100;
                         }


### PR DESCRIPTION
- Prior to PHP 8.0.0, if a string is compared to a number or a numeric string then the string was converted to a number before performing the comparison. So, in this case, 0 was considered equal to N/A in PHP 7, but not equal in PHP 8, creating a different behavior