### PR TITLE
New Feature #18742: Allow "User Admins" to see Users' Roles

### DIFF
--- a/application/models/User.php
+++ b/application/models/User.php
@@ -694,17 +694,37 @@ class User extends LSActiveRecord
             ],
         ];
 
-        if (Permission::model()->hasGlobalPermission('superadmin', 'read')) {
+        // NOTE: Super Administrators with just the "read" flag also have these flags
+        $permission_read_users      = Permission::model()->hasGlobalPermission('users', 'read');
+        $permission_read_usergroups = Permission::model()->hasGlobalPermission('usergroups', 'read');
+        $permission_read_surveys    = Permission::model()->hasGlobalPermission('surveys', 'read');
+
+        // Number of Surveys
+        // This info is already guessable by people able to list all Surveys
+        if ($permission_read_surveys) {
             $cols[] = array(
                 "name" => 'surveysCreated',
                 "header" => gT("No of surveys"),
                 'filter' => false
             );
+        }
+
+        // Usergroups Names
+        // This info is safe to be shown to who can read all Users and Groups.
+        // TODO: When there will be a more robust Group permissions system,
+        //       this column could be enabled by default, since each Group would
+        //       be checked individually.
+        if ($permission_read_users && $permission_read_usergroups) {
             $cols[] = array(
                 "name" => 'groupList',
                 "header" => gT("Usergroups"),
                 'filter' => false
             );
+        }
+
+        // Role Names
+        // Knowing this info makes sense if you can read all Users
+        if ($permission_read_users) {
             $cols[] = array(
                 "name" => 'roleList',
                 "header" => gT("Applied role"),


### PR DESCRIPTION
This feature helps GDPR lovers.

Before this change, the Users List had some useful columns visible only to Super Administrators.

After this change, the Users List has these columns visible also to more appropriate roles:

- User Roles names:  show also to Administrators of Users
- User Group names:  show also to Administrators of Users+Groups 
- Number of surveys: show also to Administrators of Surveys

Again, this affects only the Read-Only visibility of these info.

Some are probably still very strict, but reasonable better than before. A step toward more atomic privileges.

Example use case:

Now you can allow a GDPR consultant to have Read-Only access in your LimeSurvey Users List, to see Users' Roles, and make data protection considerations. And, you do not need anymore to elevate your GDPR Consultant to "Super Administrator" to do so. That user just needs "Users Administrator (Read)" access.

Quality Assurance tests:

Visit Configuration > User Management, and test these:

- an user with privilege "All Users - read" - now can see the column "Applied role"
    - that user still cannot edit/assign/unassign Rules
- an user with privilege "All Usergroups - read" now can see the column "Usergroups"
    - that user still cannot edit/assign/unassign Usergroups
- an user with privilege "All Surveys - read" now can see the column "No of surveys"
- be a Super Administrator and verify that you still can see all columns

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

New feature #18742:
