### PR TITLE
Fixed issue: get param not checked, exception with wrong error messag…

### DIFF
--- a/application/controllers/admin/SurveymenuController.php
+++ b/application/controllers/admin/SurveymenuController.php
@@ -53,11 +53,11 @@ class SurveymenuController extends SurveyCommonAction
             Yii::app()->user->setFlash('error', gT("Access denied"));
             $this->getController()->redirect(Yii::app()->createUrl('/admin'));
         }
-
+        $id = (int) $id;
         if ($id != 0) {
-                    $model = $this->loadModel($id);
+            $model = Surveymenu::model()->findByPk($id);
         } else {
-                    $model = new Surveymenu();
+            $model = new Surveymenu();
         }
         // Uncomment the following line if AJAX validation is needed
         // $this->performAjaxValidation($model);
@@ -186,8 +186,12 @@ class SurveymenuController extends SurveyCommonAction
             $aSurveyMenuIds = json_decode(Yii::app()->request->getPost('sItems'));
             $success = [];
             foreach ($aSurveyMenuIds as $menuid) {
-                $model = $this->loadModel($menuid);
-                $success[$menuid] = $model->delete();
+                $model = Surveymenu::model()->findByPk((int)$menuid);
+                $success[$menuid] = false;
+                if ($model !== null) {
+                    $model->delete();
+                    $success[$menuid] = true;
+                }
             }
 
             $debug = $userConfig['config']['debug'] ?? 0;
@@ -229,9 +233,12 @@ class SurveymenuController extends SurveyCommonAction
 
         if (Yii::app()->request->isPostRequest) {
             $menuid = Yii::app()->request->getPost('menuid', 0);
+            $model = Surveymenu::model()->findByPk((int)$menuid);
             $success = false;
-            $model = $this->loadModel($menuid);
-            $success = $model->delete();
+            if ($model !== null) {
+                $model->delete();
+                $success = true;
+            }
             $debug = $userConfig['config']['debug'] ?? 0;
             $returnData = array(
                 'data' => [
@@ -332,6 +339,7 @@ class SurveymenuController extends SurveyCommonAction
      * @param integer $id the ID of the model to be loaded
      * @return Surveymenu the loaded model
      * @throws CHttpException
+     * @deprecated do not use this function anymore
      */
     public function loadModel($id)
     {

--- a/application/controllers/admin/SurveymenuEntryController.php
+++ b/application/controllers/admin/SurveymenuEntryController.php
@@ -123,8 +123,9 @@ class SurveymenuEntryController extends SurveyCommonAction
             $this->getController()->redirect(Yii::app()->createUrl('/admin'));
         }
         //Update or create
+        $id = (int) $id;
         if ($id != 0) {
-            $model = $this->loadModel($id);
+            $model = SurveymenuEntries::model()->findByPk($id);
         } else {
             $model = new SurveymenuEntries();
         }
@@ -280,8 +281,12 @@ class SurveymenuEntryController extends SurveyCommonAction
             $aSurveyMenuEntryIds = json_decode(Yii::app()->request->getPost('sItems'));
             $success = [];
             foreach ($aSurveyMenuEntryIds as $menuEntryid) {
-                $model = $this->loadModel($menuEntryid);
-                $success[$menuEntryid] = $model->delete();
+                $model = SurveymenuEntries::model()->findByPk((int)$menuEntryid);
+                $success[$menuEntryid] = false;
+                if ($model !== null) {
+                    $model->delete();
+                    $success[$menuEntryid] = true;
+                }
             }
 
             $debug = $userConfig['config']['debug'] ?? 0;
@@ -323,13 +328,15 @@ class SurveymenuEntryController extends SurveyCommonAction
         if (Yii::app()->request->isPostRequest) {
             $menuEntryid = Yii::app()->request->getPost('menuEntryid', 0);
             $success = false;
-            $model = $this->loadModel($menuEntryid);
+            $model = SurveymenuEntries::model()->findByPk((int)$menuEntryid);
             //Don't delete  main menu entries when not superadmin
             if (($model->menu_id == 1 || $model->menu_id == 2) && !Permission::model()->hasGlobalPermission('superadmin', 'read')) {
                 Yii::app()->user->setFlash('error', gT("Access denied"));
                 $this->getController()->redirect(Yii::app()->createUrl('/admin'));
             }
-            $success = $model->delete();
+            if ($model !== null) {
+                $success = $model->delete();
+            }
             $debug = $userConfig['config']['debug'] ?? 0;
 
             $returnData = array(
@@ -404,6 +411,7 @@ class SurveymenuEntryController extends SurveyCommonAction
      * @param integer $id the ID of the model to be loaded
      * @return SurveymenuEntries the loaded model
      * @throws CHttpException
+     * @deprecated do not use this function in future
      */
     public function loadModel($id)
     {


### PR DESCRIPTION
Fixed issue : get param not checked, exception with wrong error message; marked the function as deprecated (same bug in both controllers SurveymenuController.php and SurveymenuEntryController.php)
