### PR TITLE
Fixed issue #18731: Edit a question "script" tab has disappeared

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -204,7 +204,7 @@ class QuestionAdministrationController extends LSBaseController
         );
 
         $showScriptField = Permission::model()->hasSurveyPermission($question->sid, 'surveycontent', 'update') &&
-            SettingsUser::getUserSettingValue('showScriptEdit', App()->user->id);
+            SettingsUser::getUserSettingValue('showScriptEdit', App()->user->id, null, null, 1);
 
         // TODO: Problem with CSRF cookie when entering directly after login.
         $modalsHtml =  Yii::app()->twigRenderer->renderViewFromFile(
@@ -957,7 +957,7 @@ class QuestionAdministrationController extends LSBaseController
             "editorpreset" => App()->session['htmleditormode'],
             "script"       =>
             Permission::model()->hasSurveyPermission($oQuestion->sid, 'surveycontent', 'update')
-                && SettingsUser::getUserSetting('showScriptEdit', App()->user->id),
+                && SettingsUser::getUserSetting('showScriptEdit', App()->user->id, null, null, 1),
         ];
 
         $this->renderJSON($aPermissions);

--- a/application/core/LsDefaultDataSets.php
+++ b/application/core/LsDefaultDataSets.php
@@ -1840,7 +1840,7 @@ class LsDefaultDataSets
     {
         return [
             ['stg_name' => 'editorPreset', 'stg_value' => 'wysiwyg'],
-            ['stg_name' => 'showScriptEditor', 'stg_value' => '1'],
+            ['stg_name' => 'showScriptEdit', 'stg_value' => '1'],
             ['stg_name' => 'noViewMode', 'stg_value' => '0'],
             ['stg_name' => 'answeroptionprefix', 'stg_value' => 'AO'],
             ['stg_name' => 'subquestionprefix', 'stg_value' => 'SQ'],

--- a/application/models/SettingsUser.php
+++ b/application/models/SettingsUser.php
@@ -179,6 +179,7 @@ class SettingsUser extends LSActiveRecord
      * @param integer|null $uid | Can be omitted to just take the currently logged in users id
      * @param integer|null $entity | optional defaults to 'null'
      * @param integer|null $entity_id | optional defaults to 'null'
+     * @param mixed $default | optional defaults to 'null'
      * @return mixed|null  The current settings value or null id there is no setting
      */
     public static function getUserSettingValue($stg_name, $uid = null, $entity = null, $entity_id = null, $default = null)


### PR DESCRIPTION
Dev: use default in question editor
