### PR TITLE
Fixed issue: error and save pages were loading twig files of wrong su…

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -86,7 +86,7 @@ class SurveysController extends LSYii_Controller
             // TODO: Remove? It seems this can never happen because it's already caught by LSYii_Application::onException() (see commit c792c2e).
             $this->spitOutJsonError($error, $oException);
         } elseif ($error) {
-            $this->spitOutHtmlError($error, $oException);
+            $this->spitOutHtmlError($error, $request->getParam('sid'));
         } else {
             throw new CHttpException(404, 'Page not found.');
         }
@@ -96,7 +96,7 @@ class SurveysController extends LSYii_Controller
      * Echo $error as HTML and end execution.
      *
      * @param array $error
-     * @param CException|null $oException
+     * @param string|null $surveyId
      *
      * @return void
      *
@@ -106,10 +106,13 @@ class SurveysController extends LSYii_Controller
      * @throws Twig_Error_Syntax
      * @throws WrongTemplateVersionException
      */
-    public function spitOutHtmlError(array $error, $oException = null)
+    public function spitOutHtmlError(array $error, $surveyId )
     {
-        // TODO: getGlobalSetting is DEPRECATED.
-        $oTemplate = Template::model()->getInstance(getGlobalSetting('defaulttheme'));
+        if($surveyId) {
+            $oTemplate = Template::model()->getInstance('', $surveyId);
+        }else{
+            $oTemplate = Template::getLastInstance();
+        }
         $this->sTemplate = $oTemplate->sTemplateName;
 
         $admin = App()->getConfig('siteadminname');

--- a/application/libraries/Save.php
+++ b/application/libraries/Save.php
@@ -73,10 +73,6 @@ class Save
         $thisstep    = $_SESSION['survey_' . $iSurveyId]['step'] ?? 0;
         $clienttoken = $_SESSION['survey_' . $iSurveyId]['token'] ?? '';
 
-        $oSurvey   = Survey::model()->findByPk($iSurveyId);
-        $sTemplate = $oSurvey->template;
-        $oTemplate = Template::model()->getInstance($sTemplate);
-
         $aSaveForm['aErrors'] = $this->aSaveErrors;
         $this->launchSaveFormEvent($iSurveyId);
         /* Construction of the form */


### PR DESCRIPTION
- Error page was initing Template model without any hint of actual survey the error was coming from
- "Resume later" page was unnecessarily initing Template + passing wrong templatename 