### PR TITLE
Fixed issue: CORS Preflight headers missing (Allow-Methods and Allow-Headers)

### DIFF
--- a/application/controllers/admin/RemoteControl.php
+++ b/application/controllers/admin/RemoteControl.php
@@ -33,6 +33,8 @@ class RemoteControl extends SurveyCommonAction
         $setAccessControlHeader = Yii::app()->getConfig('add_access_control_header', 1);
         if ($setAccessControlHeader == 1) {
             header("Access-Control-Allow-Origin: *");
+            header("Access-Control-Allow-Methods: POST");
+            header("Access-Control-Allow-Headers: *");
         }
 
         $oHandler = new remotecontrol_handle($this->controller);


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev: Limesurvey just sent the Allow-Origin header. It was missing the Allow-Methods and Allow-Headers headers.

https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
