### PR TITLE
 Fixed issue [security] #18866: Label sets can be replaced by any admin user

### DIFF
--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -343,27 +343,32 @@ class labels extends Survey_Common_Action
         $action = App()->getRequest()->getParam('action');
         Yii::app()->loadHelper('admin/label');
         $lid = (int) App()->getRequest()->getpost('lid');
-
         if ($action == "updateset" && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             updateset($lid);
             Yii::app()->setFlashMessage(gT("Label set properties sucessfully updated."), 'success');
         }
         if ($action == "insertlabelset" && Permission::model()->hasGlobalPermission('labelsets', 'create')) {
-                    $lid = insertlabelset();
+            $lid = insertlabelset();
         }
         if (($action == "modlabelsetanswers" || ($action == "ajaxmodlabelsetanswers")) && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
-                    modlabelsetanswers($lid);
+            modlabelsetanswers($lid);
         }
         if ($action == "deletelabelset" && Permission::model()->hasGlobalPermission('labelsets', 'delete')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             if (deletelabelset($lid)) {
                 Yii::app()->setFlashMessage(gT("Label set sucessfully deleted."), 'success');
                 $lid = 0;
             }
         }
         if ($lid) {
-                    $this->getController()->redirect(array("admin/labels/sa/view/lid/".$lid));
+            $this->getController()->redirect(array("admin/labels/sa/view/lid/".$lid));
         } else {
-                    $this->getController()->redirect(array("admin/labels/sa/view"));
+            $this->getController()->redirect(array("admin/labels/sa/view"));
         }
     }
 

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -354,6 +354,9 @@ class labels extends Survey_Common_Action
             $lid = insertlabelset();
         }
         if (($action == "modlabelsetanswers" || ($action == "ajaxmodlabelsetanswers")) && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             modlabelsetanswers($lid);
         }
         if ($action == "deletelabelset" && Permission::model()->hasGlobalPermission('labelsets', 'delete')) {
@@ -443,7 +446,7 @@ class labels extends Survey_Common_Action
         }
         $language = trim($language);
         if ($lid == 0) {
-            if(!Permission::model()->hasGlobalPermission('labelsets', 'create')) {
+            if (!Permission::model()->hasGlobalPermission('labelsets', 'create')) {
                 throw new CHttpException(403);
             }
             $lset = new LabelSet;
@@ -453,7 +456,7 @@ class labels extends Survey_Common_Action
 
             $lid = getLastInsertID($lset->tableName());
         } else {
-            if(!Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+            if (!Permission::model()->hasGlobalPermission('labelsets', 'update')) {
                 throw new CHttpException(403);
             }
             Label::model()->deleteAll('lid = :lid', array(':lid' => $lid));

--- a/application/controllers/admin/labels.php
+++ b/application/controllers/admin/labels.php
@@ -340,9 +340,9 @@ class labels extends Survey_Common_Action
             Yii::app()->session['flashmessage'] = gT('Access denied!');
             $this->getController()->redirect(App()->createUrl("/admin"));
         }
-        $action = returnGlobal('action');
+        $action = App()->getRequest()->getParam('action');
         Yii::app()->loadHelper('admin/label');
-        $lid = (int) returnGlobal('lid');
+        $lid = (int) App()->getRequest()->getpost('lid');
 
         if ($action == "updateset" && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
             updateset($lid);
@@ -438,6 +438,9 @@ class labels extends Survey_Common_Action
         }
         $language = trim($language);
         if ($lid == 0) {
+            if(!Permission::model()->hasGlobalPermission('labelsets', 'create')) {
+                throw new CHttpException(403);
+            }
             $lset = new LabelSet;
             $lset->label_name = Yii::app()->getRequest()->getPost('laname');
             $lset->languages = $language;
@@ -445,6 +448,9 @@ class labels extends Survey_Common_Action
 
             $lid = getLastInsertID($lset->tableName());
         } else {
+            if(!Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+                throw new CHttpException(403);
+            }
             Label::model()->deleteAll('lid = :lid', array(':lid' => $lid));
         }
         $res = 'ok'; //optimistic


### PR DESCRIPTION
Fixed issue [security] #18866: Label sets can be replaced by any admin user
Fixed issue [security]#18868: No CRSF control for delete action of label set 
Dev: check global right
Dev: use getPost for lid and send error if CRSF is deactivated