### PR TITLE
Fixed issue [security] #18866: Label sets can be created by any admin user

### DIFF
--- a/application/controllers/admin/Labels.php
+++ b/application/controllers/admin/Labels.php
@@ -351,9 +351,12 @@ class Labels extends SurveyCommonAction
 
         $action = returnGlobal('action');
         Yii::app()->loadHelper('admin/label');
-        $lid = (int) returnGlobal('lid');
+        $lid = (int) App()->getRequest()->getPost('lid');
 
         if ($action == "updateset" && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             updateset($lid);
             Yii::app()->setFlashMessage(gT("Label set successfully saved."), 'success');
         }
@@ -362,9 +365,15 @@ class Labels extends SurveyCommonAction
             $lid = $oLabelSet->lid;
         }
         if (($action == "modlabelsetanswers" || ($action == "ajaxmodlabelsetanswers")) && Permission::model()->hasGlobalPermission('labelsets', 'update')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             modlabelsetanswers($lid);
         }
         if ($action == "deletelabelset" && Permission::model()->hasGlobalPermission('labelsets', 'delete')) {
+            if (!$lid) {
+                throw new CHttpException(400);
+            }
             if (LabelSet::model()->deleteLabelSet($lid)) {
                 Yii::app()->setFlashMessage(gT("Label set successfully deleted."), 'success');
                 $lid = 0;
@@ -478,14 +487,15 @@ class Labels extends SurveyCommonAction
      */
     public function ajaxSave()
     {
+        if (!Permission::model()->hasGlobalPermission('labelsets', 'create')) {
+            throw new CHttpException(403);
+        }
         $request   = Yii::app()->getRequest();
-        $lid       = (int) $request->getPost('lid');
         $answers   = $request->getPost('answers');
         $codes     = $request->getPost('codes');
         $labelName = $request->getPost('laname');
         $languages = implode(' ', $request->getPost('languages'));
         $assessmentValues = $request->getPost('assessmentvalues', []);
-
         if (empty($labelName)) {
             throw new CHttpException(400, gT('Could not save label set: Label set name is empty.'));
         }
@@ -520,7 +530,6 @@ class Labels extends SurveyCommonAction
         if (!Permission::model()->hasGlobalPermission('labelsets', 'update')) {
             throw new CHttpException(403, gT('Access denied'));
         }
-
         $request = Yii::app()->request;
 
         $labelSetId = (int) $request->getPost('labelSetId');


### PR DESCRIPTION
Fixed issue [security] #18868: No CRSF control for action of label set
Dev: add global permission check
Dev: get lid by POST (process action came from label set edition)