### PR TITLE
Fixed issue #18885: CSRF Leading to reset Boxes

### DIFF
--- a/application/controllers/HomepageSettingsController.php
+++ b/application/controllers/HomepageSettingsController.php
@@ -28,6 +28,16 @@ class HomepageSettingsController extends LSBaseController
     }
 
     /**
+     * @return string[] action filters
+     */
+    public function filters()
+    {
+        return [
+            'postOnly + resetAllBoxes', // Only allow resetAllBoxes via POST request
+        ];
+    }
+
+    /**
      * Register js script before rendering
      *
      * @param string $view

--- a/application/models/SurveysGroups.php
+++ b/application/models/SurveysGroups.php
@@ -65,8 +65,7 @@ class SurveysGroups extends LSActiveRecord implements PermissionInterface
             array('name', 'match', 'pattern' => '/^[A-Za-z0-9_\.]+$/u','message' => gT('Group code can contain only alphanumeric character, underscore or dot. Spaces are not allowed.')),
             array('title', 'length', 'max' => 100),
             array('alwaysavailable', 'boolean'),
-            array('created, modified', 'safe'),
-            array('title, description', 'LSYii_Validators'), // XSS if non super-admin
+            array('description, created, modified', 'safe'),
             // The following rule is used by search().
             // @todo Please remove those attributes that should not be searched.
             array('gsid, name, title, description, owner_id, parent_id, created, modified, created_by', 'safe', 'on' => 'search'),

--- a/application/models/SurveysGroups.php
+++ b/application/models/SurveysGroups.php
@@ -65,7 +65,8 @@ class SurveysGroups extends LSActiveRecord implements PermissionInterface
             array('name', 'match', 'pattern' => '/^[A-Za-z0-9_\.]+$/u','message' => gT('Group code can contain only alphanumeric character, underscore or dot. Spaces are not allowed.')),
             array('title', 'length', 'max' => 100),
             array('alwaysavailable', 'boolean'),
-            array('description, created, modified', 'safe'),
+            array('created, modified', 'safe'),
+            array('title, description', 'LSYii_Validators'), // XSS if non super-admin
             // The following rule is used by search().
             // @todo Please remove those attributes that should not be searched.
             array('gsid, name, title, description, owner_id, parent_id, created, modified, created_by', 'safe', 'on' => 'search'),

--- a/application/views/homepageSettings/index.php
+++ b/application/views/homepageSettings/index.php
@@ -12,11 +12,6 @@ App()->getClientScript()->registerScript(
 );
 
 ?>
-<script type="text/javascript">
-    strConfirm = '<?php eT('Please confirm', 'js');?>';
-    strCancel = '<?php eT('Cancel', 'js');?>';
-    strOK = '<?php eT('OK', 'js');?>';
-</script>
 
 <div class="row">
     <div class="col-12 list-surveys">

--- a/application/views/homepageSettings/partial/topbarBtns/rightSideButtons.php
+++ b/application/views/homepageSettings/partial/topbarBtns/rightSideButtons.php
@@ -20,10 +20,15 @@ $this->widget(
         'id' => 'reset-button',
         'text' => gT('Reset'),
         'icon' => 'ri-refresh-line',
-        'link' => $this->createUrl('homepageSettings/resetAllBoxes/'),
         'htmlOptions' => [
             'class' => 'btn btn-warning',
-            'data-confirm' => gT('This will delete all current boxes to restore the default ones. Are you sure you want to continue?')
+            'data-bs-toggle' => "modal",
+            'data-bs-target' => '#confirmation-modal',
+            'data-btnclass' => 'btn-primary',
+            'data-btntext' => gT('OK'),
+            'data-post-url' => $this->createUrl('homepageSettings/resetAllBoxes/'),
+            'data-title' => gT("Please confirm"),
+            'data-message' => gT('This will delete all current boxes to restore the default ones. Are you sure you want to continue?'),
         ],
     ]
 );

--- a/assets/scripts/admin/homepagesettings.js
+++ b/assets/scripts/admin/homepagesettings.js
@@ -128,21 +128,6 @@ $(document).on('ready  pjax:scriptcomplete', function(){
         });
     });
 
-    /**
-     * Confirmation modal
-     */
-    $('a[data-confirm]').click(function(ev) {
-        var href = $(this).attr('href');
-        if (!$('#dataConfirmModal').length) {
-            $('body').append('<div  id="dataConfirmModal" class="modal  fade" role="dialog" aria-labelledby="dataConfirmLabel">  <div class="modal-dialog">    <div class="modal-content">      <div class="modal-header">   <h4 class="modal-title">'+strConfirm+'</h4>     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>      </div>      <div class="modal-body">      </div>      <div class="modal-footer"><a class="btn btn-primary" id="dataConfirmOK">'+strOK+'</a><button  type="button" class="btn btn-cancel" data-bs-dismiss="modal" >'+strCancel+'</button>      </div>    </div><!-- /.modal-content -->  </div><!-- /.modal-dialog --></div><!-- /.modal -->');
-        }
-        $('#dataConfirmModal').find('.modal-body').text($(this).attr('data-confirm'));
-        $('#dataConfirmOK').attr('href', href);
-        $('#dataConfirmModal').modal('show');
-        return false;
-    });
-
-
     // Create Update : icons
     if($('.option-icon').length>1){
         $('.option-icon').on('click', function (ev, that) {


### PR DESCRIPTION
This script had its own confirm. I could have put the POST in that confirm, but it didn't make sense. Took it out and used the confirmation modal that is used in other screens. As we did in 16792.