### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,10 @@
 Please report (suspected) security vulnerabilities by creating a bug report on https://bugs.limesurvey.org and mark it as private. Marking it as private will make the bug report visible to only users who have access. Another option would be to send the information to support@limesurvey.org, directly.
 
 You will receive a response from us within 48 hours. If the issue is confirmed, we will release a patch as soon as possible depending on complexity but historically within a few days.
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in limesurvey please disclose it via [our huntr page](https://huntr.dev/repos/limesurvey/limesurvey/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of limesurvey.


### PR DESCRIPTION
As requested through the platform by @c-schmitz, this will point your security policy to [huntr.dev](https://huntr.dev/repos/limesurvey/limesurvey})