### PR TITLE
Fixed issue #18932: 404 error after importing responses from a old response table

### DIFF
--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -425,7 +425,7 @@ class DataEntry extends SurveyCommonAction
                 }
                 Yii::app()->session['flashmessage'] = sprintf(gT("%s old response(s) and according timings were successfully imported."), $imported, $iRecordCountT);
             }
-            $this->getController()->redirect(["/responses/index/", 'surveyId' => $surveyid]);
+            $this->getController()->redirect(["/responses/browse/", 'surveyId' => $surveyid]);
         }
     }
 


### PR DESCRIPTION
Apparently the problem is that the Responses index page has been removed. 
A redirect statement was missing to be updated