### PR TITLE
Fixes issue #18958: Multiple numerical input text input box width not having an effect

### DIFF
--- a/application/controllers/admin/PrintableSurvey.php
+++ b/application/controllers/admin/PrintableSurvey.php
@@ -756,7 +756,7 @@ class PrintableSurvey extends SurveyCommonAction
                             $height = (isset($qidattributes['display_rows']) && $qidattributes['display_rows']) ? $qidattributes['display_rows'] : null;
 
                             if (!isset($aWidth)) {
-                                $aWidth = $this->getColumnWidth($qidattributes['label_input_columns'], $qidattributes['text_input_width']);
+                                $aWidth = $this->getColumnWidth($qidattributes['label_input_columns'], $qidattributes['text_input_columns']);
                             }
 
                             $question['type_help'] .= CHtml::tag("div", array("class" => "tip-help"), gT("Please write your answer(s) here:"));

--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -1072,7 +1072,7 @@ class questionHelper
         );
 
         self::$attributes["text_input_width"] = array(
-        "types" => Question::QT_K_MULTIPLE_NUMERICAL . Question::QT_N_NUMERICAL . Question::QT_S_SHORT_FREE_TEXT . Question::QT_T_LONG_FREE_TEXT . Question::QT_U_HUGE_FREE_TEXT . Question::QT_SEMICOLON_ARRAY_TEXT,
+        "types" => Question::QT_N_NUMERICAL . Question::QT_S_SHORT_FREE_TEXT . Question::QT_T_LONG_FREE_TEXT . Question::QT_U_HUGE_FREE_TEXT . Question::QT_SEMICOLON_ARRAY_TEXT,
         'category' => gT('Display'),
         'sortorder' => 100,
         'inputtype' => 'singleselect',
@@ -1095,9 +1095,8 @@ class questionHelper
         "help" => gT('Relative width of the text input wrapper element'),
         "caption" => gT('Text input box width'));
 
-        /* Do EXACTLY the same than text_input_width for K(multinum): must move K here and rename in a DB update and remove it + fix when import*/
         self::$attributes["text_input_columns"] = array(
-        "types" => Question::QT_Q_MULTIPLE_SHORT_TEXT . Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS,
+        "types" => Question::QT_K_MULTIPLE_NUMERICAL . Question::QT_Q_MULTIPLE_SHORT_TEXT . Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS,
         'category' => gT('Display'),
         'sortorder' => 90,
         'inputtype' => 'singleselect',

--- a/application/views/survey/questions/answer/multiplenumeric/config.xml
+++ b/application/views/survey/questions/answer/multiplenumeric/config.xml
@@ -794,7 +794,7 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
-            <name>text_input_width</name>
+            <name>text_input_columns</name>
             <category>Display</category>
             <sortorder>100</sortorder>
             <inputtype>singleselect</inputtype>


### PR DESCRIPTION
Fixed issue #18958: Multiple numerical input text input box width not having an effect
Dev: Will require a separate fix if you want to migrate from older LS / LSS files to ensure question setting text_input_width converted to text_input_columns as expected in LS6
