### PR TITLE
Fixed issue #18958: Multiple numerical input text input box width not having an effect (alternative)

### DIFF
--- a/application/models/QuestionBaseRenderer.php
+++ b/application/models/QuestionBaseRenderer.php
@@ -373,6 +373,10 @@ abstract class QuestionBaseRenderer extends StaticModel
         $labelAttributeWidth = trim((string) $this->getQuestionAttribute('label_input_columns'));
         $inputAttributeWidth = trim((string) $this->getQuestionAttribute('text_input_columns'));
 
+        if ($inputAttributeWidth === "") {
+            $inputAttributeWidth = trim((string) $this->getQuestionAttribute('text_input_width'));
+        }
+
         $attributeInputContainerWidth = intval($inputAttributeWidth);
         if ($attributeInputContainerWidth < 1 || $attributeInputContainerWidth > 12) {
             $attributeInputContainerWidth = null;


### PR DESCRIPTION
Fixed issue #18958: Multiple numerical input text input box width not having an effect 
Dev: This keeps the old text_input_width setting for multiple numerical input but allows it to render correctly