### PR TITLE
MW-458: ls cli command

### DIFF
--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -15,11 +15,23 @@ class ImportSurveyCommand extends CConsoleCommand
      * 
      * Sample command: php application/commands/console.php importsurvey import-file abcf.lss
      */
-    protected function importFile($filename)
+    protected function importFile($filename, $furtherParams)
     {
+        $params = [
+            "bTranslateLinkFields" => false,
+            "sNewSurveyName" => null,
+            "DestSurveyID" => null,
+        ];
+        if ($json = json_decode($furtherParams ?? "{}", true)) {
+            foreach ($params as $key => $value) {
+                $params[$key] = $json[$key] ?? $params[$key];
+            }
+        }
         importSurveyFile(
             Yii::app()->getConfig('tempdir') . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR . $filename,
-            false
+            $params["bTranslateLinkFields"],
+            $params["sNewSurveyName"],
+            $params["DestSurveyID"],
         );
     }
 
@@ -41,7 +53,8 @@ class ImportSurveyCommand extends CConsoleCommand
                 if (!preg_match('/^[a-zA-Z0-9_\.]*$/', $filename)) {
                     throw new Exception("Your filename can only contain letters, digits and dot");
                 }
-                $this->importFile($filename);
+                $furtherParams = $sArgument[2] ?? null;
+                $this->importFile($filename, $furtherParams);
             } break;
         }
     }

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -1,7 +1,5 @@
 <?php
 
-/*require_once "application/helpers/common_helper.php";
-require_once "application/helpers/admin/import_helper.php";*/
 Yii::import('application.helpers.replacements_helper', true);
 Yii::import('application.helpers.expressions.em_manager_helper', true);
 Yii::import('application.helpers.common_helper', true);

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -1,10 +1,20 @@
 <?php
 
-include "application/helpers/admin/import_helper.php";
+/*require_once "application/helpers/common_helper.php";
+require_once "application/helpers/admin/import_helper.php";*/
+Yii::import('application.helpers.replacements_helper', true);
+Yii::import('application.helpers.expressions.em_manager_helper', true);
+Yii::import('application.helpers.common_helper', true);
+Yii::import('application.helpers.admin.import_helper', true);
 
 class ImportSurveyCommand extends CConsoleCommand
 {
 
+    /**
+     * @param string $filename
+     * 
+     * Sample command: php application/commands/console.php importsurvey import-file abcf.lss
+     */
     protected function importFile($filename)
     {
         importSurveyFile(
@@ -13,6 +23,9 @@ class ImportSurveyCommand extends CConsoleCommand
         );
     }
 
+    /**
+     * @param array $aArguments
+     */
     public function run($sArgument)
     {
         if (!count($sArgument)) {
@@ -25,7 +38,7 @@ class ImportSurveyCommand extends CConsoleCommand
                     throw new Exception("You need to specify the file to import from");
                 }
                 $filename = $sArgument[1];
-                if (!preg_match('/^[a-zA-Z0-9\.]*$/', $filename)) {
+                if (!preg_match('/^[a-zA-Z0-9_\.]*$/', $filename)) {
                     throw new Exception("Your filename can only contain letters, digits and dot");
                 }
                 $this->importFile($filename);

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+include "application/helpers/admin/import_helper.php";
+
+class ImportSurveyCommand extends CConsoleCommand
+{
+
+    protected function importFile($filename)
+    {
+        importSurveyFile(
+            Yii::app()->getConfig('tempdir') . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR . $filename,
+            false
+        );
+    }
+
+    public function run($sArgument)
+    {
+        if (!count($sArgument)) {
+            throw new Exception("You need to specify the command to be executed");
+        }
+        $command = $sArgument[0];
+        switch ($command) {
+            case "import-file": {
+                if (count($sArgument) < 2) {
+                    throw new Exception("You need to specify the file to import from");
+                }
+                $filename = $sArgument[1];
+                if (!preg_match('/^[a-zA-Z0-9\.]*$/', $filename)) {
+                    throw new Exception("Your filename can only contain letters, digits and dot");
+                }
+                $this->importFile($filename);
+            } break;
+        }
+    }
+}

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -14,6 +14,7 @@ class ImportSurveyCommand extends CConsoleCommand
      * @param string $filename
      * 
      * Sample command: php application/commands/console.php importsurvey import-file abcf.lss
+     *                 php application/commands/console.php importsurvey import-file limesurvey_survey_979573.lss '{"bTranslateLinkFields": true, "sNewSurveyName": "Orsson", "DestSurveyID": 666999}'
      */
     protected function importFile($filename, $furtherParams)
     {
@@ -56,6 +57,7 @@ class ImportSurveyCommand extends CConsoleCommand
                 $furtherParams = $sArgument[2] ?? null;
                 $this->importFile($filename, $furtherParams);
             } break;
+            default: throw new Exception("Unsupported command");
         }
     }
 }


### PR DESCRIPTION
This CLI command is supporting the importing of lss files.

# Prerequisites for testing

1. Make sure that you install your ls-ce repo.
2. Create a survey of your liking
3. Export your template as an lss file
4. Create the tmp/templates folder on your local repo
5. move or copy your exported file into this location

# Helper

Since you might want to reset your install and reinstall your database, a tool that does just that on command may come in handy. For this purpose I have created a file at cli/cleanup.sh with the following content

```
yes | rm application/config/config.php
mysql -h ls-dev-mysql -u root -proot -e "drop database \`$1\`;show databases;"
```

as we can see, the database's name is a parameter. You can run it like this from the root of the repo:

```
./cli/cleanup.sh ls-ce
```

# How to test

You can test it by running

```
php application/commands/console.php importsurvey import-file <filename>
```

where filename is the name of your file, like **mytemplate.lss**. The file is assumed to be located at tmp/templates. You can also run it in a more customized manner, like

```
php application/commands/console.php importsurvey import-file limesurvey_survey_979573.lss
```