### PR TITLE
MW-446: Main template flow

### DIFF
--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -125,6 +125,16 @@ class AdminController extends LSYii_Controller
         if (isset(Yii::app()->session['templatetoken'])) unset(Yii::app()->session['templatetoken']);
     }
 
+    public function actionInstallTemplateByToken()
+    {
+        //exec("ls", $output);
+        if (isset(Yii::app()->session['templatetoken'])) {
+            Yii::import('application.helpers.admin.token_helper', true);
+            $filename = decodeFilename(Yii::app()->session['templatetoken']);
+            echo "php application/commands/console.php importsurvey import-file {$filename}";
+        }
+    }
+
     /**
      * Load and set session vars
      *

--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -127,11 +127,18 @@ class AdminController extends LSYii_Controller
 
     public function actionInstallTemplateByToken()
     {
-        //exec("ls", $output);
         if (isset(Yii::app()->session['templatetoken'])) {
             Yii::import('application.helpers.admin.token_helper', true);
             $filename = decodeFilename(Yii::app()->session['templatetoken']);
-            echo "php application/commands/console.php importsurvey import-file {$filename}";
+            $this->actionRemoveTemplateToken();
+            if (!preg_match('/^[a-zA-Z0-9_\.]*$/', $filename)) {
+                echo "badly formatted file";
+            } else {
+                exec("php application/commands/console.php importsurvey import-file {$filename}", $output);
+                echo ((!implode("", $output)) ? "success" : "failed to import file");
+            }
+        } else {
+            echo "Token was not found";
         }
     }
 

--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -122,7 +122,9 @@ class AdminController extends LSYii_Controller
 
     public function actionRemoveTemplateToken()
     {
-        if (isset(Yii::app()->session['templatetoken'])) unset(Yii::app()->session['templatetoken']);
+        if (isset(Yii::app()->session['templatetoken'])) {
+            unset(Yii::app()->session['templatetoken']);
+        }
     }
 
     public function actionInstallTemplateByToken()

--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -120,6 +120,11 @@ class AdminController extends LSYii_Controller
         Yii::app()->end();
     }
 
+    public function actionRemoveTemplateToken()
+    {
+        if (isset(Yii::app()->session['templatetoken'])) unset(Yii::app()->session['templatetoken']);
+    }
+
     /**
      * Load and set session vars
      *

--- a/application/controllers/admin/Authentication.php
+++ b/application/controllers/admin/Authentication.php
@@ -42,15 +42,14 @@ class Authentication extends SurveyCommonAction
         }
         /* Checking whether we have any templates to import */
         if (($templatetoken = Yii::app()->request->getParam('templatetoken', 'default')) !== 'default') {
-
             $url = Yii::app()->request->url;
             $questionPosition = strpos($url, "?");
             Yii::app()->session['templatetoken'] = Yii::app()->request->getParam('templatetoken', 'default');
-            $target = implode("?", [substr($url, 0, $questionPosition), implode("&", array_filter(explode("&", substr($url, $questionPosition + 1)), function($v, $k) {
+            $target = implode("?", [substr($url, 0, $questionPosition), implode("&", array_filter(explode("&", substr($url, $questionPosition + 1)), function ($v, $k) {
                 return strpos($v, 'templatetoken') !== 0;
             }, ARRAY_FILTER_USE_BOTH))]);
             $this->runDbUpgrade();
-            header('Location: '.$target);
+            header('Location: ' . $target);
         }
         // The page should be shown only for non logged in users
         $this->redirectIfLoggedIn();

--- a/application/controllers/admin/Authentication.php
+++ b/application/controllers/admin/Authentication.php
@@ -403,7 +403,11 @@ class Authentication extends SurveyCommonAction
         self::runDbUpgrade();
         self::cleanFailedEmailTable();
         self::createNewFailedEmailsNotification();
-        $returnUrl = App()->user->getReturnUrl(array('/admin'));
+        if (isset(Yii::app()->session['templatetoken'])) {
+            $returnUrl = App()->user->getReturnUrl(['/surveyAdministration/listSurveys']);
+        } else {
+            $returnUrl = App()->user->getReturnUrl(array('/admin'));
+        }
         Yii::app()->getController()->redirect($returnUrl);
     }
 

--- a/application/controllers/admin/Authentication.php
+++ b/application/controllers/admin/Authentication.php
@@ -40,6 +40,18 @@ class Authentication extends SurveyCommonAction
             Yii::app()->session['adminlang'] = Yii::app()->request->getParam('loginlang', 'default');
             Yii::app()->setLanguage(Yii::app()->session["adminlang"]);
         }
+        /* Checking whether we have any templates to import */
+        if (($templatetoken = Yii::app()->request->getParam('templatetoken', 'default')) !== 'default') {
+
+            $url = Yii::app()->request->url;
+            $questionPosition = strpos($url, "?");
+            Yii::app()->session['templatetoken'] = Yii::app()->request->getParam('templatetoken', 'default');
+            $target = implode("?", [substr($url, 0, $questionPosition), implode("&", array_filter(explode("&", substr($url, $questionPosition + 1)), function($v, $k) {
+                return strpos($v, 'templatetoken') !== 0;
+            }, ARRAY_FILTER_USE_BOTH))]);
+            $this->runDbUpgrade();
+            header('Location: '.$target);
+        }
         // The page should be shown only for non logged in users
         $this->redirectIfLoggedIn();
 

--- a/application/helpers/admin/token_helper.php
+++ b/application/helpers/admin/token_helper.php
@@ -90,3 +90,27 @@ function emailTokens($iSurveyID, $aResultTokens, $sType, $continueOnError = fals
     }
     return $aResult;
 }
+
+/**
+ * This method encodes a filename
+ * 
+ * @param string $filename
+ * 
+ * @return string The encoded filename
+ */
+function encodeFilename($filename)
+{
+    return base64_encode($filename);
+}
+
+/**
+ * This method decodes a filename
+ * 
+ * @param string $encoded
+ * 
+ * @return string The decoded filename
+ */
+function decodeFileName($encoded)
+{
+    return base64_decode($encoded);
+}

--- a/application/views/admin/super/layout_main.php
+++ b/application/views/admin/super/layout_main.php
@@ -29,6 +29,42 @@ $containerClass = !Yii::app()->user->isGuest ? 'container-fluid full-page-wrappe
 echo '<!-- Full page, started in SurveyCommonAction::renderWrappedTemplate() -->
 <div class="full-page-wrapper ' . $containerClass . '" id="in_survey_common_action">';
 
+if (Yii::app()->session['templatetoken'] ?? null) {
+    Yii::import('application.helpers.admin.token_helper', true);
+    $filename = decodeFilename(Yii::app()->session['templatetoken']);
+    ?>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+    <script>
+        function removeTemplateToken() {
+            alert("Kivertek a franciakat Burkina faszabol");
+        }
+    </script>
+    <div id="dialog" title="Import Template?">
+        <?php echo "Shall we import the template file of {$filename}?" ?>
+    </div>
+    <script>
+        jQuery(function() {
+            $("#dialog").dialog({
+                open: function() {
+                    $(this).closest(".ui-dialog")
+                    .find(".ui-dialog-titlebar-close")
+                    .removeClass("ui-dialog-titlebar-close")
+                    .html("<span class=\'ui-button-icon-primary ui-icon ui-icon-closethick\' id=\'dialog-close\'></span>");
+                    $(this).parent().find(".ui-dialog-title").css("width", "calc(100% - 32px)");
+                },
+                buttons: {
+                    Yes: function() {},
+                    No: function() {
+                        jQuery('#dialog-close').click();
+                    }
+                }
+            });
+        })
+    </script>'
+    <?php
+}
+
 echo $content;
 
 echo '</div>';

--- a/application/views/admin/super/layout_main.php
+++ b/application/views/admin/super/layout_main.php
@@ -29,7 +29,7 @@ $containerClass = !Yii::app()->user->isGuest ? 'container-fluid full-page-wrappe
 echo '<!-- Full page, started in SurveyCommonAction::renderWrappedTemplate() -->
 <div class="full-page-wrapper ' . $containerClass . '" id="in_survey_common_action">';
 
-if (Yii::app()->session['templatetoken'] ?? null) {
+if (((Yii::app()->session['templatetoken'] ?? null)) && (!Yii::app()->user->getIsGuest())) {
     Yii::import('application.helpers.admin.token_helper', true);
     $filename = decodeFilename(Yii::app()->session['templatetoken']);
     ?>
@@ -44,6 +44,14 @@ if (Yii::app()->session['templatetoken'] ?? null) {
         <?php echo "Shall we import the template file of {$filename}?" ?>
     </div>
     <script>
+        function sendRequest(type, url, callback, async = true, params = "") {
+            if (async !== false) async = true;
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = callback;
+            xhttp.open(type, url, async);
+            xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+            xhttp.send(params);
+        }
         jQuery(function() {
             $("#dialog").dialog({
                 open: function() {
@@ -53,6 +61,9 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     .html("<span class=\'ui-button-icon-primary ui-icon ui-icon-closethick\' id=\'dialog-close\'></span>");
                     $(this).parent().find(".ui-dialog-title").css("width", "calc(100% - 32px)");
                 },
+                close: function() {
+                    sendRequest("POST", "/index.php?r=admin/removeTemplateToken", undefined, true, `${LS.data.csrfTokenName}=${LS.data.csrfToken}`);
+                },
                 buttons: {
                     Yes: function() {},
                     No: function() {
@@ -61,7 +72,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                 }
             });
         })
-    </script>'
+    </script>
     <?php
 }
 

--- a/application/views/admin/super/layout_main.php
+++ b/application/views/admin/super/layout_main.php
@@ -29,53 +29,6 @@ $containerClass = !Yii::app()->user->isGuest ? 'container-fluid full-page-wrappe
 echo '<!-- Full page, started in SurveyCommonAction::renderWrappedTemplate() -->
 <div class="full-page-wrapper ' . $containerClass . '" id="in_survey_common_action">';
 
-if (((Yii::app()->session['templatetoken'] ?? null)) && (!Yii::app()->user->getIsGuest())) {
-    Yii::import('application.helpers.admin.token_helper', true);
-    $filename = decodeFilename(Yii::app()->session['templatetoken']);
-    ?>
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-    <script>
-        function removeTemplateToken() {
-            alert("Kivertek a franciakat Burkina faszabol");
-        }
-    </script>
-    <div id="dialog" title="Import Template?">
-        <?php echo "Shall we import the template file of {$filename}?" ?>
-    </div>
-    <script>
-        function sendRequest(type, url, callback, async = true, params = "") {
-            if (async !== false) async = true;
-            var xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = callback;
-            xhttp.open(type, url, async);
-            xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-            xhttp.send(params);
-        }
-        jQuery(function() {
-            $("#dialog").dialog({
-                open: function() {
-                    $(this).closest(".ui-dialog")
-                    .find(".ui-dialog-titlebar-close")
-                    .removeClass("ui-dialog-titlebar-close")
-                    .html("<span class=\'ui-button-icon-primary ui-icon ui-icon-closethick\' id=\'dialog-close\'></span>");
-                    $(this).parent().find(".ui-dialog-title").css("width", "calc(100% - 32px)");
-                },
-                close: function() {
-                    sendRequest("POST", "/index.php?r=admin/removeTemplateToken", undefined, true, `${LS.data.csrfTokenName}=${LS.data.csrfToken}`);
-                },
-                buttons: {
-                    Yes: function() {},
-                    No: function() {
-                        jQuery('#dialog-close').click();
-                    }
-                }
-            });
-        })
-    </script>
-    <?php
-}
-
 echo $content;
 
 echo '</div>';

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -111,9 +111,9 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     sendRequest("POST", "/index.php?r=admin/installTemplateByToken", function() {
                         if (this.readyState === 4) {
                             if (this.responseText === 'success') {
-                                sendRequest("/index.php?r=admin/removeTemplateToken", undefined, true, `${LS.data.csrfTokenName}=${LS.data.csrfToken}`);
+                                jQuery('#dialog-close').click();
                             } else {
-                                document.getElementById('#dialog').innerHTML = 'Failed to install template';
+                                document.getElementById('dialog').innerHTML = this.responseText;
                             }
                         }
                     }, true, `${LS.data.csrfTokenName}=${LS.data.csrfToken}`);

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -136,7 +136,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     if (this.responseText === 'success') {
                         context.querySelector('.modal-body-text').style.display = 'none';
                         context.querySelector('.preview').style.display = 'block';
-                        context.querySelector('.modal-title').innerText = 'Preview';
+                        context.querySelector('.modal-title').innerText = 'Question preview';
                         for (let btn of context.querySelectorAll('.btn')) btn.style.display = 'none';
                         isPreview = true;
                     } else {

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -113,17 +113,22 @@ if (Yii::app()->session['templatetoken'] ?? null) {
         let context = document.getElementById("install-template-token");
         context.classList.add("show");
         context.style.display = "block";
+        let popupBackground = document.createElement("div");
+        popupBackground.className = "modal-backdrop fade show";
+        document.body.appendChild(popupBackground);
         let isPreview = false;
         let extraParams = `${LS.data.csrfTokenName}=${LS.data.csrfToken}`;
+        function closeTemplatePopup() {
+            sendRequest("POST", "/index.php?r=admin/removeTemplateToken", undefined, true, extraParams);
+            context.classList.remove('show');
+            context.style.display = 'none';
+            if (isPreview) {
+                window.location.reload();
+            }
+            popupBackground.remove();
+        }
         for (let closeItem of context.querySelectorAll('.btn-close, .btn-cancel')) {
-            closeItem.addEventListener("click", function() {
-                sendRequest("POST", "/index.php?r=admin/removeTemplateToken", undefined, true, extraParams);
-                context.classList.remove("show");
-                context.style.display = "none";
-                if (isPreview) {
-                    window.location.reload();
-                }
-            });
+            closeItem.addEventListener("click", closeTemplatePopup);
         }
         context.querySelector('.btn-ok').addEventListener("click", function() {
             sendRequest("POST", "/index.php?r=admin/installTemplateByToken", function() {
@@ -131,6 +136,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     if (this.responseText === 'success') {
                         context.querySelector('.modal-body-text').style.display = 'none';
                         context.querySelector('.preview').style.display = 'block';
+                        context.querySelector('.modal-title').innerText = 'Preview';
                         for (let btn of context.querySelectorAll('.btn')) btn.style.display = 'none';
                         isPreview = true;
                     } else {
@@ -139,6 +145,12 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     sendRequest("POST", "/index.php?r=admin/removeTemplateToken", undefined, true, extraParams);
                 }
             }, true, extraParams);
+        });
+
+        context.addEventListener("click", closeTemplatePopup);
+
+        context.querySelector('.modal-dialog').addEventListener("click", function(evt) {
+            evt.stopPropagation();
         });
         <?php
         }

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -35,12 +35,20 @@ echo viewHelper::getViewTestTag('listSurveys');
         overflow:auto;
     }
 
-    #install-template-token:not(.preview-outer) .modal-footer .btn.btn-close {
+    #install-template-token:not(.preview-outer) .modal-footer .btn.btn-collapse {
         display: none;
     }
 
-    #install-template-token.preview-outer .modal-footer .btn:not(.btn-close) {
+    #install-template-token.preview-outer .modal-footer .btn:not(.btn-collapse) {
         display: none;
+    }
+
+    .btn.btn-collapse {
+        border: 1px solid #212529;
+    }
+
+    .btn.btn-collapse:hover {
+        color: #212529;
     }
 
 </style>
@@ -97,6 +105,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
         <div class="modal-content" style="text-align:left; color:#000;">
             <div class="modal-header">
                 <h1 class="modal-title"><?php eT('Import Survey?'); ?></h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="modal-body-text"><?php echo sprintf(gT('%sPlease confirm that you want to create your template.%s'), "<p>", "</p>"); ?></div>
@@ -106,7 +115,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
             <div class="modal-footer modal-footer-buttons">
                 <a role="button" class="btn btn-primary btn-ok"><?php eT('Use This Template'); ?></a>
                 <button type="button" class="btn btn-danger" data-bs-dismiss="modal" style="color: white;"><?php eT('No'); ?></button>
-                <button type="button" class="btn btn-close" data-bs-dismiss="modal"><?php eT('Close'); ?></button>
+                <button type="button" class="btn btn-collapse" data-bs-dismiss="modal"><?php eT('Close'); ?></button>
             </div>
         </div>
     </div>
@@ -160,7 +169,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
             }
             popupBackground.remove();
         }
-        for (let closeItem of context.querySelectorAll('.btn-close, .btn-cancel')) {
+        for (let closeItem of context.querySelectorAll('.btn-close, .btn-collapse, .btn-danger')) {
             closeItem.addEventListener("click", closeTemplatePopup);
         }
         context.querySelector('.btn-ok').addEventListener("click", function() {

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -63,17 +63,17 @@ if (Yii::app()->session['templatetoken'] ?? null) {
         <!-- Modal content-->
         <div class="modal-content" style="text-align:left; color:#000">
             <div class="modal-header">
-                <h1 class="modal-title">Import Survey?</h1>
+                <h1 class="modal-title"><?php eT('Import Survey?'); ?></h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <div class="modal-body-text"><?php echo "Shall we import the template file of {$filename}?"; ?></div>
+                <div class="modal-body-text"><?php echo sprintf(gT('Shall we import the template file of %s?'), $filename); ?></div>
                 <div class="preview" style="display: none;">mypreview</div>
             </div>
             
             <div class="modal-footer modal-footer-buttons">
-                <button type="button" class="btn btn-cancel" data-bs-dismiss="modal">No</button>
-                <a role="button" class="btn btn-danger btn-ok">Yes</a>
+                <button type="button" class="btn btn-cancel" data-bs-dismiss="modal"><?php eT('No'); ?></button>
+                <a role="button" class="btn btn-danger btn-ok"><?php eT('Yes'); ?></a>
             </div>
         </div>
     </div>
@@ -136,7 +136,7 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                     if (this.responseText === 'success') {
                         context.querySelector('.modal-body-text').style.display = 'none';
                         context.querySelector('.preview').style.display = 'block';
-                        context.querySelector('.modal-title').innerText = 'Question preview';
+                        context.querySelector('.modal-title').innerText = '<?php eT('Question preview'); ?>';
                         for (let btn of context.querySelectorAll('.btn')) btn.style.display = 'none';
                         isPreview = true;
                     } else {

--- a/application/views/surveyAdministration/listSurveys_view.php
+++ b/application/views/surveyAdministration/listSurveys_view.php
@@ -10,6 +10,40 @@
 echo viewHelper::getViewTestTag('listSurveys');
 
 ?>
+<style>
+    #install-template-token .modal-dialog {
+        transition: max-width 1s;
+    }
+    #install-template-token.preview-outer .modal-dialog {
+        max-width: 50%;
+    }
+
+    #install-template-token .modal-dialog .modal-content {
+        transition: height 1s;
+        height: 77%;
+    }
+
+    #install-template-token.preview-outer .modal-dialog {
+        height:60vh;
+    }
+
+    #install-template-token.preview-outer .modal-dialog .modal-content {
+        height: 90%;
+    }
+    #install-template-token.preview-outer .modal-dialog .modal-body {
+        height:100%;
+        overflow:auto;
+    }
+
+    #install-template-token:not(.preview-outer) .modal-footer .btn.btn-close {
+        display: none;
+    }
+
+    #install-template-token.preview-outer .modal-footer .btn:not(.btn-close) {
+        display: none;
+    }
+
+</style>
 <div class="ls-space list-surveys">
     <ul class="nav nav-tabs" id="surveysystem" role="tablist">
         <li class="nav-item"><a class="nav-link active" href="#surveys" aria-controls="surveys" role="tab" data-bs-toggle="tab"><?php eT('Survey list'); ?></a></li>
@@ -56,24 +90,23 @@ echo viewHelper::getViewTestTag('listSurveys');
 <?php
 if (Yii::app()->session['templatetoken'] ?? null) {
     Yii::import('application.helpers.admin.token_helper', true);
-    $filename = decodeFilename(Yii::app()->session['templatetoken']);
     ?>
     <div id="install-template-token" class="modal fade" role="dialog">
-    <div class="modal-dialog ">
+    <div class="modal-dialog" style="transform: translate(0, 98px);">
         <!-- Modal content-->
-        <div class="modal-content" style="text-align:left; color:#000">
+        <div class="modal-content" style="text-align:left; color:#000;">
             <div class="modal-header">
                 <h1 class="modal-title"><?php eT('Import Survey?'); ?></h1>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <div class="modal-body-text"><?php echo sprintf(gT('Shall we import the template file of %s?'), $filename); ?></div>
-                <div class="preview" style="display: none;">mypreview</div>
+                <div class="modal-body-text"><?php echo sprintf(gT('%sPlease confirm that you want to create your template.%s'), "<p>", "</p>"); ?></div>
+                <div class="preview" style="display: none;"><img src="https://mdbcdn.b-cdn.net/img/Photos/Thumbnails/Slides/2.webp" class="w-100"/></div>
             </div>
             
             <div class="modal-footer modal-footer-buttons">
-                <button type="button" class="btn btn-cancel" data-bs-dismiss="modal"><?php eT('No'); ?></button>
-                <a role="button" class="btn btn-danger btn-ok"><?php eT('Yes'); ?></a>
+                <a role="button" class="btn btn-primary btn-ok"><?php eT('Use This Template'); ?></a>
+                <button type="button" class="btn btn-danger" data-bs-dismiss="modal" style="color: white;"><?php eT('No'); ?></button>
+                <button type="button" class="btn btn-close" data-bs-dismiss="modal"><?php eT('Close'); ?></button>
             </div>
         </div>
     </div>
@@ -135,10 +168,14 @@ if (Yii::app()->session['templatetoken'] ?? null) {
                 if (this.readyState === 4) {
                     if (this.responseText === 'success') {
                         context.querySelector('.modal-body-text').style.display = 'none';
-                        context.querySelector('.preview').style.display = 'block';
+                        let preview = context.querySelector('.preview');
+                        preview.style.display = 'block';
                         context.querySelector('.modal-title').innerText = '<?php eT('Question preview'); ?>';
-                        for (let btn of context.querySelectorAll('.btn')) btn.style.display = 'none';
+                        for (let btn of context.querySelectorAll('.modal-footer .btn')) {
+                            btn.classList[btn.classList.contains('invisible') ? 'add' : 'remove']('invisible');
+                        };
                         isPreview = true;
+                        context.classList.add('preview-outer');
                     } else {
                         context.querySelector('.modal-body-text').innerHTML = this.responseText;
                     }


### PR DESCRIPTION
To test, one needs to make sure that the

tmp/templates

folder exists and there are lss files inside. (you can export a survey into lss and copy it to the desired location if needed)

Then, encode the filename (without the path) into base64 and, while being logged out, load the

http://ls-ce/index.php?templatetoken=<encoded filename>&r=admin/authentication/sa/login

path. For example:

http://ls-ce/index.php?templatetoken=bGltZXN1cnZleV9zdXJ2ZXlfOTc5NTczLmxzcw==&r=admin/authentication/sa/login

where bGltZXN1cnZleV9zdXJ2ZXlfOTc5NTczLmxzcw== is the token of limesurvey_survey_979573.lss.

The page will redirect you to the login page where you could log in.

After logging in, we expect to be redirected to the survey page and a popup being shown asking whether you want to install the template.

If you leave this unanswered and reload the page, the confirm dialog should still be displayed.

If you click:

- outside of the popup content
- the X of the fialog
- No

then the popup should be dismissed and if you reload the page, the popup should no longer be displayed.

Otherwise, if you click on Yes, then a peview should be shown (in the context of this PR this is an empty popup, it's a known issue) and if you close it, then the grid should be refreshed with the imported template.