### PR TITLE
Fixed issue #18439: Link set when create user are unusuable in text view

### DIFF
--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -585,11 +585,10 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
             if (strpos($this->Body, "<html>") === false) {
                 $this->Body = "<html>" . $this->Body . "</html>";
             }
-            $this->msgHTML($this->Body, App()->getConfig("publicdir")); // This allow embedded image if we remove the servername from image
-            if (empty($this->AltBody)) {
-                $html = new \Html2Text\Html2Text($this->Body);
-                $this->AltBody = $html->getText();
-            }
+            $this->msgHTML($this->Body, App()->getConfig("publicdir"), function($html) {
+                return (new \Html2Text\Html2Text($html))->getText();
+            }); // This allow embedded image if we remove the servername from image
+
         }
         return $this->Send();
     }

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -588,7 +588,7 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
             $this->msgHTML($this->Body, App()->getConfig("publicdir"), function($html) {
                 return (new \Html2Text\Html2Text($html))->getText();
             }); // This allow embedded image if we remove the servername from image
-
+            // TODO: Original AltBody is overwritten by msgHTML. Do we need to set it again if there was one?
         }
         return $this->Send();
     }

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -585,9 +585,7 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
             if (strpos($this->Body, "<html>") === false) {
                 $this->Body = "<html>" . $this->Body . "</html>";
             }
-            $this->msgHTML($this->Body, App()->getConfig("publicdir"), function($html) {
-                return (new \Html2Text\Html2Text($html))->getText();
-            }); // This allow embedded image if we remove the servername from image
+            $this->msgHTML($this->Body, App()->getConfig("publicdir")); // This allow embedded image if we remove the servername from image
             // TODO: Original AltBody is overwritten by msgHTML. Do we need to set it again if there was one?
         }
         return $this->Send();
@@ -986,5 +984,18 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
             }
         }
         return $aOutList;
+    }
+
+    /**
+     * @inheritdoc
+     * Override to use a better html to text converter (ex. doesn't removes links)
+     */
+    public function html2text($html, $advanced = false)
+    {
+        if (is_callable($advanced)) {
+            return call_user_func($advanced, $html);
+        }
+
+        return (new \Html2Text\Html2Text($html))->getText();
     }
 }


### PR DESCRIPTION
Altbody was never set as phpMailer always set it based on the original body.
Hence, the custom "alt-body creation" was not applied. This last was fixed.