### PR TITLE
Fixed issue 18821: Public url is not used for SURVEYURL (Tests)

### DIFF
--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace ls\tests;
+
+use Yii;
+
+/**
+ * Test LSYii_Application class.
+ */
+class LSYiiApplicationTest extends TestBaseClass
+{
+    /**
+     * Get public base url, previously set in publicurl config attribute.
+     */
+    public function testGetpublicBaseUrlFromConfig()
+    {
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+
+        Yii::app()->setConfig('publicurl', 'http://config.example.com/');
+        $url = Yii::app()->getPublicBaseUrl();
+
+        $this->assertSame($url, 'http://config.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Reset original value.
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+    }
+
+    /**
+     * Get absolute public base url, previously set in publicurl config attribute.
+     */
+    public function testGetAbsolutepublicBaseUrlFromConfig()
+    {
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+
+        Yii::app()->setConfig('publicurl', 'http://absoluteConfig.example.com/');
+        $url = Yii::app()->getPublicBaseUrl(true);
+
+        $this->assertSame($url, 'http://absoluteConfig.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Reset original value.
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+    }
+
+    /**
+     * Get public base url, previously set in baseUrl request attribute.
+     */
+    public function testGetpublicBaseUrlFromRequest()
+    {
+        $tmpPublicUrl = Yii::app()->getRequest()->getBaseUrl();
+
+        Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
+        $url = Yii::app()->getPublicBaseUrl();
+
+        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Reset original value.
+        Yii::app()->getRequest()->baseUrl = $tmpPublicUrl;
+    }
+
+    /**
+     * Get absolute public base url, previously set in baseUrl request attribute.
+     */
+    public function testGetAbsolutepublicBaseUrlFromRequest()
+    {
+        $tmpPublicUrl = Yii::app()->getRequest()->getBaseUrl();
+
+        Yii::app()->getRequest()->baseUrl = 'absoluteRequest.example.com/';
+        $url = Yii::app()->getPublicBaseUrl(true);
+
+        $this->assertSame($url, 'http://absoluteRequest.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Reset original value.
+        Yii::app()->getRequest()->baseUrl = $tmpPublicUrl;
+    }
+
+    /**
+     * Get public base url, previously set in baseUrl request attribute.
+     * A public url is also set in the baseUrl config attribute,
+     * but the one in the request attribute should be returned.
+     */
+    public function testGetpublicBaseUrlFromConfigNoSchemeInConfigPublicUrl()
+    {
+        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
+        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
+
+        // No scheme in url.
+        Yii::app()->setConfig('publicurl', '//config.example.com/path?param=1');
+        Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
+        $url = Yii::app()->getPublicBaseUrl();
+
+        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Restore original values.
+        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
+        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+    }
+
+    /**
+     * Get public base url, previously set in baseUrl request attribute.
+     * A public url is also set in the baseUrl config attribute,
+     * but the one in the request attribute should be returned.
+     */
+    public function testGetpublicBaseUrlFromConfigNoHostInConfigPublicUrl()
+    {
+        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
+        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
+
+        Yii::app()->setConfig('publicurl', 'http://');
+        Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
+        $url = Yii::app()->getPublicBaseUrl();
+
+        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+
+        // Restore original values.
+        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
+        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+    }
+
+    /**
+     * Create a public url with just a route.
+     */
+    public function testCreatePublicUrlWithARoute()
+    {
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+
+        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
+        Yii::app()->setConfig('publicurl', 'http://www.example.com/');
+        $url = Yii::app()->createPublicUrl('controller/action');
+
+        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action', 'Unexpected url. The url does not correspond with a public url and a route.');
+
+        // Restore original values.
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+    }
+
+    /**
+     * Create a public url with a route and two parameters.
+     */
+    public function testCreatePublicUrlWithParams()
+    {
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+
+        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
+        Yii::app()->setConfig('publicurl', 'http://www.example.com/');
+        $url = Yii::app()->createPublicUrl('controller/action', array('param_one' => 1, 'param_two' => 2));
+
+        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action?param_one=1&param_two=2', 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+
+        // Restore original values.
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+    }
+
+    /**
+     * Create a public url with a specific schema.
+     */
+    public function testCreatePublicUrlWithASchema()
+    {
+        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
+        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
+        $tmpHostInfo = Yii::app()->getRequest()->getHostInfo();
+
+        Yii::app()->setConfig('publicurl', 'http://www.example.com');
+        Yii::app()->getRequest()->baseUrl = 'www.example.com';
+        Yii::app()->getRequest()->hostInfo = '';
+
+        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
+        $url = Yii::app()->createPublicUrl('controller/action', array('param_one' => 1, 'param_two' => 2), 'http');
+
+        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action?param_one=1&param_two=2', 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+
+        // Restore original values.
+        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
+        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+        Yii::app()->getRequest()->hostInfo = $tmpHostInfo;
+    }
+}

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -123,11 +123,12 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
 
-        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
+        //$scriptUrl = Yii::app()->getRequest()->getScriptUrl();
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
         $url = Yii::app()->createPublicUrl('controller/action');
 
-        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action', 'Unexpected url. The url does not correspond with a public url and a route.');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
+        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
@@ -165,6 +166,8 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
         $url = Yii::app()->createPublicUrl('controller/action', array('param_one' => 1, 'param_two' => 2), 'http');
+
+        $test = Yii::app()->createUrl('controller/action');
 
         $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action?param_one=1&param_two=2', 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -123,7 +123,6 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
 
-        //$scriptUrl = Yii::app()->getRequest()->getScriptUrl();
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
         $url = Yii::app()->createPublicUrl('controller/action');
 
@@ -141,11 +140,12 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
 
-        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
-        $url = Yii::app()->createPublicUrl('controller/action', array('param_one' => 1, 'param_two' => 2));
+        $parameters = array('param_one' => 1, 'param_two' => 2);
+        $url = Yii::app()->createPublicUrl('controller/action', $parameters);
 
-        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action?param_one=1&param_two=2', 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action', $parameters);
+        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
@@ -164,12 +164,11 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getRequest()->baseUrl = 'www.example.com';
         Yii::app()->getRequest()->hostInfo = '';
 
-        $scriptUrl = Yii::app()->getRequest()->getScriptUrl();
-        $url = Yii::app()->createPublicUrl('controller/action', array('param_one' => 1, 'param_two' => 2), 'http');
+        $parameters = array('param_one' => 1, 'param_two' => 2);
+        $url = Yii::app()->createPublicUrl('controller/action', $parameters, 'http');
 
-        $test = Yii::app()->createUrl('controller/action');
-
-        $this->assertSame($url, 'http://www.example.com' . $scriptUrl . '/controller/action?param_one=1&param_two=2', 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action', $parameters);
+        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);

--- a/tests/unit/LSYiiValidatorsTest.php
+++ b/tests/unit/LSYiiValidatorsTest.php
@@ -140,6 +140,7 @@ class LSYiiValidatorsTest extends TestBaseClass
         $userName = \Yii::app()->securityManager->generateRandomString(8);
 
         $userData = array(
+            'full_name'  => $userName,
             'users_name' => $userName,
             'email'      => $userName . '@example.org'
         );

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -427,11 +427,54 @@ class SurveyTest extends TestBaseClass
     }
 
     /**
-     * Get tha alias survey url for a specific language.
+     * Get the alias survey url for a specific language.
+     * Using the get format.
      */
-    public function testGetAliasSurveyUrl()
+    public function testGetAliasSurveyUrlGet()
     {
+        $urlManager = Yii::app()->getUrlManager();
+
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
+        $tmpUrlFormat = $urlManager->getUrlFormat();
+
+        $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
+
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = 'my-arabic-survey';
+
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        Yii::app()->setConfig('publicurl', 'http://example.com');
+
+        $params = [$urlManager->routeVar => 'my-arabic-survey'];
+        $query = $urlManager->createPathInfo($params, '=', '&');
+        $expectedUrl = Yii::app()->getPublicBaseUrl(true) . '?' . $query;
+
+        $url = self::$testSurvey->getSurveyUrl('ar');
+        $this->assertSame($url, $expectedUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // No alias assert.
+        $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
+        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
+        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // Reset original value.
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = $tmpArSurveyAlias;
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        $urlManager->urlFormat = $tmpUrlFormat;
+    }
+
+    /**
+     * Get the alias survey url for a specific language.
+     * Using the path format.
+     */
+    public function testGetAliasSurveyUrlPath()
+    {
+        $urlManager = Yii::app()->getUrlManager();
+
+        $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
+        $tmpUrlFormat = $urlManager->getUrlFormat();
+
+        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
+
         self::$testSurvey->languagesettings['ar']->surveyls_alias = 'my-arabic-survey';
 
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
@@ -440,7 +483,7 @@ class SurveyTest extends TestBaseClass
         $url = self::$testSurvey->getSurveyUrl('ar');
         $this->assertSame($url, 'http://example.com/my-arabic-survey', 'Unexpected url. The url does not correspond with a public survey url.');
 
-        // No alias test.
+        // No alias assert.
         $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
         $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
         $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
@@ -448,5 +491,6 @@ class SurveyTest extends TestBaseClass
         // Reset original value.
         self::$testSurvey->languagesettings['ar']->surveyls_alias = $tmpArSurveyAlias;
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        $urlManager->urlFormat = $tmpUrlFormat;
     }
 }

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -393,10 +393,12 @@ class SurveyTest extends TestBaseClass
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
-        $url = self::$testSurvey->getSurveyUrl(null, array('param_1' => 1, 'param_2' => 2));
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'param_1' => 1, 'param_2' => 2, 'lang' => 'en'));
+        $params = array('param_1' => 1, 'param_2' => 2);
+        $url = self::$testSurvey->getSurveyUrl(null, $params);
+        $urlParams = array_merge($params, ['sid' => self::$surveyId, 'lang' => 'en']);
+        $expectedUrl = App()->createPublicUrl('survey/index', $urlParams);
 
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame($url, $expectedUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -444,12 +444,8 @@ class SurveyTest extends TestBaseClass
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
-        $params = [$urlManager->routeVar => 'my-arabic-survey'];
-        $query = $urlManager->createPathInfo($params, '=', '&');
-        $expectedUrl = Yii::app()->getPublicBaseUrl(true) . '?' . $query;
-
         $url = self::$testSurvey->getSurveyUrl('ar');
-        $this->assertSame($url, $expectedUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame($url, 'http://example.com?r=my-arabic-survey', 'Unexpected url. The url does not correspond with a public survey url.');
 
         // No alias assert.
         $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
@@ -490,6 +486,94 @@ class SurveyTest extends TestBaseClass
 
         // Reset original value.
         self::$testSurvey->languagesettings['ar']->surveyls_alias = $tmpArSurveyAlias;
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        $urlManager->urlFormat = $tmpUrlFormat;
+    }
+
+    /**
+     * Get the alias survey url for a specific language.
+     * Using the get format.
+     *
+     * There are two languages with the same alias in this case.
+     */
+    public function testGetAliasSurveyUrlGetRepeatedAlias()
+    {
+        $urlManager = Yii::app()->getUrlManager();
+
+        $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
+        $tmpDeSurveyAlias = self::$testSurvey->languagesettings['de']->surveyls_alias;
+        $tmpUrlFormat = $urlManager->getUrlFormat();
+
+        $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
+
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = 'my-survey';
+        self::$testSurvey->languagesettings['de']->surveyls_alias = 'my-survey';
+
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        Yii::app()->setConfig('publicurl', 'http://example.com');
+
+        $arAliasUrl = self::$testSurvey->getSurveyUrl('ar');
+        $this->assertSame($arAliasUrl, 'http://example.com?r=my-survey&lang=ar', 'Unexpected url. The url does not correspond with a public survey url.');
+
+        $deAliasUrl = self::$testSurvey->getSurveyUrl('de');
+        $this->assertSame($deAliasUrl, 'http://example.com?r=my-survey&lang=de', 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // No alias assert.
+        $arUrl = self::$testSurvey->getSurveyUrl('ar', array(), false);
+        $expectedRelativeArUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
+        $this->assertSame($arUrl, 'http://example.com' . $expectedRelativeArUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        $deUrl = self::$testSurvey->getSurveyUrl('de', array(), false);
+        $expectedRelativeDeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'de'));
+        $this->assertSame($deUrl, 'http://example.com' . $expectedRelativeDeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // Reset original value.
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = $tmpArSurveyAlias;
+        self::$testSurvey->languagesettings['de']->surveyls_alias = $tmpDeSurveyAlias;
+        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        $urlManager->urlFormat = $tmpUrlFormat;
+    }
+
+    /**
+     * Get the alias survey url for a specific language.
+     * Using the path format.
+     *
+     * There are two languages with the same alias in this case.
+     */
+    public function testGetAliasSurveyUrlPathRepeatedAlias()
+    {
+        $urlManager = Yii::app()->getUrlManager();
+
+        $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
+        $tmpDeSurveyAlias = self::$testSurvey->languagesettings['de']->surveyls_alias;
+        $tmpUrlFormat = $urlManager->getUrlFormat();
+
+        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
+
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = 'my-survey';
+        self::$testSurvey->languagesettings['de']->surveyls_alias = 'my-survey';
+
+        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        Yii::app()->setConfig('publicurl', 'http://example.com');
+
+        $arAliasUrl = self::$testSurvey->getSurveyUrl('ar');
+        $this->assertSame($arAliasUrl, 'http://example.com/my-survey?lang=ar', 'Unexpected url. The url does not correspond with a public survey url.');
+
+        $deAliasUrl = self::$testSurvey->getSurveyUrl('de');
+        $this->assertSame($deAliasUrl, 'http://example.com/my-survey?lang=de', 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // No alias assert.
+        $arUrl = self::$testSurvey->getSurveyUrl('ar', array(), false);
+        $expectedRelativeArUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
+        $this->assertSame($arUrl, 'http://example.com' . $expectedRelativeArUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        $deUrl = self::$testSurvey->getSurveyUrl('de', array(), false);
+        $expectedRelativeDeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'de'));
+        $this->assertSame($deUrl, 'http://example.com' . $expectedRelativeDeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+
+        // Reset original value.
+        self::$testSurvey->languagesettings['ar']->surveyls_alias = $tmpArSurveyAlias;
+        self::$testSurvey->languagesettings['de']->surveyls_alias = $tmpDeSurveyAlias;
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
         $urlManager->urlFormat = $tmpUrlFormat;
     }


### PR DESCRIPTION
Tests for
- application/core/LSYii_Application.php
  + createPublicUrl()
  + getPublicBaseUrl()
Survey Model:
  + getSurveyUrl()
     * Multiple Languages
     * Short URL (alias) and Regular URL
     * Path and Query