### PR TITLE
19009 fix general settings default

### DIFF
--- a/application/models/services/SurveyUpdater/GeneralSettings.php
+++ b/application/models/services/SurveyUpdater/GeneralSettings.php
@@ -280,14 +280,22 @@ class GeneralSettings
             ? $fieldOpts
             : [];
 
-        // Composite inputs always have to be processed
-        // - even if the field itself is not provided
-        $isCompositeInput = (
-            isset($fieldOpts['compositeInputs'])
-        );
+        // Composite inputs should be processed
+        // - if all composite fields are provided
+        $isCompositeInput = isset($fieldOpts['compositeInputs']);
+        $compositeInputsSet = true;
+        if ($isCompositeInput) {
+            foreach ($fieldOpts['compositeInputs'] as $compositeInput) {
+                if (!isset($input[$compositeInput])) {
+                    $compositeInputsSet = false;
+                    break;
+                }
+            }
+        }
+
         if (
             !isset($input[$field])
-            && !$isCompositeInput
+            && (!$isCompositeInput || !$compositeInputsSet)
         ) {
             return $meta;
         }

--- a/application/models/services/SurveyUpdater/GeneralSettings.php
+++ b/application/models/services/SurveyUpdater/GeneralSettings.php
@@ -285,7 +285,6 @@ class GeneralSettings
         $isCompositeInput = (
             isset($fieldOpts['compositeInputs'])
         );
-
         if (
             !isset($input[$field])
             && !$isCompositeInput
@@ -296,10 +295,9 @@ class GeneralSettings
         $type = !empty($fieldOpts['type'])
             ? $fieldOpts['type']
             : null;
-        $initValue = $survey->{$field} ?? '';
         $default = !empty($fieldOpts['default'])
             ? $fieldOpts['default']
-            : $initValue;
+            : null;
 
         if (
             isset($fieldOpts['canUpdate'])

--- a/tests/unit/services/SurveyUpdater/GeneralSettings/GeneralSettingsDispatchesEventsTest.php
+++ b/tests/unit/services/SurveyUpdater/GeneralSettings/GeneralSettingsDispatchesEventsTest.php
@@ -45,7 +45,7 @@ class GeneralSettingsDispatchesEventsTest extends TestBaseClass
 
         $generalSettings = (new GeneralSettingsFactory)->make($mockSet);
 
-        $generalSettings->update(1, []);
+        $generalSettings->update(1, ['printanswers' => 'Y']);
 
         $this->assertContains('beforeSurveySettingsSave', $eventsTriggered);
     }


### PR DESCRIPTION
Fixed issue #19009: Cannot unset expiry or start date of survey

Only values fields provided in the input array should be updated.  Composite fields should only be updated if all composite fields are provided. Default value should default to NULL where no other default value is provided.
