### PR TITLE
Fixed bug #18627 Missing SQL query errors in admin mail (SQL CODE THAT FAILED)

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -2600,10 +2600,9 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                         }
                         try {
                             $iNewID = SurveyDynamic::model($iSurveyID)->insertRecords($aInsertData);
-
                             if (!$iNewID) {
                                 throw new Exception("Error, no entry id was returned.", 1);
-                            }            
+                            }
                         } catch (Exception $e) {
                             throw new Exception(gT("Error") . ": Failed to insert data in response table<br />");
                         }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -2599,7 +2599,11 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                             }
                         }
                         try {
-                            SurveyDynamic::model($iSurveyID)->insertRecords($aInsertData);
+                            $iNewID = SurveyDynamic::model($iSurveyID)->insertRecords($aInsertData);
+
+                            if (!$iNewID) {
+                                throw new Exception("Error, no entry id was returned.", 1);
+                            }            
                         } catch (Exception $e) {
                             throw new Exception(gT("Error") . ": Failed to insert data in response table<br />");
                         }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -2598,7 +2598,9 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                                 }
                             }
                         }
-                        if (!SurveyDynamic::model($iSurveyID)->insertRecords($aInsertData)) {
+                        try {
+                            SurveyDynamic::model($iSurveyID)->insertRecords($aInsertData);
+                        } catch (Exception $e) {
                             throw new Exception(gT("Error") . ": Failed to insert data in response table<br />");
                         }
                         $results['responses']++;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5062,7 +5062,9 @@ class LimeExpressionManager
             } catch (Exception $e) {
                 $srid = null;
                 $message .= $this->gT("Unable to insert record into survey table"); // TODO - add SQL error?
-                submitfailed($this->gT("Unable to insert record into survey table"), $e->getMessage());
+                $query = $e->getMessage();
+                $trace = $e->getTraceAsString();
+                submitfailed($this->gT("Unable to insert record into survey table"), $query . "\n\n" . $trace);
             }
 
             //Insert Row for Timings, if needed

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5055,15 +5055,16 @@ class LimeExpressionManager
             SurveyDynamic::sid($this->sid);
             $oSurvey = new SurveyDynamic();
 
-            $iNewID = $oSurvey->insertRecords($sdata);
-            if ($iNewID) {    // Checked
+            try {
+                $iNewID = $oSurvey->insertRecords($sdata);
                 $srid = $iNewID;
                 $_SESSION[$this->sessid]['srid'] = $iNewID;
-            } else {
+            } catch (Exception $e) {
                 $srid = null;
                 $message .= $this->gT("Unable to insert record into survey table"); // TODO - add SQL error?
-                submitfailed($this->gT("Unable to insert record into survey table"));
+                submitfailed($this->gT("Unable to insert record into survey table"), $e->getMessage());
             }
+
             //Insert Row for Timings, if needed
             if ($this->surveyOptions['savetimings']) {
                 SurveyTimingDynamic::sid($this->sid);

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5057,11 +5057,9 @@ class LimeExpressionManager
 
             try {
                 $iNewID = $oSurvey->insertRecords($sdata);
-
                 if (!$iNewID) {
                     throw new Exception("Error, no entry id was returned.", 1);
                 }
-
                 $srid = $iNewID;
                 $_SESSION[$this->sessid]['srid'] = $iNewID;
             } catch (Exception $e) {

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5057,6 +5057,11 @@ class LimeExpressionManager
 
             try {
                 $iNewID = $oSurvey->insertRecords($sdata);
+
+                if (!$iNewID) {
+                    throw new Exception("Error, no entry id was returned.", 1);
+                }
+
                 $srid = $iNewID;
                 $_SESSION[$this->sessid]['srid'] = $iNewID;
             } catch (Exception $e) {

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -120,8 +120,8 @@ class SurveyDynamic extends LSActiveRecord
             $record->$k = $v;
         }
 
-        $record->encryptSave();
-        return $record->id;
+        $res = $record->encryptSave();
+        return $res ? $record->id : $res;
     }
 
     /**

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -120,8 +120,11 @@ class SurveyDynamic extends LSActiveRecord
             $record->$k = $v;
         }
 
-        $record->encryptSave();
-        return $record->id;
+        if ($record->encryptSave()) {
+            return $record->id;
+        } else {
+            throw new \Exception('There was an error, the record could not be saved.', 1);
+        }
     }
 
     /**

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -120,12 +120,8 @@ class SurveyDynamic extends LSActiveRecord
             $record->$k = $v;
         }
 
-        try {
-            $record->encryptSave();
-            return $record->id;
-        } catch (Exception $e) {
-            return false;
-        }
+        $record->encryptSave();
+        return $record->id;
     }
 
     /**

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -120,11 +120,8 @@ class SurveyDynamic extends LSActiveRecord
             $record->$k = $v;
         }
 
-        if ($record->encryptSave()) {
-            return $record->id;
-        } else {
-            throw new \Exception('There was an error, the record could not be saved.', 1);
-        }
+        $record->encryptSave();
+        return $record->id;
     }
 
     /**

--- a/tests/TestBaseClass.php
+++ b/tests/TestBaseClass.php
@@ -140,6 +140,8 @@ class TestBaseClass extends TestCase
         \Yii::app()->session['loginID'] = 1;
 
         if (self::$testSurvey) {
+            // Clear database cache.
+            \Yii::app()->db->schema->refresh();
             if (!self::$testSurvey->delete()) {
                 self::assertTrue(
                     false,

--- a/tests/unit/models/SurveyDynamicTest.php
+++ b/tests/unit/models/SurveyDynamicTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ls\tests;
+
+use Yii;
+
+class SurveyDynamicTest extends TestBaseClass
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setupBeforeClass();
+
+        // Import survey.
+        $filename = self::$surveysFolder . '/limesurvey_survey_161359_quickTranslation.lss';
+        self::importSurvey($filename);
+
+        // Activate survey.
+        $activator = new \SurveyActivator(self::$testSurvey);
+        $activator->activate();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // Expire survey and delete response table.
+        self::$testSurvey->expire();
+        $responseTableName = \SurveyDynamic::model(self::$surveyId)->tableName();
+        \Yii::app()->db->createCommand()->dropTable($responseTableName);
+
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * Testing that a new response can be correctly inserted.
+     */
+    public function testInsertResponse()
+    {
+        $responseId = \SurveyDynamic::model(self::$surveyId)->insertRecords(array('startlanguage' => 'en'));
+        $response = \SurveyDynamic::model()->findByPk($responseId);
+
+        $this->assertIsNumeric($responseId, 'The newly inserted response id should have been returned.');
+        $this->assertInstanceOf('SurveyDynamic', $response, 'The newly inserted response should have been returned.');
+    }
+
+    /**
+     * Testing that an exception is thrown when
+     * response insertion fails.
+     */
+    public function testErrorInsertingResponse()
+    {
+        $this->expectException(\CException::class);
+
+        // Table column name incorrectly spelled.
+        $responseId = \SurveyDynamic::model(self::$surveyId)->insertRecords(array('starlanguage' => 'en'));
+    }
+}

--- a/tests/unit/models/SurveyDynamicTest.php
+++ b/tests/unit/models/SurveyDynamicTest.php
@@ -21,11 +21,6 @@ class SurveyDynamicTest extends TestBaseClass
 
     public static function tearDownAfterClass(): void
     {
-        // Expire survey and delete response table.
-        self::$testSurvey->expire();
-        $responseTableName = \SurveyDynamic::model(self::$surveyId)->tableName();
-        \Yii::app()->db->createCommand()->dropTable($responseTableName);
-
         parent::tearDownAfterClass();
     }
 


### PR DESCRIPTION
- Moving out the try/catch 
  + from inside the mdoel method `insertRecords` 
  + to outside of the model, usually controller.
- Adding test
- Adding more info to the submitfailed