### PR TITLE
Fixed issue #18574: Fruity: If a variation is selected at survey level, custom.css is not loaded as expected

### DIFF
--- a/application/views/themeOptions/update.php
+++ b/application/views/themeOptions/update.php
@@ -194,7 +194,7 @@ echo viewHelper::getViewTestTag('surveyTemplateOptionsUpdate');
                                 <div class="row">
                                     <div class="form-group">
                                         <?php echo $form->labelEx($model, 'files_css'); ?>
-                                        <?php echo $form->textArea($model, 'files_css', ['rows' => 6, 'cols' => 50]); ?>
+                                        <?php echo $form->textArea($model, 'files_css', ['rows' => 6, 'cols' => 50, 'data-inherit-source' => 'optionCssFiles']); ?>
                                         <?php echo $form->error($model, 'files_css'); ?>
                                     </div>
                                 </div>
@@ -229,7 +229,7 @@ echo viewHelper::getViewTestTag('surveyTemplateOptionsUpdate');
                                 <div class="row">
                                     <div class="form-group">
                                         <?php echo $form->labelEx($model, 'cssframework_css'); ?>
-                                        <?php echo $form->textArea($model, 'cssframework_css', ['rows' => 6, 'cols' => 50]); ?>
+                                        <?php echo $form->textArea($model, 'cssframework_css', ['rows' => 6, 'cols' => 50, 'data-inherit-source' => 'optionCssFramework']); ?>
                                         <?php echo $form->error($model, 'cssframework_css'); ?>
                                     </div>
                                 </div>

--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -336,9 +336,16 @@ var ThemeOptions = function () {
     }
 
     var removeVariationsFromField = function (fieldSelector) {
-        if ($(fieldSelector).val() === 'inherit') return;
+        var plainValue = $(fieldSelector).val();
+        if (plainValue === 'inherit') {
+            var inheritSource = $(fieldSelector).data('inherit-source');
+            if (!inheritSource) {
+                return;
+            }
+            plainValue = JSON.parse($('#' + inheritSource).val());
+        }
         try {
-            var currentValue = JSON.parse($(fieldSelector).val());
+            var currentValue = JSON.parse(plainValue);
         } catch (error) {
             var currentValue = {};
         }

--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -394,9 +394,10 @@ var ThemeOptions = function () {
             var filesField = selectedThemeMode == 'add' ? '#TemplateConfiguration_files_css' : '#TemplateConfiguration_cssframework_css';
             removeVariationsFromField('#TemplateConfiguration_files_css');
             removeVariationsFromField('#TemplateConfiguration_cssframework_css');
-            if (selectedTheme != 'inherit') {
-                addVariationToField(selectedTheme, filesField, selectedThemeMode);
+            if (selectedTheme == 'inherit') {
+                selectedTheme = $('#simple_edit_options_cssframework').data('inheritvalue');
             }
+            addVariationToField(selectedTheme, filesField, selectedThemeMode);
         });
     }
 


### PR DESCRIPTION
When applying a variation to a theme which inherits all css files, this happened:
- When adding the variation, overwrote the "inherit" and was only leaving the variation css.
- Then when rendering, nothing was inherited and only the variation css was loaded.

Solution:
- When adding the varaition, and the css files is "inherit", it replaces it by the "contents of the parent" (what should be inherited).
- Then the variation is added.