### PR TITLE
MW-543: Implemented adjustments to make sure that the command is

### DIFF
--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -8,13 +8,21 @@ Yii::import('application.helpers.admin.import_helper', true);
 class ImportSurveyCommand extends CConsoleCommand
 {
 
+    const ALLOWED_MAIN_PATHS = [
+        'tmp' .DIRECTORY_SEPARATOR . 'upload',
+    ];
+
     /**
+     * @param string $path
      * @param string $filename
+     * @param string $furtherParams JSON representation
      * 
-     * Sample command: php application/commands/console.php importsurvey import-file abcf.lss
-     *                 php application/commands/console.php importsurvey import-file limesurvey_survey_979573.lss '{"bTranslateLinkFields": true, "sNewSurveyName": "Orsson", "DestSurveyID": 666999}'
+     * @return void
+     * 
+     * Sample command: php application/commands/console.php importsurvey import-file tmp/upload/youfile.lss
+     *                 php application/commands/console.php importsurvey import-file tmp/upload/youfile.lss '{"bTranslateLinkFields": true, "sNewSurveyName": "Orsson", "DestSurveyID": 666999}'
      */
-    protected function importFile($filename, $furtherParams)
+    protected function importFile($path, $filename, $furtherParams)
     {
         $params = [
             "bTranslateLinkFields" => false,
@@ -26,8 +34,8 @@ class ImportSurveyCommand extends CConsoleCommand
                 $params[$key] = $json[$key] ?? $params[$key];
             }
         }
-        importSurveyFile(
-            Yii::app()->getConfig('tempdir') . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR . $filename,
+        return importSurveyFile(
+            $path . DIRECTORY_SEPARATOR . $filename,
             $params["bTranslateLinkFields"],
             $params["sNewSurveyName"],
             $params["DestSurveyID"],
@@ -46,14 +54,25 @@ class ImportSurveyCommand extends CConsoleCommand
         switch ($command) {
             case "import-file": {
                 if (count($sArgument) < 2) {
-                    throw new Exception("You need to specify the file to import from");
+                    throw new Exception("You need to specify the import path");
                 }
-                $filename = $sArgument[1];
-                if (!preg_match('/^[a-zA-Z0-9_\.]*$/', $filename)) {
+                $fullPath = $sArgument[1];
+
+                if (($lastSlashPosition = strripos($fullPath, DIRECTORY_SEPARATOR)) === false) {
+                    throw new Exception("Invalid path");
+                }
+                $path = substr($fullPath, 0, $lastSlashPosition);
+                $filename = substr($fullPath, $lastSlashPosition + 1);
+                if (!preg_match('/^[a-zA-Z0-9_\. ]*$/', $filename)) {
                     throw new Exception("Your filename can only contain letters, digits and dot");
                 }
                 $furtherParams = $sArgument[2] ?? null;
-                $this->importFile($filename, $furtherParams);
+                $result = $this->importFile($path, $filename, $furtherParams);
+                if (is_array($result) && isset($result['newsid'])) {
+                    echo $result['newsid'];
+                } else {
+                    echo "something went wrong";
+                }
             } break;
             default: throw new Exception("Unsupported command");
         }

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -7,35 +7,20 @@ Yii::import('application.helpers.admin.import_helper', true);
 
 class ImportSurveyCommand extends CConsoleCommand
 {
-
-    const ALLOWED_MAIN_PATHS = [
-        'tmp' .DIRECTORY_SEPARATOR . 'upload',
-    ];
-
     /**
-     * @param string $path
      * @param string $filename
-     * @param string $furtherParams JSON representation
-     * 
-     * @return void
-     * 
-     * Sample command: php application/commands/console.php importsurvey import-file tmp/upload/youfile.lss
-     *                 php application/commands/console.php importsurvey import-file tmp/upload/youfile.lss '{"bTranslateLinkFields": true, "sNewSurveyName": "Orsson", "DestSurveyID": 666999}'
+     * @return array Import result
      */
-    protected function importFile($path, $filename, $furtherParams)
+    protected function importFile($filename)
     {
+        // TODO: Add support to customize these.
         $params = [
             "bTranslateLinkFields" => false,
             "sNewSurveyName" => null,
             "DestSurveyID" => null,
         ];
-        if ($json = json_decode($furtherParams ?? "{}", true)) {
-            foreach ($params as $key => $value) {
-                $params[$key] = $json[$key] ?? $params[$key];
-            }
-        }
         return importSurveyFile(
-            $path . DIRECTORY_SEPARATOR . $filename,
+            $filename,
             $params["bTranslateLinkFields"],
             $params["sNewSurveyName"],
             $params["DestSurveyID"],
@@ -43,38 +28,19 @@ class ImportSurveyCommand extends CConsoleCommand
     }
 
     /**
-     * @param array $aArguments
+     * Sample command: php application/commands/console.php importsurvey tmp/upload/youfile.lss
+     *
+     * @param string[] $arguments
+     * @return void
      */
-    public function run($sArgument)
+    public function run($arguments)
     {
-        if (!count($sArgument)) {
-            throw new Exception(gT("You need to specify the command to be executed"));
-        }
-        $command = $sArgument[0];
-        switch ($command) {
-            case "import-file": {
-                if (count($sArgument) < 2) {
-                    throw new Exception(gT("You need to specify the import path"));
-                }
-                $fullPath = $sArgument[1];
-
-                if (($lastSlashPosition = strripos($fullPath, DIRECTORY_SEPARATOR)) === false) {
-                    throw new Exception(gT("Invalid path"));
-                }
-                $path = substr($fullPath, 0, $lastSlashPosition);
-                $filename = substr($fullPath, $lastSlashPosition + 1);
-                if (!preg_match('/^[a-zA-Z0-9_\. ]*$/', $filename)) {
-                    throw new Exception(gT("Your filename can only contain letters, digits and dot"));
-                }
-                $furtherParams = $sArgument[2] ?? null;
-                $result = $this->importFile($path, $filename, $furtherParams);
-                if (is_array($result) && isset($result['newsid'])) {
-                    echo $result['newsid'];
-                } else {
-                    echo gT("something went wrong");
-                }
-            } break;
-            default: throw new Exception(gT("Unsupported command"));
+        $file = $arguments[0];
+        $result = $this->importFile($file);
+        if (is_array($result) && isset($result['newsid'])) {
+            echo $result['newsid'];
+        } else {
+            echo gT("Something went wrong");
         }
     }
 }

--- a/application/commands/ImportSurveyCommand.php
+++ b/application/commands/ImportSurveyCommand.php
@@ -48,33 +48,33 @@ class ImportSurveyCommand extends CConsoleCommand
     public function run($sArgument)
     {
         if (!count($sArgument)) {
-            throw new Exception("You need to specify the command to be executed");
+            throw new Exception(gT("You need to specify the command to be executed"));
         }
         $command = $sArgument[0];
         switch ($command) {
             case "import-file": {
                 if (count($sArgument) < 2) {
-                    throw new Exception("You need to specify the import path");
+                    throw new Exception(gT("You need to specify the import path"));
                 }
                 $fullPath = $sArgument[1];
 
                 if (($lastSlashPosition = strripos($fullPath, DIRECTORY_SEPARATOR)) === false) {
-                    throw new Exception("Invalid path");
+                    throw new Exception(gT("Invalid path"));
                 }
                 $path = substr($fullPath, 0, $lastSlashPosition);
                 $filename = substr($fullPath, $lastSlashPosition + 1);
                 if (!preg_match('/^[a-zA-Z0-9_\. ]*$/', $filename)) {
-                    throw new Exception("Your filename can only contain letters, digits and dot");
+                    throw new Exception(gT("Your filename can only contain letters, digits and dot"));
                 }
                 $furtherParams = $sArgument[2] ?? null;
                 $result = $this->importFile($path, $filename, $furtherParams);
                 if (is_array($result) && isset($result['newsid'])) {
                     echo $result['newsid'];
                 } else {
-                    echo "something went wrong";
+                    echo gT("something went wrong");
                 }
             } break;
-            default: throw new Exception("Unsupported command");
+            default: throw new Exception(gT("Unsupported command"));
         }
     }
 }


### PR DESCRIPTION
Adjusted the CLI command so it's more compatible with the message queue.

How to test:

- make sure you have a file, I'll call it `<yourtemplate>.lss`
- copy this file to `tmp/upload`, relative to the root folder
- run a proper CLI (see below)
- check the grid

Test command example without parameters

```
php application/commands/console.php importsurvey import-file tmp/upload/<yourtemplate>.lss
```

Test command example with parameters

```
php application/commands/console.php importsurvey import-file tmp/upload/<yourtemplate>.lss '{"bTranslateLinkFields": true, "sNewSurveyName": "Orsson", "DestSurveyID": 666999}'
```

Example after two imports

![image](https://github.com/LimeSurvey/LimeSurvey/assets/2805488/17ff1c70-0ae0-4fe1-a223-bad22ddbc611)
