### PR TITLE
Updated translation in SurveysGroupsPermissionController.php

### DIFF
--- a/application/controllers/SurveysGroupsPermissionController.php
+++ b/application/controllers/SurveysGroupsPermissionController.php
@@ -396,9 +396,9 @@ class SurveysGroupsPermissionController extends LSBaseController
             }
         }
         if ($success) {
-            App()->setFlashMessage("Surveys groups permissions were successfully updated.");
+            App()->setFlashMessage(gT("Surveys groups permissions were successfully updated."));
         } else {
-            App()->setFlashMessage("An error happened when updating surveys groups permissions.", 'danger');
+            App()->setFlashMessage(gT("An error happened when updating surveys groups permissions."), 'danger');
         }
         if ($type == 'group') {
             App()->request->redirect(App()->getController()->createUrl('surveysGroupsPermission/index', array('id' => $id)));


### PR DESCRIPTION
2 missing translation keywords in setFlashMessage() were added in SurveysGroupsPermissionController.php

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
