### PR TITLE
Fixed issue #19072: CDbException with Microsoft SQL Server

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1601,12 +1601,21 @@ class Survey extends LSActiveRecord implements PermissionInterface
                 'join' => $groupJoins,
             ]);
             $groupCondition = "t.gsid=:gsid";
-            $groupCondition .= " OR parentGroup2.gsid=:gsid";
-            $groupCondition .= " OR parentGroup3.gsid=:gsid";
-            $groupCondition .= " OR parentGroup4.gsid=:gsid";
-            $groupCondition .= " OR parentGroup5.gsid=:gsid";
+            $groupCondition .= " OR parentGroup2.gsid=:gsid2"; // MSSQL issue with single param for multiple value, issue #19072
+            $groupCondition .= " OR parentGroup3.gsid=:gsid3";
+            $groupCondition .= " OR parentGroup4.gsid=:gsid4";
+            $groupCondition .= " OR parentGroup5.gsid=:gsid5";
             $criteria->addCondition($groupCondition, 'AND');
-            $criteria->params = array_merge($criteria->params, [':gsid' => $this->gsid]);
+            $criteria->params = array_merge(
+                $criteria->params,
+                [
+                    ':gsid' => $this->gsid,
+                    ':gsid2' => $this->gsid,
+                    ':gsid3' => $this->gsid,
+                    ':gsid4' => $this->gsid,
+                    ':gsid5' => $this->gsid
+                ]
+            );
         }
 
         // Active filter


### PR DESCRIPTION
Dev: MSSQL didn't allow one param for multiple value
Dev: create 5 different params

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
