### PR TITLE
Fixed issue #19083: Fruity23 theme invalidated after selecting Questi…

### DIFF
--- a/themes/survey/fruity_twentythree/config.xml
+++ b/themes/survey/fruity_twentythree/config.xml
@@ -190,10 +190,8 @@
                     <file type="view" role="subview">./subviews/survey/group_subviews/group_name.twig</file>
                     <file type="view" role="subview">./subviews/survey/question.twig</file>
                     <file type="view" role="subview">./subviews/survey/question_container.twig</file>
-                    <file type="view" role="subview">./subviews/survey/question_subviews/question_text_container.twig
-                    </file>
-                    <file type="view" role="subview">./subviews/survey/question_subviews/question_text_content.twig
-                    </file>
+                    <file type="view" role="subview">./subviews/survey/question_subviews/question_text_container.twig</file>
+                    <file type="view" role="subview">./subviews/survey/question_subviews/question_text_content.twig</file>
                     <file type="view" role="subview">./subviews/survey/question_subviews/answers.twig</file>
                     <file type="view" role="subview">./subviews/survey/question_subviews/survey_question_help.twig</file>
                     <file type="view" role="subview">./subviews/survey/question_subviews/valid_message_and_help.twig</file>


### PR DESCRIPTION
…on from Screen dropdown

After selecting Question from the Screen dropdown of an extended Fruity23 theme, the theme get's invalidated.

Error message (popup) is shown: „Theme xyz has been uninstalled because it’s not compatible with this LimeSurvey version. Can’t find file: ./subviews/survey/question_subviews/question_text_container.twig“

First approach was to check if any twig files were missing. -> All files are located in the specified folders. 

Second approach was a diff compare of fruit23’s config.xml with a correctly working config.xml. Turns out that there are unexpected line breaks and white spaces in line 193 and 195 before the closing </file> tag.

I removed the unnecessary line breaks and spaces, now any extended Fruity 23 theme is working correctly!

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #19083
