### PR TITLE
Fixed issue #16908: Importing question with multiple languages can leave garbage on the DB

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -744,7 +744,7 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 continue;
             }
 
-            // Avoid inserting question if its language is not in the survey.
+            // Avoid inserting attribute if the language of the question is not in the survey.
             if (!in_array($insertdata['language'], $surveyLanguages)) {
                 continue;
             }
@@ -860,7 +860,7 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
             }
             unset($insertdata['id']);
 
-            // Avoid inserting question if its language is not in the survey.
+            // Avoid inserting attribute if the language of the question is not in the survey.
             if (!in_array($insertdata['language'], $surveyLanguages)) {
                 continue;
             }
@@ -952,7 +952,7 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
             }
             unset($insertdata['id']);
 
-            // Avoid inserting answer if its language is not in the survey.
+            // Avoid inserting attribute if the language of the question is not in the survey.
             if (!in_array($insertdata['language'], $surveyLanguages)) {
                 continue;
             }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -846,12 +846,19 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
 
     //  Import question_l10ns
     if (isset($xml->question_l10ns->rows->row)) {
+        $surveyLanguages = Survey::model()->findByPk($iNewSID)->allLanguages;
         foreach ($xml->question_l10ns->rows->row as $row) {
             $insertdata = array();
             foreach ($row as $key => $value) {
                 $insertdata[(string) $key] = (string) $value;
             }
             unset($insertdata['id']);
+
+            // Avoid inserting question if its language is not in the survey.
+            if (!in_array($insertdata['language'], $surveyLanguages)) {
+                continue;
+            }
+
             // now translate any links
             // TODO: Should this depend on $options['translinkfields']?
             $insertdata['question'] = translateLinks('survey', $iOldSID, $iNewSID, $insertdata['question']);

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -951,6 +951,12 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 $insertdata[(string) $key] = (string) $value;
             }
             unset($insertdata['id']);
+
+            // Avoid inserting answer if its language is not in the survey.
+            if (!in_array($insertdata['language'], $surveyLanguages)) {
+                continue;
+            }
+
             // now translate any links
             if ($options['translinkfields']) {
                 $insertdata['answer'] = translateLinks('survey', $iOldSID, $iNewSID, $insertdata['answer']);

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -749,11 +749,6 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 continue;
             }
 
-            // Avoid inserting attribute if the language of the question is not in the survey.
-            if (!in_array($insertdata['language'], $surveyLanguages)) {
-                continue;
-            }
-
             if (!isset($insertdata['mandatory']) || trim($insertdata['mandatory']) == '') {
                 $insertdata['mandatory'] = 'N';
             }
@@ -784,6 +779,12 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 $oQuestionL10n->help = $insertdata['help'];
                 $oQuestionL10n->language = $insertdata['language'];
             }
+
+            // Avoid inserting attribute if the language of the question is not in the survey.
+            if (!in_array($insertdata['language'], $surveyLanguages)) {
+                unset($oQuestionL10n);
+            }
+
             if (!$options['autorename']) {
                 $sScenario = 'archiveimport';
             } else {

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -602,6 +602,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields)
 function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array('autorename' => false,'translinkfields' => true))
 {
     $sBaseLanguage = Survey::model()->findByPk($iNewSID)->language;
+    $surveyLanguages = Survey::model()->findByPk($iNewSID)->allLanguages;
     $sXMLdata = file_get_contents($sFullFilePath);
     $xml = simplexml_load_string($sXMLdata, 'SimpleXMLElement', LIBXML_NONET);
     if ($xml->LimeSurveyDocType != 'Question') {
@@ -742,6 +743,12 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
             if ($insertdata['gid'] == 0) {
                 continue;
             }
+
+            // Avoid inserting question if its language is not in the survey.
+            if (!in_array($insertdata['language'], $surveyLanguages)) {
+                continue;
+            }
+
             if (!isset($insertdata['mandatory']) || trim($insertdata['mandatory']) == '') {
                 $insertdata['mandatory'] = 'N';
             }
@@ -846,7 +853,6 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
 
     //  Import question_l10ns
     if (isset($xml->question_l10ns->rows->row)) {
-        $surveyLanguages = Survey::model()->findByPk($iNewSID)->allLanguages;
         foreach ($xml->question_l10ns->rows->row as $row) {
             $insertdata = array();
             foreach ($row as $key => $value) {

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -749,6 +749,11 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 continue;
             }
 
+            // Avoid inserting attribute if the language of the question is not in the survey.
+            if (!in_array($insertdata['language'], $surveyLanguages)) {
+                continue;
+            }
+
             if (!isset($insertdata['mandatory']) || trim($insertdata['mandatory']) == '') {
                 $insertdata['mandatory'] = 'N';
             }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -739,13 +739,13 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
                 if (!in_array($insertdata['language'], $aLanguagesSupported)) {
                     continue;
                 }
+
+                // Avoid inserting attribute if the language of the question is not in the survey.
+                if (!in_array($insertdata['language'], $surveyLanguages)) {
+                    continue;
+                }
             }
             if ($insertdata['gid'] == 0) {
-                continue;
-            }
-
-            // Avoid inserting attribute if the language of the question is not in the survey.
-            if (!in_array($insertdata['language'], $surveyLanguages)) {
                 continue;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML import language validation. Questions, subquestions, question translations, and answer translations are now filtered to match the destination survey's configured language set. This prevents import of language variants not supported in the target survey, ensuring data consistency and avoiding potential import errors related to unsupported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->