### PR TITLE
New feature #19109: Allow 'remove' in cpd_importParticipants

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -3888,7 +3888,6 @@ class remotecontrol_handle
         if ($remove) {
             $allParticipants = Participant::model()->getParticipantsWithoutLimit();
             foreach ($allParticipants as $dbParticipant) {
-
                 if (!array_search($dbParticipant["participant_id"], array_column($participants, "participant_id"))) {
                     Participant::model()->deleteParticipants($dbParticipant["participant_id"]);
                     $aResponse['RemoveCount']++;

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -3886,15 +3886,11 @@ class remotecontrol_handle
         // Remove param is set to True
         // Remove all participants whose ID does not appear in the import list.
         if ($remove) {
-            $allParticipants = Participant::model()->getParticipantsWithoutLimit();
-            foreach ($allParticipants as $dbParticipant) {
-                if (!array_search($dbParticipant["participant_id"], array_column($participants, "participant_id"))) {
-                    Participant::model()->deleteParticipants($dbParticipant["participant_id"]);
-                    $aResponse['RemoveCount']++;
-                }
-            }
+    		$participantsId = array_column($participants, 'participant_id');
+    		$criteria = new CDbCriteria();
+    		$criteria->addNotInCondition('participant_id', $participantsId);
+    		$aResponse['RemoveCount'] = Participant::model()->deleteAll($criteria);
         }
-
         return $aResponse;
     }
 

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -3780,7 +3780,6 @@ class remotecontrol_handle
     }
 
 
-
     /**
      * Import a participant into the LimeSurvey CPDB
      *
@@ -3884,7 +3883,8 @@ class remotecontrol_handle
             }
         }
 
-        //
+        // Remove param is set to True
+        // Remove all participants whose ID does not appear in the import list.
         if ($remove) {
             $allParticipants = Participant::model()->getParticipantsWithoutLimit();
             foreach ($allParticipants as $dbParticipant) {


### PR DESCRIPTION
New feature #19109
Dev:
I have a single source of truth, where all my participants are registered.
Using the function 'cpd_importParticipants' I can import and update participants. I always keep the ID's in sync.

I want the function 'cpd_importParticipants' to delete all participants from the CPD if their ID is not in the import list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional participant removal during imports. When enabled, participants not included in the import list are automatically removed, with the removal count reported in the import status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->