### PR TITLE
Fixed issue [security] #19106: Deleted account still has permissions

### DIFF
--- a/application/core/ConsoleApplication.php
+++ b/application/core/ConsoleApplication.php
@@ -6,11 +6,14 @@
 */
 
 require_once(dirname(dirname(__FILE__)) . '/helpers/globals.php');
+require_once __DIR__ . '/Traits/LSApplicationTrait.php';
 
 use LimeSurvey\PluginManager\LimesurveyApi;
 
 class ConsoleApplication extends CConsoleApplication
 {
+    use LSApplicationTrait;
+
     protected $config = array();
 
     /**

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -18,6 +18,7 @@
  */
 
 require_once(dirname(dirname(__FILE__)) . '/helpers/globals.php');
+require_once __DIR__ . '/Traits/LSApplicationTrait.php';
 
 /**
 * Implements global config
@@ -36,6 +37,8 @@ require_once(dirname(dirname(__FILE__)) . '/helpers/globals.php');
 */
 class LSYii_Application extends CWebApplication
 {
+    use LSApplicationTrait;
+
     protected $config = array();
 
     /**
@@ -713,26 +716,5 @@ class LSYii_Application extends CWebApplication
             $baseUrl = $sPublicUrl;
         }
         return $baseUrl;
-    }
-
-    /**
-     * get the current id of connected user,
-     * check if user exist before return for security
-     * @return int|null user id
-     */
-    public function getCurrentUserId()
-    {
-        if(empty(App()->session['loginID'])) {
-            // NULL for guest
-            return App()->session['loginID'];
-        }
-        if (!is_null($this->currentUserId) && $this->currentUserId == App()->session['loginID']) {
-            return $this->currentUserId;
-        }
-        $this->currentUserId = App()->session['loginID'];
-        if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
-            $this->currentUserId = 0;
-        }
-        return $this->currentUserId;
     }
 }

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -722,9 +722,6 @@ class LSYii_Application extends CWebApplication
      */
     public function getCurrentUserId()
     {
-        if (App() instanceof CConsoleApplication) {
-            return null;
-        }
         if(empty(App()->session['loginID'])) {
             // NULL for guest
             return App()->session['loginID'];

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -56,6 +56,9 @@ class LSYii_Application extends CWebApplication
      */
     protected $dbVersion;
 
+    /* @var integer| null the current userId for all action */
+    private $currentUserId;
+
     /**
      *
      * Initiates the application
@@ -710,5 +713,29 @@ class LSYii_Application extends CWebApplication
             $baseUrl = $sPublicUrl;
         }
         return $baseUrl;
+    }
+
+    /**
+     * get the current id of connected user,
+     * check if user exist before return for security
+     * @return int|null user id
+     */
+    public function getCurrentUserId()
+    {
+        if (App() instanceof CConsoleApplication) {
+            return null;
+        }
+        if(empty(App()->session['loginID'])) {
+            // NULL for guest
+            return App()->session['loginID'];
+        }
+        if (!is_null($this->currentUserId) && $this->currentUserId == App()->session['loginID']) {
+            return $this->currentUserId;
+        }
+        $this->currentUserId = App()->session['loginID'];
+        if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
+            $this->currentUserId = 0;
+        }
+        return $this->currentUserId;
     }
 }

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Trait for ConsoleApplication and LSYii_Application
+ *
+ * @version 0.1.0
+ */
+
+trait LSApplicationTrait
+{
+    /**
+     * get the current id of connected user,
+     * check if user exist before return for security
+     * @return int|null user id
+     */
+    public function getCurrentUserId()
+    {
+        if(empty(App()->session['loginID'])) {
+            // NULL for guest
+            return App()->session['loginID'];
+        }
+        if (!is_null($this->currentUserId) && $this->currentUserId == App()->session['loginID']) {
+            return $this->currentUserId;
+        }
+        $this->currentUserId = App()->session['loginID'];
+        if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
+            $this->currentUserId = 0;
+        }
+        return $this->currentUserId;
+    }
+}

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -8,6 +8,9 @@
 
 trait LSApplicationTrait
 {
+
+    /* @var integer| null the current userId for all action */
+    private $currentUserId;
     /**
      * get the current id of connected user,
      * check if user exist before return for security
@@ -16,12 +19,17 @@ trait LSApplicationTrait
     public function getCurrentUserId()
     {
         if(empty(App()->session['loginID'])) {
-            // NULL for guest
+            /**
+             * NULL for guest,
+             * null by default for CConsoleapplication, but Permission always return true for console
+             * Test can update only App()->session['loginID'] to set the user
+             */
             return App()->session['loginID'];
         }
         if (!is_null($this->currentUserId) && $this->currentUserId == App()->session['loginID']) {
             return $this->currentUserId;
         }
+        /* use App()->session and not App()->user fot easiest unit test */
         $this->currentUserId = App()->session['loginID'];
         if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
             $this->currentUserId = 0;

--- a/application/models/Permission.php
+++ b/application/models/Permission.php
@@ -769,8 +769,7 @@ class Permission extends LSActiveRecord
                 /* Alt : return 1st forcedAdmin ? */
                 throw new Exception('Permission must not be tested with console application.');
             }
-            /* See TestBaseClass tearDownAfterClass */
-            $iUserID = Yii::app()->session['loginID'];
+            return App()->getCurrentUserId();
         }
         return $iUserID;
     }

--- a/application/models/Permission.php
+++ b/application/models/Permission.php
@@ -757,7 +757,9 @@ class Permission extends LSActiveRecord
     }
 
     /**
-     * get the default/fixed $iUserID
+     * Get the default/fixed $iUserID for Permission only
+     * Use App()->getCurrentUserId() for all other purpose
+     * @todo move to private function
      * @param integer|null $iUserID optional user id
      * @return int user id
      * @throws Exception

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1677,7 +1677,7 @@ class Survey extends LSActiveRecord implements PermissionInterface
     protected static function getPermissionCriteria($userid = null)
     {
         if (!$userid) {
-            $userid = Yii::app()->user->id;
+            $userid = App()->getCurrentUserId();
         }
         // Note: reflect Permission::hasPermission
         $criteriaPerm = new CDbCriteria();

--- a/application/models/SurveysGroups.php
+++ b/application/models/SurveysGroups.php
@@ -419,19 +419,20 @@ class SurveysGroups extends LSActiveRecord implements PermissionInterface
     {
         $criteriaPerm = new CDbCriteria();
         if (!Permission::model()->hasGlobalPermission("surveys", 'read') || !Permission::model()->hasGlobalPermission("surveysgroups", 'read')) {
+            $userid = App()->getCurrentUserId();
             /* owner of surveygroup */
-            $criteriaPerm->compare('t.owner_id', Yii::app()->user->id, false);
+            $criteriaPerm->compare('t.owner_id', $userid, false);
             /* Simple permission on SurveysGroup inside a group */
             $criteriaPerm->mergeWith(array(
-                'join' => "LEFT JOIN {{permissions}} AS permissions ON (permissions.entity_id = t.gsid AND permissions.permission='group' AND permissions.entity='surveysgroups' AND permissions.uid='" . Yii::app()->user->id . "') ",
+                'join' => "LEFT JOIN {{permissions}} AS permissions ON (permissions.entity_id = t.gsid AND permissions.permission='group' AND permissions.entity='surveysgroups' AND permissions.uid='" . $userid . "') ",
             ));
             $criteriaPerm->compare('permissions.read_p', '1', false, 'OR');
             /* Permission on Survey inside a group */
             $criteriaPerm->mergeWith(array(
                 'join' => "LEFT JOIN {{surveys}} AS surveys ON (surveys.gsid = t.gsid)
-                        LEFT JOIN {{permissions}} AS surveypermissions ON (surveypermissions.entity_id = surveys.sid AND surveypermissions.permission='survey' AND surveypermissions.entity='survey' AND surveypermissions.uid='" . Yii::app()->user->id . "') ",
+                        LEFT JOIN {{permissions}} AS surveypermissions ON (surveypermissions.entity_id = surveys.sid AND surveypermissions.permission='survey' AND surveypermissions.entity='survey' AND surveypermissions.uid='" . $userid . "') ",
             ));
-            $criteriaPerm->compare('surveys.owner_id', Yii::app()->user->id, false, 'OR');
+            $criteriaPerm->compare('surveys.owner_id', $userid, false, 'OR');
             $criteriaPerm->compare('surveypermissions.read_p', '1', false, 'OR');
             /* default survey group is always avaliable */
             $criteriaPerm->compare('t.gsid', '1', false, 'OR');

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -150,6 +150,36 @@ class User extends LSActiveRecord
     }
 
     /**
+     * @inheritDoc
+     * Delete user in related model after deletion
+     * return void
+     **/
+    protected function afterDelete()
+    {
+        parent::afterDelete();
+        /* Delete all permission */
+        Permission::model()->deleteAll(
+            "uid = :uid",
+            [":uid" => $this->uid]
+        );
+        /* Delete potential roles */
+        UserInPermissionrole::model()->deleteAll(
+            "uid = :uid",
+            [":uid" => $this->uid]
+        );
+        /* User settings */
+        SettingsUser::model()->deleteAll(
+            "uid = :uid",
+            [":uid" => $this->uid]
+        );
+        /* User in group */
+        UserInGroup::model()->deleteAll(
+            "uid = :uid",
+            [":uid" => $this->uid]
+        );
+    }
+
+    /**
      * @return string
      */
     public function getSurveysCreated()


### PR DESCRIPTION
Dev: check user existence before Permission
Dev: delete related Permission and settings after user deletion
Dev: always check session value

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
