### PR TITLE
Fixed issue [security] #19107: Superadmin can update any admin's information

### DIFF
--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -1322,7 +1322,10 @@ class UserManagementController extends LSBaseController
         // Abort if logged in user has no access to this user.
         // Using same logic as User::getButtons().
         $userManager = new UserManager(Yii::app()->user, $oUser);
-        if (!$userManager->canEdit() || $aUser['uid'] == Yii::app()->user->id) {
+        if (
+            !$userManager->canEdit()
+            || $aUser['uid'] == Yii::app()->user->id // To update self : must use personal settings
+        ) {
             throw new CHttpException(403, gT("You do not have permission to access this page."));
         }
 

--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -1310,21 +1310,18 @@ class UserManagementController extends LSBaseController
     /**
      * Update admin-user
      *
-     * REFACTORED (in UserManagementController)
-     *
      * @param array $aUser array with user details
      * @return object user - updated user object
      * @throws CException
      */
     public function updateAdminUser(array $aUser): User
     {
-        $oUser = User::model()->findByPk($aUser['uid']);
+        $oUser = $this->loadModel($aUser['uid']);
         // Abort if logged in user has no access to this user.
         // Using same logic as User::getButtons().
-        $userManager = new UserManager(Yii::app()->user, $oUser);
         if (
-            !$userManager->canEdit()
-            || $aUser['uid'] == Yii::app()->user->id // To update self : must use personal settings
+            !$oUser->canEdit()
+            || $aUser['uid'] == App()->user->id // To update self : must use personal settings
         ) {
             throw new CHttpException(403, gT("You do not have permission to access this page."));
         }

--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -1319,20 +1319,10 @@ class UserManagementController extends LSBaseController
     public function updateAdminUser(array $aUser): User
     {
         $oUser = User::model()->findByPk($aUser['uid']);
-        //If the user id of the post is spoofed somehow it would be possible to edit superadmin users
-        //Therefore we need to make sure no non-superadmin can modify superadmin accounts
-        //Since this should NEVER be the case without hacking the software, this will silently just do nothing.
-        if (
-            !Permission::model()->hasGlobalPermission('superadmin', 'read', Yii::app()->user->id)
-            && Permission::model()->hasGlobalPermission('superadmin', 'read', $oUser->uid)
-        ) {
-            throw new CException("This action is not allowed, and should never happen", 500);
-        }
-
         // Abort if logged in user has no access to this user.
         // Using same logic as User::getButtons().
         $userManager = new UserManager(Yii::app()->user, $oUser);
-        if (!$userManager->canEdit()) {
+        if (!$userManager->canEdit() || $aUser['uid'] == Yii::app()->user->id) {
             throw new CHttpException(403, gT("You do not have permission to access this page."));
         }
 

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -540,13 +540,8 @@ class User extends LSActiveRecord
             'linkAttributes'   => [
                 'data-href' => $editUrl,
             ],
-            'enabledCondition' =>
-                ($permission_superadmin_read
-                    && $this->uid != 1
-                )
-                || (!$permission_superadmin_read
-                    && $this->canEdit(App()->session['loginID'])
-                )
+            'enabledCondition' => $this->canEdit()
+                                && $this->uid != App()->user->getId()
         ];
         $dropdownItems[] = [
             'title'            => gT('Template permissions'),
@@ -972,15 +967,12 @@ class User extends LSActiveRecord
     /**
      * Returns true if logged in user with id $loginId can edit this user
      *
-     * @param int $loginId
      * @return bool
      */
-    public function canEdit($loginId)
+    public function canEdit()
     {
-        return
-            Permission::model()->hasGlobalPermission('superadmin', 'read')
-            || $this->uid == $loginId
-            || (Permission::model()->hasGlobalPermission('users', 'update') && $this->parent_id == $loginId);
+        $userManager = new UserManager(App()->getUser(), $this);
+        return $userManager->canEdit();
     }
 
     /**

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -973,7 +973,7 @@ class User extends LSActiveRecord
     public function canEdit($managerId = null)
     {
         if (is_null($managerId)) {
-            Permission::model()->getUserId();
+            $managerId = Permission::model()->getUserId();
         }
         /* user can update himself */
         if ($managerId == $this->uid) {

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -541,7 +541,7 @@ class User extends LSActiveRecord
                 'data-href' => $editUrl,
             ],
             'enabledCondition' => $this->canEdit()
-                                && $this->uid != App()->user->getId()
+                                && $this->uid != App()->user->getId() // To update self : must use personal settings
         ];
         $dropdownItems[] = [
             'title'            => gT('Template permissions'),

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -987,11 +987,12 @@ class User extends LSActiveRecord
         if (Permission::isForcedSuperAdmin($this->uid)) {
             return false;
         }
-        /* If target user is superamdin : managingUser must be allowed to create superadmin */
+        /* If target user is superamdin : managingUser must be allowed to create superadmin and be parent */
         if (Permission::model()->hasGlobalPermission('superadmin', 'read', $this->uid)) {
-            return Permission::model()->hasGlobalPermission('superadmin', 'create', $managerId);
+            return Permission::model()->hasGlobalPermission('superadmin', 'create', $managerId)
+                && $this->parent_id == $managerId;
         }
-        /* superamin can update all othert user */
+        /* superamin can update all other user */
         if (Permission::model()->hasGlobalPermission('superadmin', 'read', $managerId)) {
             return true;
         }

--- a/application/models/services/UserManager.php
+++ b/application/models/services/UserManager.php
@@ -77,29 +77,7 @@ class UserManager
         if (empty($this->managingUser) || empty($this->targetUser)) {
             return false;
         }
-        /* user can update himself */
-        if ($this->managingUser == $this->targetUser) {
-            return true;
-        }
-        /* forcedsuperamdin (user #1) can always update all */
-        if (Permission::isForcedSuperAdmin($this->managingUser->id)) {
-            return true;
-        }
-        /* forcedsuperamdin can not be update (except by another forcedsuperamdin done before) */
-        if (Permission::isForcedSuperAdmin($this->targetUser->uid)) {
-            return false;
-        }
-        /* If target user is superamdin : managingUser must be allowed to create superadmin */
-        if (Permission::model()->hasGlobalPermission('superadmin', 'read', $this->targetUser->uid)) {
-            return Permission::model()->hasGlobalPermission('superadmin', 'create', $this->managingUser->id);
-        }
-        /* superamin can update all othert user */
-        if (Permission::model()->hasGlobalPermission('superadmin', 'read', $this->managingUser->id)) {
-            return true;
-        }
-        /* Finally : simple user can update only childs users */
-        return Permission::model()->hasGlobalPermission('users', 'update', $this->managingUser->id)
-                && $this->targetUser->parent_id == $this->managingUser->id;
+        return $this->targetUser->canEdit($this->managingUser->id);
     }
 
     /**

--- a/application/models/services/UserManager.php
+++ b/application/models/services/UserManager.php
@@ -68,7 +68,8 @@ class UserManager
     }
 
     /**
-     * Returns true if the managing user can edit the target user
+     * Returns true if the managing user can edit the attribute of the target user
+     * Return true if target is same then managing (user can always update himself)
      * @return bool
      */
     public function canEdit()
@@ -76,14 +77,29 @@ class UserManager
         if (empty($this->managingUser) || empty($this->targetUser)) {
             return false;
         }
-
-        return
-            Permission::model()->hasGlobalPermission('superadmin', 'read', $this->managingUser->id)
-            || $this->targetUser->uid == $this->managingUser->id
-            || (
-                Permission::model()->hasGlobalPermission('users', 'update', $this->managingUser->id)
-                && $this->targetUser->parent_id == $this->managingUser->id
-            );
+        /* user can update himself */
+        if ($this->managingUser == $this->targetUser) {
+            return true;
+        }
+        /* forcedsuperamdin (user #1) can always update all */
+        if (Permission::isForcedSuperAdmin($this->managingUser->id)) {
+            return true;
+        }
+        /* forcedsuperamdin can not be update (except by another forcedsuperamdin done before) */
+        if (Permission::isForcedSuperAdmin($this->targetUser->uid)) {
+            return false;
+        }
+        /* If target user is superamdin : managingUser must be allowed to create superadmin */
+        if (Permission::model()->hasGlobalPermission('superadmin', 'read', $this->targetUser->uid)) {
+            return Permission::model()->hasGlobalPermission('superadmin', 'create', $this->managingUser->id);
+        }
+        /* superamin can update all othert user */
+        if (Permission::model()->hasGlobalPermission('superadmin', 'read', $this->managingUser->id)) {
+            return true;
+        }
+        /* Finally : simple user can update only childs users */
+        return Permission::model()->hasGlobalPermission('users', 'update', $this->managingUser->id)
+                && $this->targetUser->parent_id == $this->managingUser->id;
     }
 
     /**

--- a/tests/TestBaseClass.php
+++ b/tests/TestBaseClass.php
@@ -274,4 +274,16 @@ class TestBaseClass extends TestCase
         }
         return $results;
     }
+
+    /**
+     * Set user id
+     * @param integer $userid
+     * return void
+     */
+    public function setUserId($userid)
+    {
+        /* @todo check if session can be set */
+        \Yii::app()->session['loginID'] = $userid;
+        \Yii::app()->user->setId($userid);
+    }
 }

--- a/tests/TestBaseClass.php
+++ b/tests/TestBaseClass.php
@@ -274,16 +274,4 @@ class TestBaseClass extends TestCase
         }
         return $results;
     }
-
-    /**
-     * Set user id
-     * @param integer $userid
-     * return void
-     */
-    public function setUserId($userid)
-    {
-        /* @todo check if session can be set */
-        \Yii::app()->session['loginID'] = $userid;
-        \Yii::app()->user->setId($userid);
-    }
 }

--- a/tests/unit/controllers/UserManagementTest.php
+++ b/tests/unit/controllers/UserManagementTest.php
@@ -118,14 +118,14 @@ class UserManagementTest extends TestBaseClass
         try {
             $oUserManagementController->updateAdminUser($aChangeDataSet);
         } catch(\CException $exception) {
-            if($exception->getCode() == 403) {
-                
+            if($exception->statusCode == 403) {
                 \Yii::app()->session['loginID'] = 1;
                 $this->assertTrue(true);
                 return;
             }
+            /* throw the exception : user was not updated, but bad exception happen */
+            throw $exception;
         }
-
         \Yii::app()->session['loginID'] = 1;
         throw new \Exception( 
             "Test ".__METHOD__ ." failed: \n"

--- a/tests/unit/controllers/UserManagementTest.php
+++ b/tests/unit/controllers/UserManagementTest.php
@@ -114,19 +114,19 @@ class UserManagementTest extends TestBaseClass
         $oUserManagementController = new \UserManagementController('userManagement');
         $aChangeDataSet = $this->dataSet['change_admin_user'];
         $aChangeDataSet['uid'] = 1;
-        $this->setUserId(self::$newUserId);
+        \Yii::app()->session['loginID'] = self::$newUserId;
         try {
             $oUserManagementController->updateAdminUser($aChangeDataSet);
         } catch(\CException $exception) {
-            if($exception->getCode() == 500) {
+            if($exception->getCode() == 403) {
                 
-                $this->setUserId(1);
+                \Yii::app()->session['loginID'] = 1;
                 $this->assertTrue(true);
                 return;
             }
         }
 
-        $this->setUserId(1);
+        \Yii::app()->session['loginID'] = 1;
         throw new \Exception( 
             "Test ".__METHOD__ ." failed: \n"
             ."The admin user has been changed"

--- a/tests/unit/controllers/UserManagementTest.php
+++ b/tests/unit/controllers/UserManagementTest.php
@@ -114,19 +114,19 @@ class UserManagementTest extends TestBaseClass
         $oUserManagementController = new \UserManagementController('userManagement');
         $aChangeDataSet = $this->dataSet['change_admin_user'];
         $aChangeDataSet['uid'] = 1;
-        \Yii::app()->session['loginID'] = self::$newUserId;
+        $this->setUserId(self::$newUserId);
         try {
             $oUserManagementController->updateAdminUser($aChangeDataSet);
         } catch(\CException $exception) {
             if($exception->getCode() == 500) {
                 
-                \Yii::app()->session['loginID'] = 1;
+                $this->setUserId(1);
                 $this->assertTrue(true);
                 return;
             }
         }
 
-        \Yii::app()->session['loginID'] = 1;
+        $this->setUserId(1);
         throw new \Exception( 
             "Test ".__METHOD__ ." failed: \n"
             ."The admin user has been changed"


### PR DESCRIPTION
Dev: move all test to UserManager (maybe need to be in User->hasPermission)
Dev: forcedsuperamdin can update all other user (include forcedsuperamdin)
Dev: forcedsuperamdin can be updated only by forcedsuperamdin
Dev: superadmin can be update only by superamdin with create permission (maybe need update êrmission)
Dev: other can be updated by superadmin or parent