### PR TITLE
Bug/19108 subquestion save

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2964,13 +2964,11 @@ class QuestionAdministrationController extends LSBaseController
                     )
                 ) {
                     throw (
-                        new LSUserException(
+                    new LSUserException(
                         500,
                         gT('Could not save subquestion')
-                        )
-                    )->setDetailedErrors(
-                        ['Subquestion codes must be unique.']
-                    );
+                    )
+                    )->setDetailedErrors(['Subquestion codes must be unique.']);
                 }
                 $codes[$subquestionId][$scaleId][] = $data['code'];
             }

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -114,9 +114,9 @@ class QuestionAdministrationController extends LSBaseController
      * @return void
      * @throws CHttpException
      */
-    public function actionEdit(int $qid, string $tabOverviewEditor = null)
+    public function actionEdit(int $questionId, string $tabOverviewEditor = null)
     {
-        $questionId = (int) $qid;
+        $questionId = (int) $questionId;
         if (!in_array($tabOverviewEditor, ['overview', 'editor'], true)) {
             $tabOverviewEditor = null;
         }
@@ -195,6 +195,7 @@ class QuestionAdministrationController extends LSBaseController
         $jsVariablesHtml = $this->renderPartial(
             '/admin/survey/Question/_subQuestionsAndAnwsersJsVariables',
             [
+                'qid'               => $question->qid,
                 'anslangs'          => $question->survey->allLanguages,
                 // TODO
                 'assessmentvisible' => false,

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -159,7 +159,7 @@ class QuestionAdministrationController extends LSBaseController
      * @throws CException
      * @todo Move to service class
      */
-    public function renderFormAux(Question $question)
+    private function renderFormAux(Question $question)
     {
         Yii::app()->loadHelper("admin.htmleditor");
         Yii::app()->getClientScript()->registerPackage('ace');
@@ -260,6 +260,32 @@ class QuestionAdministrationController extends LSBaseController
         $this->render(
             'create',
             $viewData
+        );
+    }
+
+    public function actionAjaxLoadExtraOptions($questionId)
+    {
+        $questionId = (int) $questionId;
+        $question = Question::model()->findByPk($questionId);
+        if (empty($question)) {
+            throw new CHttpException(404, gT('Invalid question id'));
+        }
+
+        if (!Permission::model()->hasSurveyPermission($question->sid, 'surveycontent', 'update')) {
+            Yii::app()->user->setFlash('error', gT("Access denied"));
+            $this->redirect(Yii::app()->request->urlReferrer);
+        }
+        Yii::app()->loadHelper("admin.htmleditor");
+        PrepareEditorScript(false, $this);
+        App()->session['FileManagerContext'] = "edit:survey:{$question->sid}";
+        initKcfinder();
+
+        $this->renderPartial(
+            'extraOptions',
+            [
+                'question' => $question,
+                'survey' => $question->survey,
+            ]
         );
     }
 

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -272,7 +272,7 @@ class QuestionAdministrationController extends LSBaseController
             throw new CHttpException(404, gT('Invalid question id'));
         }
 
-        if (!Permission::model()->hasSurveyPermission($question->sid, 'surveycontent', 'update')) {
+        if (!Permission::model()->hasSurveyPermission($question->sid, 'surveycontent', 'read')) {
             Yii::app()->user->setFlash('error', gT("Access denied"));
             $this->redirect(Yii::app()->request->urlReferrer);
         }

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -114,9 +114,9 @@ class QuestionAdministrationController extends LSBaseController
      * @return void
      * @throws CHttpException
      */
-    public function actionEdit(int $questionId, string $tabOverviewEditor = null)
+    public function actionEdit(int $qid, string $tabOverviewEditor = null)
     {
-        $questionId = (int) $questionId;
+        $questionId = (int) $qid;
         if (!in_array($tabOverviewEditor, ['overview', 'editor'], true)) {
             $tabOverviewEditor = null;
         }

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2906,7 +2906,7 @@ class QuestionAdministrationController extends LSBaseController
                     $subquestion->relevance = $data['relevance'];
                 }
                 $subquestion->scale_id = $scaleId;
-                $subquestion->setScenario('save-set');
+                $subquestion->setScenario('save-all');
                 if (!$subquestion->save()) {
                     array_push($errorQuestions, $subquestion);
                     continue;

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2906,7 +2906,7 @@ class QuestionAdministrationController extends LSBaseController
                     $subquestion->relevance = $data['relevance'];
                 }
                 $subquestion->scale_id = $scaleId;
-                $subquestion->setScenario('save-all');
+                $subquestion->setScenario('saveall');
                 if (!$subquestion->save()) {
                     array_push($errorQuestions, $subquestion);
                     continue;

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2964,11 +2964,13 @@ class QuestionAdministrationController extends LSBaseController
                     )
                 ) {
                     throw (
-                    new LSUserException(
-                        500,
-                        gT('Could not save subquestion')
-                    )
-                    )->setDetailedErrors(['Subquestion codes must be unique.']);
+                        new LSUserException(
+                            500,
+                            gT('Could not save subquestion')
+                        )
+                    )->setDetailedErrors(
+                        ['Subquestion codes must be unique.']
+                    );
                 }
                 $codes[$subquestionId][$scaleId][] = $data['code'];
             }

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -190,7 +190,7 @@ class Question extends LSActiveRecord
                         )
                     ),
                     'message' => gT('Subquestion codes must be unique.'),
-                    'except' => 'save-set'
+                    'except' => 'save-all'
             );
             /* Disallow other title if question allow other */
             $oParentQuestion = Question::model()->findByPk(array("qid" => $this->parent_qid));

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -189,7 +189,8 @@ class Question extends LSActiveRecord
                         ':scale_id' => $this->scale_id
                         )
                     ),
-                    'message' => gT('Subquestion codes must be unique.')
+                    'message' => gT('Subquestion codes must be unique.'),
+                    'except' => 'save-set'
             );
             /* Disallow other title if question allow other */
             $oParentQuestion = Question::model()->findByPk(array("qid" => $this->parent_qid));
@@ -266,7 +267,7 @@ class Question extends LSActiveRecord
                 'except' => 'archiveimport'
             );
             $aRules[] = array(
-                'title', 'match', 'pattern' => '/^[[:alnum:]]*$/',
+                'title', 'match', 'pattern' => '/^[a-zA-z0-9]*$/',
                 'message' => gT('Subquestion codes may only contain alphanumeric characters.'),
                 'except' => 'archiveimport'
             );

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -150,8 +150,8 @@ class Question extends LSActiveRecord
     {
         /* Basic rules */
         $aRules = array(
-            array('title', 'required', 'on' => 'update, insert', 'message' => gT('The question code is mandatory.', 'unescaped')),
-            array('title', 'length', 'min' => 1, 'max' => 20, 'on' => 'update, insert'),
+            array('title', 'required', 'on' => 'update, insert, saveall', 'message' => gT('The question code is mandatory.', 'unescaped')),
+            array('title', 'length', 'min' => 1, 'max' => 20, 'on' => 'update, insert, saveall'),
             array('qid,sid,gid,parent_qid', 'numerical', 'integerOnly' => true),
             array('qid', 'unique','message' => sprintf(gT("Question id (qid) : '%s' is already in use."), $this->qid)),// Still needed ?
             array('other', 'in', 'range' => array('Y', 'N'), 'allowEmpty' => true),
@@ -190,7 +190,7 @@ class Question extends LSActiveRecord
                         )
                     ),
                     'message' => gT('Subquestion codes must be unique.'),
-                    'except' => 'save-all'
+                    'except' => 'saveall'
             );
             /* Disallow other title if question allow other */
             $oParentQuestion = Question::model()->findByPk(array("qid" => $this->parent_qid));

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -704,7 +704,7 @@ class Question extends LSActiveRecord
         $url         = App()->createUrl("questionAdministration/view/surveyid/$this->sid/gid/$this->gid/qid/$this->qid");
         $previewUrl  = Yii::app()->createUrl("survey/index/action/previewquestion/sid/");
         $previewUrl .= '/' . $this->sid . '/gid/' . $this->gid . '/qid/' . $this->qid;
-        $editurl     = Yii::app()->createUrl("questionAdministration/edit/questionId/$this->qid/tabOverviewEditor/editor");
+        $editurl     = Yii::app()->createUrl("questionAdministration/edit/qid/$this->qid/tabOverviewEditor/editor");
 
         $permission_edit_question = Permission::model()->hasSurveyPermission($this->sid, 'surveycontent', 'update');
         $permission_summary_question = Permission::model()->hasSurveyPermission($this->sid, 'surveycontent', 'read');

--- a/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
+++ b/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
@@ -26,7 +26,7 @@ $scriptVariables = [
     'lsextraoptionsurl'     => Yii::app()->createUrl(
         'questionAdministration/ajaxLoadExtraOptions',
         [
-            'questionId' => Yii::app()->request->getParam('qid')
+            'questionId' => $qid
         ]
     ),
     'subquestions'     => [

--- a/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
+++ b/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
@@ -24,10 +24,10 @@ $scriptVariables = [
     'lspickurl'        => Yii::app()->createUrl('/questionAdministration/getLabelsetPicker'),
     'sCheckLabelURL'   => Yii::app()->createUrl('/questionAdministration/checkLabel'),
     'lsextraoptionsurl'     => Yii::app()->createUrl(
-            'questionAdministration/ajaxLoadExtraOptions',
-            [
-                'questionId' => Yii::app()->request->getParam('questionId')
-            ]
+        'questionAdministration/ajaxLoadExtraOptions',
+        [
+            'questionId' => Yii::app()->request->getParam('qid')
+        ]
     ),
     'subquestions'     => [
         'newansweroption_text'     => gT('New subquestion','js'),

--- a/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
+++ b/application/views/admin/survey/Question/_subQuestionsAndAnwsersJsVariables.php
@@ -23,6 +23,12 @@ $scriptVariables = [
     'lsdetailurl'      => Yii::app()->createUrl('/questionAdministration/getLabelsetDetails'),
     'lspickurl'        => Yii::app()->createUrl('/questionAdministration/getLabelsetPicker'),
     'sCheckLabelURL'   => Yii::app()->createUrl('/questionAdministration/checkLabel'),
+    'lsextraoptionsurl'     => Yii::app()->createUrl(
+            'questionAdministration/ajaxLoadExtraOptions',
+            [
+                'questionId' => Yii::app()->request->getParam('questionId')
+            ]
+    ),
     'subquestions'     => [
         'newansweroption_text'     => gT('New subquestion','js'),
         'quickaddtitle'            => gT('Quick-add subquestion','js'),

--- a/application/views/questionAdministration/create.php
+++ b/application/views/questionAdministration/create.php
@@ -20,7 +20,7 @@
 </style>
 
 <!-- NB: These must be inside #pjax-content to work with pjax. -->
-<?= $jsVariablesHtml; ?>
+<?php echo $jsVariablesHtml; ?>
 <?= $modalsHtml; ?>
 <?php $visibilityEditor = true; //should be displayed ?>
 <?php $visibilityOverview = false; ?>

--- a/application/views/questionAdministration/subquestionRow.twig
+++ b/application/views/questionAdministration/subquestionRow.twig
@@ -8,7 +8,6 @@
  * @var $first
  * @var $subquestion
  * @var $subquestionl10n
- * @var $oldCode ???
  *
  * NB : !!! If you edit this view, remember to check if answer option row view need also to be updated !!!
  */
@@ -59,18 +58,6 @@
 
         <!-- Code (title) -->
         <td class="code-title" style="vertical-align: middle;">
-            <!-- TODO: What is "oldCode"??? -->
-            {% if oldCode %}
-                <input
-                    type='hidden'
-                    class='oldcode code-title'
-                    maxlength="20"
-                    id='subquestions[{{ subquestion.qid }}][{{ scale_id }}][oldcode]'
-                    name='subquestions[{{ subquestion.qid }}][{{ scale_id }}][oldcode]'
-                    value="{{ subquestion.title|escape('html_attr') }}"
-                />
-            {% endif %}
-
             <input
                 type='text'
                 class="code form-control input"
@@ -102,7 +89,7 @@
 
     <!-- Subquestion text -->
     <td  class="subquestion-text" style="vertical-align: middle;">
-        <div class="input-group">        
+        <div class="input-group">
             <!-- NB: Class "answer" is used for both subquestions and answer options. -->
             <input
                 type='text'

--- a/application/views/questionAdministration/subquestions.twig
+++ b/application/views/questionAdministration/subquestions.twig
@@ -69,8 +69,7 @@
                                 'first'     : first,
                                 'subquestion': subquestion,
                                 'subquestionl10n': subquestion.questionl10ns[lang],
-                                'language'  : lang,
-                                'oldCode'   : true,
+                                'language'  : lang
                             } %}
 
                             {% set position = position + 1 %}

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -1876,6 +1876,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
               $('#extra-options-container').replaceWith( response );
               $('.btnaddsubquestion').off('click.subquestions').on('click.subquestions', addSubquestionInput);
               $('.btndelsubquestion').off('click.subquestions').on('click.subquestions', deleteSubquestionInput);
+              makeAnswersTableSortable();
               // Hide loading gif.
               $('#ls-loading').hide();
             },

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -1925,16 +1925,16 @@ $(document).on('ready pjax:scriptcomplete', function () {
 
             // Update the side-bar.
             LS.EventBus.$emit('updateSideBar', {'updateQuestions': true});
+            reloadExtraOptions();
 
             if (textStatus === 'success') {
               // Show confirm message.
-              LS.LsGlobalNotifier.createAlert(json.message + 'test', 'success', {showCloseButton: true});
+              LS.LsGlobalNotifier.createAlert(json.message, 'success', {showCloseButton: true});
             } else {
               // Show error message.
               LS.LsGlobalNotifier.createAlert(json.message, 'danger', {showCloseButton: true});
             }
             updateQuestionSummary();
-            reloadExtraOptions();
           },
           error: (data) => {
             $('#ls-loading').hide();

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -687,7 +687,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
             $bodyItem.append(`<h2>${labelSet.label_name}</h2>`);  // jshint ignore: line
             $itemList.appendTo($bodyItem);
           });
-          
+
           if (isEmpty) {
             showLabelSetAlert(languageJson.labelSetEmpty);
           } else {
@@ -726,7 +726,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
 
   /**
    * Hides the alert in the label set's modal
-   * 
+   *
    * @return {void}
    */
   function hideLabelSetAlert() /*: void */ {
@@ -1240,9 +1240,9 @@ $(document).on('ready pjax:scriptcomplete', function () {
                 <select class="form-select" name="laname">
                   <option value=""></option>
                 </select>
-              </div>' 
+              </div>'
             `;
-            // 
+            //
             child = template.content.firstElementChild;
             if (child) {
               targetParent.after(child);
@@ -1539,7 +1539,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
     });
     return duplicateCodes.length == 0;
   }
-  
+
   /**
    * Return a function that can be used to check code uniqueness.
    * Used by subquestions and answer options.
@@ -1866,6 +1866,27 @@ $(document).on('ready pjax:scriptcomplete', function () {
         });
       };
 
+      const reloadExtraOptions = () => {
+        // Show loading gif.
+        $('#ls-loading').show();
+        // Post complete form to controller.
+        $.get({
+            url: languageJson.lsextraoptionsurl,
+            success: (response /*: string */, textStatus /*: string */) => {
+              $('#extra-options-container').replaceWith( response );
+              $('.btnaddsubquestion').off('click.subquestions').on('click.subquestions', addSubquestionInput);
+              $('.btndelsubquestion').off('click.subquestions').on('click.subquestions', deleteSubquestionInput);
+              // Hide loading gif.
+              $('#ls-loading').hide();
+            },
+            error: (data) => {
+              $('#ls-loading').hide();
+              alert('Internal error from saveFormWithAjax: no data.responseJSON found');
+              throw 'abort';
+            }
+        });
+      };
+
       // Helper function after unique check.
       const saveFormWithAjax /*: (void) => (void) */ = () => {
         const data = {};
@@ -1906,12 +1927,13 @@ $(document).on('ready pjax:scriptcomplete', function () {
 
             if (textStatus === 'success') {
               // Show confirm message.
-              LS.LsGlobalNotifier.createAlert(json.message, 'success', {showCloseButton: true});
+              LS.LsGlobalNotifier.createAlert(json.message + 'test', 'success', {showCloseButton: true});
             } else {
               // Show error message.
               LS.LsGlobalNotifier.createAlert(json.message, 'danger', {showCloseButton: true});
             }
             updateQuestionSummary();
+            reloadExtraOptions();
           },
           error: (data) => {
             $('#ls-loading').hide();
@@ -2125,7 +2147,7 @@ $(document).on('ready pjax:scriptcomplete', function () {
       $('#' + id).width(width).height(height);
       $('#' + id).closest('.jquery-ace-wrapper').width(width).height(height);
     });
-    
+
     $('#relevance').on('keyup', showConditionsWarning);
 
     $(document).on('focusout', '#subquestions table.subquestions-table:first-of-type td.code-title input.code', syncAnswerSubquestionCode);

--- a/tests/functional/backend/SaveQuestionAttributesTest.php
+++ b/tests/functional/backend/SaveQuestionAttributesTest.php
@@ -125,7 +125,7 @@ class SaveQuestionAttributesTest extends TestBaseClassWeb
             $savebutton = $web->findElement(WebDriverBy::id('save-and-close-button-create-question'));
             $savebutton->click();
 
-            $alert = $this->waitForElementShim($web, '#notif-container .alert');
+            $alert = $this->waitForElementShim($web, '#notif-container .alert', 20);
             $web->wait(10)->until(WebDriverExpectedCondition::visibilityOf($alert));
 
             self::$testHelper->takeScreenshot(self::$webDriver, __CLASS__ . '_' . __FUNCTION__ . '_afterSave');


### PR DESCRIPTION
Fix subquestion editing and code uniqueness validation.

This PR fixes several issues:

- Order of subquestions can cause unexpected uniqueness validation error because codes are validated one at a time, at the point of saving each subquestion rather than up front as a set. This was fixed by disabling the unique validation at the point of save and doing the validation of the set before saving.
- Using old code to reference question records can produce unexpected results when updating a subquestion code. Switched to referencing subquestions by qid.
- The subquestion table was not being reloaded after save. 

When testing this we should test these question types:

- Multiple choice (Type: M)
- Array (Texts) (Type: ;)