### PR TITLE
Fixed issue #19132: Icon selection in the "Dashboard editor/create box" does not work

### DIFF
--- a/assets/scripts/admin/homepagesettings.js
+++ b/assets/scripts/admin/homepagesettings.js
@@ -136,7 +136,7 @@ $(document).on('ready  pjax:scriptcomplete', function(){
             var iconId = $(ev.currentTarget).attr('data-iconId');
 
             // Set icon preview and hidden input
-            $('input[name="Box[ico]"]').val(iconId);
+            $('input[name="Box[ico]"]').val(icon);
             $('#chosen-icon').attr('class', icon + ' text-success');
         });
     }


### PR DESCRIPTION
Fixed issue #19132: Icon selection in the "Dashboard editor/create box" does not work
[https://bugs.limesurvey.org/view.php?id=19132](https://bugs.limesurvey.org/view.php?id=19132)