### PR TITLE
Fixed issue #19117: Account past their expiration date can be still active

### DIFF
--- a/application/controllers/admin/Authentication.php
+++ b/application/controllers/admin/Authentication.php
@@ -270,17 +270,8 @@ class Authentication extends SurveyCommonAction
      */
     public function logout()
     {
-        /* Adding beforeLogout event */
-        $beforeLogout = new PluginEvent('beforeLogout');
-        App()->getPluginManager()->dispatchEvent($beforeLogout);
-        regenerateCSRFToken();
         App()->user->logout();
         App()->user->setFlash('loginmessage', gT('Logout successful.'));
-
-        /* Adding afterLogout event */
-        $event = new PluginEvent('afterLogout');
-        App()->getPluginManager()->dispatchEvent($event);
-
         $this->getController()->redirect(array('/admin/authentication/sa/login'));
     }
 

--- a/application/core/LSWebUser.php
+++ b/application/core/LSWebUser.php
@@ -26,6 +26,39 @@ class LSWebUser extends CWebUser
     }
 
     /**
+     * @inheritDoc
+     * Replace auto getter to check if currentb uiser is valid or not
+     */
+    public function getId()
+    {
+        if (empty(parent::getId())) {
+            return parent::getId();
+        }
+        $id = App()->getCurrentUserId();
+        if (empty($id)) {
+            /* If still connected but invalid : logout */
+            $this->logout();
+        }
+        return $id;
+    }
+
+    /**
+     * @inheritDoc
+     * Add the specific plugin event and regerenaret CRSF
+     */
+    public function logout($destroySession = true)
+    {
+        /* Adding beforeLogout event */
+        $beforeLogout = new PluginEvent('beforeLogout');
+        App()->getPluginManager()->dispatchEvent($beforeLogout);
+        regenerateCSRFToken();
+        parent::logout($destroySession);
+        /* Adding afterLogout event */
+        $event = new PluginEvent('afterLogout');
+        App()->getPluginManager()->dispatchEvent($event);
+    }
+
+    /**
      * @inheritdoc
      * replace by a fixed string
      */

--- a/application/core/LSWebUser.php
+++ b/application/core/LSWebUser.php
@@ -44,6 +44,16 @@ class LSWebUser extends CWebUser
 
     /**
      * @inheritDoc
+     * Set id in session too
+     */
+    public function setId($id)
+    {
+        parent::setId($id);
+        \Yii::app()->session['loginID'] = $id;
+    }
+
+    /**
+     * @inheritDoc
      * Add the specific plugin event and regerenaret CRSF
      */
     public function logout($destroySession = true)

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -8,7 +8,6 @@
 
 trait LSApplicationTrait
 {
-
     /* @var integer| null the current userId for all action */
     private $currentUserId;
     /**
@@ -18,7 +17,7 @@ trait LSApplicationTrait
      */
     public function getCurrentUserId()
     {
-        if(empty(App()->session['loginID'])) {
+        if (empty(App()->session['loginID'])) {
             /**
              * NULL for guest,
              * null by default for CConsoleapplication, but Permission always return true for console
@@ -31,7 +30,7 @@ trait LSApplicationTrait
         }
         /* use App()->session and not App()->user fot easiest unit test */
         $this->currentUserId = App()->session['loginID'];
-        if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
+        if ($this->currentUserId && !User::model()->active()->findByPk($this->currentUserId)) {
             $this->currentUserId = 0;
         }
         return $this->currentUserId;

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -937,6 +937,19 @@ class User extends LSActiveRecord
         ));
     }
 
+    /** @inheritdoc */
+    public function scopes()
+    {
+        return array(
+            'active' => array(
+                'condition' => "expires > :now OR expires IS NULL",
+                'params' => array(
+                    'now' => dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", Yii::app()->getConfig("timeadjust")),
+                )
+            )
+        );
+    }
+
     /**
      * Creates a validation key and saves it in table user for this user.
      *


### PR DESCRIPTION
Dev: add active scope to User
Dev: use App->getCurrentuserId in App()->user->id (used in authorisation)
Dev: logout invalid user