### PR TITLE
Fixed issue #19117: Account past their expiration date can be still active

### DIFF
--- a/application/controllers/admin/Authentication.php
+++ b/application/controllers/admin/Authentication.php
@@ -270,17 +270,8 @@ class Authentication extends SurveyCommonAction
      */
     public function logout()
     {
-        /* Adding beforeLogout event */
-        $beforeLogout = new PluginEvent('beforeLogout');
-        App()->getPluginManager()->dispatchEvent($beforeLogout);
-        regenerateCSRFToken();
         App()->user->logout();
         App()->user->setFlash('loginmessage', gT('Logout successful.'));
-
-        /* Adding afterLogout event */
-        $event = new PluginEvent('afterLogout');
-        App()->getPluginManager()->dispatchEvent($event);
-
         $this->getController()->redirect(array('/admin/authentication/sa/login'));
     }
 

--- a/application/core/LSWebUser.php
+++ b/application/core/LSWebUser.php
@@ -23,8 +23,8 @@ class LSWebUser extends CWebUser
             return parent::getId();
         }
         $id = App()->getCurrentUserId();
-        if (empty($id)) {
-            /* If still connected but invalid : logout */
+        if ($id === 0) {
+            /* User is still connected but invalid : logout */
             $this->logout();
         }
         return $id;

--- a/application/core/LSWebUser.php
+++ b/application/core/LSWebUser.php
@@ -32,6 +32,16 @@ class LSWebUser extends CWebUser
 
     /**
      * @inheritDoc
+     * Set id in session too
+     */
+    public function setId($id)
+    {
+        parent::setId($id);
+        \Yii::app()->session['loginID'] = $id;
+    }
+
+    /**
+     * @inheritDoc
      * Add the specific plugin event and regenerate CSRF
      */
     public function logout($destroySession = true)

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -8,7 +8,6 @@
 
 trait LSApplicationTrait
 {
-
     /* @var integer| null the current userId for all action */
     private $currentUserId;
     /**
@@ -18,7 +17,7 @@ trait LSApplicationTrait
      */
     public function getCurrentUserId()
     {
-        if(empty(App()->session['loginID'])) {
+        if (empty(App()->session['loginID'])) {
             /**
              * NULL for guest,
              * null by default for CConsoleapplication, but Permission always return true for console
@@ -31,7 +30,7 @@ trait LSApplicationTrait
         }
         /* use App()->session and not App()->user fot easiest unit test */
         $this->currentUserId = App()->session['loginID'];
-        if ($this->currentUserId && !User::model()->findByPk($this->currentUserId)) {
+        if ($this->currentUserId && !User::model()->active()->findByPk($this->currentUserId)) {
             $this->currentUserId = 0;
         }
         return $this->currentUserId;

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -13,7 +13,7 @@ trait LSApplicationTrait
     /**
      * get the current id of connected user,
      * check if user exist before return for security
-     * @return int|null user id
+     * @return int|null user id, 0 mean invalid user
      */
     public function getCurrentUserId()
     {

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -127,6 +127,19 @@ class User extends LSActiveRecord
         );
     }
 
+    /** @inheritdoc */
+    public function scopes()
+    {
+        return array(
+            'active' => array(
+                'condition' => "expires > :now OR expires IS NULL",
+                'params' => array(
+                    'now' => dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", Yii::app()->getConfig("timeadjust")),
+                )
+            )
+        );
+    }
+
     public function attributeLabels()
     {
         return [


### PR DESCRIPTION
Dev: add active scope to User
Dev: use App->getCurrentuserId in App()->user->id (used in authorisation)
Dev: logout invalid user