### PR TITLE
'Fixed issue #19160 - subquestion save, scale id code

### DIFF
--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2772,6 +2772,7 @@ class QuestionAdministrationController extends LSBaseController
                     $subquestion = Question::model()->findByAttributes([
                         'sid' => $question->sid,
                         'parent_qid' => $question->qid,
+                        'scale_id' => $scaleId,
                         'title' => $data['oldcode']
                     ]);
                 }

--- a/application/controllers/QuestionAdministrationController.php
+++ b/application/controllers/QuestionAdministrationController.php
@@ -2767,6 +2767,12 @@ class QuestionAdministrationController extends LSBaseController
         $subquestionIds = [];
         foreach ($subquestionsArray as $subquestionArray) {
             foreach ($subquestionArray as $scaleId => $data) {
+                if (!isset($data['code'])) {
+                    throw new CHttpException(
+                        500,
+                        'Internal error: Missing mandatory field code for question: ' . json_encode($data)
+                    );
+                }
                 $subquestion = null;
                 if (isset($data['oldcode'])) {
                     $subquestion = Question::model()->findByAttributes([
@@ -2779,23 +2785,16 @@ class QuestionAdministrationController extends LSBaseController
                 if (!$subquestion) {
                     $subquestion = new Question();
                 }
-
-                $subquestion->sid        = $question->sid;
-                $subquestion->gid        = $question->gid;
+                $subquestion->sid = $question->sid;
+                $subquestion->gid = $question->gid;
                 $subquestion->parent_qid = $question->qid;
+                $subquestion->scale_id = $scaleId;
                 $subquestion->question_order = $questionOrder;
                 $questionOrder++;
-                if (!isset($data['code'])) {
-                    throw new CHttpException(
-                        500,
-                        'Internal error: Missing mandatory field code for question: ' . json_encode($data)
-                    );
-                }
-                $subquestion->title      = $data['code'];
+                $subquestion->title = $data['code'];
                 if ($scaleId === 0) {
-                    $subquestion->relevance  = $data['relevance'];
+                    $subquestion->relevance = $data['relevance'];
                 }
-                $subquestion->scale_id   = $scaleId;
                 if (!$subquestion->save()) {
                     throw (new LSUserException(500, gT("Could not save subquestion")))
                         ->setDetailedErrorsFromModel($subquestion);


### PR DESCRIPTION
Partial fix of subquestion uniqueness handling. This fixes the issue of using the same sub-id code within on a different scale. 

This PR does not fix the issue of re-naming a subquestion code to one that already existed. I think this is an edge case and I don't think its worth the effort of fixing this in 5.x.