### PR TITLE
Fixed issue #19140: Problem with viewing LimeSurvey notifications

### DIFF
--- a/application/controllers/admin/NotificationController.php
+++ b/application/controllers/admin/NotificationController.php
@@ -116,7 +116,7 @@ class NotificationController extends SurveyCommonAction
         if (!$oNotification) {
             throw new CHttpException(404, sprintf(gT("Notification %s not found"), $notId));
         }
-        if ($oNotification->entity_id !== (string) App()->user->id) {
+        if ((int) $oNotification->entity_id !== (int) App()->user->id) {
             throw new CHttpException(403, gT("You do not have permission to access this page."));
         }
 


### PR DESCRIPTION
Fixed issue #19140: Problem with viewing LimeSurvey notifications

https://bugs.limesurvey.org/view.php?id=19140

5.x

