### PR TITLE
Fixed issue #19173: encrypted file upload question - delete file results in crash

### DIFF
--- a/application/models/Response.php
+++ b/application/models/Response.php
@@ -109,14 +109,18 @@ abstract class Response extends Dynamic
             ->findAllByAttributes($aConditions);
         $files = array();
         foreach ($aQuestions as $question) {
+            $encrypted = $question->encrypted === 'Y';
             $field = $question->sid . 'X' . $question->gid . 'X' . $question->qid;
             $fieldDataJson = $this->getAttribute($field);
-            if ($question->encrypted === 'Y') {
+            if ($encrypted) {
                 $fieldDataJson = self::decryptSingle($fieldDataJson);
             }
             $fieldData = json_decode(stripslashes($fieldDataJson), true);
             if (is_array($fieldData)) {
-                $files[$field] = $fieldData;
+                $files[$field] = array(
+                    'files' => $fieldData,
+                    'encrypted' => $encrypted,
+                );
             }
         }
         return $files;
@@ -179,8 +183,14 @@ abstract class Response extends Dynamic
         $success = 0;
         $uploaddir = Yii::app()->getConfig('uploaddir') . "/surveys/{$this->dynamicId}/files/";
         $filesData = $this->getFilesAndSqga();
-        foreach ($filesData as $sgqa => $fileInfos) {
-            foreach ($fileInfos as $i => $fileInfo) {
+        foreach ($filesData as $sgqa => $aQuestion) {
+
+            [
+                'files' => $files,
+                'encrypted' => $encrypted,
+            ] = $aQuestion;
+
+            foreach ($files as $i => $fileInfo) {
                 $basename = basename($fileInfo['filename']);
                 $fullFilename = $uploaddir . $basename;
 
@@ -190,8 +200,15 @@ abstract class Response extends Dynamic
                         $errors[] = $fileInfo['filename'];
                     } else {
                         //$filesData[$sgqa][$i]['filename'] = 'deleted';
-                        $fileInfos[$i]['name'] = $fileInfo['name'] . sprintf(' (%s)', gT('deleted'));
-                        $this->$sgqa = json_encode($fileInfos);
+                        $files[$i]['name'] = $fileInfo['name'] . sprintf(' (%s)', gT('deleted'));
+
+                        $sEncoded = json_encode($files);
+
+                        if($encrypted) {
+                            $sEncoded = self::encryptSingle($sEncoded);
+                        }
+
+                        $this->$sgqa = $sEncoded;
                         $result = $this->save();
                         if ($result) {
                             $success++;


### PR DESCRIPTION
Fixed issue #19173: encrypted file upload question - delete file results in crash

[https://bugs.limesurvey.org/view.php?id=19173](https://bugs.limesurvey.org/view.php?id=19173)

5.x