### PR TITLE
Fixed issue: failed emails resend vars column needs to be mediumtext for mysql

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '6.3.0';
-$config['dbversionnumber'] = 615;
+$config['dbversionnumber'] = 616;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/helpers/update/updates/Update_616.php
+++ b/application/helpers/update/updates/Update_616.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+class Update_616 extends DatabaseUpdateBase
+{
+    public function up()
+    {
+        switch ($this->db->driverName) {
+            case 'mysql':
+                \alterColumn(
+                    '{{failed_emails}}',
+                    'resend_vars',
+                    'mediumtext',
+                    false
+                );
+                break;
+        }
+    }
+}

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -1178,7 +1178,7 @@ function populateDatabase($oDB)
                 'created' => "datetime NOT NULL",  //this one has always to be set to delete after x days ...
                 'status' => "string(20) NULL DEFAULT 'SEND FAILED'",
                 'updated' => "datetime NULL",
-                'resend_vars' => "text NOT NULL"
+                'resend_vars' => "mediumtext NOT NULL"
             ]
         );
 


### PR DESCRIPTION
Fixed issue: Content of a failed email could exceed the amount of bytes a text column can handle in mysql