### PR TITLE
Add configurable open-in-editor button

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -828,5 +828,8 @@ $config['passwordValidationRules'] = array(
     'symbol' => 0,
 );
 
+// Enable or disable single page application editor
+$config['editorEnabled'] = false;
+
 return $config;
 //settings deleted

--- a/application/core/TopbarConfiguration.php
+++ b/application/core/TopbarConfiguration.php
@@ -93,7 +93,7 @@ class TopbarConfiguration
         if (!empty($sid)) {
             $config['sid'] = $sid;
         }
-     
+
         return new self($config);
     }
 
@@ -204,6 +204,15 @@ class TopbarConfiguration
             || $hasSurveyContentPermission
             || !is_null($extraToolsMenuItems);
 
+        $editorEnabled = Yii::app()->getConfig('editorEnabled') ?? false;
+
+        $editorUrl = Yii::app()->request->getUrlReferrer(
+            Yii::app()->createUrl(
+                'editorlink/index',
+                ['route' => 'survey/' . $sid]
+            )
+        );
+
         return array(
             'sid' => $sid,
             'oSurvey' => $oSurvey,
@@ -233,6 +242,8 @@ class TopbarConfiguration
             'beforeSurveyBarRender' => $beforeSurveyBarRender ?? [],
             'showToolsMenu' => $showToolsMenu,
             'surveyLanguages' => self::getSurveyLanguagesArray($oSurvey),
+            'editorEnabled' => $editorEnabled,
+            'editorUrl' => $editorUrl
         );
     }
 
@@ -286,10 +297,15 @@ class TopbarConfiguration
             return [];
         }
 
-        $closeUrl = Yii::app()->request->getUrlReferrer(Yii::app()->createUrl("responses/browse/", ['surveyId' => $sid]));
+        $closeUrl = Yii::app()->request->getUrlReferrer(
+            Yii::app()->createUrl(
+                "responses/browse/",
+                ['surveyId' => $sid]
+            )
+        );
 
         return array(
-            'closeUrl' => $closeUrl,
+            'closeUrl' => $closeUrl
         );
     }
 

--- a/application/views/surveyAdministration/partial/topbar/surveyTopbarRight_view.php
+++ b/application/views/surveyAdministration/partial/topbar/surveyTopbarRight_view.php
@@ -145,3 +145,23 @@ if (!empty($showImportButton)) {
 }
 ?>
 
+<?php
+    if ($editorEnabled && $editorUrl) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'editor-link-button',
+                'id' => 'editor-link-button',
+                'text' => gT('Open in new Editor'),
+                'icon' => 'ri-article-line',
+                'link' => $editorUrl,
+                'htmlOptions' => [
+                    'class' => 'btn btn-secondary',
+                    'role' => 'button',
+                ],
+            ]
+        );
+    }
+?>
+
+


### PR DESCRIPTION
Add button to access new editor. By default it is configured to be invisable.