### PR TITLE
Fixed issue #19183: No editing possible after setting the survey background

### DIFF
--- a/application/views/themeOptions/options_core.php
+++ b/application/views/themeOptions/options_core.php
@@ -23,8 +23,8 @@ $bInherit = (!empty($aTemplateConfiguration['sid']) || !empty($aTemplateConfigur
 
         $backgroundImageFile .= '</optgroup>';
         if (isset($oParentOptions['backgroundimagefile']) && $oParentOptions['backgroundimagefile'] == $image['filepath']){ 
-            $backgroundfileInheritPreview = $backgroundimagefileInheritPreview . $image['preview'];
-            $backgroundfileInheritFilename = $backgroundimagefileInheritFilename . $image['filename']; 
+            $backgroundfileInheritPreview = $backgroundfileInheritPreview . $image['preview'];
+            $backgroundfileInheritFilename = $backgroundfileInheritFilename . $image['filename']; 
         }
         $backgroundImageFile .=  '<option data-lightbox-src="' . $image['preview'] . '" value="' . $image['filepath'] . '">' . $image['filename'] . '</option>';
     }


### PR DESCRIPTION
Fixed issue #19183: No editing possible after setting the survey background

https://bugs.limesurvey.org/view.php?id=19183

5.x