### PR TITLE
Fixed issue #19057: incorrect handling of wrong input in create dummy participant form

### DIFF
--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -1027,7 +1027,11 @@ class Tokens extends SurveyCommonAction
             }
             $aData['thissurvey'] = getSurveyInfo($iSurveyId);
             $aData['surveyid'] = $iSurveyId;
-            if ($cntAttributeErrors > 0) { // attribute validation errors
+            if ($newDummyToken === 0) {
+                $aData['success'] = false;
+                Yii::app()->session['flashmessage'] = gT("No dummy participants were added.");
+                $this->getController()->redirect(array("/admin/tokens/sa/browse/surveyid/{$iSurveyId}"));
+            } elseif ($cntAttributeErrors > 0) { // attribute validation errors
                 $aData['dateformatdetails'] = getDateFormatData(Yii::app()->session['dateformat'], App()->language);
                 $aData['aAttributeFields'] = getParticipantAttributes($iSurveyId);
 

--- a/application/views/admin/token/dummytokenform.php
+++ b/application/views/admin/token/dummytokenform.php
@@ -24,7 +24,7 @@
                 <div class="mb-3 col-6">
                     <label  class=" form-label" for='amount'><?php eT("Number of participants:"); ?></label>
                     <div class="">
-                        <input class='form-control' type='text' size='20' id='amount' name='amount' value="<?php echo $amount; ?>" />
+                        <input class='form-control' type='number' min='1' size='20' id='amount' name='amount' value="<?php echo $amount; ?>" />
                     </div>
                 </div>
 


### PR DESCRIPTION
Fixed issue #19057: incorrect handling of wrong input in create dummy participant form

[https://bugs.limesurvey.org/view.php?id=19057](https://bugs.limesurvey.org/view.php?id=19057)

master