### PR TITLE
Fix CSRF validation for remotecontrol API route

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -156,7 +156,7 @@ $internalConfig = array(
             'noCsrfValidationParams' => array(),
             'noCsrfValidationRoutes' => array(
                 'rest',
-                'remotecontrol',
+                'admin/remotecontrol',
                 'plugins/unsecure',
             ),
             'csrfCookie' => array(

--- a/application/core/LSHttpRequest.php
+++ b/application/core/LSHttpRequest.php
@@ -264,6 +264,6 @@ class LSHttpRequest extends CHttpRequest
         // For example the routes "rest" (in the case of "index.php/rest?...") or "rest/..." (in the case of
         // "index.php/rest/...") should be matched by the rule "rest", but the route "admin/menus/sa/restore"
         // should not.
-        return preg_match('#^' . $rule . '$|^' . $rule . '/#', (string) $route);
+        return preg_match('#^/?' . $rule . '$|^/?' . $rule . '/#', (string) $route);
     }
 }

--- a/tests/unit/CsrfHttpRequestTest.php
+++ b/tests/unit/CsrfHttpRequestTest.php
@@ -41,8 +41,8 @@ class CsrfHttpRequestTest extends TestBaseClass
     public function testRemoteControlRoutesSkipCsrfValidation()
     {
         $routes = array(
-            'remotecontrol/actionOnItemById/15',
-            'remotecontrol/action',
+            'admin/remotecontrol/actionOnItemById/15',
+            'admin/remotecontrol/action',
         );
 
         foreach ($routes as $route) {

--- a/tests/unit/CsrfHttpRequestTest.php
+++ b/tests/unit/CsrfHttpRequestTest.php
@@ -43,6 +43,7 @@ class CsrfHttpRequestTest extends TestBaseClass
         $routes = array(
             'admin/remotecontrol/actionOnItemById/15',
             'admin/remotecontrol/action',
+            '/admin/remotecontrol',
         );
 
         foreach ($routes as $route) {


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixes an error introduced in #3588. The changes made the remote control route, `admin/remotecontrol`, no longer skip CSRF validation.

I can report the bug in https://bugs.limesurvey.org, but this error is present only in the `master` branch and I thought it quicker to send a PR.

Fixed issue [#19220](https://bugs.limesurvey.org/view.php?id=19220)