### PR TITLE
Fixed issue #19224: Advanced ranking does not respect max answer when drag-n-drop

### DIFF
--- a/themes/question/ranking_advanced/survey/questions/answer/ranking/assets/scripts/advanced_ranking.js
+++ b/themes/question/ranking_advanced/survey/questions/answer/ranking/assets/scripts/advanced_ranking.js
@@ -33,7 +33,12 @@ var AdvancedRankingQuestion = function (options) {
         var sortableObjectChoice = {
             group: "sortable-" + questionId,
             ghostClass: "ls-rank-placeholder",
-            onEnd: function(){updateRankingNumber();}
+            onEnd: function(){updateRankingNumber();},
+            onMove: function (ev) {
+                if (max_answers > 0 && $('#sortable-rank-' + questionId + ' li').length >= max_answers) {
+                    return false;
+                }
+            }
         },
         sortableObjectRank = {
             group: "sortable-" + questionId,


### PR DESCRIPTION
Number of choices checked on move.
