### PR TITLE
Fixed issue #19228: Setting Bruteforce timeout values to empty string causes the administrator to be locked out

### DIFF
--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -91,15 +91,19 @@ class FailedLoginAttempt extends LSActiveRecord
 
         switch ($attemptType) {
             case FailedLoginAttempt::TYPE_LOGIN:
-                $timeOut = Yii::app()->getConfig('timeOutTime');
-                $maxLoginAttempt = Yii::app()->getConfig('maxLoginAttempt');
+                $timeOut = floatval(App()->getConfig('timeOutTime'));
+                $maxLoginAttempt = intval(App()->getConfig('maxLoginAttempt'));
                 break;
             case FailedLoginAttempt::TYPE_TOKEN:
-                $timeOut = Yii::app()->getConfig('timeOutParticipants');
-                $maxLoginAttempt = Yii::app()->getConfig('maxLoginAttemptParticipants');
+                $timeOut = floatval(App()->getConfig('timeOutParticipants'));
+                $maxLoginAttempt = intval(App()->getConfig('maxLoginAttemptParticipants'));
                 break;
             default:
                 throw new InvalidArgumentException(sprintf("Invalid attempt type: %s", $attemptType));
+        }
+        // Return false if disable
+        if ($maxLoginAttempt <= 0) {
+            return false;
         }
 
         if (Yii::app()->getConfig('DBVersion') <= 480) {
@@ -124,6 +128,7 @@ class FailedLoginAttempt extends LSActiveRecord
         if ($row != null) {
             $lastattempt = strtotime($row->last_attempt);
             if (time() > $lastattempt + $timeOut) {
+                // always true if $timeOut = 0
                 $this->deleteAttempts($attemptType);
             } else {
                 $isLockedOut = true;

--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -91,11 +91,11 @@ class FailedLoginAttempt extends LSActiveRecord
 
         switch ($attemptType) {
             case FailedLoginAttempt::TYPE_LOGIN:
-                $timeOut = floatval(App()->getConfig('timeOutTime'));
+                $timeOut = intval(App()->getConfig('timeOutTime'));
                 $maxLoginAttempt = intval(App()->getConfig('maxLoginAttempt'));
                 break;
             case FailedLoginAttempt::TYPE_TOKEN:
-                $timeOut = floatval(App()->getConfig('timeOutParticipants'));
+                $timeOut = intval(App()->getConfig('timeOutParticipants'));
                 $maxLoginAttempt = intval(App()->getConfig('maxLoginAttemptParticipants'));
                 break;
             default:

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -127,8 +127,8 @@
             </label>
             <textarea class="form-control" id='loginIpWhitelist'
                       name='loginIpWhitelist'><?php echo htmlspecialchars(Yii::app()->getConfig('loginIpWhitelist')); ?></textarea>
-            <span
-                class='hint'><?php eT("List of IP addresses to exclude from the maximum login attempts check. Separate each IP address with a comma or a new line."); ?></span>
+            <p
+                class='help-block'><?php eT("List of IP addresses to exclude from the maximum login attempts check. Separate each IP address with a comma or a new line."); ?></p>
         </div>
 
         <div class="form-group">
@@ -136,8 +136,9 @@
                 <?php eT("Maximum number of attempts:"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0" name="maxLoginAttempt"
+                <input class="form-control" type="number" min="1"  step="1"  pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                        value="<?= Yii::app()->getConfig('maxLoginAttempt') ?>"/>
+            <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
         </div>
         <div class="form-group">
@@ -145,9 +146,10 @@
                 <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0"  name="timeOutTime"
+                <input class="form-control" type="number" min="0"  name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
                        value="<?= Yii::app()->getConfig('timeOutTime') ?>"/>
             </div>
+            <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
         </div>
 
     </div>
@@ -161,8 +163,8 @@
             </label>
             <textarea class="form-control" id='tokenIpWhitelist'
                       name='tokenIpWhitelist'><?php echo htmlspecialchars(Yii::app()->getConfig('tokenIpWhitelist')); ?></textarea>
-            <span
-                class='hint'><?php eT("List of IP addresses to exclude from the maximum token validation attempts check. Separate each IP address with a comma or a new line."); ?></span>
+            <p
+                class='help-block'><?php eT("List of IP addresses to exclude from the maximum token validation attempts check. Separate each IP address with a comma or a new line."); ?></p>
         </div>
 
         <div class="form-group">
@@ -170,8 +172,9 @@
                 <?php eT("Maximum number of attempts:"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0"  name="maxLoginAttemptParticipants"
+                <input class="form-control" type="number" min="1"  pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                        value="<?= Yii::app()->getConfig('maxLoginAttemptParticipants') ?>"/>
+                <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
         </div>
         <div class="form-group">
@@ -179,8 +182,9 @@
                 <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0" name="timeOutParticipants"
+                <input class="form-control" type="number" min="0" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
                        value="<?= Yii::app()->getConfig('timeOutParticipants') ?>"/>
+                <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
             </div>
         </div>
 

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -138,7 +138,7 @@
             <div class="">
                 <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"/>
-            <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
+            <p class="help-block"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></p>
             </div>
         </div>
         <div class="form-group">
@@ -149,7 +149,7 @@
                 <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"/>
             </div>
-            <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
+            <p class="help-block"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></p>
         </div>
 
     </div>
@@ -174,7 +174,7 @@
             <div class="">
                 <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ?? intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"/>
-                <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
+                <p class="help-block"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></p>
             </div>
         </div>
         <div class="form-group">
@@ -184,7 +184,7 @@
             <div class="">
                 <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"/>
-                <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
+                <p class="help-block"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></p>
             </div>
         </div>
 

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -136,7 +136,7 @@
                 <?php eT("Maximum number of attempts:"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="1"  step="1"  pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
+                <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"/>
             <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
@@ -146,8 +146,8 @@
                 <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0"  name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('timeOutTime') !== "" ?? floatval(App()->getConfig('timeOutTime')) ?>"/>
+                <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
+                       value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"/>
             </div>
             <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
         </div>
@@ -172,7 +172,7 @@
                 <?php eT("Maximum number of attempts:"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="1"  pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
+                <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                        value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ?? intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"/>
                 <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
@@ -182,8 +182,8 @@
                 <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
             </label>
             <div class="">
-                <input class="form-control" type="number" min="0" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('timeOutParticipants') !== "" ?? floatval(App()->getConfig('timeOutParticipants')) ?>"/>
+                <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
+                       value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"/>
                 <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
             </div>
         </div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -137,7 +137,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"/>
+                       value="<?= App()->getConfig('maxLoginAttempt') !== "" ? intval(App()->getConfig('maxLoginAttempt')) : "" ?>"/>
             <p class="help-block"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></p>
             </div>
         </div>
@@ -147,7 +147,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"/>
+                       value="<?= App()->getConfig('timeOutTime') !== "" ? intval(App()->getConfig('timeOutTime')) : "" ?>"/>
             </div>
             <p class="help-block"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></p>
         </div>
@@ -173,7 +173,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ?? intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"/>
+                       value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ? intval(App()->getConfig('maxLoginAttemptParticipants')) : "" ?>"/>
                 <p class="help-block"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></p>
             </div>
         </div>
@@ -183,7 +183,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"/>
+                       value="<?= App()->getConfig('timeOutParticipants') !== "" ? intval(App()->getConfig('timeOutParticipants')) : "" ?>"/>
                 <p class="help-block"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></p>
             </div>
         </div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -137,7 +137,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="1"  step="1"  pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= Yii::app()->getConfig('maxLoginAttempt') ?>"/>
+                       value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"/>
             <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
         </div>
@@ -147,7 +147,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="0"  name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= Yii::app()->getConfig('timeOutTime') ?>"/>
+                       value="<?= App()->getConfig('timeOutTime') !== "" ?? floatval(App()->getConfig('timeOutTime')) ?>"/>
             </div>
             <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
         </div>
@@ -173,7 +173,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="1"  pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= Yii::app()->getConfig('maxLoginAttemptParticipants') ?>"/>
+                       value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ?? intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"/>
                 <p class="help-block"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></p>
             </div>
         </div>
@@ -183,7 +183,7 @@
             </label>
             <div class="">
                 <input class="form-control" type="number" min="0" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
-                       value="<?= Yii::app()->getConfig('timeOutParticipants') ?>"/>
+                       value="<?= App()->getConfig('timeOutParticipants') !== "" ?? floatval(App()->getConfig('timeOutParticipants')) ?>"/>
                 <p class="help-block"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></p>
             </div>
         </div>


### PR DESCRIPTION
Dev: update HTML and put some information and restriction
Dev: check final value as integre or float