### PR TITLE
Fixed issue #19228: Setting Bruteforce timeout values to empty string causes the administrator to be locked out

### DIFF
--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -91,17 +91,20 @@ class FailedLoginAttempt extends LSActiveRecord
 
         switch ($attemptType) {
             case FailedLoginAttempt::TYPE_LOGIN:
-                $timeOut = Yii::app()->getConfig('timeOutTime');
-                $maxLoginAttempt = Yii::app()->getConfig('maxLoginAttempt');
+                $timeOut = floatval(App()->getConfig('timeOutTime'));
+                $maxLoginAttempt = intval(App()->getConfig('maxLoginAttempt'));
                 break;
             case FailedLoginAttempt::TYPE_TOKEN:
-                $timeOut = Yii::app()->getConfig('timeOutParticipants');
-                $maxLoginAttempt = Yii::app()->getConfig('maxLoginAttemptParticipants');
+                $timeOut = floatval(App()->getConfig('timeOutParticipants'));
+                $maxLoginAttempt = intval(App()->getConfig('maxLoginAttemptParticipants'));
                 break;
             default:
                 throw new InvalidArgumentException(sprintf("Invalid attempt type: %s", $attemptType));
         }
-
+        // Return false if disable my maxLoginAttempt
+        if ($maxLoginAttempt <= 0) {
+            return false;
+        }
         if (Yii::app()->getConfig('DBVersion') <= 480) {
             $criteria = new CDbCriteria();
             $criteria->condition = 'number_attempts >= :attempts AND ip = :ip';
@@ -124,6 +127,7 @@ class FailedLoginAttempt extends LSActiveRecord
         if ($row != null) {
             $lastattempt = strtotime((string) $row->last_attempt);
             if (time() > $lastattempt + $timeOut) {
+                // always true if $timeOut <= 0
                 $this->deleteAttempts($attemptType);
             } else {
                 $isLockedOut = true;

--- a/application/models/FailedLoginAttempt.php
+++ b/application/models/FailedLoginAttempt.php
@@ -91,11 +91,11 @@ class FailedLoginAttempt extends LSActiveRecord
 
         switch ($attemptType) {
             case FailedLoginAttempt::TYPE_LOGIN:
-                $timeOut = floatval(App()->getConfig('timeOutTime'));
+                $timeOut = intval(App()->getConfig('timeOutTime'));
                 $maxLoginAttempt = intval(App()->getConfig('maxLoginAttempt'));
                 break;
             case FailedLoginAttempt::TYPE_TOKEN:
-                $timeOut = floatval(App()->getConfig('timeOutParticipants'));
+                $timeOut = intval(App()->getConfig('timeOutParticipants'));
                 $maxLoginAttempt = intval(App()->getConfig('maxLoginAttemptParticipants'));
                 break;
             default:

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -155,7 +155,7 @@
                         <?php eT("Maximum number of attempts:"); ?>
                     </label>
                     <div class="">
-                        <input class="form-control" type="number" min="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
+                        <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
                         />
                         <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are deleted each time.") ?></div>
@@ -166,7 +166,7 @@
                         <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                     </label>
                     <div class="">
-                        <input class="form-control" type="number" min="0" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
+                        <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"
                         />
                         <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
@@ -194,7 +194,7 @@
                     <?php eT("Maximum number of attempts:"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" type="number" min="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
+                    <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
@@ -205,7 +205,7 @@
                     <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" type="number" min="0" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
+                    <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -147,7 +147,7 @@
                         <?php eT("IP whitelist:"); ?>
                     </label>
                     <textarea class="form-control" id='loginIpWhitelist' name='loginIpWhitelist'><?php echo htmlspecialchars((string) Yii::app()->getConfig('loginIpWhitelist')); ?></textarea>
-                    <span class='hint'><?php eT("List of IP addresses to exclude from the maximum login attempts check. Separate each IP address with a comma or a new line."); ?></span>
+                    <div class='form-text'><?php eT("List of IP addresses to exclude from the maximum login attempts check. Separate each IP address with a comma or a new line."); ?></div>
                 </div>
 
                 <div class="mb-3">
@@ -155,7 +155,10 @@
                         <?php eT("Maximum number of attempts:"); ?>
                     </label>
                     <div class="">
-                        <input class="form-control" type="number" min="0" name="maxLoginAttempt" value="<?= Yii::app()->getConfig('maxLoginAttempt') ?>" />
+                        <input class="form-control" type="number" min="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
+                            value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
+                        />
+                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are deleted each time.") ?></div>
                     </div>
                 </div>
                 <div class="mb-3">
@@ -163,7 +166,10 @@
                         <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                     </label>
                     <div class="">
-                        <input class="form-control" type="number" min="0" name="timeOutTime" value="<?= Yii::app()->getConfig('timeOutTime') ?>" />
+                        <input class="form-control" type="number" min="0" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
+                            value="<?= App()->getConfig('timeOutTime') !== "" ?? floatval(App()->getConfig('timeOutTime')) ?>"
+                        />
+                        <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
                     </div>
                 </div>
             </div>
@@ -178,7 +184,7 @@
                     <?php eT("IP whitelist:"); ?>
                 </label>
                 <textarea class="form-control" id='tokenIpWhitelist' name='tokenIpWhitelist'><?php echo htmlspecialchars((string) Yii::app()->getConfig('tokenIpWhitelist')); ?></textarea>
-                <span class='hint'>
+                <span class='form-text'>
                     <?php eT("List of IP addresses to exclude from the maximum token validation attempts check. Separate each IP address with a comma or a new line."); ?>
                 </span>
             </div>
@@ -188,7 +194,10 @@
                     <?php eT("Maximum number of attempts:"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" min="0" type="number" name="maxLoginAttemptParticipants" value="<?= Yii::app()->getConfig('maxLoginAttemptParticipants') ?>" />
+                    <input class="form-control" min="1" type="number" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
+                        value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
+                    />
+                    <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
                 </div>
             </div>
             <div class="mb-3">
@@ -196,7 +205,10 @@
                     <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" type="number" min="0" name="timeOutParticipants" value="<?= Yii::app()->getConfig('timeOutParticipants') ?>" />
+                    <input class="form-control" type="number" min="0" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
+                        value="<?= App()->getConfig('timeOutParticipants') !== "" ?? floatval(App()->getConfig('timeOutParticipants')) ?>"
+                    />
+                    <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
                 </div>
             </div>
 

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -158,7 +158,7 @@
                         <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
                         />
-                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
+                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attempts are never checked.") ?></div>
                     </div>
                 </div>
                 <div class="mb-3">

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -166,8 +166,8 @@
                         <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                     </label>
                     <div class="">
-                        <input class="form-control" type="number" min="0" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
-                            value="<?= App()->getConfig('timeOutTime') !== "" ?? floatval(App()->getConfig('timeOutTime')) ?>"
+                        <input class="form-control" type="number" min="0" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
+                            value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"
                         />
                         <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
                     </div>
@@ -194,7 +194,7 @@
                     <?php eT("Maximum number of attempts:"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" min="1" type="number" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
+                    <input class="form-control" type="number" min="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
@@ -205,8 +205,8 @@
                     <?php eT("Lockout time in seconds (after maximum number of attempts):"); ?>
                 </label>
                 <div class="">
-                    <input class="form-control" type="number" min="0" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
-                        value="<?= App()->getConfig('timeOutParticipants') !== "" ?? floatval(App()->getConfig('timeOutParticipants')) ?>"
+                    <input class="form-control" type="number" min="0" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
+                        value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
                 </div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -156,7 +156,7 @@
                     </label>
                     <div class="">
                         <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
-                            value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
+                            value="<?= App()->getConfig('maxLoginAttempt') !== "" ? intval(App()->getConfig('maxLoginAttempt')) : "" ?>"
                         />
                         <div class="form-text"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></div>
                     </div>
@@ -167,7 +167,7 @@
                     </label>
                     <div class="">
                         <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
-                            value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"
+                            value="<?= App()->getConfig('timeOutTime') !== "" ? intval(App()->getConfig('timeOutTime')) : "" ?>"
                         />
                         <div class="form-text"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></div>
                     </div>
@@ -195,7 +195,7 @@
                 </label>
                 <div class="">
                     <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
-                        value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
+                        value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ? intval(App()->getConfig('maxLoginAttemptParticipants')) : "" ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></div>
                 </div>
@@ -206,7 +206,7 @@
                 </label>
                 <div class="">
                     <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
-                        value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"
+                        value="<?= App()->getConfig('timeOutParticipants') !== "" ? intval(App()->getConfig('timeOutParticipants')) : "" ?>"
                     />
                     <div class="form-text"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></div>
                 </div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -158,7 +158,7 @@
                         <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
                         />
-                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attempts are never checked.") ?></div>
+                        <div class="form-text"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></div>
                     </div>
                 </div>
                 <div class="mb-3">
@@ -197,7 +197,7 @@
                     <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
                     />
-                    <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attempts are never checked.") ?></div>
+                    <div class="form-text"><?= gT("Set an empty value to disable brute force protection. Number of attempts are never checked.") ?></div>
                 </div>
             </div>
             <div class="mb-3">

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -158,7 +158,7 @@
                         <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttempt" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('maxLoginAttempt') !== "" ?? intval(App()->getConfig('maxLoginAttempt')) ?>"
                         />
-                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are deleted each time.") ?></div>
+                        <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
                     </div>
                 </div>
                 <div class="mb-3">
@@ -169,7 +169,7 @@
                         <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutTime" placeholder="<?= gT("Disabled") ?>"
                             value="<?= App()->getConfig('timeOutTime') !== "" ?? intval(App()->getConfig('timeOutTime')) ?>"
                         />
-                        <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
+                        <div class="form-text"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></div>
                     </div>
                 </div>
             </div>
@@ -197,7 +197,7 @@
                     <input class="form-control" type="number" min="1" step="1" pattern="^\d*$" name="maxLoginAttemptParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('maxLoginAttemptParticipants') !== "" ??  intval(App()->getConfig('maxLoginAttemptParticipants')) ?>"
                     />
-                    <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attemps are never checked.") ?></div>
+                    <div class="form-text"><?= gT("Set an empty value disable brute force protection. Number of attempts are never checked.") ?></div>
                 </div>
             </div>
             <div class="mb-3">
@@ -208,7 +208,7 @@
                     <input class="form-control" type="number" min="0" step="1" pattern="^\d*$" name="timeOutParticipants" placeholder="<?= gT("Disabled") ?>"
                         value="<?= App()->getConfig('timeOutParticipants') !== "" ?? intval(App()->getConfig('timeOutParticipants')) ?>"
                     />
-                    <div class="form-text"><?= gT("Set an empty value or 0 disable brute force protection. Number of attemps are deleted each time.") ?></div>
+                    <div class="form-text"><?= gT("Set an empty value or 0 to disable brute force protection. Number of attempts are deleted each time.") ?></div>
                 </div>
             </div>
 


### PR DESCRIPTION
Dev: update HTML and put some information and restriction
Dev: check final value as integer or float