### PR TITLE
Fixed issue #19323: Error When updating running Update_619.php on MSSQL

### DIFF
--- a/application/helpers/update/updates/Update_619.php
+++ b/application/helpers/update/updates/Update_619.php
@@ -11,6 +11,14 @@ class Update_619 extends DatabaseUpdateBase
      */
     public function up()
     {
-        $this->db->createCommand()->addColumn('{{users}}', 'user_status', 'BOOLEAN DEFAULT TRUE');
+        switch ($this->db->driverName)
+        {
+            case 'mssql':
+              \addColumn('{{users}}', 'user_status', 'BIT DEFAULT 1 NOT NULL');
+              break;
+            default:
+            \addColumn('{{users}}', 'user_status', 'BOOLEAN DEFAULT TRUE');
+        }
+        //$this->db->createCommand()->addColumn('{{users}}', 'user_status', 'BOOLEAN DEFAULT TRUE');
     }
 }


### PR DESCRIPTION
Updated to hopefully fix bug #19323.

The change in code for MSSQL was used on a production instance at work, and allows the upgrade to continue.
I have not tested the switch-case, but I used the one present in Update_616.php as a basis for what I did here.