### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -941,7 +941,6 @@ class UpdateForm extends CFormModel
         curl_setopt($ch, CURLOPT_COOKIEFILE, $this->path_cookie);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, false); // We don't want the header to be written in the zip file !
-        curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_FILE, $pFile);
         curl_exec($ch);


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)


Fixed issue: N/A due to this being a minor fix.
