### PR TITLE
Fixed issue #19352: Ranking advanced question type shows item numbers even when disabled

### DIFF
--- a/themes/question/ranking_advanced/survey/questions/answer/ranking/answer.twig
+++ b/themes/question/ranking_advanced/survey/questions/answer/ranking/answer.twig
@@ -35,7 +35,7 @@
 {% set show_number=question_template_attribute.show_number %}
 {# {% set show_handle="yes" %} #}
 
-{% set show_number="yes" %}
+{# {% set show_number="yes" %} #}
 
 
 <!-- answer -->


### PR DESCRIPTION
Fixed issue #19352: Ranking advanced question type shows weird numbers in front of every item
