### PR TITLE
dev: support beforeControllerAction and afterControllerAction events …

### DIFF
--- a/application/controllers/RestController.php
+++ b/application/controllers/RestController.php
@@ -25,6 +25,7 @@ class RestController extends LSYii_Controller
      * Run REST controller actions with beforeControllerAction
      * and afterControllerAction events.
      *
+	 * @param string $actionID action ID
      * @return void
      */
     public function run($actionID)

--- a/application/controllers/RestController.php
+++ b/application/controllers/RestController.php
@@ -25,7 +25,7 @@ class RestController extends LSYii_Controller
      * Run REST controller actions with beforeControllerAction
      * and afterControllerAction events.
      *
-	 * @param string $actionID action ID
+     * @param string $actionID action ID
      * @return void
      */
     public function run($actionID)

--- a/application/controllers/RestController.php
+++ b/application/controllers/RestController.php
@@ -31,7 +31,7 @@ class RestController extends LSYii_Controller
     {
         Yii::app()->loadConfig('rest');
         $action = new CInlineAction($this, 'index');
-        if(Yii::app()->beforeControllerAction($this, $action)) {
+        if (Yii::app()->beforeControllerAction($this, $action)) {
             $endpointFactory = DI::getContainer()
                 ->get(EndpointFactory::class);
 

--- a/application/controllers/RestController.php
+++ b/application/controllers/RestController.php
@@ -20,19 +20,26 @@ use LimeSurvey\DI;
 class RestController extends LSYii_Controller
 {
     /**
-     * Run REST controller action.
+     * Runs the named action.
      *
-     * @param string $actionID action ID
+     * Run REST controller actions with beforeControllerAction
+     * and afterControllerAction events.
+     *
      * @return void
      */
     public function run($actionID)
     {
-        $endpointFactory = DI::getContainer()
-            ->get(EndpointFactory::class);
-
         Yii::app()->loadConfig('rest');
-        ($endpointFactory)->create(
-            Yii::app()->request
-        )->run();
+        $action = new CInlineAction($this, 'index');
+        if(Yii::app()->beforeControllerAction($this, $action)) {
+            $endpointFactory = DI::getContainer()
+                ->get(EndpointFactory::class);
+
+            ($endpointFactory)->create(
+                Yii::app()->request
+            )->run();
+
+            Yii::app()->afterControllerAction($this, $action);
+        }
     }
 }


### PR DESCRIPTION
Add support for beforeControllerAction and afterControllerAction events to RestController. This is needed so we can extend the REST API config in cloud.
