### PR TITLE
MW-946: Aggregated common operations on group starts

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6758,9 +6758,10 @@ class LimeExpressionManager
      * @param boolean|null $anonymized - whether anonymized
      * @param int|null $surveyid - the surveyId
      * @param boolean|null $forceRefresh - whether to force refresh of setting variable and token mappings (should be done rarely)
+     * @param boolean|null $postponeAggregation - whether to postpone aggregation
      * @return void
      */
-    public static function StartProcessingGroup($gseq = null, $anonymized = false, $surveyid = null, $forceRefresh = false)
+    public static function StartProcessingGroup($gseq = null, $anonymized = false, $surveyid = null, $forceRefresh = false, $postponeAggregation = false)
     {
         $LEM =& LimeExpressionManager::singleton();
         $LEM->em->StartProcessingGroup(
@@ -6772,18 +6773,37 @@ class LimeExpressionManager
         if (!is_null($gseq)) {
             $LEM->currentGroupSeq = $gseq;
             if (!is_null($surveyid)) {
-                $LEM->setVariableAndTokenMappingsForExpressionManager($surveyid, $forceRefresh, $anonymized);
+                if (!$postponeAggregation) {
+                    $LEM->setVariableAndTokenMappingsForExpressionManager($surveyid, $forceRefresh, $anonymized);
+                }
                 if ($gseq > $LEM->maxGroupSeq) {
                     $LEM->maxGroupSeq = $gseq;
                 }
 
                 if (!$LEM->allOnOnePage || ($LEM->allOnOnePage && !$LEM->processedRelevance)) {
-                    $LEM->ProcessAllNeededRelevance();  // TODO - what if this is called using Survey or Data Entry format?
-                    $LEM->_CreateSubQLevelRelevanceAndValidationEqns();
+                    if (!$postponeAggregation) {
+                        $LEM->ProcessAllNeededRelevance();  // TODO - what if this is called using Survey or Data Entry format?
+                        $LEM->_CreateSubQLevelRelevanceAndValidationEqns();
+                    }
                     $LEM->processedRelevance = true;
                 }
             }
         }
+    }
+
+    /**
+     * Does the group start's common logic in an aggregated manner
+     * @param boolean|null $anonymized - whether anonymized
+     * @param int|null $surveyid - the surveyId
+     * @param boolean|null $forceRefresh - whether to force refresh of setting variable and token mappings (should be done rarely)
+     * @return void
+     */
+    public static function AggregateGroupStart($anonymized = false, $surveyid = null, $forceRefresh = false)
+    {
+        $LEM =& LimeExpressionManager::singleton();
+        $LEM->setVariableAndTokenMappingsForExpressionManager($surveyid, $forceRefresh, $anonymized);
+        $LEM->ProcessAllNeededRelevance();  // TODO - what if this is called using Survey or Data Entry format?
+        $LEM->_CreateSubQLevelRelevanceAndValidationEqns();
     }
 
     /**

--- a/application/models/services/Proxy/ProxyExpressionManager.php
+++ b/application/models/services/Proxy/ProxyExpressionManager.php
@@ -64,14 +64,12 @@ class ProxyExpressionManager
                 $aGroup['gid'],
                 $survey->anonymized != 'Y',
                 $surveyId,
-                true,
                 true
             );
         }
         LimeExpressionManager::AggregateGroupStart(
             $survey->anonymized != 'Y',
-            $surveyId,
-            true
+            $surveyId
         );
         foreach ($aGrouplist as $aGroup) {
             LimeExpressionManager::FinishProcessingGroup();

--- a/application/models/services/Proxy/ProxyExpressionManager.php
+++ b/application/models/services/Proxy/ProxyExpressionManager.php
@@ -64,13 +64,14 @@ class ProxyExpressionManager
                 $aGroup['gid'],
                 $survey->anonymized != 'Y',
                 $surveyId,
-                false,
+                true,
                 true
             );
         }
         LimeExpressionManager::AggregateGroupStart(
             $survey->anonymized != 'Y',
-            $surveyId
+            $surveyId,
+            true
         );
         foreach ($aGrouplist as $aGroup) {
             LimeExpressionManager::FinishProcessingGroup();

--- a/application/models/services/Proxy/ProxyExpressionManager.php
+++ b/application/models/services/Proxy/ProxyExpressionManager.php
@@ -64,6 +64,7 @@ class ProxyExpressionManager
                 $aGroup['gid'],
                 $survey->anonymized != 'Y',
                 $surveyId,
+                false,
                 true
             );
         }

--- a/application/models/services/Proxy/ProxyExpressionManager.php
+++ b/application/models/services/Proxy/ProxyExpressionManager.php
@@ -63,8 +63,16 @@ class ProxyExpressionManager
             LimeExpressionManager::StartProcessingGroup(
                 $aGroup['gid'],
                 $survey->anonymized != 'Y',
-                $surveyId
+                $surveyId,
+                false,
+                true
             );
+        }
+        LimeExpressionManager::AggregateGroupStart(
+            $survey->anonymized != 'Y',
+            $surveyId
+        );
+        foreach ($aGrouplist as $aGroup) {
             LimeExpressionManager::FinishProcessingGroup();
         }
         LimeExpressionManager::FinishProcessingPage();

--- a/application/models/services/QuestionAttributeFetcher.php
+++ b/application/models/services/QuestionAttributeFetcher.php
@@ -84,7 +84,7 @@ class QuestionAttributeFetcher
         }
 
         static $survey = null;
-        if ($survey === null){
+        if ($survey === null) {
             $survey = $this->question->survey;
         }
         if (isset($survey->sid) && $survey->sid !== $this->question->sid) {


### PR DESCRIPTION
This is a performance improvement for MW-946, the idea is to improve the speed of the `reset` method by aggregating the survey-level operations that were previously done for each group and thus performing the repetitive operations only once.

Measurements:

Before:

Language Settings took 0.010984897613525 seconds
General Settings took 0.0005490779876709 seconds
URL Params took 9.5367431640625E-7 seconds
Proxy Reset took 12.65425491333 seconds
Template Config took 0.0011730194091797 seconds
Database::actionUpdateSurveyLocaleSettings took 12.67779302597

After:

Language Settings took 0.012439012527466 seconds
General Settings took 0.00066709518432617 seconds
URL Params took 9.5367431640625E-7 seconds
Proxy Reset took 3.8038971424103 seconds
Template Config took 0.001168966293335 seconds
Database::actionUpdateSurveyLocaleSettings took 3.828782081604 seconds