### PR TITLE
Fixed #19217: PHP8 Error Type NULL

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2927,7 +2927,7 @@ function getTokenFieldsAndNames($surveyid, $bOnlyAttributes = false)
     );
 
     $aExtraTokenFields = getAttributeFieldNames($surveyid);
-    $aSavedExtraTokenFields = Survey::model()->findByPk($surveyid)->tokenAttributes;
+    $aSavedExtraTokenFields = Survey::model()->findByPk($surveyid)->tokenAttributes ?? [];
 
     // Drop all fields that are in the saved field description but not in the table definition
     $aSavedExtraTokenFields = array_intersect_key($aSavedExtraTokenFields, array_flip($aExtraTokenFields));

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -671,8 +671,10 @@ class Survey extends LSActiveRecord implements PermissionInterface
      */
     public function getTokenAttributes()
     {
-        $attdescriptiondata = decodeTokenAttributes($this->attributedescriptions);
-
+        $attdescriptiondata = decodeTokenAttributes($this->attributedescriptions ?? '');
+        if (!is_array(reset($attdescriptiondata))) {
+            $attdescriptiondata = null;
+        }
         // Catches malformed data
         if ($attdescriptiondata && strpos(key(reset($attdescriptiondata)), 'attribute_') === false) {
             // don't know why yet but this breaks normal tokenAttributes functionning


### PR DESCRIPTION
* Fixed: 19217 Update Survey.php

$attdescriptiondata = decodeTokenAttributes($this->attributedescriptions ?? ''); change to
$attdescriptiondata = decodeTokenAttributes($this->attributedescriptions ?? []); In PHP 7 it is a warning
in PHP 8 it's a 500! parameter key() must be an array!!

* Fixed 10217: Update common_helper.php

$aSavedExtraTokenFields = Survey::model()->findByPk($surveyid)->tokenAttributes; change to:
$aSavedExtraTokenFields = Survey::model()->findByPk($surveyid)->tokenAttributes ?? []; In PHP 7 it is a warning
in PHP 8 it's a 500! $aSavedExtraTokenFields is not allowed to be NULL anymore! in function array_intersect_key()!

* Update common_helper.php

Corrected code line 2946

* #19217: Update Survey.php

revert back to from ?? [] to ?? '' on line 667

* #19217: Update Survey.php

Extra check on first element of array
If it is not an array set array to NULL

* #19217: Update Survey.php

Final edit after line 667:
Check on array after reset(array)

* #19217: Update Survey.php

And some missing spaces...
this one should pass!!!
