### PR TITLE
Fixed issue: Integrity check very slow when having a lot of surveys

### DIFF
--- a/application/controllers/admin/CheckIntegrity.php
+++ b/application/controllers/admin/CheckIntegrity.php
@@ -606,7 +606,7 @@ class CheckIntegrity extends SurveyCommonAction
         }
 
         // Deactivate surveys that have a missing response table
-        $survey = new SurveyNoEvent();
+        $survey = new SurveyLight();
         $oSurveys = $survey->findAll(array('order' => 'sid'));
         $oDB = Yii::app()->getDb();
         $oDB->schemaCachingDuration = 0; // Deactivate schema caching
@@ -925,7 +925,7 @@ class CheckIntegrity extends SurveyCommonAction
         /*   Check survey languagesettings and restore them if they don't exist    */
         /***************************************************************************/
 
-        $surveyModel = new SurveyNoEvent();
+        $surveyModel = new SurveyLight();
         $surveys = $surveyModel->findAll();
         foreach ($surveys as $survey) {
             $aLanguages = $survey->additionalLanguages;

--- a/application/controllers/admin/CheckIntegrity.php
+++ b/application/controllers/admin/CheckIntegrity.php
@@ -622,7 +622,7 @@ class CheckIntegrity extends SurveyCommonAction
         /** Check for active surveys if questions are in the correct group **/
         // Commented out the following code parts, because it is unlikely that the columns are not in the correct group
         // Will leave the code in for now just in case
-        
+
         /* foreach ($oSurveys as $oSurvey) {
             // This actually clears the schema cache, not just refreshes it
             $oDB->schema->refresh();

--- a/application/controllers/admin/CheckIntegrity.php
+++ b/application/controllers/admin/CheckIntegrity.php
@@ -619,7 +619,7 @@ class CheckIntegrity extends SurveyCommonAction
             }
         }
 
-        /** 
+        /**
          * Check for active surveys if questions are in the correct group
          * This will only run if an additional URL parameter checkResponseTableFields=y is set
          * This is to prevent this costly check from running on every page load

--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -2010,7 +2010,7 @@ class DataEntry extends SurveyCommonAction
     private function returnAccessCodeIsNotValidOrAlreadyInUseErrorMessage(): string
     {
         $errormsg = CHtml::tag('div', array('class' => 'warningheader'), gT("Error"));
-        $errormsg .= CHtml::tag('p', array(), gT("The access code have provided is not valid or has already been used."));
+        $errormsg .= CHtml::tag('p', array(), gT("The provided access code is not valid or has already been used."));
         return $errormsg;
     }
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4429,21 +4429,10 @@ function fixSubquestions()
     ->limit(10000)
     ->query();
     $aRecords = $surveyidresult->readAll();
-
-    $dbVersionNumber = SettingGlobal::getDBVersionNumber();
-
-    if ($dbVersionNumber < 148) {
-        $aQuestionTypes = QuestionType::modelsAttributes();
-    } else {
-        $aQuestionTypes = QuestionTheme::findQuestionMetaDataForAllTypes(); //be careful!!! only use this if QuestionTheme already exists (see updateDB ...)
-    }
+    $aQuestionTypes = QuestionTheme::findQuestionMetaDataForAllTypes(); //be careful!!! only use this if QuestionTheme already exists (see updateDB ...)
     while (count($aRecords) > 0) {
         foreach ($aRecords as $sv) {
-            if ($dbVersionNumber < 148) {
-                $hasSubquestions = $aQuestionTypes[$sv['type']]['subquestions'];
-            } else {
-                $hasSubquestions = (int)$aQuestionTypes[$sv['type']]['settings']->subquestions;
-            }
+            $hasSubquestions = (int)$aQuestionTypes[$sv['type']]['settings']->subquestions;
             if ($hasSubquestions) {
                 // If the question type allows subquestions, set the type in each subquestion
                 Yii::app()->db->createCommand("update {{questions}} set type='{$sv['type']}', gid={$sv['gid']} where qid={$sv['qid']}")->execute();

--- a/application/helpers/update/updates/Update_148.php
+++ b/application/helpers/update/updates/Update_148.php
@@ -93,7 +93,7 @@ class Update_148 extends DatabaseUpdateBase
 
     private function fixSubquestions148()
     {
-        $surveyidresult = Yii::app()->db->createCommand()
+        $surveyidresult = $this->db->createCommand()
         ->select('sq.qid, q.gid , q.type ')
         ->from('{{questions}} sq')
         ->join('{{questions}} q', 'sq.parent_qid=q.qid')
@@ -107,7 +107,7 @@ class Update_148 extends DatabaseUpdateBase
                 $hasSubquestions = $aQuestionTypes[$sv['type']]['subquestions'];
                 if ($hasSubquestions) {
                     // If the question type allows subquestions, set the type in each subquestion
-                    Yii::app()->db->createCommand("update {{questions}} set type='{$sv['type']}', gid={$sv['gid']} where qid={$sv['qid']}")->execute();
+                    $this->db->createCommand("update {{questions}} set type='{$sv['type']}', gid={$sv['gid']} where qid={$sv['qid']}")->execute();
                 } else {
                     // If the question type doesn't allow subquestions, delete each subquestion
                     // Model is used because more tables are involved.
@@ -117,7 +117,7 @@ class Update_148 extends DatabaseUpdateBase
                     }
                 }
             }
-            $surveyidresult = Yii::app()->db->createCommand()
+            $surveyidresult = $this->db->createCommand()
             ->select('sq.qid, q.gid , q.type ')
             ->from('{{questions}} sq')
             ->join('{{questions}} q', 'sq.parent_qid=q.qid')

--- a/application/helpers/update/updates/Update_148.php
+++ b/application/helpers/update/updates/Update_148.php
@@ -88,7 +88,7 @@ class Update_148 extends DatabaseUpdateBase
         // Add language field to question_attributes table
         addColumn('{{question_attributes}}', 'language', "string(20)");
         upgradeQuestionAttributes148();
-        $his->fixSubquestions148();
+        $this->fixSubquestions148();
     }
 
     private function fixSubquestions148()

--- a/application/helpers/update/updates/Update_148.php
+++ b/application/helpers/update/updates/Update_148.php
@@ -101,7 +101,7 @@ class Update_148 extends DatabaseUpdateBase
         ->limit(10000)
         ->query();
         $aRecords = $surveyidresult->readAll();
-        $aQuestionTypes = QuestionType::modelsAttributes();
+        $aQuestionTypes = \QuestionType::modelsAttributes();
         while (count($aRecords) > 0) {
             foreach ($aRecords as $sv) {
                 $hasSubquestions = $aQuestionTypes[$sv['type']]['subquestions'];
@@ -111,7 +111,7 @@ class Update_148 extends DatabaseUpdateBase
                 } else {
                     // If the question type doesn't allow subquestions, delete each subquestion
                     // Model is used because more tables are involved.
-                    $oSubquestion = Question::model()->find("qid=:qid", array("qid" => $sv['qid']));
+                    $oSubquestion = \Question::model()->find("qid=:qid", array("qid" => $sv['qid']));
                     if (!empty($oSubquestion)) {
                         $oSubquestion->delete();
                     }

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -29,7 +29,7 @@ class SurveyDynamic extends LSActiveRecord
     /** @var int $sid */
     protected static $sid = 0;
 
-    /** @var array $survey */
+    /** @var Survey $survey */
     protected static $survey;
 
     /** @var  boolean $bHaveToken */

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -50,7 +50,6 @@ class SurveyDynamic extends LSActiveRecord
             ->queryRow();
         if ($survey) {
             self::sid($survey['sid']);
-            self::$survey = $survey;
             $refresh = true;
         }
 
@@ -1083,4 +1082,20 @@ class SurveyDynamic extends LSActiveRecord
     {
         return self::$sid;
     }
+
+    /**
+     * Get current survey for other model/function
+     * Using a getter to avoid query during model creation
+     * @return Survey
+     */
+    public function getSurvey()
+    {
+        if (self::$sid && self::$survey === null) {
+            self::$survey = Survey::model()->findByPk(self::$sid);
+        }
+        return self::$survey;
+    }
+
+
+
 }

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -47,9 +47,10 @@ class SurveyDynamic extends LSActiveRecord
             ->select('{{surveys.sid}}')
             ->from('{{surveys}}')
             ->where('{{surveys.sid}} = :sid', array(':sid' => $sid))
-            ->queryRow();        
+            ->queryRow();
         if ($survey) {
             self::sid($survey['sid']);
+            self::$survey = $survey;
             $refresh = true;
         }
 

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -1095,7 +1095,4 @@ class SurveyDynamic extends LSActiveRecord
         }
         return self::$survey;
     }
-
-
-
 }

--- a/application/models/SurveyDynamic.php
+++ b/application/models/SurveyDynamic.php
@@ -29,7 +29,7 @@ class SurveyDynamic extends LSActiveRecord
     /** @var int $sid */
     protected static $sid = 0;
 
-    /** @var Survey $survey */
+    /** @var array $survey */
     protected static $survey;
 
     /** @var  boolean $bHaveToken */
@@ -43,10 +43,13 @@ class SurveyDynamic extends LSActiveRecord
     public static function model($sid = null)
     {
         $refresh = false;
-        $survey = Survey::model()->findByPk($sid);
+        $survey = Yii::app()->db->createCommand()
+            ->select('{{surveys.sid}}')
+            ->from('{{surveys}}')
+            ->where('{{surveys.sid}} = :sid', array(':sid' => $sid))
+            ->queryRow();        
         if ($survey) {
-            self::sid($survey->sid);
-            self::$survey = $survey;
+            self::sid($survey['sid']);
             $refresh = true;
         }
 

--- a/application/models/SurveyLight.php
+++ b/application/models/SurveyLight.php
@@ -15,7 +15,10 @@
 
 
 /**
- * Class SurveyNoEvent
+ * Class SurveyLight
+ * 
+ * This is a light version of the normal Survey model, without the afterFindSurvey event.
+ * It was created because for mass queries, the afterFindSurvey event is most times not needed and it slows down the process.
  *
  * @property integer $sid Survey ID
  * @property integer $owner_id
@@ -145,7 +148,7 @@
  * @property boolean $isDateExpired Whether survey is expired depending on the current time and survey configuration status
  * @method mixed active()
  */
-class SurveyNoEvent extends Survey
+class SurveyLight extends Survey
 {
     /**
      * afterFindSurvey to fix and/or add some survey attribute

--- a/application/models/SurveyLight.php
+++ b/application/models/SurveyLight.php
@@ -151,10 +151,8 @@
 class SurveyLight extends Survey
 {
     /**
-     * afterFindSurvey to fix and/or add some survey attribute
-     * - event afterFindSurvey (for all attributes)
-     * - Fix template name to be sure template exist
-     * - setOptions for inherited value
+     * This event is left empty on purpose because we don't  in this SurveyLight
+     * model we don't want the inherited costly afterFindSurvey event
      */
     public function afterFindSurvey()
     {

--- a/application/models/SurveyLight.php
+++ b/application/models/SurveyLight.php
@@ -16,7 +16,7 @@
 
 /**
  * Class SurveyLight
- * 
+ *
  * This is a light version of the normal Survey model, without the afterFindSurvey event.
  * It was created because for mass queries, the afterFindSurvey event is most times not needed and it slows down the process.
  *

--- a/application/models/SurveyNoEvent.php
+++ b/application/models/SurveyNoEvent.php
@@ -147,8 +147,6 @@
  */
 class SurveyNoEvent extends Survey
 {
-
-
     /**
      * afterFindSurvey to fix and/or add some survey attribute
      * - event afterFindSurvey (for all attributes)
@@ -157,6 +155,5 @@ class SurveyNoEvent extends Survey
      */
     public function afterFindSurvey()
     {
-    
     }
 }

--- a/application/models/SurveyNoEvent.php
+++ b/application/models/SurveyNoEvent.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+* LimeSurvey
+* Copyright (C) 2007-2011 The LimeSurvey Project Team / Carsten Schmitz
+* All rights reserved.
+* License: GNU/GPL License v2 or later, see LICENSE.php
+* LimeSurvey is free software. This version may have been modified pursuant
+* to the GNU General Public License, and as distributed it includes or
+* is derivative of works licensed under the GNU General Public License or
+* other free or open source software licenses.
+* See COPYRIGHT.php for copyright notices and details.
+*
+*/
+
+
+/**
+ * Class SurveyNoEvent
+ *
+ * @property integer $sid Survey ID
+ * @property integer $owner_id
+ * @property integer $gsid survey group id, from which this survey belongs to and inherits values from when set to 'I'
+ * @property string $admin Survey Admin's full name
+ * @property string $active Whether survey is acive or not (Y/N)
+ * @property string $expires Expiry date (YYYY-MM-DD hh:mm:ss)
+ * @property string $startdate Survey Start date (YYYY-MM-DD hh:mm:ss)
+ * @property string $adminemail Survey administrator email address
+ * @property string $anonymized Whether survey is anonymized or not (Y/N)
+ * @property string $format A : All in one, G : Group by group, Q : question by question, I : inherit value from survey group
+ * @property string $savetimings Whether survey timings are saved (Y/N)
+ * @property string $template Template name
+ * @property string $language Survey base language
+ * @property string $additional_languages Survey additional languages delimited by space ' '
+ * @property string $datestamp Whether respondents' datestamps will be saved (Y/N)
+ * @property string $usecookie Are cookies used to prevent repeated participation (Y/N)
+ * @property string $allowregister Allow public registration (Y/N)
+ * @property string $allowsave Is participant allowed save and resume later (Y/N)
+ * @property integer $autonumber_start
+ * @property integer $tokenlength Token length: MIN:5 MAX:36
+ * @property string $autoredirect Automatically load URL when survey complete: (Y/N)
+ * @property string $allowprev Allow backwards navigation (Y/N)
+ * @property string $printanswers Participants may print answers: (Y/N)
+ * @property string $ipaddr Whether Participants IP address will be saved: (Y/N)
+ * @property string $ipanonymize Whether id addresses should be anonymized (Y/N)
+ * @property string $refurl Save referrer URL: (Y/N)
+ * @property string $datecreated Date survey was created (YYYY-MM-DD hh:mm:ss)
+ * @property string $publicstatistics Public statistics: (Y/N)
+ * @property string $publicgraphs Show graphs in public statistics: (Y/N)
+ * @property string $listpublic List survey publicly: (Y/N)
+ * @property string $htmlemail Use HTML format for token emails: (Y/N)
+ * @property string $sendconfirmation Send confirmation emails:(Y/N)
+ * @property string $tokenanswerspersistence Enable token-based response persistence: (Y/N)
+ * @property string $assessments Enable assessment mode: (Y/N)
+ * @property string $usecaptcha
+ * @property string $usetokens
+ * @property string $bounce_email Bounce email address
+ * @property string $attributedescriptions
+ * @property string $emailresponseto e-mail address to send detailed admin notification email to
+ * @property string $emailnotificationto Email address to send basic admin notification email to
+ * @property string $showxquestions Show "There are X questions in this survey": (Y/N)
+ * @property string $showgroupinfo Show group name and/or group description: (Y/N)
+ * @property string $shownoanswer Show "No answer": (Y/N)
+ * @property string $showqnumcode Show question number and/or code: (Y/N)
+ * @property integer $bouncetime
+ * @property string $bounceprocessing
+ * @property string $bounceaccounttype
+ * @property string $bounceaccounthost
+ * @property string $bounceaccountpass
+ * @property string $bounceaccountencryption
+ * @property string $bounceaccountuser
+ * @property string $showwelcome Show welcome screen: (Y/N)
+ * @property string $showprogress how progress bar: (Y/N)
+ * @property integer $questionindex Show question index / allow jumping (0: diabled; 1: Incremental; 2: Full)
+ * @property integer $navigationdelay Navigation delay (seconds) (It shows the number of seconds before the previous,
+ * next, and submit buttons are enabled. If none is specified, the option will use the default value, which is "0" (seconds))
+ * @property string $nokeyboard Show on-screen keyboard: (Y/N)
+ * @property string $alloweditaftercompletion Allow multiple responses or update responses with one token: (Y/N)
+ * @property string $googleanalyticsstyle Google Analytics style: (0: off; 1:Default; 2:Survey-SID/Group)
+ * @property string $googleanalyticsapikey Google Analytics Tracking ID
+ * @property string $tokenencryptionoptions Token encryption options
+ *
+ * @property Permission[] $permissions
+ * @property SurveyLanguageSetting[] $languagesettings
+ * @property User $owner
+ * @property QuestionGroup[] $groups
+ * @property Quota[] $quotas
+ * @property Question[] $allQuestions All survey questions including subquestions
+ * @property Question[] $baseQuestions Survey questions NOT including subquestions
+ * @property Question[] $quotableQuestions
+ *
+ * @property integer $countFullAnswers Full-answers count
+ * @property integer $countPartialAnswers Full-answers count
+ * @property integer $countTotalAnswers Total-answers count
+ * @property integer $groupsCount Number of groups in a survey (in base language)
+ * @property array $surveyinfo
+ * @property SurveyLanguageSetting $currentLanguageSettings Survey languagesettings in currently active language
+ * @property string[] $allLanguages
+ * @property string[] $additionalLanguages Additional survey languages
+ * @property array $tokenAttributes Additional token attribute names
+ * @property string $creationDate Creation date formatted according to user format
+ * @property string $startDateFormatted Start date formatted according to user format
+ * @property string $expiryDateFormatted Expiry date formatted according to user format
+ * @property string $tokensTableName Name of survey tokens table
+ * @property string $responsesTableName Name of survey resonses table
+ * @property string $timingsTableName Name of survey timings table
+ * @property boolean $hasTokensTable Whether survey has a tokens table or not
+ * @property boolean $hasResponsesTable Wheteher the survey responses (data) table exists in DB
+ * @property boolean $hasTimingsTable Wheteher the survey timings table exists in DB
+ * @property string $googleanalyticsapikeysetting Returns the value for the SurveyEdit GoogleAnalytics API-Key UseGlobal Setting
+ * @property integer $countTotalQuestions Count of questions (in that language, without subquestions)
+ * @property integer $countInputQuestions Count of questions that need input (skipping text-display etc.)
+ * @property integer $countNoInputQuestions Count of questions that DO NOT need input (skipping text-display etc.)
+ *
+ * All Y/N columns in the model can be accessed as boolean values:
+ * @property bool $isActive Whether Survey is active
+ * @property bool $isAnonymized Whether survey is anonymized or not
+ * @property bool $isSaveTimings Whether survey timings are saved
+ * @property bool $isDateStamp Whether respondents' datestamps will be saved
+ * @property bool $isUseCookie Are cookies used to prevent repeated participation
+ * @property bool $isAllowRegister Allow public registration
+ * @property bool $isAllowSave Is participant allowed save and resume later
+ * @property bool $isAutoRedirect Automatically load URL when survey complete
+ * @property bool $isAllowPrev Allow backwards navigation
+ * @property bool $isPrintAnswers Participants may print answers
+ * @property bool $isIpAddr Whether Participants IP address will be saved
+ * @property bool $isIpAnonymize Whether Participants IP address will be saved
+ * @property bool $isRefUrl Save referrer URL
+ * @property bool $isPublicStatistics Public statistics
+ * @property bool $isPublicGraphs Show graphs in public statistics
+ * @property bool $isListPublic List survey publicly
+ * @property bool $isHtmlEmail Use HTML format for token emails
+ * @property bool $isSendConfirmation Send confirmation emails
+ * @property bool $isTokenAnswersPersistence Enable token-based response persistence
+ * @property bool $isAssessments Enable assessment mode
+ * @property bool $isShowXQuestions Show "There are X questions in this survey"
+ * @property bool $isShowGroupInfo Show group name and/or group description
+ * @property bool $isShowNoAnswer Show "No answer"
+ * @property bool $isShowQnumCode Show question number and/or code
+ * @property bool $isShowWelcome Show welcome screen
+ * @property bool $isShowProgress how progress bar
+ * @property bool $showsurveypolicynotice Show the security notice
+ * @property bool $isNoKeyboard Show on-screen keyboard
+ * @property bool $isAllowEditAfterCompletion Allow multiple responses or update responses with one token
+ * @property SurveyLanguageSetting $defaultlanguage
+ * @property boolean $isDateExpired Whether survey is expired depending on the current time and survey configuration status
+ * @method mixed active()
+ */
+class SurveyNoEvent extends Survey
+{
+
+
+    /**
+     * afterFindSurvey to fix and/or add some survey attribute
+     * - event afterFindSurvey (for all attributes)
+     * - Fix template name to be sure template exist
+     * - setOptions for inherited value
+     */
+    public function afterFindSurvey()
+    {
+    
+    }
+}

--- a/application/views/admin/checkintegrity/check_view.php
+++ b/application/views/admin/checkintegrity/check_view.php
@@ -69,7 +69,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($assessments as $assessment) { ?>
-                                <li>AID:<?php echo $assessment['id']; ?><?php eT("Assessment:"); ?><?php eT("Reason:"); ?><?php echo $assessment['reason']; ?></li><?php
+                                <li>AID:<?php echo $assessment['id']; ?><?php eT("Assessment:"); ?><?php eT("Reason:"); ?> <?php echo $assessment['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -84,7 +84,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($answers as $answer) { ?>
-                                <li>QID:<?php echo $answer['qid']; ?><?php eT("Code:"); ?><?php echo $answer['code']; ?><?php eT("Reason:"); ?><?php echo $answer['reason']; ?></li><?php
+                                <li>QID:<?php echo $answer['qid']; ?> <?php eT("Code:"); ?> <?php echo $answer['code']; ?> <?php eT("Reason:"); ?><?php echo $answer['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -99,7 +99,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($answer_l10ns as $answer) { ?>
-                                <li>AID:<?php echo $answer['aid']; ?><?php eT("ID:"); ?><?php echo $answer['id']; ?><?php eT("Reason:"); ?><?php echo $answer['reason']; ?></li><?php
+                                <li>AID:<?php echo $answer['aid']; ?> <?php eT("ID:"); ?><?php echo $answer['id']; ?> <?php eT("Reason:"); ?><?php echo $answer['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -114,7 +114,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($surveys as $survey) { ?>
-                                <li>SID:<?php echo $survey['sid']; ?><?php eT("Reason:"); ?><?php echo $survey['reason']; ?></li><?php
+                                <li>SID:<?php echo $survey['sid']; ?> <?php eT("Reason:"); ?><?php echo $survey['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -129,7 +129,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($surveylanguagesettings as $surveylanguagesetting) { ?>
-                                <li>SLID:<?php echo $surveylanguagesetting['slid']; ?><?php eT("Reason:"); ?><?php echo $surveylanguagesetting['reason']; ?></li><?php
+                                <li>SLID:<?php echo $surveylanguagesetting['slid']; ?> <?php eT("Reason:"); ?><?php echo $surveylanguagesetting['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -144,7 +144,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($questions as $question) { ?>
-                                <li>QID:<?php echo $question['qid']; ?><?php eT("Reason:"); ?><?php echo $question['reason']; ?></li><?php
+                                <li>QID:<?php echo $question['qid']; ?> <?php eT("Reason:"); ?><?php echo $question['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -159,7 +159,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($question_l10ns as $question) { ?>
-                                <li>QID:<?php echo $question['qid']; ?><?php eT("ID:"); ?><?php echo $question['id']; ?><?php eT("Reason:"); ?><?php echo $question['reason']; ?></li><?php
+                                <li>QID:<?php echo $question['qid']; ?><?php eT("ID:"); ?><?php echo $question['id']; ?> <?php eT("Reason:"); ?><?php echo $question['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -192,7 +192,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($groups as $group) { ?>
-                                <li>GID:<?php echo $group['gid']; ?><?php eT("Reason:"); ?><?php echo $group['reason']; ?></li><?php
+                                <li>GID:<?php echo $group['gid']; ?> <?php eT("Reason:"); ?><?php echo $group['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -207,7 +207,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($group_l10ns as $group) { ?>
-                                <li>GID:<?php echo $group['gid']; ?><?php eT("ID:"); ?><?php echo $group['id']; ?><?php eT("Reason:"); ?><?php echo $group['reason']; ?></li><?php
+                                <li>GID:<?php echo $group['gid']; ?><?php eT("ID:"); ?><?php echo $group['id']; ?> <?php eT("Reason:"); ?><?php echo $group['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>
@@ -222,7 +222,7 @@ echo viewHelper::getViewTestTag('checkIntegrity');
                         <ul class="list-unstyled">
                             <?php
                             foreach ($user_in_groups as $user_in_group) { ?>
-                                <li>UID:<?php echo $user_in_group['uid']; ?> UGID:<?php echo $user_in_group['ugid']; ?><?php eT("Reason:"); ?><?php echo $user_in_group['reason']; ?></li><?php
+                                <li>UID:<?php echo $user_in_group['uid']; ?> UGID:<?php echo $user_in_group['ugid']; ?> <?php eT("Reason:"); ?><?php echo $user_in_group['reason']; ?></li><?php
                             } ?>
                         </ul>
                     </li>


### PR DESCRIPTION
Dev There is no way to detach the very costly event handler AfterFindSurvey from a model so a new model  <s>SurveyNoEvent </s> SurveyLight was introduced for the special cases of using an activeRecord model for Survey->findAll 

I also conditioned a part of the integrity check that was very costly and checked every field in every response table
