### PR TITLE
MW-1026: Avoiding session reset upon database preview

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3276,7 +3276,7 @@ class LimeExpressionManager
         if (isset($_SESSION['LEMforceRefresh'])) {
             unset($_SESSION['LEMforceRefresh']);
             $forceRefresh = true;
-        } elseif ($forceRefresh === false && !empty($this->knownVars) && !$this->sPreviewMode) {
+        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database'))) {
             return false;   // means that those variables have been cached and no changes needed
         }
         $now = microtime(true);


### PR DESCRIPTION
This is a performance patch, a direct follow-up of my chat with @Shnoulle about session reset in `setVariableAndTokenMappingsForExpressionManager` being executed too often, slowing down the entire system. According to my tests, there are cases when we set the preview mode to 'database' and therefore we reset for each group because of the criteria at https://github.com/LimeSurvey/LimeSurvey/blob/ad0a1d650b8aeb166b11bc252e75aea99c31b8ce/application/helpers/expressions/em_manager_helper.php#L3279

We can see that if the preview is not equivalent to false, then we end up doing the entirety of the reset for each and every call, so when we loop the groups at https://github.com/LimeSurvey/LimeSurvey/blob/ad0a1d650b8aeb166b11bc252e75aea99c31b8ce/application/models/services/Proxy/ProxyExpressionManager.php#L63 force refresh being false, but at https://github.com/LimeSurvey/LimeSurvey/blob/ad0a1d650b8aeb166b11bc252e75aea99c31b8ce/application/helpers/expressions/em_manager_helper.php#L4539 which is being executed for each group we already have the preview mode being set to 'database' because of https://github.com/LimeSurvey/LimeSurvey/blob/ad0a1d650b8aeb166b11bc252e75aea99c31b8ce/application/models/services/Proxy/ProxyExpressionManager.php#L49

so we do a reset for each and every group and that eats up all our memory and time resources, creating spikes.

We will need to check other use-cases of this feature as well whether we have similar preview mode sets that slow down the entire system.

Measurements:

**Survey1 Text Element Save 1 15.49s - 3.25
Survey1 Reload: 1.85 - 0.34s
Survey1 Start: 2.62s - 1.94s
Survey2 Reload: 11.56s -> 0.81s
Survey2 Text Element Save 4.3 minutes - 40.68s
Survey2 Start: 21.6s - 20 s**