### PR TITLE
MW-1028: Improved performance of survey logic file

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3276,7 +3276,7 @@ class LimeExpressionManager
         if (isset($_SESSION['LEMforceRefresh'])) {
             unset($_SESSION['LEMforceRefresh']);
             $forceRefresh = true;
-        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database'))) {
+        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database') || ($this->sPreviewMode === 'logic'))) {
             return false;   // means that those variables have been cached and no changes needed
         }
         $now = microtime(true);


### PR DESCRIPTION
Huge survey
survey logic file 3.5m - 21.86s
survey logic printable 3.4m - 28s
Big Survey
survey logic file 12.63s - 4.99s
survey logic printable 13s - 6s