### PR TITLE
Qe 790 rest api always expects path format urls

### DIFF
--- a/application/core/LSHttpRequest.php
+++ b/application/core/LSHttpRequest.php
@@ -280,10 +280,6 @@ class LSHttpRequest extends CHttpRequest
             $restRoutePattern,
             $this->getRequestUri(),
         ) === 1;
-        $restRoute = preg_match(
-            $restRoutePattern,
-            $this->getParam('r')
-        ) === 1;
         return $restPath || $restRoute;
     }
 }

--- a/application/core/LSYii_Application.php
+++ b/application/core/LSYii_Application.php
@@ -94,6 +94,17 @@ class LSYii_Application extends CWebApplication
             $aApplicationConfig = $this->getTwigCustomExtensionsConfig($baseConfig['usertwigextensionrootdir'], $aApplicationConfig);
         }
 
+        // REST API always expects URLS in path mode regardless of site setting
+        // - it is not possible to call App request object here
+        if (
+            preg_match(
+                '#^(/)?(index.php/)?rest(/.*)?#',
+                $_SERVER['REQUEST_URI'],
+            ) === 1
+        ) {
+            $aApplicationConfig['components']['urlManager']['urlFormat'] = 'path';
+        }
+
         /* Construct CWebApplication */
         parent::__construct($aApplicationConfig);
 


### PR DESCRIPTION
Force requests to the REST API to always work with URL format "path" regardless of the URL format configured in the application. Allows us to avoid the complication of trying to support two different URL formats.
