### PR TITLE
MW-1031: getQuestionQttributesForEMPerformance

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8273,29 +8273,29 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
 #                return $aStaticQuestionAttributesForEM[$surveyid][0][$lang][$qid];
 #            }
         if ($qid) {
-            $oQids = Question::model()->findAll(
+            $oQuestions = Question::model()->findAll(
                 [
                     'condition' => "qid=:qid and parent_qid=0",
                     'params'    => [':qid' => $qid]
                 ]
             );
         } elseif ($surveyid) {
-            $oQids = Question::model()->findAll(
+            $oQuestions = Question::model()->findAll(
                 [
                     'condition' => "sid=:sid and parent_qid=0",
                     'params'    => [':sid' => $surveyid]
                 ]
             );
         } else {
-            $oQids = Question::model()->findAll(
+            $oQuestions = Question::model()->findAll(
                 [
                     'condition' => "parent_qid=0",
                 ]
             );
         }
         $aQuestionAttributesForEM = [];
-        foreach ($oQids as $oQid) {
-            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($oQid, $lang);
+        foreach ($oQuestions as $oQuestion) {
+            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($oQuestion, $lang);
             // Change array lang to value
             foreach ($aAttributesValues as &$aAttributeValue) {
                 if (is_array($aAttributeValue)) {
@@ -8307,7 +8307,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     }
                 }
             }
-            $aQuestionAttributesForEM[$oQid->qid] = $aAttributesValues;
+            $aQuestionAttributesForEM[$oQuestion->qid] = $aAttributesValues;
         }
         EmCacheHelper::set($cacheKey, $aQuestionAttributesForEM);
         return $aQuestionAttributesForEM;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8272,39 +8272,24 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
 #            {
 #                return $aStaticQuestionAttributesForEM[$surveyid][0][$lang][$qid];
 #            }
+
         if ($qid) {
-            $oQids = Question::model()->findAll(
-                [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
-                    'condition' => "qid=:qid and parent_qid=0",
-                    'params'    => [':qid' => $qid]
-                ]
-            );
+            $oQids = Yii::app()->db->createCommand(
+                "SELECT qid FROM {{questions}} where qid = " . intval($qid) . " and parent_qid = 0"
+            )->query()->readAll();
         } elseif ($surveyid) {
-            $oQids = Question::model()->findAll(
-                [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
-                    'condition' => "sid=:sid and parent_qid=0",
-                    'params'    => [':sid' => $surveyid]
-                ]
-            );
+            $oQids = Yii::app()->db->createCommand(
+                "SELECT qid FROM {{questions}} where sid = " . intval($surveyid) . " and parent_qid = 0"
+            )->query()->readAll();
         } else {
-            $oQids = Question::model()->findAll(
-                [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
-                    'condition' => "parent_qid=0",
-                ]
-            );
+            $oQids = Yii::app()->db->createCommand(
+                "SELECT qid FROM {{questions}} where parent_qid = 0"
+            )->query()->readAll();
         }
         $aQuestionAttributesForEM = [];
         foreach ($oQids as $oQid) {
-            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($oQid->qid, $lang);
+            $qid = $oQid["qid"];
+            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($qid, $lang);
             // Change array lang to value
             foreach ($aAttributesValues as &$aAttributeValue) {
                 if (is_array($aAttributeValue)) {
@@ -8316,7 +8301,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     }
                 }
             }
-            $aQuestionAttributesForEM[$oQid->qid] = $aAttributesValues;
+            $aQuestionAttributesForEM[$qid] = $aAttributesValues;
         }
         EmCacheHelper::set($cacheKey, $aQuestionAttributesForEM);
         return $aQuestionAttributesForEM;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8272,24 +8272,39 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
 #            {
 #                return $aStaticQuestionAttributesForEM[$surveyid][0][$lang][$qid];
 #            }
-
         if ($qid) {
-            $oQids = Yii::app()->db->createCommand(
-                "SELECT qid FROM {{questions}} where qid = " . intval($qid) . " and parent_qid = 0"
-            )->query()->readAll();
+            $oQids = Question::model()->findAll(
+                [
+                    'select'    => 'qid',
+                    'group'     => 'qid',
+                    'distinct'  => true,
+                    'condition' => "qid=:qid and parent_qid=0",
+                    'params'    => [':qid' => $qid]
+                ]
+            );
         } elseif ($surveyid) {
-            $oQids = Yii::app()->db->createCommand(
-                "SELECT qid FROM {{questions}} where sid = " . intval($surveyid) . " and parent_qid = 0"
-            )->query()->readAll();
+            $oQids = Question::model()->findAll(
+                [
+                    'select'    => 'qid',
+                    'group'     => 'qid',
+                    'distinct'  => true,
+                    'condition' => "sid=:sid and parent_qid=0",
+                    'params'    => [':sid' => $surveyid]
+                ]
+            );
         } else {
-            $oQids = Yii::app()->db->createCommand(
-                "SELECT qid FROM {{questions}} where parent_qid = 0"
-            )->query()->readAll();
+            $oQids = Question::model()->findAll(
+                [
+                    'select'    => 'qid',
+                    'group'     => 'qid',
+                    'distinct'  => true,
+                    'condition' => "parent_qid=0",
+                ]
+            );
         }
         $aQuestionAttributesForEM = [];
         foreach ($oQids as $oQid) {
-            $qid = $oQid["qid"];
-            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($qid, $lang);
+            $aAttributesValues = QuestionAttribute::model()->getQuestionAttributes($oQid, $lang);
             // Change array lang to value
             foreach ($aAttributesValues as &$aAttributeValue) {
                 if (is_array($aAttributeValue)) {
@@ -8301,7 +8316,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                     }
                 }
             }
-            $aQuestionAttributesForEM[$qid] = $aAttributesValues;
+            $aQuestionAttributesForEM[$oQid->qid] = $aAttributesValues;
         }
         EmCacheHelper::set($cacheKey, $aQuestionAttributesForEM);
         return $aQuestionAttributesForEM;

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8275,9 +8275,6 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         if ($qid) {
             $oQids = Question::model()->findAll(
                 [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
                     'condition' => "qid=:qid and parent_qid=0",
                     'params'    => [':qid' => $qid]
                 ]
@@ -8285,9 +8282,6 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         } elseif ($surveyid) {
             $oQids = Question::model()->findAll(
                 [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
                     'condition' => "sid=:sid and parent_qid=0",
                     'params'    => [':sid' => $surveyid]
                 ]
@@ -8295,9 +8289,6 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         } else {
             $oQids = Question::model()->findAll(
                 [
-                    'select'    => 'qid',
-                    'group'     => 'qid',
-                    'distinct'  => true,
                     'condition' => "parent_qid=0",
                 ]
             );

--- a/application/models/QuestionAttribute.php
+++ b/application/models/QuestionAttribute.php
@@ -219,16 +219,21 @@ class QuestionAttribute extends LSActiveRecord
      * --prepare an easier/smaller array to return
      *
      * @access public
-     * @param int $iQuestionID
+     * @param int|Question $q
      * @param string $sLanguage restrict to this language (if null $oQuestion->survey->allLanguages will be used)
      * @return array|false
      *
      * @throws CException throws exception if questiontype is null
      */
-    public function getQuestionAttributes($iQuestionID, $sLanguage = null)
+    public function getQuestionAttributes($q, $sLanguage = null)
     {
+        $receivedIDOnly = (!($q instanceof Question));
+        if ($receivedIDOnly) {
+            $iQuestionID = intval($q);
+        } else {
+            $iQuestionID = $q->qid;
+        }
         static $survey = '';
-        $iQuestionID = (int)$iQuestionID;
         // Limit the size of the attribute cache due to memory usage
         $cacheKey = 'getQuestionAttributes_' . $iQuestionID . '_' . json_encode($sLanguage);
         if (EmCacheHelper::useCache()) {
@@ -238,7 +243,11 @@ class QuestionAttribute extends LSActiveRecord
             }
         }
 
-        $oQuestion = Question::model()->find("qid=:qid", ['qid' => $iQuestionID]);
+        if ($receivedIDOnly) {
+            $oQuestion = Question::model()->find("qid=:qid", ['qid' => $iQuestionID]);
+        } else {
+            $oQuestion = $q;
+        }
         if (empty($oQuestion)) {
             return false; // return false but don't set $aQuestionAttributesStatic[$iQuestionID]
         }


### PR DESCRIPTION
This is a performance optimization that affects survey settings tab loading.

Measurements:

Text elements	6.98s	0.49s
Privacy policy	 	6.93s	0.65s
Presentation	 	6.8s	0.45s
Participant settings	 	6.95s	0.45s
Notifications & data	 	6.87s	0.43s
Publication & access	 	6.79s	0.46s
Panel integration	 	8.23s	1.12s
Resources	 	6.89s	0.44s
Simple plugins	 	10.67s	0.46s