### PR TITLE
(re)add placeholder attribute to shortfreetext

### DIFF
--- a/application/views/survey/questions/answer/shortfreetext/config.xml
+++ b/application/views/survey/questions/answer/shortfreetext/config.xml
@@ -85,6 +85,18 @@
             <readonly_when_active></readonly_when_active>
         </attribute>
         <attribute>
+            <name>placeholder</name>
+            <category>Display</category>
+            <sortorder>12</sortorder>
+            <inputtype>text</inputtype>
+            <expression>1</expression>
+            <i18n>1</i18n>
+            <help>A placeholder answer to a question. This will appear in the answer field and disappear when real answer text is entered.</help>
+            <caption>Placeholder answer</caption>
+            <readonly></readonly>
+            <readonly_when_active></readonly_when_active>
+        </attribute>
+        <attribute>
             <name>hide_tip</name>
             <category>Display</category>
             <sortorder>100</sortorder>


### PR DESCRIPTION
It seems like the `placeholder` attribute disappeared from the `config.xml` of the `shortfreetext`. It was originally added in https://github.com/LimeSurvey/LimeSurvey/commit/5bee16c650597a2558055bf5efe274b5ae5bae77#diff-c09efae4fbf789f03cf5d036252e7035597df5cdf585440522f40d7b23040989 but for some reason removed in https://github.com/LimeSurvey/LimeSurvey/commit/6c4897029df9e746a70cbc90237d657c8fc26e4e

The template `./shortfreetext/text/item.twig` and `./shortfreetext/textarea/item.twig` still make use of it.. so all that's missing is this entry...