### PR TITLE
Qe 722 rest api config

### DIFF
--- a/application/libraries/Api/ApiConfig.php
+++ b/application/libraries/Api/ApiConfig.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace LimeSurvey\Api;
+
+/**
+ * RestConfig
+ *
+ */
+class ApiConfig
+{
+    private $config = [];
+
+    public function __construct(&$config = [])
+    {
+        $this->config = &$config;
+    }
+
+    /**
+     * Get entire config array
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * Set entire config array
+     */
+    public function setConfig($config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Set config by path
+     */
+    public function setPath($path, $value)
+    {
+        $pathElements = explode('.', $path);
+        $field = array_pop($pathElements);
+        $parent = &$this->getPath(
+            implode('.', $pathElements),
+            true
+        );
+        $parent[$field] = $value;
+    }
+
+    /**
+     * Get config by path
+     */
+    public function &getPath($path, $createParents = false)
+    {
+        $result = &$this->pathReducer(
+            explode('.', $path),
+            $this->config,
+            $createParents
+        );
+        return $result;
+    }
+
+    /**
+     * Path Reducer
+     */
+    private function &pathReducer($pathElements, &$initData, $createParents = false)
+    {
+        $nullRef = null;
+        if (empty($pathElements)) {
+            return $initData;
+        }
+        $carry = &$initData;
+        if (is_array($pathElements) && !empty($pathElements)) {
+            foreach ($pathElements as $pathElement) {
+                if (!isset($carry[$pathElement])) {
+                    if ($createParents) {
+                        $carry[$pathElement] = [];
+                    } else {
+                        $carry = $nullRef;
+                        break;
+                    }
+                }
+                $carry = &$carry[$pathElement];
+            }
+        }
+        return $carry;
+    }
+}

--- a/application/libraries/Api/ApiConfig.php
+++ b/application/libraries/Api/ApiConfig.php
@@ -3,13 +3,19 @@
 namespace LimeSurvey\Api;
 
 /**
- * RestConfig
+ * ApiConfig
  *
  */
 class ApiConfig
 {
+    /** @var array */
     private $config = [];
 
+    /**
+     * ApiConfig
+     *
+     * @param array $config
+     */
     public function __construct(&$config = [])
     {
         $this->config = &$config;
@@ -17,6 +23,8 @@ class ApiConfig
 
     /**
      * Get entire config array
+     *
+     * @return array
      */
     public function &getConfig()
     {
@@ -25,6 +33,9 @@ class ApiConfig
 
     /**
      * Set entire config array
+     *
+     * @param array $config
+     * @return void
      */
     public function setConfig(&$config)
     {
@@ -33,6 +44,10 @@ class ApiConfig
 
     /**
      * Set config by path
+     *
+     * @param string $path
+     * @param mixed $value
+     * @return void
      */
     public function setPath($path, $value)
     {
@@ -47,6 +62,10 @@ class ApiConfig
 
     /**
      * Get config by path
+     *
+     * @param string $path
+     * @param boolean $createParents
+     * @return array|null
      */
     public function &getPath($path, $createParents = false)
     {
@@ -60,6 +79,11 @@ class ApiConfig
 
     /**
      * Path Reducer
+     *
+     * @param array $pathElements
+     * @param array $initData
+     * @param boolean $createParents
+     * @return array|null
      */
     private function &pathReducer($pathElements, &$initData, $createParents = false)
     {
@@ -68,18 +92,16 @@ class ApiConfig
             return $initData;
         }
         $carry = &$initData;
-        if (is_array($pathElements) && !empty($pathElements)) {
-            foreach ($pathElements as $pathElement) {
-                if (!isset($carry[$pathElement])) {
-                    if ($createParents) {
-                        $carry[$pathElement] = [];
-                    } else {
-                        $carry = $nullRef;
-                        break;
-                    }
+        foreach ($pathElements as $pathElement) {
+            if (!isset($carry[$pathElement])) {
+                if ($createParents) {
+                    $carry[$pathElement] = [];
+                } else {
+                    $carry = $nullRef;
+                    break;
                 }
-                $carry = &$carry[$pathElement];
             }
+            $carry = &$carry[$pathElement];
         }
         return $carry;
     }

--- a/application/libraries/Api/ApiConfig.php
+++ b/application/libraries/Api/ApiConfig.php
@@ -18,7 +18,7 @@ class ApiConfig
     /**
      * Get entire config array
      */
-    public function getConfig()
+    public function &getConfig()
     {
         return $this->config;
     }
@@ -26,9 +26,9 @@ class ApiConfig
     /**
      * Set entire config array
      */
-    public function setConfig($config)
+    public function setConfig(&$config)
     {
-        $this->config = $config;
+        $this->config = &$config;
     }
 
     /**

--- a/application/libraries/Api/Rest/Endpoint/EndpointFactory.php
+++ b/application/libraries/Api/Rest/Endpoint/EndpointFactory.php
@@ -8,19 +8,23 @@ use DI\FactoryInterface;
 use LimeSurvey\Api\{
     Command\Options,
     Rest\Endpoint,
+    Rest\RestConfig,
     ApiException
 };
 
 class EndpointFactory
 {
     protected FactoryInterface $diFactory;
+    protected RestConfig $restConfig;
 
     /**
      * @param FactoryInterface $diFactory
+     * @param RestConfig $restConfig
      */
-    public function __construct(FactoryInterface $diFactory)
+    public function __construct(FactoryInterface $diFactory, RestConfig $restConfig)
     {
         $this->diFactory = $diFactory;
+        $this->restConfig = $restConfig;
     }
 
     /**
@@ -81,7 +85,7 @@ class EndpointFactory
     protected function parseEndpointConfig(CHttpRequest $request)
     {
         // rest config contains specification of all endpoints
-        $restConfig = Yii::app()->getConfig('rest');
+        $restConfig = $this->restConfig->getConfig();
         $apiVersion = $request->getParam('_api_version');
         $entity = $request->getParam('_entity');
         $id = $request->getParam('_id', null);

--- a/application/libraries/Api/Rest/RestConfig.php
+++ b/application/libraries/Api/Rest/RestConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LimeSurvey\Api\Rest;
+
+use LimeSurvey\Api\ApiConfig;
+use Yii;
+
+/**
+ * RestConfig
+ *
+ */
+class RestConfig extends ApiConfig
+{
+    public function __construct()
+    {
+        $yiiRestConfig = Yii::app()->getConfig('rest');
+        $this->setConfig($yiiRestConfig);
+    }
+}

--- a/tests/unit/api/ApiConfigTest.php
+++ b/tests/unit/api/ApiConfigTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ls\tests\unit\api;
+
+use ls\tests\TestBaseClass;
+use LimeSurvey\Api\ApiConfig;
+
+/**
+ * @testdox API Config
+ */
+class ApiConfigTest extends TestBaseClass
+{
+    /**
+     * @testdox getPath() returns value at path
+     */
+    public function testGetPathReturnsValueAtPath()
+    {
+        $data = [
+            'a' => [
+                'b' => [
+                    'c' => 123
+                ]
+            ]
+        ];
+        $config = new ApiConfig($data);
+        $this->assertEquals(123, $config->getPath('a.b.c'));
+    }
+
+    /**
+     * @testdox setPath() sets value at path
+     */
+    public function testSetPathSetsValueAtPath()
+    {
+        $data = [
+            'a' => [
+                'b' => [
+                    'c' => 123
+                ]
+            ]
+        ];
+        $config = new ApiConfig($data);
+        $config->setPath('a.b.c', 456);
+        $this->assertEquals(456, $data['a']['b']['c']);
+    }
+
+    /**
+     * @testdox setPath() initializes parents
+     */
+    public function testSetPathInitializesParents()
+    {
+        $data = [
+            'a' => []
+        ];
+        $config = new ApiConfig($data);
+        $config->setPath('a.b.c', 789);
+        $this->assertEquals(789, $data['a']['b']['c']);
+    }
+
+     /**
+     * @testdox getPath() does not initialize parents
+     */
+    public function testGetPathDoesnotInitializeParents()
+    {
+        $data = [
+            'a' => []
+        ];
+        $config = new ApiConfig($data);
+        $this->assertEquals(null, $config->getPath('a.b.c'));
+    }
+}


### PR DESCRIPTION
Added a class called RestConfig which allows you to set REST config data using a config path. This greatly simplifies modifying config data at run time.

```
$restConfig = DI::getContainer()->get(RestConfig::class);
$restConfig->setPath('rest.v1/session.POST.commandClass', SessionKeyCreateCloud::class);
```
 