### PR TITLE
Fixed issue #19442: Generated analytics script does not properly escape question group name

### DIFF
--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -746,7 +746,7 @@ class LS_Twig_Extension extends AbstractExtension
             }
         }
 
-        $trackURL = htmlspecialchars($surveyName . '-[' . $surveyId . ']/[' . $page . ']-' . $groupName, ENT_QUOTES);
+        $trackURL = htmlspecialchars($surveyName . '-[' . $surveyId . ']/[' . $page . ']-' . $groupName);
         return $trackURL;
     }
 }

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -746,7 +746,7 @@ class LS_Twig_Extension extends AbstractExtension
             }
         }
 
-        $trackURL = htmlspecialchars($surveyName . '-[' . $surveyId . ']/[' . $page . ']-' . $groupName);
+        $trackURL = htmlspecialchars($surveyName . '-[' . $surveyId . ']/[' . $page . ']-' . $groupName, ENT_QUOTES);
         return $trackURL;
     }
 }

--- a/themes/survey/fruity_twentythree/views/subviews/header/google_analytics.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/header/google_analytics.twig
@@ -37,7 +37,7 @@
 
             ga('create', '{{ aSurveyInfo.googleanalyticsapikey }}', 'auto');
             ga('send', 'pageview');
-            ga('send', 'pageview', '{{ trackUrl }}');
+            ga('send', 'pageview', '{{ trackUrl|escape }}');
             </script>
         {% endif %}
     {% else %}
@@ -53,7 +53,7 @@
 
             {% if not (aSurveyInfo.googleanalyticsstyle is defined and aSurveyInfo.googleanalyticsstyle == 1) %}
                 {% set trackUrl = getGoogleAnalyticsTrackingUrl(aSurveyInfo.sid, aSurveyInfo.trackUrlPageName ?? '') %}
-                gtag('event', 'page_view', { page_title: '{{ trackUrl }}' })
+                gtag('event', 'page_view', { page_title: '{{ trackUrl|escape }}' })
             {% endif %}
         </script>
     {% endif %}

--- a/themes/survey/vanilla/views/subviews/header/google_analytics.twig
+++ b/themes/survey/vanilla/views/subviews/header/google_analytics.twig
@@ -37,7 +37,7 @@
 
             ga('create', '{{ aSurveyInfo.googleanalyticsapikey }}', 'auto');
             ga('send', 'pageview');
-            ga('send', 'pageview', '{{ trackUrl }}');
+            ga('send', 'pageview', '{{ trackUrl|escape }}');
             </script>
         {% endif %}
     {% else %}
@@ -53,7 +53,7 @@
 
             {% if not (aSurveyInfo.googleanalyticsstyle is defined and aSurveyInfo.googleanalyticsstyle == 1) %}
                 {% set trackUrl = getGoogleAnalyticsTrackingUrl(aSurveyInfo.sid, aSurveyInfo.trackUrlPageName ?? '') %}
-                gtag('event', 'page_view', { page_title: '{{ trackUrl }}' })
+                gtag('event', 'page_view', { page_title: '{{ trackUrl|escape }}' })
             {% endif %}
         </script>
     {% endif %}


### PR DESCRIPTION
Fixed issue #19442: Generated analytics script does not properly escape question group name

https://bugs.limesurvey.org/view.php?id=19442

master