### PR TITLE
MW-1040: Refactored getQuestionAttributes usage at ResponsesController

### DIFF
--- a/application/controllers/ResponsesController.php
+++ b/application/controllers/ResponsesController.php
@@ -167,6 +167,8 @@ class ResponsesController extends LSBaseController
             $fnames[] = ["submitdate", gT("Submission date"), gT("Completed"), "0", 'D', 'code' => 'submitdate'];
         }
         $fnames[] = ["completed", gT("Completed"), "0"];
+        $qids = [];
+        $fields = [];
 
         foreach ($fieldmap as $field) {
             if ($field['fieldname'] == 'lastpage' || $field['fieldname'] == 'submitdate') {
@@ -192,7 +194,22 @@ class ResponsesController extends LSBaseController
                     'code' => viewHelper::getFieldCode($field, ['LEMcompat' => true])
                 ];
             } elseif ($field['aid'] !== 'filecount') {
-                $qidattributes = QuestionAttribute::model()->getQuestionAttributes($field['qid']);
+                $qids[] = $field['qid'];
+                $fields[] = $field;
+
+            } else {
+                $fnames[] = [$field['fieldname'], gT("File count")];
+            }
+        }
+
+        if (count($qids)) {
+            $rawQuestions = Question::model()->findAllByPk($qids);
+            $questions = [];
+            foreach ($rawQuestions as $rawQuestion) {
+                $questions[$rawQuestion->qid] = $rawQuestion;
+            }
+            foreach ($fields as $field) {
+                $qidattributes = QuestionAttribute::model()->getQuestionAttributes($questions[$field['qid']]);
 
                 for ($i = 0; $i < $qidattributes['max_num_of_files']; $i++) {
                     $filenum = sprintf(gT("File %s"), $i + 1);
@@ -236,8 +253,6 @@ class ResponsesController extends LSBaseController
                         "index"    => $i
                     ];
                 }
-            } else {
-                $fnames[] = [$field['fieldname'], gT("File count")];
             }
         }
 

--- a/application/controllers/ResponsesController.php
+++ b/application/controllers/ResponsesController.php
@@ -196,7 +196,6 @@ class ResponsesController extends LSBaseController
             } elseif ($field['aid'] !== 'filecount') {
                 $qids[] = $field['qid'];
                 $fields[] = $field;
-
             } else {
                 $fnames[] = [$field['fieldname'], gT("File count")];
             }


### PR DESCRIPTION
`ResponsesController` has been refactored here to gather the questions separately using a single query and pass the question object to `QuestionAttribute::getQuestionAttributes` instead of an id, subsequently caching the questions without loading them individuall again (because they were already loaded)

Improvement magnitude: minor

Measurement:

3.32s - 3.10s

How to test:

1. Visit a survey page
2. Click on responses
3. Click the ... icon in the Action column for a response record
4. Click on view response details