### PR TITLE
Task/lb 132 encoding problems with the body of notification emails

### DIFF
--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -1922,12 +1922,11 @@ class DataEntry extends SurveyCommonAction
                                 $mailer->addAddress($saver['email']);
                                 $mailer->setSurvey($surveyid);
                                 $mailer->emailType = 'savesurveydetails';
-                                $mailer->isHTML(false);
                                 $mailer->Subject = gT("Saved Survey Details");
-                                $message = gT("Thank you for saving your survey in progress. The following details can be used to return to this survey and continue where you left off.", "unescaped");
+                                $message = gT("Thank you for saving your survey in progress. The following details can be used to return to this survey and continue where you left off.");
                                 $message .= "\n\n" . $thissurvey['name'] . "\n\n";
                                 $message .= gT("Name") . ": " . $saver['identifier'] . "\n";
-                                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):", "unescaped") . "\n";
+                                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):") . "\n";
                                 $aParams = array('lang' => $saver['language'], 'loadname' => $saver['identifier']);
                                 $message .= Yii::app()->getController()->createAbsoluteUrl("/survey/index/sid/{$surveyid}/loadall/reload/scid/{$arSaveControl->scid}/", $aParams);
                                 $mailer->Body = $message;

--- a/application/controllers/admin/DataEntry.php
+++ b/application/controllers/admin/DataEntry.php
@@ -1922,11 +1922,12 @@ class DataEntry extends SurveyCommonAction
                                 $mailer->addAddress($saver['email']);
                                 $mailer->setSurvey($surveyid);
                                 $mailer->emailType = 'savesurveydetails';
+                                $mailer->isHTML(false);
                                 $mailer->Subject = gT("Saved Survey Details");
-                                $message = gT("Thank you for saving your survey in progress. The following details can be used to return to this survey and continue where you left off.");
+                                $message = gT("Thank you for saving your survey in progress. The following details can be used to return to this survey and continue where you left off.", "unescaped");
                                 $message .= "\n\n" . $thissurvey['name'] . "\n\n";
                                 $message .= gT("Name") . ": " . $saver['identifier'] . "\n";
-                                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):") . "\n";
+                                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):", "unescaped") . "\n";
                                 $aParams = array('lang' => $saver['language'], 'loadname' => $saver['identifier']);
                                 $message .= Yii::app()->getController()->createAbsoluteUrl("/survey/index/sid/{$surveyid}/loadall/reload/scid/{$arSaveControl->scid}/", $aParams);
                                 $mailer->Body = $message;

--- a/application/libraries/Save.php
+++ b/application/libraries/Save.php
@@ -211,11 +211,11 @@ class Save
                 $mailer->emailType = 'savesurveydetails';
                 $mailer->isHTML(false);
                 $mailer->Subject = gT("Saved Survey Details") . " - " . $thissurvey['name'];
-                $message  = gT("Thank you for saving your survey in progress.  The following details can be used to return to this survey and continue where you left off.  Please make sure to remember your password - we cannot retrieve it for you.");
+                $message  = gT("Thank you for saving your survey in progress.  The following details can be used to return to this survey and continue where you left off.  Please make sure to remember your password - we cannot retrieve it for you.", "unescaped");
                 $message .= "\n\n" . $thissurvey['name'] . "\n\n";
                 $message .= gT("Name") . ": " . Yii::app()->getRequest()->getPost('savename') . "\n";
                 $message .= gT("Password") . ": ***************\n\n";
-                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):") . "\n";
+                $message .= gT("Reload your survey by clicking on the following link (or pasting it into your browser):", "unescaped") . "\n";
                 $aParams  = array('scid' => $scid, 'lang' => App()->language);
                 if (!empty($clienttoken)) {
                     $aParams['token'] = $clienttoken;


### PR DESCRIPTION
Bug fix for "Save Survey Details" email.

This adds the "unescaped" parameter to the translation function to avoid escaping special characters for the body of the mail that is not supposed to be in HTML format.

This affects languages that uses apostrophes like Catalan, Portuguese and so on.

Test instructions:
Please create a survey, for example, in Catalan or use a test survey and change the main language to Catalan.
Start the survey and use the functionality "Continue later" in the survey options in the upper right corner.
Field the required forms and check your email for the translated text.

Actual result:

> Gràcies per desar l&#039;enquesta en curs...

Expected result:

> Gràcies per desar l'enquesta en curs...

Thanks.