### PR TITLE
Fixed issue #CT-681: Answer options order (answer_order) is missing as an attribute definition and causes the value to not persist through tsv exports and imports

### DIFF
--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -836,7 +836,7 @@ class questionHelper
         );
 
         self::$attributes["random_order"] = array(
-        "types" => Question::QT_EXCLAMATION_LIST_DROPDOWN . Question::QT_A_ARRAY_5_POINT . Question::QT_B_ARRAY_10_CHOICE_QUESTIONS . Question::QT_C_ARRAY_YES_UNCERTAIN_NO . Question::QT_E_ARRAY_INC_SAME_DEC . Question::QT_F_ARRAY . Question::QT_H_ARRAY_COLUMN . Question::QT_K_MULTIPLE_NUMERICAL . Question::QT_L_LIST . Question::QT_M_MULTIPLE_CHOICE . Question::QT_O_LIST_WITH_COMMENT . Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS . Question::QT_Q_MULTIPLE_SHORT_TEXT . Question::QT_R_RANKING . Question::QT_1_ARRAY_DUAL . Question::QT_COLON_ARRAY_NUMBERS . Question::QT_SEMICOLON_ARRAY_TEXT,
+        "types" => Question::QT_A_ARRAY_5_POINT . Question::QT_B_ARRAY_10_CHOICE_QUESTIONS . Question::QT_C_ARRAY_YES_UNCERTAIN_NO . Question::QT_E_ARRAY_INC_SAME_DEC . Question::QT_F_ARRAY . Question::QT_H_ARRAY_COLUMN . Question::QT_K_MULTIPLE_NUMERICAL . Question::QT_M_MULTIPLE_CHOICE . Question::QT_O_LIST_WITH_COMMENT . Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS . Question::QT_Q_MULTIPLE_SHORT_TEXT . Question::QT_1_ARRAY_DUAL . Question::QT_COLON_ARRAY_NUMBERS . Question::QT_SEMICOLON_ARRAY_TEXT,
             'category' => gT('Display'),
             'sortorder' => 100,
             'inputtype' => 'singleselect',
@@ -846,6 +846,19 @@ class questionHelper
             'default' => 0,
             "help" => gT('Present subquestions/answer options in random order'),
             "caption" => gT('Random order')
+        );
+
+        self::$attributes["answer_order"] = array(
+            "types" => Question::QT_L_LIST . Question::QT_R_RANKING . Question::QT_EXCLAMATION_LIST_DROPDOWN,
+            'category' => gT('Display'),
+            'sortorder' => 100,
+            'inputtype' => 'singleselect',
+            'options' => array('normal' => gT('Normal'), 'random' => gT("Random"), 'alphabetical' => gT("Alphabetical")),
+            //1=>gT('Randomize on each page load')  // Shnoulle : replace by yes till we have only one solution
+            //2=>gT('Randomize once on survey start')  //Mdekker: commented out as code to handle this was removed in refactoring
+            'default' => 0,
+            "help" => gT('Present answer options in normal, random or alphabetical order'),
+            "caption" => gT('Answer options order')
         );
 
         self::$attributes["showpopups"] = array(

--- a/application/models/QuestionTemplate.php
+++ b/application/models/QuestionTemplate.php
@@ -381,9 +381,12 @@ class QuestionTemplate extends CFormModel
      * @param string $type
      * @return array
      * @todo Move to QuestionTheme?
+     * @todo This is not the same as QuestionTheme::findQuestionMetaDataForAllTypes() which is the database layer
+     * @todo this should check the filestructure instead of the database as this is the filestructure layer
      */
     public static function getQuestionTemplateList($type)
     {
+        // todo: incorrect, this should check the filestructure instead of the database as this is the filestructure layer
         /** @var QuestionTheme[] */
         $questionThemes = QuestionTheme::model()->findAllByAttributes(
             [],


### PR DESCRIPTION
…s an attribute definition and causes the value to not persist through tsv exports and imports

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
