### PR TITLE
CT-698: Fixed a link

### DIFF
--- a/application/views/admin/super/sidemenu.php
+++ b/application/views/admin/super/sidemenu.php
@@ -23,7 +23,7 @@
     $getQuestionsUrl = $this->createUrl("/surveyAdministration/getAjaxQuestionGroupArray/", ["surveyid" => $surveyid]);
     $getMenuUrl = $this->createUrl("/surveyAdministration/getAjaxMenuArray/", ["surveyid" => $surveyid]);
     $createQuestionGroupLink = $this->createUrl("/questionGroupsAdministration/add/", ["surveyid" =>  $surveyid]);
-    $createQuestionLink = "questionAdministration/view/surveyid/".$surveyid;
+    $createQuestionLink = $this->createUrl("/questionAdministration/create/", ["surveyid" => $surveyid]);
     $unlockLockOrganizerUrl = $this->createUrl("admin/user/sa/togglesetting/", ['surveyid' => $surveyid]);
 
     $updateOrderLink =  $this->createUrl("/questionGroupsAdministration/updateOrder/", ["surveyid" =>  $surveyid]);


### PR DESCRIPTION
# Problem statement

On `https://ls-cloud/admin/conditions/sa/index/subaction/editconditionsform/surveyid/<some sid>/gid/<some gid>/qid/<some qid>`

if we click on add question, then we get the error of

![image](https://github.com/LimeSurvey/cloud_client_limesurvey/assets/2805488/8e5f0eda-257d-465e-bf93-e391d430ffbb)

which turned out to be caused by some cloud-specific error, specifying `$createQuestionLink` to be a view page, which is a mistake. Fixing the link fixed the issue as well.