### PR TITLE
QE-831: Fixed API support for language setting change

### DIFF
--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -108,23 +108,8 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
     public function validateOperation(OpInterface $op): array
     {
         $validationData = [];
-        $checkDataEntityId = $this->getSurveyIdFromContext($op);
-        $checkDataCollection = $this->validateCollection($op, []);
-        if (empty($checkDataEntityId) && empty($checkDataCollection)) {
-            if (!$this->getSurveyIdFromContext($op)) {
-                // operation data has an entity id and props came as collection
-                $validationData = $this->addErrorToValidationData(
-                    'props can not come as collection if id is set',
-                    $validationData
-                );
-            }
-        } elseif (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
-            // operation data has no entity id and props came not as collection
-            $validationData = $checkDataCollection;
-        } elseif (!empty($checkDataEntityId)) {
-            // operation data has no entity id so collection indexes are validated
-            $validationData = $this->validateCollectionIndex($op, $validationData);
-        }
+        
+        $validationData = $this->validateCollectionIndex($op, $validationData);
 
         if (empty($validationData)) {
             $validationData = $this->transformer->validateAll(

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -121,11 +121,14 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
     public function validateOperation(OpInterface $op): array
     {
         $validationData = [];
-        $checkDataEntityId = $this->validateEntityId($op, []);
+        $checkDataEntityId = $this->getSurveyIdFromContext($op);
         $checkDataCollection = $this->validateCollection($op, []);
         if (empty($checkDataEntityId) && empty($checkDataCollection)) {
             // operation data has an entity id and props came as collection
-            // kept this case to avoid redefining the else ifs
+            $validationData = $this->addErrorToValidationData(
+                'props can not come as collection if id is set',
+                $validationData
+            );
         } elseif (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
             // operation data has no entity id and props came not as collection
             $validationData = $checkDataCollection;

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -124,11 +124,13 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
         $checkDataEntityId = $this->getSurveyIdFromContext($op);
         $checkDataCollection = $this->validateCollection($op, []);
         if (empty($checkDataEntityId) && empty($checkDataCollection)) {
-            // operation data has an entity id and props came as collection
-            $validationData = $this->addErrorToValidationData(
-                'props can not come as collection if id is set',
-                $validationData
-            );
+            if (!$this->getSurveyIdFromContext($op)) {
+                // operation data has an entity id and props came as collection
+                $validationData = $this->addErrorToValidationData(
+                    'props can not come as collection if id is set',
+                    $validationData
+                );
+            }
         } elseif (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
             // operation data has no entity id and props came not as collection
             $validationData = $checkDataCollection;

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -108,7 +108,7 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
     public function validateOperation(OpInterface $op): array
     {
         $validationData = [];
-        
+
         $validationData = $this->validateCollectionIndex($op, $validationData);
 
         if (empty($validationData)) {

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -123,7 +123,10 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
         $validationData = [];
         $checkDataEntityId = $this->validateEntityId($op, []);
         $checkDataCollection = $this->validateCollection($op, []);
-        if (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
+        if (empty($checkDataEntityId) && empty($checkDataCollection)) {
+            // operation data has an entity id and props came as collection
+            // kept this case to avoid redefining the else ifs
+        } elseif (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
             // operation data has no entity id and props came not as collection
             $validationData = $checkDataCollection;
         } elseif (!empty($checkDataEntityId)) {

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -96,23 +96,21 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
         $languageSettings = $diContainer->get(
             LanguageSettings::class
         );
-        foreach ($op->getProps() as $languageCode => $props) {
-            $data = $this->transformer->transformAll(
-                $props,
-                [
-                    'operation' => $op->getType()->getId(),
-                    'entityId'  => $languageCode,
-                    'sid'       => $this->getSurveyIdFromContext($op)
-                ]
-            );
-            if (empty($data)) {
-                $this->throwNoValuesException($op);
-            }
-            $languageSettings->update(
-                $this->getSurveyIdFromContext($op),
-                $data
-            );
+        $data = $this->transformer->transformAll(
+            $op->getProps(),
+            [
+                'operation' => $op->getType()->getId(),
+                'entityId'  => $op->getEntityId(),
+                'sid'       => $this->getSurveyIdFromContext($op)
+            ]
+        );
+        if (empty($data)) {
+            $this->throwNoValuesException($op);
         }
+        $languageSettings->update(
+            $this->getSurveyIdFromContext($op),
+            $data
+        );
     }
 
     /**
@@ -125,10 +123,7 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
         $validationData = [];
         $checkDataEntityId = $this->validateEntityId($op, []);
         $checkDataCollection = $this->validateCollection($op, []);
-        if (empty($checkDataEntityId) && empty($checkDataCollection)) {
-            // operation data has an entity id and props came as collection
-            // kept this case to avoid redefining the else ifs
-        } elseif (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
+        if (!empty($checkDataEntityId) && !empty($checkDataCollection)) {
             // operation data has no entity id and props came not as collection
             $validationData = $checkDataCollection;
         } elseif (!empty($checkDataEntityId)) {

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerLanguageSettingsUpdate.php
@@ -51,20 +51,7 @@ class OpHandlerLanguageSettingsUpdate implements OpHandlerInterface
     }
 
     /**
-     * This handler accepts two different approaches to update the language settings:
-     * Approach 1 (single language):
-     * - in this case the language needs to be part of the id array
-     * - patch structure:
-     *      {
-     *          "entity": "languageSetting",
-     *          "op": "update",
-     *          "id": "de",
-     *          "props": {
-     *              "title": "Beispielfragebogen"
-     *          }
-     *      }
-     *
-     * Approach 2 (multiple languages):
+     * This handler accepts the following format to update the language settings:
      * - in this case the languages need to be indexes of the props array
      * - language must not be part of the id array
      * - patch structure:

--- a/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputSurveyLanguageSettings.php
+++ b/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputSurveyLanguageSettings.php
@@ -89,19 +89,7 @@ class TransformerInputSurveyLanguageSettings extends Transformer
         array $collection,
         array $options
     ): array {
-        $props = [];
-        $entityId = array_key_exists(
-            'entityId',
-            $options
-        ) ? $options['entityId'] : null;
-        if (!empty($entityId)) {
-            // indicator for variant 1
-            $props[$entityId] = $collection;
-        } else {
-            // variant 2
-            $props = $collection;
-        }
-
+        $props = $collection;
         $surveyId = array_key_exists('sid', $options) ? $options['sid'] : null;
         foreach (array_keys($props) as $language) {
             $props[$language]['sid'] = $surveyId;

--- a/tests/unit/api/opHandlers/OpHandlerLanguageSettingsTest.php
+++ b/tests/unit/api/opHandlers/OpHandlerLanguageSettingsTest.php
@@ -48,20 +48,6 @@ class OpHandlerLanguageSettingsTest extends TestBaseClass
     }
 
     /**
-     * @testdox has correct data output when provided with single language
-     */
-    public function testLanguageSettingsUpdateDataStructureSingle()
-    {
-        $op = $this->getOp(
-            $this->getPropsSingleArray(),
-            'en'
-        );
-        $outputData = $this->transformAll($op);
-        $this->assertArrayHasKey('en', $outputData);
-        $this->assertArrayHasKey('surveyls_title', $outputData['en']);
-    }
-
-    /**
      * @testdox has correct data output when provided with multiple languages
      */
     public function testLanguageSettingsUpdateDataStructureMultiple()


### PR DESCRIPTION
Since this is about language settings, we receive props such as

```
[
    {
        id: 918864,
        op: "update",
        entity: "languageSetting",
        props: {
            en: {
                title: "kdsjdskl"
           }
        }
    }
]
```

whereas other end points do not receive languages, as they are not language-dependant.

As a result, in the `handle` method of `OpHandlerLanguageSettingsUpdate`we can simply loop the props, the keys being the languages and the values being the corresponding values. Previously, `'entityId' => $op->getEntityId()` was passing the survey id as the language :)