### PR TITLE
CT-740: Fixed an XSS issue related to the survey title

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -774,7 +774,7 @@ function getSurveyInfo($surveyid, $languagecode = '', $force = false)
         if ($result) {
             $aSurveyAtrributes = array_replace($result->survey->attributes, $aSurveyOptions);
             $thissurvey = array_merge($aSurveyAtrributes, $result->attributes);
-            $thissurvey['name'] = $thissurvey['surveyls_title'];
+            $thissurvey['name'] = htmlspecialchars($thissurvey['surveyls_title'], ENT_QUOTES, 'UTF-8');
             $thissurvey['description'] = $thissurvey['surveyls_description'];
             $thissurvey['welcome'] = $thissurvey['surveyls_welcometext'];
             $thissurvey['datasecurity_notice_label'] = $thissurvey['surveyls_policy_notice_label'];


### PR DESCRIPTION
Escaped title so it cannot be XSS-exploited.

@c-schmitz please let me know if we need to move the escape from here to someplace else.

![image](https://github.com/LimeSurvey/LimeSurvey/assets/2805488/c8aee3bd-ce61-4634-a2db-d1d2f1e21ec5)

The gravity of the situation consists in an admin being able to XSS-hack visitors of his survey, including other admins who are doing a preview