### PR TITLE
Fixed issue #19514: File Upload - scrolling not possible on mobile

### DIFF
--- a/application/views/survey/questions/answer/file_upload/answer.twig
+++ b/application/views/survey/questions/answer/file_upload/answer.twig
@@ -52,7 +52,7 @@
 
 <!-- modal -->
 <div id="file-upload-modal-{{fileid}}" class="modal fade file-upload-modal" role="dialog">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
 
         <!-- Modal content-->
         <div class="modal-content">


### PR DESCRIPTION
Dialog is scrollable and visible on mobile. Doesn't center it yet on large screens.