### PR TITLE
New feature: added beforeGetTemplate plugin event

### DIFF
--- a/application/models/Template.php
+++ b/application/models/Template.php
@@ -365,6 +365,12 @@ class Template extends LSActiveRecord
      */
     public static function getTemplateConfiguration($sTemplateName = null, $iSurveyId = null, $iSurveyGroupId = null, $bForceXML = false, $abstractInstance = false)
     {
+        $event = new PluginEvent('beforeGetTemplate');
+        $event->set('surveyId', $iSurveyId);
+        $event->set('template', $sTemplateName);
+        $event = App()->getPluginManager()->dispatchEvent($event);
+        $sTemplateName = $event->get('template');
+
 
         // First we try to get a configuration row from DB
         if (!$bForceXML) {


### PR DESCRIPTION
I am proposing to add a plugin event to be able to change the survey template. 

I have done this since via the event `afterFindSurvey`, but since there is way too much `Survey::findByPk($sid)` calls, using `afterFindSurvey` event for virtually any type of plugin manipulation seems to generate a huge overhead.

Discussion is very welcome :)