### PR TITLE
dev: remove duplicate survey-find-by-pk calls

### DIFF
--- a/application/controllers/ResponsesController.php
+++ b/application/controllers/ResponsesController.php
@@ -1081,11 +1081,11 @@ class ResponsesController extends LSBaseController
         $aData['imageurl'] = App()->getConfig('imageurl');
         $aData['action'] = App()->request->getParam('action');
         $aData['all'] = App()->request->getParam('all');
-
+        $oSurvey = Survey::model()->findByPk($surveyId);
         //OK. IF WE GOT THIS FAR, THEN THE SURVEY EXISTS AND IT IS ACTIVE, SO LETS GET TO WORK.
         if (!empty($language)) {
             $aData['language'] = $language;
-            $aData['languagelist'] = $languagelist = Survey::model()->findByPk($surveyId)->additionalLanguages;
+            $aData['languagelist'] = $languagelist = $oSurvey->additionalLanguages;
             $aData['languagelist'][] = Survey::model()->findByPk($surveyId)->language;
             if (!in_array($aData['language'], $languagelist)) {
                 $aData['language'] = $thissurvey['language'];
@@ -1094,7 +1094,7 @@ class ResponsesController extends LSBaseController
             $aData['language'] = $thissurvey['language'];
         }
 
-        $aData['qulanguage'] = Survey::model()->findByPk($surveyId)->language;
+        $aData['qulanguage'] = $oSurvey->language;
 
         $aData['surveyoptions'] = '';
         $aData['browseoutput'] = '';

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -1457,7 +1457,6 @@ class Tokens extends SurveyCommonAction
      */
     public function email(int $iSurveyId)
     {
-        $iSurveyId = (int) $iSurveyId;
         $aData = array();
         $survey = Survey::model()->findByPk($iSurveyId);
 
@@ -1485,8 +1484,8 @@ class Tokens extends SurveyCommonAction
         initKcfinder();
         Yii::app()->loadHelper('replacements');
 
-        $aSurveyLangs = Survey::model()->findByPk($iSurveyId)->additionalLanguages;
-        $sBaseLanguage = Survey::model()->findByPk($iSurveyId)->language;
+        $aSurveyLangs = $survey->additionalLanguages;
+        $sBaseLanguage = $survey->language;
         array_unshift($aSurveyLangs, $sBaseLanguage);
         $aTokenFields = getTokenFieldsAndNames($iSurveyId, true);
         $iAttributes = 0;
@@ -1555,12 +1554,13 @@ class Tokens extends SurveyCommonAction
                 $mail->setSurvey($iSurveyId);
                 $mail->emailType = $sSubAction;
                 $mail->replaceTokenAttributes = true;
+                $allLanguages = $survey->getAllLanguages();
                 foreach ($emresult as $emrow) {
                     $mailLanguage = $emrow['language'];
                     if (empty($mailLanguage)) {
                         $mailLanguage = $sBaseLanguage;
                     }
-                    if (!in_array($mailLanguage, Survey::model()->findByPk($iSurveyId)->getAllLanguages())) {
+                    if (!in_array($mailLanguage, $allLanguages)) {
                         $mailLanguage = $sBaseLanguage;
                         $tokenoutput .= CHtml::tag(
                             "div",
@@ -1726,7 +1726,6 @@ class Tokens extends SurveyCommonAction
      */
     public function exportdialog(int $iSurveyId)
     {
-        $iSurveyId = (int)$iSurveyId;
         $survey = Survey::model()->findByPk($iSurveyId);
         $aData = array();
 
@@ -1759,10 +1758,9 @@ class Tokens extends SurveyCommonAction
                     'name' => 'submit',
                 ),
             );
-            $oSurvey = Survey::model()->findByPk($iSurveyId);
 
             $aOptionsStatus = array('0' => gT('All participants'), '1' => gT('Completed'), '2' => gT('Not completed'));
-            if (!$oSurvey->isAnonymized && $oSurvey->isActive) {
+            if (!$survey->isAnonymized && $survey->isActive) {
                 $aOptionsStatus['3'] = gT('Not started');
                 $aOptionsStatus['4'] = gT('Started but not yet completed');
             }

--- a/application/controllers/survey/SurveyIndex.php
+++ b/application/controllers/survey/SurveyIndex.php
@@ -133,12 +133,12 @@ class SurveyIndex extends CAction
         $sMaintenanceMode = getGlobalSetting('maintenancemode');
         if ($sMaintenanceMode == 'hard') {
             if ($previewmode === false) {
-                Yii::app()->twigRenderer->renderTemplateFromFile("layout_maintenance.twig", array('oSurvey' => Survey::model()->findByPk($surveyid), 'aSurveyInfo' => $thissurvey), false);
+                Yii::app()->twigRenderer->renderTemplateFromFile("layout_maintenance.twig", array('oSurvey' => $oSurvey, 'aSurveyInfo' => $thissurvey), false);
             }
         } elseif ($sMaintenanceMode == 'soft') {
             if ($move === null) {
                 if ($previewmode === false) {
-                    Yii::app()->twigRenderer->renderTemplateFromFile("layout_maintenance.twig", array('oSurvey' => Survey::model()->findByPk($surveyid), 'aSurveyInfo' => $thissurvey), false);
+                    Yii::app()->twigRenderer->renderTemplateFromFile("layout_maintenance.twig", array('oSurvey' => $oSurvey, 'aSurveyInfo' => $thissurvey), false);
                 }
             }
         }

--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -676,9 +676,11 @@ window.addEventListener('message', function(event) {
         $aData["aSurveyInfo"] = array_merge($aData["aSurveyInfo"], $oTemplate->getClassAndAttributes());
 
         $languagecode = App()->getLanguage();
-        if (!empty($aData['aSurveyInfo']['sid']) && Survey::model()->findByPk($aData['aSurveyInfo']['sid'])) {
-            if (!in_array($languagecode, Survey::model()->findByPk($aData['aSurveyInfo']['sid'])->getAllLanguages())) {
-                $languagecode = Survey::model()->findByPk($aData['aSurveyInfo']['sid'])->language;
+        $surveyId = $aData['aSurveyInfo']['sid'];
+        $oSurvey = Survey::model()->findByPk($surveyId);
+        if ($oSurvey instanceof Survey) {
+            if (!in_array($languagecode, $oSurvey->getAllLanguages())) {
+                $languagecode = $oSurvey->language;
             }
         }
 

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -320,8 +320,9 @@ class LimeMailer extends PHPMailer
             throw new \CException("Invalid token");
         }
         $this->oToken = $oToken;
-        $this->mailLanguage = Survey::model()->findByPk($this->surveyId)->language;
-        if (in_array($oToken->language, Survey::model()->findByPk($this->surveyId)->getAllLanguages())) {
+        $oSurvey = Survey::model()->findByPk($this->surveyId);
+        $this->mailLanguage = $oSurvey->language;
+        if (in_array($oToken->language, $oSurvey->getAllLanguages())) {
             $this->mailLanguage = $oToken->language;
         }
         $this->eventName = 'beforeTokenEmail';
@@ -348,8 +349,9 @@ class LimeMailer extends PHPMailer
             /* To force to current language with token must send Yii::app()->getLanguage() as param */
             $language = $this->oToken->language;
         }
-        if (!in_array($language, Survey::model()->findByPk($this->surveyId)->getAllLanguages())) {
-            $language = Survey::model()->findByPk($this->surveyId)->language;
+        $oSurvey = Survey::model()->findByPk($this->surveyId);
+        if (!in_array($language, $oSurvey->getAllLanguages())) {
+            $language = $oSurvey->language;
         }
         $this->mailLanguage = $language;
         if (!in_array($emailType, ['invite','remind','register','confirm','admin_notification','admin_responses'])) {

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1524,8 +1524,9 @@ class SurveyRuntimeHelper
                 if ($oResponse) {
                     $oResponse->delete(true); /* delete response line + files uploaded , warninbg : beforeDelete don't happen with deleteAll */
                 }
+                $oSurvey = Survey::model()->findByPk($this->iSurveyid);
 
-                if (Survey::model()->findByPk($this->iSurveyid)->savetimings == "Y") {
+                if ($oSurvey->savetimings == "Y") {
                     SurveyTimingDynamic::model($this->iSurveyid)->deleteAll("id=:srid", array(":srid" => $sessionSurvey['srid'])); /* delete timings ( @todo must move it to Response )*/
                 }
 
@@ -1550,7 +1551,7 @@ class SurveyRuntimeHelper
 
             $this->aSurveyInfo['surveyUrl'] = $restarturl;
             $this->aSurveyInfo['include_content'] = 'clearall';
-            Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($this->iSurveyid), 'aSurveyInfo' => $this->aSurveyInfo), false);
+            Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => $oSurvey, 'aSurveyInfo' => $this->aSurveyInfo), false);
         }
     }
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2369,8 +2369,9 @@ function languageDropdown($surveyid, $selected)
  */
 function languageDropdownClean($surveyid, $selected)
 {
-    $slangs = Survey::model()->findByPk($surveyid)->additionalLanguages;
-    $baselang = Survey::model()->findByPk($surveyid)->language;
+    $oSurvey = Survey::model()->findByPk($surveyid);
+    $slangs = $oSurvey->additionalLanguages;
+    $baselang = $oSurvey->language;
     array_unshift($slangs, $baselang);
     $html = "<select class='form-select listboxquestions' id='language' name='language'>\n";
     foreach ($slangs as $lang) {
@@ -3701,8 +3702,9 @@ function cleanLanguagesFromSurvey($iSurveyID, $availlangs, $baselang = null)
 function fixLanguageConsistency($sid, $availlangs = '', $baselang = '')
 {
     $sid = (int) $sid;
+    $oSurvey = Survey::model()->findByPk($sid);
     if (empty($baselang)) {
-        $baselang = Survey::model()->findByPk($sid)->language;
+        $baselang = $oSurvey->language;
     }
     if (trim($availlangs) != '') {
         $availlangs = sanitize_languagecodeS($availlangs);
@@ -3715,7 +3717,7 @@ function fixLanguageConsistency($sid, $availlangs = '', $baselang = '')
             unset($languagesToCheck[$key]);
         }
     } else {
-        $languagesToCheck = Survey::model()->findByPk($sid)->additionalLanguages;
+        $languagesToCheck = $oSurvey->additionalLanguages;
     }
     if (count($languagesToCheck) == 0) {
         return true; // Survey only has one language

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -1033,8 +1033,9 @@ function surveyGetXMLData($iSurveyID, $exclude = array())
     $xml->writeElement('LimeSurveyDocType', 'Survey');
     $xml->writeElement('DBVersion', getGlobalSetting("DBVersion"));
     $xml->startElement('languages');
-    $surveylanguages = Survey::model()->findByPk($iSurveyID)->additionalLanguages;
-    $surveylanguages[] = Survey::model()->findByPk($iSurveyID)->language;
+    $oSurvey = Survey::model()->findByPk($iSurveyID);
+    $surveylanguages = $oSurvey->additionalLanguages;
+    $surveylanguages[] = $oSurvey->language;
     foreach ($surveylanguages as $surveylanguage) {
         $xml->writeElement('language', $surveylanguage);
     }
@@ -1072,8 +1073,9 @@ function getXMLDataSingleTable($iSurveyID, $sTableName, $sDocType, $sXMLTableTag
     $xml->writeElement('LimeSurveyDocType', $sDocType);
     $xml->writeElement('DBVersion', getGlobalSetting("DBVersion"));
     $xml->startElement('languages');
-    $aSurveyLanguages = Survey::model()->findByPk($iSurveyID)->additionalLanguages;
-    $aSurveyLanguages[] = Survey::model()->findByPk($iSurveyID)->language;
+    $oSurvey = Survey::model()->findByPk($iSurveyID);
+    $aSurveyLanguages = $oSurvey->additionalLanguages;
+    $aSurveyLanguages[] = $oSurvey->language;
     foreach ($aSurveyLanguages as $sSurveyLanguage) {
         $xml->writeElement('language', $sSurveyLanguage);
     }
@@ -2200,8 +2202,9 @@ function questionExport($action, $iSurveyID, $gid, $qid)
     $xml->writeElement('LimeSurveyDocType', 'Question');
     $xml->writeElement('DBVersion', getGlobalSetting('DBVersion'));
     $xml->startElement('languages');
-    $aLanguages = Survey::model()->findByPk($iSurveyID)->additionalLanguages;
-    $aLanguages[] = Survey::model()->findByPk($iSurveyID)->language;
+    $oSurvey = Survey::model()->findByPk($iSurveyID);
+    $aLanguages = $oSurvey->additionalLanguages;
+    $aLanguages[] = $oSurvey->language;
     foreach ($aLanguages as $sLanguage) {
         $xml->writeElement('language', $sLanguage);
     }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -881,8 +881,9 @@ class LimeExpressionManager
     {
         $LEM =& LimeExpressionManager::singleton();
         $LEM->SetSurveyId($iSurveyId); // This update session only if needed
-        if (!in_array(Yii::app()->session['LEMlang'], Survey::model()->findByPk($iSurveyId)->getAllLanguages())) {
-            $LEM->SetEMLanguage(Survey::model()->findByPk($iSurveyId)->language);// Reset language only if needed
+        $oSurvey = Survey::model()->findByPk($iSurveyId);
+        if (!in_array(Yii::app()->session['LEMlang'], $oSurvey->getAllLanguages())) {
+            $LEM->SetEMLanguage($oSurvey->language);// Reset language only if needed
         }
         $LEM->setVariableAndTokenMappingsForExpressionManager($iSurveyId);
         return $LEM->qcode2sgqa;

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -2146,8 +2146,10 @@ function SetSurveyLanguage($surveyid, $sLanguage)
     $default_language = Yii::app()->getConfig('defaultlang');
 
     if (isset($surveyid) && $surveyid > 0) {
-        $default_survey_language     = Survey::model()->findByPk($surveyid)->language;
-        $additional_survey_languages = Survey::model()->findByPk($surveyid)->getAdditionalLanguages();
+        $oSurvey = Survey::model()->findByPk($surveyid);
+
+        $default_survey_language     = $oSurvey->language;
+        $additional_survey_languages = $oSurvey->getAdditionalLanguages();
 
         if (
             empty($sLanguage)                                                   //check if there

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -622,15 +622,18 @@ function testKeypad($sUseKeyPad)
 // ---------------------------------------------------------------
 function do_language($ia)
 {
+    $surveyId = (int) Yii::app()->getConfig('surveyID');
+    $oSurvey = Survey::model()->findByPk($surveyId);
+
     $checkconditionFunction = "checkconditions";
-    $answerlangs            = Survey::model()->findByPk(Yii::app()->getConfig('surveyID'))->additionalLanguages;
-    $answerlangs[]          = Survey::model()->findByPk(Yii::app()->getConfig('surveyID'))->language;
-    $sLang                  = $_SESSION['survey_' . Yii::app()->getConfig('surveyID')]['s_lang'];
+    $answerlangs            = $oSurvey->additionalLanguages;
+    $answerlangs[]          = $oSurvey->language;
+    $sLang                  = $_SESSION['survey_' . $surveyId]['s_lang'];
     $coreClass              = "ls-answers answer-item dropdow-item language-item";
     $inputnames = [];
 
     if (!in_array($sLang, $answerlangs)) {
-        $sLang = Survey::model()->findByPk(Yii::app()->getConfig('surveyID'))->language;
+        $sLang = $oSurvey->language;
     }
 
     $inputnames[] = $ia[1];

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -428,7 +428,6 @@ class remotecontrol_handle
                 // Remove invalid fields
                 $aDestinationFields = array_flip(Survey::model()->tableSchema->columnNames);
                 $aSurveyData = array_intersect_key($aSurveyData, $aDestinationFields);
-                $oSurvey = Survey::model()->findByPk($iSurveyID);
                 $aBasicAttributes = $oSurvey->getAttributes();
                 $aResult = array();
 
@@ -865,7 +864,6 @@ class remotecontrol_handle
                 if (!isset($aLanguages[$sLanguage])) {
                     return array('status' => 'Invalid language');
                 }
-                $oSurvey = Survey::model()->findByPk($iSurveyID);
                 if ($sLanguage == $oSurvey->language) {
                     return array('status' => 'Cannot remove base language');
                 }
@@ -1058,7 +1056,7 @@ class remotecontrol_handle
                 $oQuestionGroupL10n = new QuestionGroupL10n();
                 $oQuestionGroupL10n->group_name = $sGroupTitle;
                 $oQuestionGroupL10n->description = $sGroupDescription;
-                $oQuestionGroupL10n->language = Survey::model()->findByPk($iSurveyID)->language;
+                $oQuestionGroupL10n->language = $oSurvey->language;
                 $oQuestionGroupL10n->gid = $oGroup->gid;
 
                 if ($oQuestionGroupL10n->save()) {
@@ -3399,7 +3397,7 @@ class remotecontrol_handle
     {
          // check sessionKey is valid or not
         if ($this->_checkSessionKey($sSessionKey)) {
-                $oSurvey = Survey::model()->findByPk($iSurveyID);
+            $oSurvey = Survey::model()->findByPk($iSurveyID);
             if (!isset($oSurvey)) {
                   return array('status' => 'Error: Invalid survey ID');
             }

--- a/application/views/admin/export/statistics_subviews/_question.php
+++ b/application/views/admin/export/statistics_subviews/_question.php
@@ -373,10 +373,10 @@
                 break;
 
 
-
+            $oSurvey = Survey::model()->findByPk($surveyid);
             case Question::QT_I_LANGUAGE: // Language
-                $survlangs = Survey::model()->findByPk($surveyid)->additionalLanguages;
-                $survlangs[] = Survey::model()->findByPk($surveyid)->language;
+                $survlangs = $oSurvey->additionalLanguages;
+                $survlangs[] = $oSurvey->language;
                 foreach ($survlangs  as $availlang)
                 {
                     echo "\t<option value='".$availlang."'";

--- a/application/views/admin/super/sidemenu.php
+++ b/application/views/admin/super/sidemenu.php
@@ -42,8 +42,9 @@
         "top" => [],
         "bottom" => [],
     ];
+    $oSurvey = Survey::model()->findByPk($surveyid);
     foreach ($menuObjectArray as $position => $arr) {
-        $menuObjectArray[$position] = Survey::model()->findByPk($surveyid)->getSurveyMenus($position);
+        $menuObjectArray[$position] = $oSurvey->getSurveyMenus($position);
     }
 
 
@@ -56,7 +57,7 @@
             gid: '.($gid ?? 'null').',
             options: [],
             surveyid: '.$surveyid.',
-            isActive: '.(Survey::model()->findByPk($surveyid)->isActive ? "true" : "false").',
+            isActive: '.($oSurvey->isActive ? "true" : "false").',
             basemenus: '.json_encode($menuObjectArray).',
             updateOrderLink: "'.$updateOrderLink.'",
             unlockLockOrganizerUrl: "'.$unlockLockOrganizerUrl.'",

--- a/application/views/admin/token/massive_actions/_update.php
+++ b/application/views/admin/token/massive_actions/_update.php
@@ -4,9 +4,9 @@
  * Edit multiple tokens
  */
 $iSurveyId = (int) Yii::app()->request->getParam('surveyid');
-$attrfieldnames = Survey::model()->findByPk($iSurveyId)->tokenAttributes;
-$aCoreTokenFields = array('validfrom', 'validuntil', 'firstname', 'lastname', 'emailstatus', 'token', 'language', 'sent', 'remindersent', 'completed', 'usesleft');
 $oSurvey = Survey::model()->findByPk($iSurveyId);
+$attrfieldnames = $oSurvey->tokenAttributes;
+$aCoreTokenFields = array('validfrom', 'validuntil', 'firstname', 'lastname', 'emailstatus', 'token', 'language', 'sent', 'remindersent', 'completed', 'usesleft');
 $sCointainerClass = ($oSurvey->anonymized != 'Y' ?  'yes-no-date-container' : 'yes-no-container');
 $locale = convertLStoDateTimePickerLocale(Yii::app()->session['adminlang']);
 ?>

--- a/application/views/layouts/sidemenu.php
+++ b/application/views/layouts/sidemenu.php
@@ -42,8 +42,9 @@
         "top" => [],
         "bottom" => [],
     ];
+    $oSurvey = Survey::model()->findByPk($surveyid);
     foreach ($menuObjectArray as $position => $arr) {
-        $menuObjectArray[$position] = Survey::model()->findByPk($surveyid)->getSurveyMenus($position);
+        $menuObjectArray[$position] = $oSurvey->getSurveyMenus($position);
     }
 
     Yii::app()->getClientScript()->registerScript('SideBarGlobalObject', '
@@ -57,7 +58,7 @@
             gid: '.($gid ?? 'null').',
             options: [],
             surveyid: '.$surveyid.',
-            isActive: '.(Survey::model()->findByPk($surveyid)->isActive ? "true" : "false").',
+            isActive: '.($oSurvey->isActive ? "true" : "false").',
             basemenus: '.json_encode($menuObjectArray).',
             updateOrderLink: "'.$updateOrderLink.'",
             unlockLockOrganizerUrl: "'.$unlockLockOrganizerUrl.'",


### PR DESCRIPTION
went through the code looking specifically uses of un-necessary duplicate survey findByPk() calls. 
There is a plugin event related to Survey afterFind() so any such call will also run the event and any plugin attached to that event. relates to #3816

