### PR TITLE
New feature #17227: Set role for new ldap users automatically

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -117,6 +117,15 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
         'allowInitialUser' => array(
             'type' => 'checkbox',
             'label' => 'Allow initial user to login via LDAP',
+        ),
+        // Need to be defined here otherwise saving does not work
+        'defaultRole' => array(
+            'type' => 'select',
+            'options' => array(),
+            'htmlOptions' => array('empty' => 'None'),
+            'default' => 'none', 
+            'label' => 'Select a default role for all LDAP users',
+            'help' => 'The role must have the "Use LDAP authentication" permission. Other global permissions are disabled.'
         )
     );
 
@@ -390,6 +399,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
     /**
      * Modified getPluginSettings since we have a select box that autosubmits
      * and we only want to show the relevant options.
+     * Also append existing roles as options during runtime.
      *
      * @param boolean $getValues
      * @return array
@@ -397,6 +407,15 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
     public function getPluginSettings($getValues = true)
     {
         $aPluginSettings = parent::getPluginSettings($getValues);
+        // Dynamically append available roles as options
+        $roles = $this->api->getRoles();
+        $roleOptions = array();
+        foreach ($roles as $role){
+            $roleOptions[$role->ptid] = $role->name;
+        }
+        
+        $aPluginSettings['defaultRole']['options'] = $roleOptions;
+
         if ($getValues) {
             $ldapmode = $aPluginSettings['ldapmode']['current'];
             $ldapver = $aPluginSettings['ldapversion']['current'];
@@ -485,6 +504,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
         $bindpwd = $this->get('bindpwd');
         $groupsearchbase        = $this->get('groupsearchbase');
         $groupsearchfilter      = $this->get('groupsearchfilter');
+        $defaultrole   = $this->get('defaultRole');
 
         /* Get the conexion, createConnection return an error in array, never return false */
         $ldapconn = $this->createConnection();
@@ -589,6 +609,20 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
             }
         }
         // If we made it here, authentication was a success and we do have a valid user
+        
+        // If requested assign role to user
+        if (!empty($defaultrole)){
+            // Ensure $defaultrole is a valid ptid 
+            // the id can be invalid if the role set as default is deleted and 
+            // the plugin settings are never saved after
+            $role = $this->api->getRole($defaultrole);
+            if ($role !== null) {
+                $this->api->addUserInRole($defaultrole, $user->uid);
+            }else{
+                $this->log("Trying to assign a non existend role. Check and save the LDAP Plugin Settings", \CLogger::LEVEL_WARNING);
+            }
+        }
+
         $this->pluginManager->dispatchEvent(new PluginEvent('newUserLogin', $this));
         /* Set the username as found in LimeSurvey */
         $this->setUsername($user->users_name);

--- a/application/libraries/PluginManager/LimesurveyApi.php
+++ b/application/libraries/PluginManager/LimesurveyApi.php
@@ -513,6 +513,73 @@ class LimesurveyApi
         return \UserGroup::model()->findAllAsArray();
     }
 
+
+    /**
+     * Returns an array of all roles / permissiontemplates
+     *
+     * @return array
+     */
+    public function getRoles()
+    {
+        return \Permissiontemplates::model()->findAllAsArray();    
+    }
+
+
+    /**
+     * Returns a role / permissiontemplate object by $ptid
+     * Returns null if the object does not exist
+     *
+     * @param int $ptid The role / permissiontemplate ID
+     * @return \Permissiontemplates|null
+     */
+    public function getRole($ptid)
+    {
+        return \Permissiontemplates::model()->findByAttributes(array('ptid' => $ptid));
+    }
+
+
+    /**
+     * Adds a new role / permissiontemplate object
+     * Returns null if the object does not exist
+     *
+     * @param string $roleName The name vor the new role
+     * @param string $description The description of the new role 
+     * @param int $create_by user uid . Default is the admin user (1)
+     * @return boolean True or false if role was added or not
+     */
+    public function addRole($roleName, $description, $created_by = 1)
+    {
+        $roleName = flattenText($roleName, false, true, 'UTF-8', true);
+        $description = flattenText($description);
+        if (isset($roleName) && strlen((string) $roleName) > 0) {
+            $newRole = new \Permissiontemplates();
+            $newRole->name = $roleName;
+            $newRole->description = $description;
+            $newRole->created_by = $created_by;
+            # @todo formate of date ?
+            $newRole->created_at = date('Y-m-d H:i:s');
+            $newRole->renewed_last = date('Y-m-d H:i:s');
+            return (boolean) $newRole->save();
+        }else {
+            throw new InvalidArgumentException('must provide a role name');
+        }
+    }
+
+    /**
+     * Adds a role to a User
+     * @param integer $ptid The ID of the role/ permissiontemplate the user should be added to
+     * @param integer $uid The Id of the user that should have the new role assigned  
+     */
+    public function addUserInRole($ptid, $uid)
+    {
+        $role = $this->getRole($ptid);
+        if ($role !== null ){
+            return $role -> applyToUser($uid);
+        }else{
+            throw new InvalidArgumentException('Ust provide a valid ptid / permissiontemplate can not be found');    
+        }
+    }
+
     /**
      * Returns a UserGroup object by ugid
      * Returns null if the object does not exist
@@ -537,6 +604,8 @@ class LimesurveyApi
     {
         return \UserInGroup::model()->findByPk(array('ugid' => $ugid, 'uid' => $uid));
     }
+
+    
 
     /**
      * Adds a new user group

--- a/application/models/Permissiontemplates.php
+++ b/application/models/Permissiontemplates.php
@@ -279,6 +279,21 @@ class Permissiontemplates extends CActiveRecord
     }
 
     /**
+     * Finds all active records satisfying the specified condition but returns them as array
+     * 
+     * See {@link find()} for detailed explanation about $condition and $params.
+     * @param mixed $condition query condition or criteria.
+     * @param array $params parameters to be bound to an SQL statement.
+     * @return array list of active records satisfying the specified condition. An empty array is returned if none is found.
+     */
+    public function findAllAsArray($condition = '', $params = [])
+    {
+        Yii::trace(get_class($this) . '.findAll()', 'system.db.ar.CActiveRecord');
+        $criteria = $this->getCommandBuilder()->createCriteria($condition, $params);
+        return $this->query($criteria, true, false); //Notice the third parameter 'false'
+    }
+
+    /**
      * @return SimpleXMLElement
      */
     public function compileExportXML()


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

New feature #17227: Set role for new ldap users automatically
Dev: Please advice on date format in the LimesurveyApi function addRole. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable default role setting for LDAP authentication. Administrators can now select a role to automatically assign to users upon successful LDAP authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->