### PR TITLE
Fixed issue #19555: afterFindSurvey gets triggered excessively

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1008,7 +1008,9 @@ class Survey extends LSActiveRecord implements PermissionInterface
             }
         }
         $model = parent::findByPk($pk, $condition, $params);
-        $model ?? $model->afterFindSurvey();
+        if (!is_null($model)) {
+            $model->afterFindSurvey();
+        }
         return $model;
     }
 

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1008,7 +1008,7 @@ class Survey extends LSActiveRecord implements PermissionInterface
             }
         }
         $model = parent::findByPk($pk, $condition, $params);
-            $model ?? $model->afterFindSurvey();
+        $model ?? $model->afterFindSurvey();
         return $model;
     }
 

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -185,7 +185,6 @@ class Survey extends LSActiveRecord implements PermissionInterface
         if ($this->isNewRecord) {
             $this->setAttributeDefaults();
         }
-        $this->attachEventHandler("onAfterFind", array($this, 'afterFindSurvey'));
     }
 
     private function setAttributeDefaults()
@@ -1003,11 +1002,13 @@ class Survey extends LSActiveRecord implements PermissionInterface
                 $model = parent::findByPk($pk, $condition, $params);
                 if (!is_null($model)) {
                     self::$findByPkCache[$pk] = $model;
+                    $model->afterFindSurvey();
                 }
                 return $model;
             }
         }
         $model = parent::findByPk($pk, $condition, $params);
+            $model ?? $model->afterFindSurvey();
         return $model;
     }
 


### PR DESCRIPTION
There is some additional discussion regarding this fix in #3816

The [afterFindSurvey event](https://manual.limesurvey.org/AfterFindSurvey) gets triggered each time survey is found found via `Survey::findByPk()`, but as well always when survey is found via relations eg `$question->survey`. 

With a survey page of multiple questions and even sub-questions the event `afterFindSurvey` might get triggered tens of times on one survey page load. 

There is a discussion whether this is a  bug or a feature. 

1) It's a feature view
`afterFindSurvey` event is tightly related to instantianting any survey object, also meaning it must be triggered after initializing a survey via relations or any time a survey object is populated. In this case it is not a bug and we should not fix it, this PR should be closed.

2) It's a bug view
The event manual states that the event is for:
> to be able to modify/override some display parameters for current display session

This means the whole display session (survey page) - meaning it does not need to be triggered tens of times during a a page load. 
It is not related to initializing _any_ Survey object it is meant specifically to trigger after `Survey::findByPk()`. In this case It's a bug and this PR will move the triggering essentially from populating any survey record to specifically only if `Survey::findByPk()` returns a new object (not stored also via `Survey::$findByPkCache`)