### PR TITLE
Fixed issue: On group/question preview a PHP error is thrown if the qid/gid is invalid

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -157,7 +157,7 @@ class SurveysController extends LSYii_Controller
         $aError['type'] = $error['code'];
         $aError['error'] = $title;
         if (!empty($error['message'])) {
-            $aError['title'] = ' - ' . nl2br(CHtml::encode($error['message']) ?? '');   
+            $aError['title'] = ' - ' . nl2br(CHtml::encode($error['message']) ?? '');
         }
         $aError['message'] = $message;
         $aError['contact'] = $contact;

--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -126,7 +126,7 @@ class SurveysController extends LSYii_Controller
                 /* CRSF issue */
                 $title = gT('400: Bad Request');
                 $message = gT('The request could not be understood by the server due to malformed syntax.')
-                    . gT('Please do not repeat the request without modifications.');
+                    . ' ' . gT('Please do not repeat the request without modifications.');
                 break;
             case '401':
                 $title = gT('401: Unauthorized');
@@ -156,7 +156,9 @@ class SurveysController extends LSYii_Controller
         }
         $aError['type'] = $error['code'];
         $aError['error'] = $title;
-        $aError['title'] = nl2br(CHtml::encode($error['message']) ?? '');
+        if (!empty($error['message'])) {
+            $aError['title'] = ' - ' . nl2br(CHtml::encode($error['message']) ?? '');   
+        }
         $aError['message'] = $message;
         $aError['contact'] = $contact;
 

--- a/application/controllers/survey/SurveyIndex.php
+++ b/application/controllers/survey/SurveyIndex.php
@@ -106,8 +106,18 @@ class SurveyIndex extends CAction
                 throw new CHttpException(401, $message);
             } else {
                 killSurveySession($surveyid);
-                if ((intval($param['qid']) && $param['action'] == 'previewquestion')) {
+                // Check if group exists
+                $arGroup = QuestionGroup::model()->findByPk(intval($param['gid']));
+                if (empty($arGroup)) {
+                    throw new CHttpException(400, gT("Invalid group ID"));
+                }
+                if ($param['action'] == 'previewquestion') {
                     $previewmode = 'question';
+                    // Check if question exists
+                    $arQuestion = Question::model()->findByPk(intval($param['qid']));
+                    if (empty($arQuestion)) {
+                        throw new CHttpException(400, gT("Invalid question ID"));
+                    }
                 }
                 if ((intval($param['gid']) && $param['action'] == 'previewgroup')) {
                     $previewmode = 'group';
@@ -649,7 +659,7 @@ class SurveyIndex extends CAction
     private function getParameters($args = array(), $post = array())
     {
         $param = array();
-        if (@$args[0] == __CLASS__) {
+        if (isset($args[0]) && $args[0] == __CLASS__) {
             array_shift($args);
         }
         $iArgCount = count($args);

--- a/application/controllers/survey/SurveyIndex.php
+++ b/application/controllers/survey/SurveyIndex.php
@@ -106,15 +106,15 @@ class SurveyIndex extends CAction
                 throw new CHttpException(401, $message);
             } else {
                 killSurveySession($surveyid);
-                // Check if group exists
-                $arGroup = QuestionGroup::model()->findByPk(intval($param['gid']));
+                // Check if group exists in this survey
+                $arGroup = QuestionGroup::model()->find("sid = :sid and gid = :gid", [":sid" => $surveyid, ":gid" => intval($param['gid'])]);
                 if (empty($arGroup)) {
                     throw new CHttpException(400, gT("Invalid group ID"));
                 }
                 if ($param['action'] == 'previewquestion') {
                     $previewmode = 'question';
-                    // Check if question exists
-                    $arQuestion = Question::model()->findByPk(intval($param['qid']));
+                    // Check if question exists in this survey and group
+                    $arQuestion = Question::model()->find("sid = :sid and qid = :qid and gid = :gid", [":sid" => $surveyid, ":qid" => intval($param['qid']), ":gid" => intval($param['gid'])]);
                     if (empty($arQuestion)) {
                         throw new CHttpException(400, gT("Invalid question ID"));
                     }

--- a/application/core/SurveyCommonAction.php
+++ b/application/core/SurveyCommonAction.php
@@ -162,7 +162,7 @@ class SurveyCommonAction extends CAction
         if (!empty($params['iGroupId'])) {
             if ((string) (int) $params['iGroupId'] !== (string) $params['iGroupId']) {
                 // pgsql need filtering before find
-                throw new CHttpException(403, gT("Invalid group id"));
+                throw new CHttpException(403, gT("Invalid group ID"));
             }
             $oGroup = QuestionGroup::model()->find("gid=:gid", array(":gid" => $params['iGroupId'])); //Move this in model to use cache
             if (!$oGroup) {


### PR DESCRIPTION
Fixes the issue that using invalid question ID or group ID in the preview URL would throw the PHP error
500: Internal Server Error array_key_exists(): Argument #2 ($array) must be of type array, null given 

Now question ID and group ID are checked if they exist in that particualr survey (and group)