### PR TITLE
Fixed issue #CT-778: wrong placeholder fields in html editor

### DIFF
--- a/application/controllers/LimereplacementfieldsController.php
+++ b/application/controllers/LimereplacementfieldsController.php
@@ -212,8 +212,26 @@ class LimeReplacementFieldsController extends LSBaseController
                 $question = "[{$row['subquestion2']}] " . $question;
             }
 
+            $replacementCode = $row['title'];
+            if (array_key_exists('aid', $row) && $row['aid'] !== '') {
+                $replacementCode = $row['title'] . '_' . $row['aid'];
+                if (array_key_exists('scale_id', $row)) {
+                    $replacementCode = $replacementCode . '_' . $row['scale_id'];
+                }
+                if (strpos($replacementCode, '_other') === false) {
+                    $replacementCode = $replacementCode . '.shown';
+                }
+            }
             $shortquestion = $row['title'] . ": " . flattenText($question);
-            $cquestions[] = array($shortquestion, $row['qid'], $row['type'], $row['fieldname'], $row['previouspage'], $row['title']);
+            $cquestions[] = array(
+                $shortquestion,
+                $row['qid'],
+                $row['type'],
+                $row['fieldname'],
+                $row['previouspage'],
+                $row['title'],
+                $replacementCode
+            );
         }
         return $cquestions;
     }

--- a/application/controllers/LimereplacementfieldsController.php
+++ b/application/controllers/LimereplacementfieldsController.php
@@ -16,8 +16,8 @@ class LimeReplacementFieldsController extends LSBaseController
 {
     /**
      *
-     * @todo: document me ...
-     *
+     * action used to provide the html editor with data for the
+     * placeholder fields modal
      * @return false|string|string[]|null
      * @throws CException
      * @throws CHttpException
@@ -75,8 +75,13 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
+     * Returns array of relevant questions based on the given fieldmap
+     *
+     * @param mixed $action
      * @param integer $gid
      * @param integer $qid
+     * @param array $fieldmap
+     * @param mixed $questionType
      * @param string $surveyformat
      * @return array
      */
@@ -102,11 +107,16 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
+     * Returns true if the question should be added to the list
+     * or false if it should not
+     * depending on the passed parameters
      *
-     * @todo: document me ..
-     *
+     * @param mixed $action
      * @param integer $gid
      * @param integer $qid
+     * @param array $question
+     * @param mixed $previousQuestion
+     * @return bool|void
      */
     private function shouldAddQuestion($action, $gid, $qid, array $question, $previousQuestion)
     {
@@ -161,11 +171,18 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
+     * Updates the question list with info on
+     * previouspage (isPreviousPageQuestion).
+     * Returns the value of $isPreviousPageQuestion
      *
-     * @todo: document me
-     *
+     * @param mixed $action
      * @param integer $gid
+     * @param array $field
+     * @param mixed $questionType
      * @param string $surveyformat
+     * @param bool $isPreviousPageQuestion
+     * @param array $questionList
+     * @return bool
      */
     private function addQuestionToList($action, $gid, array $field, $questionType, $surveyformat, $isPreviousPageQuestion, &$questionList)
     {
@@ -189,8 +206,9 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
-     *
-     * @todo: document me
+     * Returns array with relevant question data especially
+     * for limeReplacementFields view to populate the replacement field list
+     * in the html editor
      *
      * @param array $questions
      * @return array
@@ -211,17 +229,8 @@ class LimeReplacementFieldsController extends LSBaseController
             if (isset($row['subquestion2'])) {
                 $question = "[{$row['subquestion2']}] " . $question;
             }
+            $replacementCode = $this->getReplacementCodeByArray($row);
 
-            $replacementCode = $row['title'];
-            if (array_key_exists('aid', $row) && $row['aid'] !== '') {
-                $replacementCode = $row['title'] . '_' . $row['aid'];
-                if (array_key_exists('scale_id', $row)) {
-                    $replacementCode = $replacementCode . '_' . $row['scale_id'];
-                }
-                if (strpos($replacementCode, '_other') === false) {
-                    $replacementCode = $replacementCode . '.shown';
-                }
-            }
             $shortquestion = $row['title'] . ": " . flattenText($question);
             $cquestions[] = array(
                 $shortquestion,
@@ -462,14 +471,14 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
+     * Returns an multidimensional array
+     * containing the replacement fields for the given fieldtype.
+     * Probably never used.
      *
-     *
-     * @todo document me ..
-     *
-     * @param $fieldtype
-     * @param null $surveyid
-     * @param null $gid
-     * @param null $qid
+     * @param mixed $fieldtype
+     * @param integer $surveyid
+     * @param integer $gid
+     * @param integer $qid
      * @return array
      */
     public function getNewTypeResponse($fieldtype, $surveyid = null, $gid = null, $qid = null)
@@ -492,16 +501,37 @@ class LimeReplacementFieldsController extends LSBaseController
     }
 
     /**
+     * Should return previous questions as a multidimensional array.
+     * [
+     *   QUESTIONCODE_SUBQUESTIONCODE = [
+     *     "type" => 'question',
+     *     "value" => 'Question text'
+     *   ],
+     *   QUESTIONCODE = [
+     *     "type" => 'question',
+     *     "value" => 'Question text'
+     *   ],
+     * ]
      *
-     * @todo: document me
+     * Most likely not used anymore.
+     * The building of the criteria has a logical error when qid is passed.
+     * if group id is passed but no question id:
+     *   -> we get all (parent) questions of the group and of the groups before.
+     * if question id is passed
+     *   -> we get all questions of the group and of the groups before
+     *      but only those with a sortorder below the ordernumber of the
+     *      current question. (This is the error)
      *
      * @param $surveyid
-     * @param null $gid
-     * @param null $qid
+     * @param integer $gid
+     * @param integer $qid
      * @return array
      */
-    private function collectQuestionReplacements($surveyid, $gid = null, $qid = null)
-    {
+    private function collectQuestionReplacements(
+        $surveyid,
+        $gid = null,
+        $qid = null
+    ) {
         $oSurvey = Survey::model()->findByPk($surveyid);
         $oCurrentQuestion = Question::model()->findByPk($qid);
         $aResult = [];
@@ -518,11 +548,20 @@ class LimeReplacementFieldsController extends LSBaseController
 
         if ($qid != null) {
             $oCriteria->with = ['group'];
-            $oCriteria->compare('group_order', '<=' . $oCurrentQuestion->group->group_order);
+            $oCriteria->compare(
+                'group_order',
+                '<=' . $oCurrentQuestion->group->group_order
+            );
             if ($oCurrentQuestion->parent_qid != 0) {
-                $oCriteria->compare('question_order', '<' . $oCurrentQuestion->parent->question_order);
+                $oCriteria->compare(
+                    'question_order',
+                    '<' . $oCurrentQuestion->parent->question_order
+                );
             } else {
-                $oCriteria->compare('question_order', '<' . $oCurrentQuestion->question_order);
+                $oCriteria->compare(
+                    'question_order',
+                    '<' . $oCurrentQuestion->question_order
+                );
             }
         }
 
@@ -564,5 +603,31 @@ class LimeReplacementFieldsController extends LSBaseController
             }
         }
         return $aResult;
+    }
+
+    /**
+     * Analyzes the question parameters and returns the replacement code
+     * for html editor "Placeholder fields"
+     * simple questions: QUESTIONCODE.shown
+     * subquestions:  QUESTIONCODE_SUBQCODE.shown
+     * other option: QUESTIONCODE_other (.shown is not working in that case)
+     * question types using scale_id: QUESTIONCODE_SUBQCODE_SCALEID.shown
+     *
+     * @param array $question
+     * @return string
+     */
+    private function getReplacementCodeByArray(array $question)
+    {
+        $replacementCode = $question['title'];
+        if (array_key_exists('aid', $question) && $question['aid'] !== '') {
+            $replacementCode = $question['title'] . '_' . $question['aid'];
+            if (array_key_exists('scale_id', $question)) {
+                $replacementCode = $replacementCode . '_' . $question['scale_id'];
+            }
+        }
+        if (strpos($replacementCode, '_other') === false) {
+            $replacementCode = $replacementCode . '.shown';
+        }
+        return $replacementCode;
     }
 }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8632,7 +8632,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                 // NB: No break needed
             case 'code':
             case 'NAOK':
-                if (isset($var['code'])) {
+                if (array_key_exists('code', $var) && isset($var['code'])) {
                     return $var['code'];    // for static values like TOKEN
                 } else {
                     if (isset($_SESSION[$this->sessid][$sgqa])) {

--- a/application/views/limereplacementfields/limeReplacementFields_view.php
+++ b/application/views/limereplacementfields/limeReplacementFields_view.php
@@ -46,7 +46,7 @@
                     $isDisabled = " disabled='disabled'";
                 }
                 ?>
-                    <option value='<?php echo $cqn[5];?>.shown' title='<?php echo $cqn[0];?>' <?php echo $isDisabled;?>><?php echo $cqn[0];?></option>
+                    <option value='<?php echo $cqn[6];?>' title='<?php echo $cqn[0];?>' <?php echo $isDisabled;?>><?php echo $cqn[0];?></option>
                     <?php
             }
             ?>


### PR DESCRIPTION
When selecting placeholder fields for previous questions in the html editor via the { } button,
the generated qcodes where wrong for some occasions.

It was QUESTIONCODE.shown all the time.
for simple question types like textthat's ok, but subquestions/answeroptions, other option, scaleids need other formats.

What I adjusted here:

- For subquestions it is now QUESTIONCODE_SUBQCODE.shown
- For other options of those it is now  QUESTIONCODE_other (.shown is not working in that case)
- If the question has scale_ids then it is now QUESTIONCODE_SUBQCODE_SCALEID.shown

I can provide a test lss, if needed,  it is attached to task CT-778.