### PR TITLE
Fixed issue CT-896: Fixed question PDF export at statistics

### DIFF
--- a/application/views/admin/export/generatestats/_statisticsoutput_header.php
+++ b/application/views/admin/export/generatestats/_statisticsoutput_header.php
@@ -15,9 +15,9 @@
         <tr class="active">
             <th colspan='4' align='center' style='text-align: center; '>
                 <strong>
-                    <?php echo sprintf(gT("Summary for %s"),$outputs['qtitle']); ?>
+                    <?php echo sprintf(gT("Summary for %s"), $outputs['qtitle']); ?>
                 </strong>
-                <button class="float-end action_js_export_to_pdf btn btn-outline-secondary btn-sm d-print-none" data-question-id="quid_<?php echo $outputs['parentqid'];?>" data-bs-toggle="tooltip" title="<?php eT('Export this question to PDF.'); ?>">
+                <button class="float-end action_js_export_to_pdf btn btn-outline-secondary btn-sm d-print-none" data-question-id="quid_<?php echo $outputs['parentqid'];?>" data-bs-toggle="tooltip" title="<?php eT('Export this question to PDF.'); ?>" onclick="return false;">
                     <i class="ri-file-pdf-line"></i>
                 </button>
             </th>
@@ -36,19 +36,19 @@
                 </strong>
             </th>
 
-            <?php if ($bShowCount  = true): ?>
+            <?php if ($bShowCount  = true) : ?>
                 <th width='' align='center' >
                     <strong><?php eT("Count"); ?></strong>
                 </th>
             <?php endif;?>
 
-            <?php if ($bShowPercentage  = true): ?>
-                <th width='' align='center' <?=(!$bSum ? 'colspan="2"' :'')?>>
+            <?php if ($bShowPercentage  = true) : ?>
+                <th width='' align='center' <?=(!$bSum ? 'colspan="2"' : '')?>>
                     <strong><?php eT("Gross percentage");?></strong>
                 </th>
             <?php endif;?>
 
-            <?php if($bSum): ?>
+            <?php if ($bSum) : ?>
                 <th width='' align='center' >
                     <strong>
                         <?php eT("Top 2, Middle, Bottom 2");?>


### PR DESCRIPTION
Problem-statement as received:

> so I created a survey, sent it around, stopped it so I could take the statistics for my thesis. I clicked on “Ausgabeformat: html”, “Statistik-Grafiken: AN” and some of my questions, then on “Statistik anzeigen” so the statistics appeared in my browser with the table of the results and the graphics with it. Then I wanted to download this as pdf by clicking on the small button right next to it which says “Exportieren Sie diese Frage als pdf.” Something loaded but nothing was downloaded and the page still looked the same.

The problem reproduced and the cause of the problem was that while the entire page is a form, the <button> tags representing the question export as PDF were submitting the form. This PR prevents them from submitting the form.