### PR TITLE
fixed issue #19675 : error Non-static method CActiveRecord::findAll() cannot be called…

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -295,7 +295,7 @@ function convertGETtoPOST($url)
 */
 function calculateTotalFileUploadUsage()
 {
-    $aRows = Survey::findAll();
+    $aRows = Survey::model()->findAll();
     $iTotalSize = 0.0;
     foreach ($aRows as $aRow) {
         $sFilesPath = Yii::app()->getConfig("uploaddir") . '/surveys/' . $aRow->sid . '/files';


### PR DESCRIPTION
If we set a value for iFileUploadTotalSpaceMB > 0 Limesurvey crash with this error :

`Non-static method CActiveRecord::findAll() cannot be called statically`

Using model instead static call fix it