### PR TITLE
HOTFIX: wrong changes for (Fixed issue 19700) for multipleChoice ques…

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9937,7 +9937,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                 /* No validty control ? size ? */
                 break;
             case 'M':
-                if ($value != "Y" || (substr($sgq, -5) != 'other' && $other == 'Y')) {
+                if ($value != "Y" && (substr($sgq, -5) != 'other' && $other == 'Y')) {
                     $LEM->addValidityString($sgq, $value, gT("%s is an invalid value for this question"), $set);
                     return false;
                 }


### PR DESCRIPTION
Dev: HOTFIX changes in em_manager_helper lead to bug, where mulitple choice question type (M) could not be answered anymore although it is set to mandatory. It was not possible anymore for a participant to finish the survey...
