### PR TITLE
Feature/19773 make reordering tab title translatable

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -11,10 +11,10 @@
  * See COPYRIGHT.php for copyright notices and details.
  */
 
-$config['versionnumber'] = '6.6.4';
+$config['versionnumber'] = '6.6.5';
 $config['dbversionnumber'] = 623;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;
-$config['assetsversionnumber'] = '30405';
+$config['assetsversionnumber'] = '30406';
 return $config;

--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -86,7 +86,7 @@ class SurveysController extends LSYii_Controller
             // TODO: Remove? It seems this can never happen because it's already caught by LSYii_Application::onException() (see commit c792c2e).
             $this->spitOutJsonError($error, $oException);
         } elseif ($error) {
-            $this->spitOutHtmlError($error, $request->getParam('sid', $request->getParam('surveyid')));
+            $this->spitOutHtmlError($error, (int) $request->getParam('sid', $request->getParam('surveyid')));
         } else {
             throw new CHttpException(404, 'Page not found.');
         }

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4664,14 +4664,11 @@ class LimeExpressionManager
                         $value = null;  // can't upload a file via GET
                         break;
                 }
-                /* Validate validity of startingValues : do not show error */
-                if (self::checkValidityAnswer($knownVar['type'], $value, $knownVar['sgqa'], $LEM->questionSeq2relevance[$knownVar['qseq']], false)) {
-                    $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
-                    $LEM->updatedValues[$knownVar['sgqa']] = [
-                        'type'  => $knownVar['type'],
-                        'value' => $value,
-                    ];
-                }
+                $_SESSION[$LEM->sessid][$knownVar['sgqa']] = $value;
+                $LEM->updatedValues[$knownVar['sgqa']] = [
+                    'type'  => $knownVar['type'],
+                    'value' => $value,
+                ];
             }
             $LEM->_UpdateValuesInDatabase();
         }
@@ -9937,7 +9934,10 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
                 /* No validty control ? size ? */
                 break;
             case 'M':
-                if ($value != "Y" || (substr($sgq, -5) != 'other' && $other == 'Y')) {
+                if (
+                    $value != "Y" // Y is always valid
+                    && (substr($sgq, -5) != 'other' && $other == 'Y') // Other can be valid if it's other
+                ) {
                     $LEM->addValidityString($sgq, $value, gT("%s is an invalid value for this question"), $set);
                     return false;
                 }

--- a/application/views/admin/survey/organizeGroupsAndQuestions_view.php
+++ b/application/views/admin/survey/organizeGroupsAndQuestions_view.php
@@ -9,7 +9,7 @@ App()->getClientScript()->registerCssFile(Yii::app()->getConfig('publicstyleurl'
         <div class='col-md-8'>
             <?php
             $this->widget('ext.AlertWidget.AlertWidget', [
-                    'header' => 'Reordering',
+                    'header' => gT("Reordering"),
                     'text' => gT("To reorder questions/questiongroups just drag the question/group with your mouse to the desired position.") . ' ' .
                         ($surveyActivated ? gT("Survey is activated, you can not move a question to another group.") : "") . ' ' .
                         gT("After you are done, please click the 'Save' button to save your changes."),

--- a/docs/release_notes.txt
+++ b/docs/release_notes.txt
@@ -34,6 +34,9 @@ Thank you to everyone who helped with this new release!
 
 CHANGE LOG
 ------------------------------------------------------
+Changes from 6.6.4 (build 240923) to 6.6.5 (build 240924) September 24, 2024
+Fixed issue: multiple choice question cannot be answered if "other" option has been enabled
+
 Changes from 6.6.3 (build 240909) to 6.6.4 (build 240923) September 23, 2024
 +New feature #19722: Unable to use ExpressionScript code when export by remote control (#3948) (Denis Chenu)
 -Fixed issue #CR-1447:  Empty strpos() needle while importing answers to responses in debug mode (#3964) (Rami Shenouda)


### PR DESCRIPTION
n General survey settings > Overview questions & groups > Reorder (Tab)
The title (Reordering) in the blue alert info is not translatable