### PR TITLE
New feature #19774: Make labels on filtering page translatable

### DIFF
--- a/application/views/admin/export/statistics_view.php
+++ b/application/views/admin/export/statistics_view.php
@@ -35,7 +35,7 @@ echo viewHelper::getViewTestTag('statisticsIndex');
         'items' => [
             [
                 'id' => 'general-filters-item',
-                'title' => 'General filters',
+                'title' => gT('General filters'),
                 'open' => $filterchoice_state == '' && empty($summary),
                 'content' => $this->renderPartial(
                     '/admin/export/statistics_subviews/_general_filters',
@@ -56,7 +56,7 @@ echo viewHelper::getViewTestTag('statisticsIndex');
             ],
             [
                 'id' => 'response-filters-item',
-                'title' => 'Response filters',
+                'title' => gT('Response filters'),
                 'open' => $filterchoice_state == '' && empty($summary),
                 'content' => $this->renderPartial(
                     '/admin/export/statistics_subviews/_response_filters',


### PR DESCRIPTION
1) Create a new survey with one or two questions.
2) Answer the survey (two or three times) as a respondent to get some answers.
3) Go to the survey screen > settings > statistics.
4) A menu appears on the right for statistics.
It displays the menu titles in English, they are not translated.
"General filters" and "Response filters" are not translatable 