### PR TITLE
Fixed issue #19687: php8.3 compatibility - Zend (xmlrpc related)

### DIFF
--- a/application/commands/WipeCommand.php
+++ b/application/commands/WipeCommand.php
@@ -137,7 +137,7 @@ class WipeCommand extends CConsoleCommand
             Yii::app()->db->createCommand($actquery)->execute();
             $actquery = "update {{settings_global}} set stg_value='Sea_Green' where stg_name='admintheme'";
             Yii::app()->db->createCommand($actquery)->execute();
-            $actquery = "update {{plugins}} set active=0 where name='TwoFactorAdminLogin'";
+            $actquery = "update {{plugins}} set active=0 where name='TwoFactorAdminLogin' OR name='AuditLog'";
             Yii::app()->db->createCommand($actquery)->execute();
 
             foreach (LsDefaultDataSets::getTemplatesData() as $template) {

--- a/application/controllers/admin/RemoteControl.php
+++ b/application/controllers/admin/RemoteControl.php
@@ -99,7 +99,7 @@ class RemoteControl extends SurveyCommonAction
     public function test()
     {
         // Enable if you want to test this function
-        $enabled = true;
+        $enabled = false;
         if ($enabled) {
             $RPCType = Yii::app()->getConfig("RPCInterface");
             $serverUrl = App()->createAbsoluteUrl('/admin/remotecontrol');

--- a/application/controllers/admin/RemoteControl.php
+++ b/application/controllers/admin/RemoteControl.php
@@ -111,6 +111,8 @@ class RemoteControl extends SurveyCommonAction
                 require_once('Zend/XmlRpc/Client.php');
 
                 $client = new Zend_XmlRpc_Client($serverUrl);
+                // Increase timeout (default is 10 seconds). Importing the survey may take a while.
+                $client->getHttpClient()->setConfig(['timeout' => 300]);
             } elseif ($RPCType == 'json') {
                 Yii::app()->loadLibrary('jsonRPCClient');
                 $client = new jsonRPCClient($serverUrl);

--- a/application/controllers/admin/RemoteControl.php
+++ b/application/controllers/admin/RemoteControl.php
@@ -99,7 +99,7 @@ class RemoteControl extends SurveyCommonAction
     public function test()
     {
         // Enable if you want to test this function
-        $enabled = false;
+        $enabled = true;
         if ($enabled) {
             $RPCType = Yii::app()->getConfig("RPCInterface");
             $serverUrl = App()->createAbsoluteUrl('/admin/remotecontrol');

--- a/application/helpers/Zend/Exception.php
+++ b/application/helpers/Zend/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,83 +14,29 @@
  *
  * @category   Zend
  * @package    Zend
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
 * @category   Zend
 * @package    Zend
-* @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+* @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
 * @license    http://framework.zend.com/license/new-bsd     New BSD License
 */
 class Zend_Exception extends Exception
 {
-    /**
-     * @var null|Exception
-     */
-    private $_previous = null;
-
     /**
      * Construct the exception
      *
      * @param  string $msg
      * @param  int $code
      * @param  Exception $previous
-     * @return Exception
+     * @return void
      */
-    public function __construct($msg = '', $code = 0, Exception $previous = null)
+    public function __construct($msg = '', $code = 0, \Throwable $previous = null)
     {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-            parent::__construct($msg, (int) $code);
-            $this->_previous = $previous;
-        } else {
-            parent::__construct($msg, (int) $code, $previous);
-        }
-    }
-
-    /**
-     * Overloading
-     *
-     * For PHP < 5.3.0, provides access to the getPrevious() method.
-     *
-     * @param  string $method
-     * @param  array $args
-     * @return null|Exception
-     */
-    public function __call($method, array $args)
-    {
-        if ('getprevious' == strtolower($method)) {
-            return $this->_getPrevious();
-        }
-        return null;
-    }
-
-    /**
-     * String representation of the exception
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-            if (null !== ($e = $this->getPrevious())) {
-                return $e->__toString()
-                        . "\n\nNext "
-                        . parent::__toString();
-            }
-        }
-        return parent::__toString();
-    }
-
-    /**
-     * Returns previous Exception
-     *
-     * @return Exception|null
-     */
-    protected function _getPrevious()
-    {
-        return $this->_previous;
+        parent::__construct($msg, (int) $code, $previous);
     }
 }

--- a/application/helpers/Zend/Http/Client.php
+++ b/application/helpers/Zend/Http/Client.php
@@ -72,6 +72,11 @@ require_once 'Zend/Http/Response/Stream.php';
 class Zend_Http_Client
 {
     /**
+     * @var mixed|string|bool
+     */
+    protected $_stream_name;
+
+    /**
      * HTTP request methods
      */
     const GET     = 'GET';
@@ -120,7 +125,7 @@ class Zend_Http_Client
      *
      * @var array
      */
-    protected $config = array(
+    protected $config = [
         'maxredirects'    => 5,
         'strictredirects' => false,
         'useragent'       => 'Zend_Http_Client',
@@ -133,7 +138,7 @@ class Zend_Http_Client
         'output_stream'   => false,
         'encodecookies'   => true,
         'rfc3986_strict'  => false
-    );
+    ];
 
     /**
      * The adapter used to perform the actual connection to the server
@@ -154,7 +159,7 @@ class Zend_Http_Client
      *
      * @var array
      */
-    protected $headers = array();
+    protected $headers = [];
 
     /**
      * HTTP request method
@@ -168,14 +173,14 @@ class Zend_Http_Client
      *
      * @var array
      */
-    protected $paramsGet = array();
+    protected $paramsGet = [];
 
     /**
      * Associative array of POST parameters
      *
      * @var array
      */
-    protected $paramsPost = array();
+    protected $paramsPost = [];
 
     /**
      * Request body content type (for POST requests)
@@ -213,7 +218,7 @@ class Zend_Http_Client
      *
      * @var array
      */
-    protected $files = array();
+    protected $files = [];
 
     /**
      * Ordered list of keys from key/value pair data to include in body
@@ -223,7 +228,7 @@ class Zend_Http_Client
      *
      * @var array
      */
-    protected $body_field_order = array();
+    protected $body_field_order = [];
 
     /**
      * The client's cookie jar
@@ -261,13 +266,6 @@ class Zend_Http_Client
     protected $_unmaskStatus = false;
 
     /**
-     * Status if the http_build_query function escapes brackets
-     *
-     * @var boolean
-     */
-    protected $_queryBracketsEscaped = true;
-
-    /**
      * Fileinfo magic database resource
      *
      * This variable is populated the first time _detectFileMimeType is called
@@ -292,8 +290,6 @@ class Zend_Http_Client
         if ($config !== null) {
             $this->setConfig($config);
         }
-
-        $this->_queryBracketsEscaped = version_compare(phpversion(), '5.1.3', '>=');
     }
 
     /**
@@ -355,10 +351,11 @@ class Zend_Http_Client
      * @return Zend_Http_Client
      * @throws Zend_Http_Client_Exception
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
+
         } elseif (! is_array($config)) {
             /** @see Zend_Http_Client_Exception */
             require_once 'Zend/Http/Client/Exception.php';
@@ -366,7 +363,7 @@ class Zend_Http_Client
         }
 
         foreach ($config as $k => $v) {
-            $this->config[strtolower((string) $k)] = $v;
+            $this->config[strtolower($k)] = $v;
         }
 
         // Pass configuration options to the adapter if it exists
@@ -395,8 +392,7 @@ class Zend_Http_Client
             throw new Zend_Http_Client_Exception("'{$method}' is not a valid HTTP request method.");
         }
 
-        if (
-            ($method == self::POST
+        if (($method == self::POST
                 || $method == self::PUT
                 || $method == self::DELETE
                 || $method == self::PATCH
@@ -470,7 +466,7 @@ class Zend_Http_Client
         if (is_string($value)) {
             $value = trim($value);
         }
-        $this->headers[$normalized_name] = array($name, $value);
+        $this->headers[$normalized_name] = [$name, $value];
 
         return $this;
     }
@@ -504,9 +500,8 @@ class Zend_Http_Client
     public function setParameterGet($name, $value = null)
     {
         if (is_array($name)) {
-            foreach ($name as $k => $v) {
+            foreach ($name as $k => $v)
                 $this->_setParameter('GET', $k, $v);
-            }
         } else {
             $this->_setParameter('GET', $name, $value);
         }
@@ -524,9 +519,8 @@ class Zend_Http_Client
     public function setParameterPost($name, $value = null)
     {
         if (is_array($name)) {
-            foreach ($name as $k => $v) {
+            foreach ($name as $k => $v)
                 $this->_setParameter('POST', $k, $v);
-            }
         } else {
             $this->_setParameter('POST', $name, $value);
         }
@@ -544,7 +538,7 @@ class Zend_Http_Client
      */
     protected function _setParameter($type, $name, $value)
     {
-        $parray = array();
+        $parray = [];
         $type = strtolower($type);
         switch ($type) {
             case 'get':
@@ -552,10 +546,9 @@ class Zend_Http_Client
                 break;
             case 'post':
                 $parray = &$this->paramsPost;
-                if ($value === null) {
-                    if (isset($this->body_field_order[$name])) {
+                if ( $value === null ) {
+                    if (isset($this->body_field_order[$name]))
                         unset($this->body_field_order[$name]);
-                    }
                 } else {
                     $this->body_field_order[$name] = self::VTYPE_SCALAR;
                 }
@@ -563,9 +556,7 @@ class Zend_Http_Client
         }
 
         if ($value === null) {
-            if (isset($parray[$name])) {
-                unset($parray[$name]);
-            }
+            if (isset($parray[$name])) unset($parray[$name]);
         } else {
             $parray[$name] = $value;
         }
@@ -624,11 +615,11 @@ class Zend_Http_Client
                 throw new Zend_Http_Client_Exception("Invalid or not supported authentication type: '$type'");
             }
 
-            $this->auth = array(
+            $this->auth = [
                 'user' => (string) $user,
                 'password' => (string) $password,
                 'type' => $type
-            );
+            ];
         }
 
         return $this;
@@ -706,11 +697,9 @@ class Zend_Http_Client
             if ($cookie instanceof Zend_Http_Cookie) {
                 $this->cookiejar->addCookie($cookie);
             } elseif (is_string($cookie) && $value !== null) {
-                $cookie = Zend_Http_Cookie::fromString(
-                    "{$cookie}={$value}",
-                    $this->uri,
-                    $this->config['encodecookies']
-                );
+                $cookie = Zend_Http_Cookie::fromString("{$cookie}={$value}",
+                                                       $this->uri,
+                                                       $this->config['encodecookies']);
                 $this->cookiejar->addCookie($cookie);
             }
         } else {
@@ -720,16 +709,16 @@ class Zend_Http_Client
                 $cookie = $name;
             }
 
-            if (preg_match("/[=,; \t\r\n\013\014]/", (string) $cookie)) {
+            if (preg_match("/[=,; \t\r\n\013\014]/", $cookie)) {
                 /** @see Zend_Http_Client_Exception */
                 require_once 'Zend/Http/Client/Exception.php';
                 throw new Zend_Http_Client_Exception("Cookie name cannot contain these characters: =,; \t\r\n\013\014 ({$cookie})");
             }
 
-            $value = addslashes((string) $value);
+            $value = addslashes($value);
 
             if (! isset($this->headers['cookie'])) {
-                $this->headers['cookie'] = array('Cookie', '');
+                $this->headers['cookie'] = ['Cookie', ''];
             }
             $this->headers['cookie'][1] .= $cookie . '=' . $value . '; ';
         }
@@ -774,12 +763,12 @@ class Zend_Http_Client
         // Force enctype to multipart/form-data
         $this->setEncType(self::ENC_FORMDATA);
 
-        $this->files[] = array(
+        $this->files[] = [
             'formname' => $formname,
             'filename' => basename($filename),
             'ctype'    => $ctype,
             'data'     => $data
-        );
+        ];
 
         $this->body_field_order[$formname] = self::VTYPE_FILE;
 
@@ -804,7 +793,7 @@ class Zend_Http_Client
      *
      * This function is here for two reasons:
      * 1. For advanced user who would like to set their own data, already encoded
-     * 2. For backwards compatibility: If someone uses the old post($data) method.
+     * 2. For backwards compatibilty: If someone uses the old post($data) method.
      *    this method will be used to set the encoded data.
      *
      * $data can also be stream (such as file) from which the data will be read.
@@ -820,7 +809,7 @@ class Zend_Http_Client
         if (is_resource($data)) {
             // We've got stream data
             $stat = @fstat($data);
-            if ($stat) {
+            if($stat) {
                 $this->setHeaders(self::CONTENT_LENGTH, $stat['size']);
             }
         }
@@ -842,7 +831,7 @@ class Zend_Http_Client
      */
     public function setUnmaskStatus($status = true)
     {
-        $this->_unmaskStatus = (bool)$status;
+        $this->_unmaskStatus = (BOOL)$status;
         return $this;
     }
 
@@ -871,14 +860,14 @@ class Zend_Http_Client
     public function resetParameters($clearAll = false)
     {
         // Reset parameter data
-        $this->paramsGet     = array();
-        $this->paramsPost    = array();
-        $this->files         = array();
+        $this->paramsGet     = [];
+        $this->paramsPost    = [];
+        $this->files         = [];
         $this->raw_post_data = null;
         $this->enctype       = null;
 
-        if ($clearAll) {
-            $this->headers = array();
+        if($clearAll) {
+            $this->headers = [];
             $this->last_request = null;
             $this->last_response = null;
         } else {
@@ -938,7 +927,7 @@ class Zend_Http_Client
                 throw new Zend_Http_Client_Exception("Unable to load adapter '$adapter': {$e->getMessage()}", 0, $e);
             }
 
-            $adapter = new $adapter();
+            $adapter = new $adapter;
         }
 
         if (! $adapter instanceof Zend_Http_Client_Adapter_Interface) {
@@ -975,7 +964,7 @@ class Zend_Http_Client
      */
     public function setStream($streamfile = true)
     {
-        $this->setConfig(array("output_stream" => $streamfile));
+        $this->setConfig(["output_stream" => $streamfile]);
         return $this;
     }
 
@@ -996,18 +985,16 @@ class Zend_Http_Client
     protected function _openTempStream()
     {
         $this->_stream_name = $this->config['output_stream'];
-        if (!is_string($this->_stream_name)) {
+        if(!is_string($this->_stream_name)) {
             // If name is not given, create temp name
-            $this->_stream_name = tempnam(
-                $this->config['stream_tmp_dir'] ?? sys_get_temp_dir(),
-                'Zend_Http_Client'
-            );
+            $this->_stream_name = tempnam(isset($this->config['stream_tmp_dir'])?$this->config['stream_tmp_dir']:sys_get_temp_dir(),
+                 'Zend_Http_Client');
         }
 
         if (false === ($fp = @fopen($this->_stream_name, "w+b"))) {
-            if ($this->adapter instanceof Zend_Http_Client_Adapter_Interface) {
-                $this->adapter->close();
-            }
+                if ($this->adapter instanceof Zend_Http_Client_Adapter_Interface) {
+                    $this->adapter->close();
+                }
                 require_once 'Zend/Http/Client/Exception.php';
                 throw new Zend_Http_Client_Exception("Could not open temp file {$this->_stream_name}");
         }
@@ -1047,21 +1034,17 @@ class Zend_Http_Client
             $uri = clone $this->uri;
             if (! empty($this->paramsGet)) {
                 $query = $uri->getQuery();
-                if (! empty($query)) {
-                    $query .= '&';
-                }
-                $query .= http_build_query($this->paramsGet, null, '&');
+                   if (! empty($query)) {
+                       $query .= '&';
+                   }
+                $query .= http_build_query($this->paramsGet, '', '&');
                 if ($this->config['rfc3986_strict']) {
-                    $query = str_replace('+', '%20', (string) $query);
+                    $query = str_replace('+', '%20', $query);
                 }
 
                 // @see ZF-11671 to unmask for some services to foo=val1&foo=val2
                 if ($this->getUnmaskStatus()) {
-                    if ($this->_queryBracketsEscaped) {
-                        $query = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', (string) $query);
-                    } else {
-                        $query = preg_replace('/\\[(?:[0-9]|[1-9][0-9]+)\\]=/', '=', (string) $query);
-                    }
+                    $query = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
                 }
 
                 $uri->setQuery($query);
@@ -1071,21 +1054,18 @@ class Zend_Http_Client
             $headers = $this->_prepareHeaders();
 
             // check that adapter supports streaming before using it
-            if (is_resource($body) && !($this->adapter instanceof Zend_Http_Client_Adapter_Stream)) {
+            if(is_resource($body) && !($this->adapter instanceof Zend_Http_Client_Adapter_Stream)) {
                 /** @see Zend_Http_Client_Exception */
                 require_once 'Zend/Http/Client/Exception.php';
                 throw new Zend_Http_Client_Exception('Adapter does not support streaming');
             }
 
             // Open the connection, send the request and read the response
-            $this->adapter->connect(
-                $uri->getHost(),
-                $uri->getPort(),
-                ($uri->getScheme() == 'https' ? true : false)
-            );
+            $this->adapter->connect($uri->getHost(), $uri->getPort(),
+                ($uri->getScheme() == 'https' ? true : false));
 
-            if ($this->config['output_stream']) {
-                if ($this->adapter instanceof Zend_Http_Client_Adapter_Stream) {
+            if($this->config['output_stream']) {
+                if($this->adapter instanceof Zend_Http_Client_Adapter_Stream) {
                     $stream = $this->_openTempStream();
                     $this->adapter->setOutputStream($stream);
                 } else {
@@ -1095,13 +1075,8 @@ class Zend_Http_Client
                 }
             }
 
-            $this->last_request = $this->adapter->write(
-                $this->method,
-                $uri,
-                $this->config['httpversion'],
-                $headers,
-                $body
-            );
+            $this->last_request = $this->adapter->write($this->method,
+                $uri, $this->config['httpversion'], $headers, $body);
 
             $response = $this->adapter->read();
             if (! $response) {
@@ -1110,7 +1085,7 @@ class Zend_Http_Client
                 throw new Zend_Http_Client_Exception('Unable to read response, or response is empty');
             }
 
-            if ($this->config['output_stream']) {
+            if($this->config['output_stream']) {
                 $streamMetaData = stream_get_meta_data($stream);
                 if ($streamMetaData['seekable']) {
                     rewind($stream);
@@ -1119,7 +1094,7 @@ class Zend_Http_Client
                 $this->adapter->setOutputStream(null);
                 $response = Zend_Http_Response_Stream::fromStream($response, $stream);
                 $response->setStreamName($this->_stream_name);
-                if (!is_string($this->config['output_stream'])) {
+                if(!is_string($this->config['output_stream'])) {
                     // we used temp name, will need to clean up
                     $response->setCleanup(true);
                 }
@@ -1138,17 +1113,17 @@ class Zend_Http_Client
 
             // If we got redirected, look for the Location header
             if ($response->isRedirect() && ($location = $response->getHeader('location'))) {
+
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers (See ZF-11283)
-                $location = trim((string) $location);
+                $location = trim($location);
 
                 // Check whether we send the exact same request again, or drop the parameters
                 // and send a GET request
-                if (
-                    $response->getStatus() == 303 ||
-                    ((! $this->config['strictredirects']) && ($response->getStatus() == 302 ||
-                       $response->getStatus() == 301))
-                ) {
+                if ($response->getStatus() == 303 ||
+                   ((! $this->config['strictredirects']) && ($response->getStatus() == 302 ||
+                       $response->getStatus() == 301))) {
+
                     $this->resetParameters();
                     $this->setMethod(self::GET);
                 }
@@ -1157,7 +1132,9 @@ class Zend_Http_Client
                 if (($scheme = substr($location, 0, 6)) && ($scheme == 'http:/' || $scheme == 'https:')) {
                     $this->setHeaders('host', null);
                     $this->setUri($location);
+
                 } else {
+
                     // Split into path and query and set the query
                     if (strpos($location, '?') !== false) {
                         list($location, $query) = explode('?', $location, 2);
@@ -1167,22 +1144,24 @@ class Zend_Http_Client
                     $this->uri->setQuery($query);
 
                     // Else, if we got just an absolute path, set it
-                    if (strpos($location, '/') === 0) {
+                    if(strpos($location, '/') === 0) {
                         $this->uri->setPath($location);
 
                         // Else, assume we have a relative path
                     } else {
                         // Get the current path directory, removing any trailing slashes
                         $path = $this->uri->getPath();
-                        $path = rtrim(substr((string) $path, 0, strrpos((string) $path, '/')), "/");
+                        $path = rtrim(substr($path, 0, strrpos($path, '/')), "/");
                         $this->uri->setPath($path . '/' . $location);
                     }
                 }
                 ++$this->redirectCounter;
+
             } else {
                 // If we didn't get any location, stop redirecting
                 break;
             }
+
         } while ($this->redirectCounter < $this->config['maxredirects']);
 
         return $response;
@@ -1195,18 +1174,19 @@ class Zend_Http_Client
      */
     protected function _prepareHeaders()
     {
-        $headers = array();
+        $headers = [];
 
         // Set the host header
         if (! isset($this->headers['host'])) {
             $host = $this->uri->getHost();
 
             // If the port is not default, add it
-            if (
-                ! (($this->uri->getScheme() == 'http' && $this->uri->getPort() == 80) ||
-                  ($this->uri->getScheme() == 'https' && $this->uri->getPort() == 443))
-            ) {
-                $host .= ':' . $this->uri->getPort();
+            $scheme = $this->uri->getScheme();
+            $port = $this->uri->getPort();
+
+            if (!(($scheme === 'http' && $port == 80) ||
+                  ($scheme === 'https' && $port == 443))) {
+                $host .= ':' . $port;
             }
 
             $headers[] = "Host: {$host}";
@@ -1230,10 +1210,9 @@ class Zend_Http_Client
         }
 
         // Set the Content-Type header
-        if (
-            ($this->method == self::POST || $this->method == self::PUT) &&
-            (! isset($this->headers[strtolower(self::CONTENT_TYPE)]) && isset($this->enctype))
-        ) {
+        if (($this->method == self::POST || $this->method == self::PUT) &&
+           (! isset($this->headers[strtolower(self::CONTENT_TYPE)]) && isset($this->enctype))) {
+
             $headers[] = self::CONTENT_TYPE . ': ' . $this->enctype;
         }
 
@@ -1250,11 +1229,8 @@ class Zend_Http_Client
 
         // Load cookies from cookie jar
         if (isset($this->cookiejar)) {
-            $cookstr = $this->cookiejar->getMatchingCookies(
-                $this->uri,
-                true,
-                Zend_Http_CookieJar::COOKIE_STRING_CONCAT
-            );
+            $cookstr = $this->cookiejar->getMatchingCookies($this->uri,
+                true, Zend_Http_CookieJar::COOKIE_STRING_CONCAT);
 
             if ($cookstr) {
                 $headers[] = "Cookie: {$cookstr}";
@@ -1292,10 +1268,9 @@ class Zend_Http_Client
         }
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
-        if (
-            function_exists('mb_internal_encoding') &&
-            ((int) ini_get('mbstring.func_overload')) & 2
-        ) {
+        if (function_exists('mb_internal_encoding') &&
+           ((int) ini_get('mbstring.func_overload')) & 2) {
+
             $mbIntEnc = mb_internal_encoding();
             mb_internal_encoding('ASCII');
         }
@@ -1313,25 +1288,25 @@ class Zend_Http_Client
         $body = '';
 
         // If we have files to upload, force enctype to multipart/form-data
-        if (count($this->files) > 0) {
+        if (count ($this->files) > 0) {
             $this->setEncType(self::ENC_FORMDATA);
         }
 
         // If we have POST parameters or files, encode and add them to the body
         if (count($this->paramsPost) > 0 || count($this->files) > 0) {
-            switch ($this->enctype) {
+            switch($this->enctype) {
                 case self::ENC_FORMDATA:
                     // Encode body as multipart/form-data
                     $boundary = '---ZENDHTTPCLIENT-' . md5(microtime());
                     $this->setHeaders(self::CONTENT_TYPE, self::ENC_FORMDATA . "; boundary={$boundary}");
 
                     // Encode all files and POST vars in the order they were given
-                    foreach ($this->body_field_order as $fieldName => $fieldType) {
+                    foreach ($this->body_field_order as $fieldName=>$fieldType) {
                         switch ($fieldType) {
                             case self::VTYPE_FILE:
                                 foreach ($this->files as $file) {
-                                    if ($file['formname'] === $fieldName) {
-                                        $fhead = array(self::CONTENT_TYPE => $file['ctype']);
+                                    if ($file['formname']===$fieldName) {
+                                        $fhead = [self::CONTENT_TYPE => $file['ctype']];
                                         $body .= self::encodeFormData($boundary, $file['formname'], $file['data'], $file['filename'], $fhead);
                                     }
                                 }
@@ -1375,7 +1350,7 @@ class Zend_Http_Client
 
         // Set the Content-Length if we have a body or if request is POST/PUT
         if ($body || $this->method == self::POST || $this->method == self::PUT) {
-            $this->setHeaders(self::CONTENT_LENGTH, strlen((string) $body));
+            $this->setHeaders(self::CONTENT_LENGTH, strlen($body));
         }
 
         if (isset($mbIntEnc)) {
@@ -1405,15 +1380,13 @@ class Zend_Http_Client
     protected function _getParametersRecursive($parray, $urlencode = false)
     {
         // Issue a deprecated notice
-        trigger_error(
-            "The " .  __METHOD__ . " method is deprecated and will be dropped in 2.0.",
-            E_USER_NOTICE
-        );
+        trigger_error("The " .  __METHOD__ . " method is deprecated and will be dropped in 2.0.",
+            E_USER_NOTICE);
 
         if (! is_array($parray)) {
             return $parray;
         }
-        $parameters = array();
+        $parameters = [];
 
         foreach ($parray as $name => $value) {
             if ($urlencode) {
@@ -1425,15 +1398,15 @@ class Zend_Http_Client
                 $name .= ($urlencode ? '%5B%5D' : '[]');
                 foreach ($value as $subval) {
                     if ($urlencode) {
-                        $subval = urlencode((string) $subval);
+                        $subval = urlencode($subval);
                     }
-                    $parameters[] = array($name, $subval);
+                    $parameters[] = [$name, $subval];
                 }
             } else {
                 if ($urlencode) {
-                    $value = urlencode((string) $value);
+                    $value = urlencode($value);
                 }
-                $parameters[] = array($name, $value);
+                $parameters[] = [$name, $value];
             }
         }
 
@@ -1445,7 +1418,7 @@ class Zend_Http_Client
      *
      * This method will try to detect the MIME type of a file. If the fileinfo
      * extension is available, it will be used. If not, the mime_magic
-     * extension which is deprected but is still available in many PHP setups
+     * extension which is deprecated but is still available in many PHP setups
      * will be tried.
      *
      * If neither extension is available, the default application/octet-stream
@@ -1467,6 +1440,7 @@ class Zend_Http_Client
             if (self::$_fileInfoDb) {
                 $type = finfo_file(self::$_fileInfoDb, $file);
             }
+
         } elseif (function_exists('mime_content_type')) {
             $type = mime_content_type($file);
         }
@@ -1489,10 +1463,10 @@ class Zend_Http_Client
      * @param array $headers Associative array of optional headers @example ("Content-Transfer-Encoding" => "binary")
      * @return string
      */
-    public static function encodeFormData($boundary, $name, $value, $filename = null, $headers = array())
+    public static function encodeFormData($boundary, $name, $value, $filename = null, $headers = [])
     {
         $ret = "--{$boundary}\r\n" .
-            'Content-Disposition: form-data; name="' . $name . '"';
+            'Content-Disposition: form-data; name="' . $name .'"';
 
         if ($filename) {
             $ret .= '; filename="' . $filename . '"';
@@ -1571,9 +1545,10 @@ class Zend_Http_Client
             return $parray;
         }
 
-        $parameters = array();
+        $parameters = [];
 
-        foreach ($parray as $name => $value) {
+        foreach($parray as $name => $value) {
+
             // Calculate array key
             if ($prefix) {
                 if (is_int($name)) {
@@ -1587,8 +1562,9 @@ class Zend_Http_Client
 
             if (is_array($value)) {
                 $parameters = array_merge($parameters, self::_flattenParametersArray($value, $key));
+
             } else {
-                $parameters[] = array($key, $value);
+                $parameters[] = [$key, $value];
             }
         }
 

--- a/application/helpers/Zend/Http/Client/Adapter/Curl.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Curl.php
@@ -52,14 +52,14 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
      *
      * @var array
      */
-    protected $_config = array();
+    protected $_config = [];
 
     /**
      * What host/port are we connected to?
      *
      * @var array
      */
-    protected $_connected_to = array(null, null);
+    protected $_connected_to = [null, null];
 
     /**
      * The curl session handle
@@ -103,7 +103,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception('cURL extension has to be loaded to use this Zend_Http_Client adapter.');
         }
-        $this->_invalidOverwritableCurlOptions = array(
+        $this->_invalidOverwritableCurlOptions = [
             CURLOPT_HTTPGET,
             CURLOPT_POST,
             CURLOPT_PUT,
@@ -119,7 +119,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
             CURLOPT_CONNECTTIMEOUT,
             CURL_HTTP_VERSION_1_1,
             CURL_HTTP_VERSION_1_0,
-        );
+        ];
     }
 
     /**
@@ -129,10 +129,11 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
      * @param  Zend_Config | array $config
      * @return Zend_Http_Client_Adapter_Curl
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
+
         } elseif (! is_array($config)) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception(
@@ -140,14 +141,14 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
             );
         }
 
-        if (isset($config['proxy_user']) && isset($config['proxy_pass'])) {
-            $this->setCurlOption(CURLOPT_PROXYUSERPWD, $config['proxy_user'] . ":" . $config['proxy_pass']);
+        if(isset($config['proxy_user']) && isset($config['proxy_pass'])) {
+            $this->setCurlOption(CURLOPT_PROXYUSERPWD, $config['proxy_user'].":".$config['proxy_pass']);
             unset($config['proxy_user'], $config['proxy_pass']);
         }
 
         foreach ($config as $k => $v) {
-            $option = strtolower((string) $k);
-            switch ($option) {
+            $option = strtolower($k);
+            switch($option) {
                 case 'proxy_host':
                     $this->setCurlOption(CURLOPT_PROXY, $v);
                     break;
@@ -168,22 +169,22 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
       *
       * @return array
       */
-    public function getConfig()
-    {
-        return $this->_config;
-    }
+     public function getConfig()
+     {
+         return $this->_config;
+     }
 
     /**
      * Direct setter for cURL adapter related options.
      *
      * @param  string|int $option
      * @param  mixed $value
-     * @return Zend_Http_Adapter_Curl
+     * @return Zend_Http_Client_Adapter_Curl
      */
     public function setCurlOption($option, $value)
     {
         if (!isset($this->_config['curloptions'])) {
-            $this->_config['curloptions'] = array();
+            $this->_config['curloptions'] = [];
         }
         $this->_config['curloptions'][$option] = $value;
         return $this;
@@ -206,8 +207,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
         }
 
         // If we are connected to a different server or port, disconnect first
-        if (
-            $this->_curl
+        if ($this->_curl
             && is_array($this->_connected_to)
             && ($this->_connected_to[0] != $host
             || $this->_connected_to[1] != $port)
@@ -217,8 +217,9 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
 
         // Do the actual connection
         $this->_curl = curl_init();
+
         if ($port != 80) {
-            curl_setopt($this->_curl, CURLOPT_PORT, intval($port));
+            curl_setopt($this->_curl, CURLOPT_PORT, (int)$port);
         }
 
         // Set connection timeout
@@ -262,7 +263,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
         }
 
         // Update connected_to
-        $this->_connected_to = array($host, $port);
+        $this->_connected_to = [$host, $port];
     }
 
     /**
@@ -276,7 +277,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
      * @return string        $request
      * @throws Zend_Http_Client_Adapter_Exception If connection fails, connected to wrong host, no PUT file defined, unsupported method, or unsupported cURL option
      */
-    public function write($method, $uri, $httpVersion = 1.1, $headers = array(), $body = '')
+    public function write($method, $uri, $httpVersion = 1.1, $headers = [], $body = '')
     {
         // Make sure we're properly connected
         if (!$this->_curl) {
@@ -306,15 +307,15 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
             case Zend_Http_Client::PUT:
                 // There are two different types of PUT request, either a Raw Data string has been set
                 // or CURLOPT_INFILE and CURLOPT_INFILESIZE are used.
-                if (is_resource($body)) {
+                if(is_resource($body)) {
                     $this->_config['curloptions'][CURLOPT_INFILE] = $body;
                 }
                 if (isset($this->_config['curloptions'][CURLOPT_INFILE])) {
                     // Now we will probably already have Content-Length set, so that we have to delete it
                     // from $headers at this point:
-                    foreach ($headers as $k => $header) {
-                        if (preg_match('/Content-Length:\s*(\d+)/i', (string) $header, $m)) {
-                            if (is_resource($body)) {
+                    foreach ($headers AS $k => $header) {
+                        if (preg_match('/Content-Length:\s*(\d+)/i', $header, $m)) {
+                            if(is_resource($body)) {
                                 $this->_config['curloptions'][CURLOPT_INFILESIZE] = (int)$m[1];
                             }
                             unset($headers[$k]);
@@ -326,7 +327,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
                         throw new Zend_Http_Client_Adapter_Exception("Cannot set a file-handle for cURL option CURLOPT_INFILE without also setting its size in CURLOPT_INFILESIZE.");
                     }
 
-                    if (is_resource($body)) {
+                    if(is_resource($body)) {
                         $body = '';
                     }
 
@@ -368,7 +369,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
                 throw new Zend_Http_Client_Adapter_Exception("Method currently not supported");
         }
 
-        if (is_resource($body) && $curlMethod != CURLOPT_PUT) {
+        if(is_resource($body) && $curlMethod != CURLOPT_PUT) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception("Streaming requests are allowed only with PUT");
         }
@@ -380,10 +381,10 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
         curl_setopt($this->_curl, CURLOPT_HTTP_VERSION, $curlHttp);
         curl_setopt($this->_curl, $curlMethod, $curlValue);
 
-        if ($this->out_stream) {
+        if($this->out_stream) {
             // headers will be read into the response
             curl_setopt($this->_curl, CURLOPT_HEADER, false);
-            curl_setopt($this->_curl, CURLOPT_HEADERFUNCTION, array($this, "readHeader"));
+            curl_setopt($this->_curl, CURLOPT_HEADERFUNCTION, [$this, "readHeader"]);
             // and data will be written into the file
             curl_setopt($this->_curl, CURLOPT_FILE, $this->out_stream);
         } else {
@@ -443,7 +444,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
         $response = curl_exec($this->_curl);
 
         // if we used streaming, headers are already there
-        if (!is_resource($this->out_stream)) {
+        if(!is_resource($this->out_stream)) {
             $this->_response = $response;
         }
 
@@ -495,11 +496,11 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
      */
     public function close()
     {
-        if (is_resource($this->_curl)) {
+        if(is_resource($this->_curl)) {
             curl_close($this->_curl);
         }
         $this->_curl         = null;
-        $this->_connected_to = array(null, null);
+        $this->_connected_to = [null, null];
     }
 
     /**
@@ -516,7 +517,7 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
      * Set output stream for the response
      *
      * @param resource $stream
-     * @return Zend_Http_Client_Adapter_Socket
+     * @return Zend_Http_Client_Adapter_Curl
      */
     public function setOutputStream($stream)
     {

--- a/application/helpers/Zend/Http/Client/Adapter/Exception.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/Client/Adapter/Interface.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Interface.php
@@ -40,7 +40,7 @@ interface Zend_Http_Client_Adapter_Interface
      *
      * @param array $config
      */
-    public function setConfig($config = array());
+    public function setConfig($config = []);
 
     /**
      * Connect to the remote server
@@ -61,7 +61,7 @@ interface Zend_Http_Client_Adapter_Interface
      * @param string        $body
      * @return string Request as text
      */
-    public function write($method, $url, $http_ver = '1.1', $headers = array(), $body = '');
+    public function write($method, $url, $http_ver = '1.1', $headers = [], $body = '');
 
     /**
      * Read response from server

--- a/application/helpers/Zend/Http/Client/Adapter/Proxy.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Proxy.php
@@ -56,7 +56,7 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
      *
      * @var array
      */
-    protected $config = array(
+    protected $config = [
         'ssltransport'  => 'ssl',
         'sslcert'       => null,
         'sslpassphrase' => null,
@@ -67,7 +67,7 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
         'proxy_pass'    => '',
         'proxy_auth'    => Zend_Http_Client::AUTH_BASIC,
         'persistent'    => false,
-    );
+    ];
 
     /**
      * Whether HTTPS CONNECT was already negotiated with the proxy or not
@@ -125,12 +125,9 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
      * @throws Zend_Http_Client_Adapter_Exception
      */
     public function write(
-        $method,
-        $uri,
-        $http_ver = '1.1',
-        $headers = array(),
-        $body = ''
-    ) {
+        $method, $uri, $http_ver = '1.1', $headers = [], $body = ''
+    )
+    {
         // If no proxy is set, fall back to default Socket adapter
         if (!$this->config['proxy_host']) {
             return parent::write($method, $uri, $http_ver, $headers, $body);
@@ -147,8 +144,7 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
         $host = $this->config['proxy_host'];
         $port = $this->config['proxy_port'];
 
-        if (
-            $this->connected_to[0] != "tcp://$host"
+        if ($this->connected_to[0] != "tcp://$host"
             || $this->connected_to[1] != $port
         ) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
@@ -162,9 +158,8 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
             // Check to see if one already exists
             $hasProxyAuthHeader = false;
             foreach ($headers as $k => $v) {
-                if (
-                    (string) $k == 'proxy-authorization'
-                    || preg_match("/^proxy-authorization:/i", (string) $v)
+                if ((string) $k == 'proxy-authorization'
+                    || preg_match("/^proxy-authorization:/i", $v)
                 ) {
                     $hasProxyAuthHeader = true;
                     break;
@@ -174,8 +169,7 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
                 $headers[] = 'Proxy-authorization: '
                     . Zend_Http_Client::encodeAuthHeader(
                         $this->config['proxy_user'],
-                        $this->config['proxy_pass'],
-                        $this->config['proxy_auth']
+                        $this->config['proxy_pass'], $this->config['proxy_auth']
                     );
             }
         }
@@ -183,10 +177,7 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
         // if we are proxying HTTPS, preform CONNECT handshake with the proxy
         if ($uri->getScheme() == 'https' && (!$this->negotiated)) {
             $this->connectHandshake(
-                $uri->getHost(),
-                $uri->getPort(),
-                $http_ver,
-                $headers
+                $uri->getHost(), $uri->getPort(), $http_ver, $headers
             );
             $this->negotiated = true;
         }
@@ -207,13 +198,11 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
 
         // Add all headers to the request string
         foreach ($headers as $k => $v) {
-            if (is_string($k)) {
-                $v = "$k: $v";
-            }
+            if (is_string($k)) $v = "$k: $v";
             $request .= "$v\r\n";
         }
 
-        if (is_resource($body)) {
+        if(is_resource($body)) {
             $request .= "\r\n";
         } else {
             // Add the request body
@@ -228,8 +217,8 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
             );
         }
 
-        if (is_resource($body)) {
-            if (stream_copy_to_stream($body, $this->socket) == 0) {
+        if(is_resource($body)) {
+            if(stream_copy_to_stream($body, $this->socket) == 0) {
                 require_once 'Zend/Http/Client/Adapter/Exception.php';
                 throw new Zend_Http_Client_Adapter_Exception(
                     'Error writing request to server'
@@ -251,17 +240,15 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
      * @throws Zend_Http_Client_Adapter_Exception
      */
     protected function connectHandshake(
-        $host,
-        $port = 443,
-        $http_ver = '1.1',
-        array &$headers = array()
-    ) {
+        $host, $port = 443, $http_ver = '1.1', array &$headers = []
+    )
+    {
         $request = "CONNECT $host:$port HTTP/$http_ver\r\n" .
                    "Host: " . $host . "\r\n";
 
         // Process provided headers, including important ones to CONNECT request
         foreach ($headers as $k => $v) {
-            switch (strtolower(substr((string) $v, 0, strpos((string) $v, ':')))) {
+            switch (strtolower(substr($v,0,strpos($v,':')))) {
                 case 'proxy-authorization':
                     // break intentionally omitted
 
@@ -309,15 +296,15 @@ class Zend_Http_Client_Adapter_Proxy extends Zend_Http_Client_Adapter_Socket
 
         // If all is good, switch socket to secure mode. We have to fall back
         // through the different modes
-        $modes = array(
+        $modes = [
             STREAM_CRYPTO_METHOD_TLS_CLIENT,
             STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
             STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
             STREAM_CRYPTO_METHOD_SSLv2_CLIENT
-        );
+        ];
 
         $success = false;
-        foreach ($modes as $mode) {
+        foreach($modes as $mode) {
             $success = stream_socket_enable_crypto($this->socket, true, $mode);
             if ($success) {
                 break;

--- a/application/helpers/Zend/Http/Client/Adapter/Socket.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Socket.php
@@ -58,7 +58,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      *
      * @var array
      */
-    protected $connected_to = array(null, null);
+    protected $connected_to = [null, null];
 
     /**
      * Stream for storing output
@@ -72,13 +72,13 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      *
      * @var array
      */
-    protected $config = array(
+    protected $config = [
         'persistent'    => false,
         'ssltransport'  => 'ssl',
         'sslcert'       => null,
         'sslpassphrase' => null,
         'sslusecontext' => false
-    );
+    ];
 
     /**
      * Request method - will be set by write() and might be used by read()
@@ -107,10 +107,11 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      *
      * @param Zend_Config | array $config
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
+
         } elseif (! is_array($config)) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception(
@@ -119,7 +120,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         }
 
         foreach ($config as $k => $v) {
-            $this->config[strtolower((string) $k)] = $v;
+            $this->config[strtolower($k)] = $v;
         }
     }
 
@@ -128,10 +129,10 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
       *
       * @return array
       */
-    public function getConfig()
-    {
-        return $this->config;
-    }
+     public function getConfig()
+     {
+         return $this->config;
+     }
 
      /**
      * Set the stream context for the TCP connection to the server
@@ -150,8 +151,10 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
     {
         if (is_resource($context) && get_resource_type($context) == 'stream-context') {
             $this->_context = $context;
+
         } elseif (is_array($context)) {
             $this->_context = stream_context_create($context);
+
         } else {
             // Invalid parameter
             require_once 'Zend/Http/Client/Adapter/Exception.php';
@@ -193,9 +196,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
 
         // If we are connected to the wrong host, disconnect first
         if (($this->connected_to[0] != $host || $this->connected_to[1] != $port)) {
-            if (is_resource($this->socket)) {
-                $this->close();
-            }
+            if (is_resource($this->socket)) $this->close();
         }
 
         // Now, if we are not connected, connect
@@ -203,27 +204,15 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             $context = $this->getStreamContext();
             if ($secure || $this->config['sslusecontext']) {
                 if ($this->config['sslcert'] !== null) {
-                    if (
-                        ! stream_context_set_option(
-                            $context,
-                            'ssl',
-                            'local_cert',
-                            $this->config['sslcert']
-                        )
-                    ) {
+                    if (! stream_context_set_option($context, 'ssl', 'local_cert',
+                                                    $this->config['sslcert'])) {
                         require_once 'Zend/Http/Client/Adapter/Exception.php';
                         throw new Zend_Http_Client_Adapter_Exception('Unable to set sslcert option');
                     }
                 }
                 if ($this->config['sslpassphrase'] !== null) {
-                    if (
-                        ! stream_context_set_option(
-                            $context,
-                            'ssl',
-                            'passphrase',
-                            $this->config['sslpassphrase']
-                        )
-                    ) {
+                    if (! stream_context_set_option($context, 'ssl', 'passphrase',
+                                                    $this->config['sslpassphrase'])) {
                         require_once 'Zend/Http/Client/Adapter/Exception.php';
                         throw new Zend_Http_Client_Adapter_Exception('Unable to set sslpassphrase option');
                     }
@@ -231,35 +220,36 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             }
 
             $flags = STREAM_CLIENT_CONNECT;
-            if ($this->config['persistent']) {
-                $flags |= STREAM_CLIENT_PERSISTENT;
-            }
+            if ($this->config['persistent']) $flags |= STREAM_CLIENT_PERSISTENT;
 
-            $this->socket = @stream_socket_client(
-                $host . ':' . $port,
-                $errno,
-                $errstr,
-                (int) $this->config['timeout'],
-                $flags,
-                $context
-            );
+            $this->socket = @stream_socket_client($host . ':' . $port,
+                                                  $errno,
+                                                  $errstr,
+                                                  (int) $this->config['timeout'],
+                                                  $flags,
+                                                  $context);
 
             if (! $this->socket) {
                 $this->close();
                 require_once 'Zend/Http/Client/Adapter/Exception.php';
                 throw new Zend_Http_Client_Adapter_Exception(
-                    'Unable to Connect to ' . $host . ':' . $port . '. Error #' . $errno . ': ' . $errstr
-                );
+                    'Unable to Connect to ' . $host . ':' . $port . '. Error #' . $errno . ': ' . $errstr);
+            }
+
+            //distinguish between request timeout and connect timeout like in curl adapter
+            // request_timeout defaults to connection timeout to keep backwards compatibility
+            if(!array_key_exists('request_timeout', $this->config)) {
+                $this->config['request_timeout'] = $this->config['timeout'];
             }
 
             // Set the stream timeout
-            if (! stream_set_timeout($this->socket, (int) $this->config['timeout'])) {
+            if (! stream_set_timeout($this->socket, (int) $this->config['request_timeout'])) {
                 require_once 'Zend/Http/Client/Adapter/Exception.php';
                 throw new Zend_Http_Client_Adapter_Exception('Unable to set the connection timeout');
             }
 
             // Update connected_to
-            $this->connected_to = array($host, $port);
+            $this->connected_to = [$host, $port];
         }
     }
 
@@ -273,7 +263,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      * @param string        $body
      * @return string Request as string
      */
-    public function write($method, $uri, $http_ver = '1.1', $headers = array(), $body = '')
+    public function write($method, $uri, $http_ver = '1.1', $headers = [], $body = '')
     {
         // Make sure we're properly connected
         if (! $this->socket) {
@@ -282,7 +272,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         }
 
         $host = $uri->getHost();
-        $host = (strtolower((string) $uri->getScheme()) == 'https' ? $this->config['ssltransport'] : 'tcp') . '://' . $host;
+        $host = (strtolower($uri->getScheme()) == 'https' ? $this->config['ssltransport'] : 'tcp') . '://' . $host;
         if ($this->connected_to[0] != $host || $this->connected_to[1] != $uri->getPort()) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception('Trying to write but we are connected to the wrong host');
@@ -293,18 +283,14 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
 
         // Build request headers
         $path = $uri->getPath();
-        if ($uri->getQuery()) {
-            $path .= '?' . $uri->getQuery();
-        }
+        if ($uri->getQuery()) $path .= '?' . $uri->getQuery();
         $request = "{$method} {$path} HTTP/{$http_ver}\r\n";
         foreach ($headers as $k => $v) {
-            if (is_string($k)) {
-                $v = ucfirst($k) . ": $v";
-            }
+            if (is_string($k)) $v = ucfirst($k) . ": $v";
             $request .= "$v\r\n";
         }
 
-        if (is_resource($body)) {
+        if(is_resource($body)) {
             $request .= "\r\n";
         } else {
             // Add the request body
@@ -317,8 +303,8 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             throw new Zend_Http_Client_Adapter_Exception('Error writing request to server');
         }
 
-        if (is_resource($body)) {
-            if (stream_copy_to_stream($body, $this->socket) == 0) {
+        if(is_resource($body)) {
+            if(stream_copy_to_stream($body, $this->socket) == 0) {
                 require_once 'Zend/Http/Client/Adapter/Exception.php';
                 throw new Zend_Http_Client_Adapter_Exception('Error writing request to server');
             }
@@ -342,9 +328,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             $gotStatus = $gotStatus || (strpos($line, 'HTTP') !== false);
             if ($gotStatus) {
                 $response .= $line;
-                if (rtrim($line) === '') {
-                    break;
-                }
+                if (rtrim($line) === '') break;
             }
         }
 
@@ -353,9 +337,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         $statusCode = Zend_Http_Response::extractCode($response);
 
         // Handle 100 and 101 responses internally by restarting the read again
-        if ($statusCode == 100 || $statusCode == 101) {
-            return $this->read();
-        }
+        if ($statusCode == 100 || $statusCode == 101) return $this->read();
 
         // Check headers to see what kind of connection / transfer encoding we have
         $headers = Zend_Http_Response::extractHeaders($response);
@@ -364,10 +346,9 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
          * Responses to HEAD requests and 204 or 304 responses are not expected
          * to have a body - stop reading here
          */
-        if (
-            $statusCode == 304 || $statusCode == 204 ||
-            $this->method == Zend_Http_Client::HEAD
-        ) {
+        if ($statusCode == 304 || $statusCode == 204 ||
+            $this->method == Zend_Http_Client::HEAD) {
+
             // Close the connection if requested to do so by the server
             if (isset($headers['connection']) && $headers['connection'] == 'close') {
                 $this->close();
@@ -376,8 +357,10 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         }
 
         // If we got a 'transfer-encoding: chunked' header
-        if (isset($headers['transfer-encoding'])) {
-            if (strtolower((string) $headers['transfer-encoding']) == 'chunked') {
+        if (isset($headers['transfer-encoding']) && is_string($headers['transfer-encoding'])) {
+
+            if (strtolower($headers['transfer-encoding']) == 'chunked') {
+
                 do {
                     $line  = @fgets($this->socket);
                     $this->_checkSocketReadTimeout();
@@ -401,15 +384,13 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
 
                     do {
                         $current_pos = ftell($this->socket);
-                        if ($current_pos >= $read_to) {
-                            break;
-                        }
+                        if ($current_pos >= $read_to) break;
 
-                        if ($this->out_stream) {
-                            if (stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
-                                $this->_checkSocketReadTimeout();
-                                break;
-                            }
+                        if($this->out_stream) {
+                            if(stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
+                              $this->_checkSocketReadTimeout();
+                              break;
+                             }
                         } else {
                             $line = @fread($this->socket, $read_to - $current_pos);
                             if ($line === false || strlen($line) === 0) {
@@ -423,15 +404,19 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
                     $chunk .= @fgets($this->socket);
                     $this->_checkSocketReadTimeout();
 
-                    if (!$this->out_stream) {
+                    if(!$this->out_stream) {
                         $response .= $chunk;
                     }
                 } while ($chunksize > 0);
             } else {
                 $this->close();
-                require_once 'Zend/Http/Client/Adapter/Exception.php';
+        require_once 'Zend/Http/Client/Adapter/Exception.php';
+                $encoding = $headers['transfer-encoding'];
+                if (is_array($encoding)) {
+                    $encoding = json_encode($encoding);
+                }
                 throw new Zend_Http_Client_Adapter_Exception('Cannot handle "' .
-                    $headers['transfer-encoding'] . '" transfer encoding');
+                    $encoding . '" transfer encoding');
             }
 
             // We automatically decode chunked-messages when writing to a stream
@@ -441,6 +426,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             }
         // Else, if we got the content-length header, read this number of bytes
         } elseif (isset($headers['content-length'])) {
+
             // If we got more than one Content-Length header (see ZF-9404) use
             // the last value sent
             if (is_array($headers['content-length'])) {
@@ -452,17 +438,16 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             $current_pos = ftell($this->socket);
             $chunk = '';
 
-            for (
-                $read_to = $current_pos + $contentLength;
+            for ($read_to = $current_pos + $contentLength;
                  $read_to > $current_pos;
-                 $current_pos = ftell($this->socket)
-            ) {
-                if ($this->out_stream) {
-                    if (@stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
-                         $this->_checkSocketReadTimeout();
-                         break;
-                    }
-                } else {
+                 $current_pos = ftell($this->socket)) {
+
+                 if($this->out_stream) {
+                     if(@stream_copy_to_stream($this->socket, $this->out_stream, $read_to - $current_pos) == 0) {
+                          $this->_checkSocketReadTimeout();
+                          break;
+                     }
+                 } else {
                     $chunk = @fread($this->socket, $read_to - $current_pos);
                     if ($chunk === false || strlen($chunk) === 0) {
                         $this->_checkSocketReadTimeout();
@@ -473,27 +458,26 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
                 }
 
                 // Break if the connection ended prematurely
-                if (feof($this->socket)) {
-                    break;
-                }
+                if (feof($this->socket)) break;
             }
 
         // Fallback: just read the response until EOF
         } else {
+
             do {
-                if ($this->out_stream) {
-                    if (@stream_copy_to_stream($this->socket, $this->out_stream) == 0) {
+                if($this->out_stream) {
+                    if(@stream_copy_to_stream($this->socket, $this->out_stream) == 0) {
                           $this->_checkSocketReadTimeout();
                           break;
-                    }
-                } else {
+                     }
+                }  else {
                     $buff = @fread($this->socket, 8192);
                     if ($buff === false || strlen($buff) === 0) {
                         $this->_checkSocketReadTimeout();
                         break;
-                    } else {
-                        $response .= $buff;
                     }
+
+                    $response .= $buff;
                 }
             } while (feof($this->socket) === false);
 
@@ -514,11 +498,9 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      */
     public function close()
     {
-        if (is_resource($this->socket)) {
-            @fclose($this->socket);
-        }
+        if (is_resource($this->socket)) @fclose($this->socket);
         $this->socket = null;
-        $this->connected_to = array(null, null);
+        $this->connected_to = [null, null];
     }
 
     /**
@@ -564,9 +546,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
     public function __destruct()
     {
         if (! $this->config['persistent']) {
-            if ($this->socket) {
-                $this->close();
-            }
+            if ($this->socket) $this->close();
         }
     }
 }

--- a/application/helpers/Zend/Http/Client/Adapter/Test.php
+++ b/application/helpers/Zend/Http/Client/Adapter/Test.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -55,7 +54,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      *
      * @var array
      */
-    protected $config = array();
+    protected $config = [];
 
     /**
      * Buffer of responses to be returned by the read() method.  Can be
@@ -63,7 +62,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      *
      * @var array
      */
-    protected $responses = array("HTTP/1.1 400 Bad Request\r\n\r\n");
+    protected $responses = ["HTTP/1.1 400 Bad Request\r\n\r\n"];
 
     /**
      * Current position in the response buffer
@@ -84,8 +83,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      *
      */
     public function __construct()
-    {
-    }
+    { }
 
     /**
      * Set the nextRequestWillFail flag
@@ -105,10 +103,11 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      *
      * @param Zend_Config | array $config
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
+
         } elseif (! is_array($config)) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception(
@@ -117,7 +116,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
         }
 
         foreach ($config as $k => $v) {
-            $this->config[strtolower((string) $k)] = $v;
+            $this->config[strtolower($k)] = $v;
         }
     }
 
@@ -128,7 +127,6 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      * @param string  $host
      * @param int     $port
      * @param boolean $secure
-     * @param int     $timeout
      * @throws Zend_Http_Client_Adapter_Exception
      */
     public function connect($host, $port = 80, $secure = false)
@@ -150,21 +148,17 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      * @param string        $body
      * @return string Request as string
      */
-    public function write($method, $uri, $http_ver = '1.1', $headers = array(), $body = '')
+    public function write($method, $uri, $http_ver = '1.1', $headers = [], $body = '')
     {
         $host = $uri->getHost();
-            $host = (strtolower((string) $uri->getScheme()) == 'https' ? 'sslv2://' . $host : $host);
+            $host = (strtolower($uri->getScheme()) == 'https' ? 'sslv2://' . $host : $host);
 
         // Build request headers
         $path = $uri->getPath();
-        if ($uri->getQuery()) {
-            $path .= '?' . $uri->getQuery();
-        }
+        if ($uri->getQuery()) $path .= '?' . $uri->getQuery();
         $request = "{$method} {$path} HTTP/{$http_ver}\r\n";
         foreach ($headers as $k => $v) {
-            if (is_string($k)) {
-                $v = ucfirst($k) . ": $v";
-            }
+            if (is_string($k)) $v = ucfirst($k) . ": $v";
             $request .= "$v\r\n";
         }
 
@@ -194,8 +188,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      *
      */
     public function close()
-    {
-    }
+    { }
 
     /**
      * Set the HTTP response(s) to be returned by this adapter
@@ -215,11 +208,11 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
     /**
      * Add another response to the response buffer.
      *
-     * @param string Zend_Http_Response|$response
+     * @param string|Zend_Http_Response $response
      */
     public function addResponse($response)
     {
-        if ($response instanceof Zend_Http_Response) {
+         if ($response instanceof Zend_Http_Response) {
             $response = $response->asString("\r\n");
         }
 
@@ -237,8 +230,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
         if ($index < 0 || $index >= count($this->responses)) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception(
-                'Index out of range of response buffer size'
-            );
+                'Index out of range of response buffer size');
         }
         $this->responseIndex = $index;
     }

--- a/application/helpers/Zend/Http/Client/Exception.php
+++ b/application/helpers/Zend/Http/Client/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -34,6 +33,4 @@ require_once 'Zend/Http/Exception.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Http_Client_Exception extends Zend_Http_Exception
-{
-
-}
+{}

--- a/application/helpers/Zend/Http/Cookie.php
+++ b/application/helpers/Zend/Http/Cookie.php
@@ -200,9 +200,7 @@ class Zend_Http_Cookie
      */
     public function isExpired($now = null)
     {
-        if ($now === null) {
-            $now = time();
-        }
+        if ($now === null) $now = time();
         if (is_int($this->expires) && $this->expires < $now) {
             return true;
         } else {
@@ -230,26 +228,20 @@ class Zend_Http_Cookie
      */
     public function match($uri, $matchSessionCookies = true, $now = null)
     {
-        if (is_string($uri)) {
+        if (is_string ($uri)) {
             $uri = Zend_Uri_Http::factory($uri);
         }
 
         // Make sure we have a valid Zend_Uri_Http object
-        if (! ($uri->valid() && ($uri->getScheme() == 'http' || $uri->getScheme() == 'https'))) {
+        if (! ($uri->valid() && ($uri->getScheme() == 'http' || $uri->getScheme() =='https'))) {
             require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception('Passed URI is not a valid HTTP or HTTPS URI');
         }
 
         // Check that the cookie is secure (if required) and not expired
-        if ($this->secure && $uri->getScheme() != 'https') {
-            return false;
-        }
-        if ($this->isExpired($now)) {
-            return false;
-        }
-        if ($this->isSessionCookie() && ! $matchSessionCookies) {
-            return false;
-        }
+        if ($this->secure && $uri->getScheme() != 'https') return false;
+        if ($this->isExpired($now)) return false;
+        if ($this->isSessionCookie() && ! $matchSessionCookies) return false;
 
         // Check if the domain matches
         if (! self::matchCookieDomain($this->getDomain(), $uri->getHost())) {
@@ -305,9 +297,7 @@ class Zend_Http_Cookie
         $parts   = explode(';', $cookieStr);
 
         // If first part does not include '=', fail
-        if (strpos($parts[0], '=') === false) {
-            return false;
-        }
+        if (strpos($parts[0], '=') === false) return false;
 
         // Get the name and value of the cookie
         list($name, $value) = explode('=', trim(array_shift($parts)), 2);
@@ -332,11 +322,12 @@ class Zend_Http_Cookie
             }
 
             $keyValue = explode('=', $part, 2);
-            if (count($keyValue) == 2) {
+
+            if (count($keyValue) === 2) {
                 list($k, $v) = $keyValue;
-                switch (strtolower($k)) {
+                switch (strtolower($k))    {
                     case 'expires':
-                        if (($expires = strtotime($v)) === false) {
+                        if(($expires = strtotime($v)) === false) {
                             /**
                              * The expiration is past Tue, 19 Jan 2038 03:14:07 UTC
                              * the maximum for 32-bit signed integer. Zend_Date

--- a/application/helpers/Zend/Http/CookieJar.php
+++ b/application/helpers/Zend/Http/CookieJar.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -102,22 +101,21 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @var array
      */
-    protected $cookies = array();
+    protected $cookies = [];
 
     /**
      * The Zend_Http_Cookie array
      *
      * @var array
      */
-    protected $_rawCookies = array();
+    protected $_rawCookies = [];
 
     /**
      * Construct a new CookieJar object
      *
      */
     public function __construct()
-    {
-    }
+    { }
 
     /**
      * Add a cookie to the jar. Cookie should be passed either as a Zend_Http_Cookie object
@@ -136,12 +134,8 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
         if ($cookie instanceof Zend_Http_Cookie) {
             $domain = $cookie->getDomain();
             $path = $cookie->getPath();
-            if (! isset($this->cookies[$domain])) {
-                $this->cookies[$domain] = array();
-            }
-            if (! isset($this->cookies[$domain][$path])) {
-                $this->cookies[$domain][$path] = array();
-            }
+            if (! isset($this->cookies[$domain])) $this->cookies[$domain] = [];
+            if (! isset($this->cookies[$domain][$path])) $this->cookies[$domain][$path] = [];
             $this->cookies[$domain][$path][$cookie->getName()] = $cookie;
             $this->_rawCookies[] = $cookie;
         } else {
@@ -186,7 +180,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
     public function getAllCookies($ret_as = self::COOKIE_OBJECT)
     {
         $cookies = $this->_flattenCookiesArray($this->cookies, $ret_as);
-        if ($ret_as == self::COOKIE_STRING_CONCAT_STRICT) {
+        if($ret_as == self::COOKIE_STRING_CONCAT_STRICT) {
             $cookies = rtrim(trim($cookies), ';');
         }
         return $cookies;
@@ -203,15 +197,10 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      * @param int $now Override the current time when checking for expiry time
      * @return array|string
      */
-    public function getMatchingCookies(
-        $uri,
-        $matchSessionCookies = true,
-        $ret_as = self::COOKIE_OBJECT,
-        $now = null
-    ) {
-        if (is_string($uri)) {
-            $uri = Zend_Uri::factory($uri);
-        }
+    public function getMatchingCookies($uri, $matchSessionCookies = true,
+        $ret_as = self::COOKIE_OBJECT, $now = null)
+    {
+        if (is_string($uri)) $uri = Zend_Uri::factory($uri);
         if (! $uri instanceof Zend_Uri_Http) {
             require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception("Invalid URI string or object passed");
@@ -223,16 +212,14 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
         $cookies = $this->_flattenCookiesArray($cookies, self::COOKIE_OBJECT);
 
         // Next, run Cookie->match on all cookies to check secure, time and session mathcing
-        $ret = array();
-        foreach ($cookies as $cookie) {
-            if ($cookie->match($uri, $matchSessionCookies, $now)) {
+        $ret = [];
+        foreach ($cookies as $cookie)
+            if ($cookie->match($uri, $matchSessionCookies, $now))
                 $ret[] = $cookie;
-            }
-        }
 
         // Now, use self::_flattenCookiesArray again - only to convert to the return format ;)
         $ret = $this->_flattenCookiesArray($ret, $ret_as);
-        if ($ret_as == self::COOKIE_STRING_CONCAT_STRICT) {
+        if($ret_as == self::COOKIE_STRING_CONCAT_STRICT) {
             $ret = rtrim(trim($ret), ';');
         }
 
@@ -260,10 +247,8 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
 
         // Get correct cookie path
         $path = $uri->getPath();
-        $path = substr((string) $path, 0, strrpos((string) $path, '/'));
-        if (! $path) {
-            $path = '/';
-        }
+        $path = substr($path, 0, strrpos($path, '/'));
+        if (! $path) $path = '/';
 
         if (isset($this->cookies[$uri->getHost()][$path][$cookie_name])) {
             $cookie = $this->cookies[$uri->getHost()][$path][$cookie_name];
@@ -274,7 +259,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
                     break;
 
                 case self::COOKIE_STRING_CONCAT_STRICT:
-                    return rtrim(trim((string) $cookie->__toString()), ';');
+                    return rtrim(trim($cookie->__toString()), ';');
                     break;
 
                 case self::COOKIE_STRING_ARRAY:
@@ -300,10 +285,9 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      * @param int $ret_as What value to return
      * @return array|string
      */
-    protected function _flattenCookiesArray($ptr, $ret_as = self::COOKIE_OBJECT)
-    {
+    protected function _flattenCookiesArray($ptr, $ret_as = self::COOKIE_OBJECT) {
         if (is_array($ptr)) {
-            $ret = ($ret_as == self::COOKIE_STRING_CONCAT || $ret_as == self::COOKIE_STRING_CONCAT_STRICT) ? '' : array();
+            $ret = ($ret_as == self::COOKIE_STRING_CONCAT || $ret_as == self::COOKIE_STRING_CONCAT_STRICT) ? '' : [];
             foreach ($ptr as $item) {
                 if ($ret_as == self::COOKIE_STRING_CONCAT_STRICT) {
                     $postfix_combine = (!is_array($item) ? ' ' : '');
@@ -318,7 +302,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
         } elseif ($ptr instanceof Zend_Http_Cookie) {
             switch ($ret_as) {
                 case self::COOKIE_STRING_ARRAY:
-                    return array($ptr->__toString());
+                    return [$ptr->__toString()];
                     break;
 
                 case self::COOKIE_STRING_CONCAT_STRICT:
@@ -330,7 +314,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
 
                 case self::COOKIE_OBJECT:
                 default:
-                    return array($ptr);
+                    return [$ptr];
                     break;
             }
         }
@@ -346,7 +330,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     protected function _matchDomain($domain)
     {
-        $ret = array();
+        $ret = [];
 
         foreach (array_keys($this->cookies) as $cdom) {
             if (Zend_Http_Cookie::matchCookieDomain($cdom, $domain)) {
@@ -366,13 +350,13 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     protected function _matchPath($domains, $path)
     {
-        $ret = array();
+        $ret = [];
 
         foreach ($domains as $dom => $paths_array) {
             foreach (array_keys($paths_array) as $cpath) {
                 if (Zend_Http_Cookie::matchCookiePath($cpath, $path)) {
                     if (! isset($ret[$dom])) {
-                        $ret[$dom] = array();
+                        $ret[$dom] = [];
                     }
 
                     $ret[$dom][$cpath] = $paths_array[$cpath];
@@ -406,7 +390,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_rawCookies);
     }
@@ -416,7 +400,8 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    #[\ReturnTypeWillChange]
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->_rawCookies);
     }
@@ -428,7 +413,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     public function isEmpty()
     {
-        return count($this) == 0;
+        return count($this) === 0;
     }
 
     /**
@@ -438,7 +423,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     public function reset()
     {
-        $this->cookies = $this->_rawCookies = array();
+        $this->cookies = $this->_rawCookies = [];
         return $this;
     }
 }

--- a/application/helpers/Zend/Http/Exception.php
+++ b/application/helpers/Zend/Http/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -34,6 +33,4 @@ require_once 'Zend/Exception.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Http_Exception extends Zend_Exception
-{
-
-}
+{}

--- a/application/helpers/Zend/Http/Header/Exception/InvalidArgumentException.php
+++ b/application/helpers/Zend/Http/Header/Exception/InvalidArgumentException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -34,6 +33,4 @@ require_once 'Zend/Http/Exception.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Http_Header_Exception_InvalidArgumentException extends Zend_Http_Exception
-{
-
-}
+{}

--- a/application/helpers/Zend/Http/Header/Exception/RuntimeException.php
+++ b/application/helpers/Zend/Http/Header/Exception/RuntimeException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -34,6 +33,4 @@ require_once 'Zend/Http/Exception.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Http_Header_Exception_RuntimeException extends Zend_Http_Exception
-{
-
-}
+{}

--- a/application/helpers/Zend/Http/Header/HeaderValue.php
+++ b/application/helpers/Zend/Http/Header/HeaderValue.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -64,8 +63,7 @@ final class Zend_Http_Header_HeaderValue
             // 32-126, 128-254 === visible
             // 127 === DEL
             // 255 === null byte
-            if (
-                ($ascii < 32 && $ascii !== 9)
+            if (($ascii < 32 && $ascii !== 9)
                 || $ascii === 127
                 || $ascii > 254
             ) {
@@ -101,8 +99,7 @@ final class Zend_Http_Header_HeaderValue
             // 32-126, 128-254 === visible
             // 127 === DEL
             // 255 === null byte
-            if (
-                ($ascii < 32 && $ascii !== 9)
+            if (($ascii < 32 && $ascii !== 9)
                 || $ascii === 127
                 || $ascii > 254
             ) {

--- a/application/helpers/Zend/Http/Header/SetCookie.php
+++ b/application/helpers/Zend/Http/Header/SetCookie.php
@@ -51,6 +51,10 @@ require_once "Zend/Http/Header/HeaderValue.php";
  */
 class Zend_Http_Header_SetCookie
 {
+    /**
+     * @var string
+     */
+    protected $type = 'Cookie';
 
     /**
      * Cookie name
@@ -112,6 +116,12 @@ class Zend_Http_Header_SetCookie
      * @var true
      */
     protected $httponly = null;
+    
+    /**
+     * 
+     * @var string
+     */
+    protected $sameSite = null;
 
     /**
      * Generate a new Cookie object from a cookie string
@@ -125,7 +135,7 @@ class Zend_Http_Header_SetCookie
      */
     public static function fromString($headerLine, $bypassHeaderFieldName = false)
     {
-        list($name, $value) = explode(': ', (string) $headerLine, 2);
+        [$name, $value] = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'set-cookie') {
@@ -133,61 +143,46 @@ class Zend_Http_Header_SetCookie
         }
 
         $multipleHeaders = preg_split('#(?<!Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s*#', $value);
-        $headers = array();
+        $headers = [];
         foreach ($multipleHeaders as $headerLine) {
             $header = new self();
-            $keyValuePairs = preg_split('#;\s*#', (string) $headerLine);
+            $keyValuePairs = preg_split('#;\s*#', $headerLine);
             foreach ($keyValuePairs as $keyValue) {
-                if (strpos((string) $keyValue, '=')) {
-                    list($headerKey, $headerValue) = preg_split('#=\s*#', (string) $keyValue, 2);
+                if (strpos($keyValue, '=')) {
+                    [$headerKey, $headerValue] = preg_split('#=\s*#', $keyValue, 2);
                 } else {
                     $headerKey = $keyValue;
                     $headerValue = null;
                 }
 
                 // First K=V pair is always the cookie name and value
-                if ($header->getName() === null) {
+                if ($header->getName() === NULL) {
                     $header->setName($headerKey);
                     $header->setValue($headerValue);
                     continue;
                 }
 
                 // Process the remanining elements
-                switch (str_replace(array('-', '_'), '', strtolower((string) $headerKey))) {
-                    case 'expires':
-                        $header->setExpires($headerValue);
-                        break;
-                    case 'domain':
-                        $header->setDomain($headerValue);
-                        break;
-                    case 'path':
-                        $header->setPath($headerValue);
-                        break;
-                    case 'secure':
-                        $header->setSecure(true);
-                        break;
-                    case 'httponly':
-                        $header->setHttponly(true);
-                        break;
-                    case 'version':
-                        $header->setVersion((int) $headerValue);
-                        break;
-                    case 'maxage':
-                        $header->setMaxAge((int) $headerValue);
-                        break;
+                switch (str_replace(['-', '_'], '', strtolower($headerKey))) {
+                    case 'expires' : $header->setExpires($headerValue); break;
+                    case 'domain'  : $header->setDomain($headerValue); break;
+                    case 'path'    : $header->setPath($headerValue); break;
+                    case 'secure'  : $header->setSecure(true); break;
+                    case 'httponly': $header->setHttponly(true); break;
+                    case 'version' : $header->setVersion((int) $headerValue); break;
+                    case 'maxage'  : $header->setMaxAge((int) $headerValue); break;
+                    case 'samesite'  : $header->setSameSite($headerValue); break;
                     default:
                         // Intentionally omitted
                 }
             }
             $headers[] = $header;
         }
-        return count($headers) == 1 ? array_pop($headers) : $headers;
+        return count($headers) === 1 ? array_pop($headers) : $headers;
     }
 
     /**
      * Cookie object constructor
-     *
-     * @todo Add validation of each one of the parameters (legal domain, etc.)
      *
      * @param string $name
      * @param string $value
@@ -198,9 +193,12 @@ class Zend_Http_Header_SetCookie
      * @param bool $httponly
      * @param string $maxAge
      * @param int $version
-     * @return SetCookie
+     * @param string $sameSite
+     * @return void
+     * @todo Add validation of each one of the parameters (legal domain, etc.)
+     *
      */
-    public function __construct($name = null, $value = null, $expires = null, $path = null, $domain = null, $secure = false, $httponly = false, $maxAge = null, $version = null)
+    public function __construct($name = null, $value = null, $expires = null, $path = null, $domain = null, $secure = false, $httponly = false, $maxAge = null, $version = null, $sameSite = null)
     {
         $this->type = 'Cookie';
 
@@ -239,6 +237,11 @@ class Zend_Http_Header_SetCookie
         if ($httponly) {
             $this->setHttponly($httponly);
         }
+        
+        if( !empty($sameSite) ) {
+            $this->setSameSite($sameSite);
+        }
+        
     }
 
     /**
@@ -260,20 +263,20 @@ class Zend_Http_Header_SetCookie
         }
 
         $value = $this->getValue();
-        if (strpos($value, '"') !== false) {
-            $value = '"' . urlencode(str_replace('"', '', $value)) . '"';
+        if (strpos($value,'"')!==false) {
+            $value = '"'.urlencode(str_replace('"', '', $value)).'"';
         } else {
             $value = urlencode($value);
         }
         $fieldValue = $this->getName() . '=' . $value;
 
         $version = $this->getVersion();
-        if ($version !== null) {
+        if ($version!==null) {
             $fieldValue .= '; Version=' . $version;
         }
 
         $maxAge = $this->getMaxAge();
-        if ($maxAge !== null) {
+        if ($maxAge!==null) {
             $fieldValue .= '; Max-Age=' . $maxAge;
         }
 
@@ -299,13 +302,17 @@ class Zend_Http_Header_SetCookie
         if ($this->isHttponly()) {
             $fieldValue .= '; HttpOnly';
         }
+        
+        if ($this->hasSameSiteValue()) {
+            $fieldValue .= '; SameSite=' . $this->getSameSite();
+        }
 
         return $fieldValue;
     }
 
     /**
      * @param string $name
-     * @return SetCookie
+     * @return Zend_Http_Header_SetCookie
      */
     public function setName($name)
     {
@@ -373,7 +380,7 @@ class Zend_Http_Header_SetCookie
      */
     public function setMaxAge($maxAge)
     {
-        if (!is_int($maxAge) || ($maxAge < 0)) {
+        if (!is_int($maxAge) || ($maxAge<0)) {
             throw new Zend_Http_Header_Exception_InvalidArgumentException('Invalid Max-Age number specified');
         }
         $this->maxAge = $maxAge;
@@ -391,7 +398,7 @@ class Zend_Http_Header_SetCookie
 
     /**
      * @param int $expires
-     * @return SetCookie
+     * @return Zend_Http_Header_SetCookie
      */
     public function setExpires($expires)
     {
@@ -455,7 +462,40 @@ class Zend_Http_Header_SetCookie
     {
         return $this->path;
     }
+    
+    /**
+     * 
+     * @return string
+     */
+    public function getSameSite() {
+        return $this->sameSite;
+    }
 
+    /**
+     * 
+     * @param string $sameSite
+     * @return void
+     */
+    public function setSameSite($sameSite) {
+        
+        $validOptions = ['Strict', 'Lax', 'None'];
+        
+        if( !in_array($sameSite, $validOptions)) {
+            throw new Zend_Http_Header_Exception_InvalidArgumentException('Invalid SameSite value, use one of: ' . implode(', ', $validOptions) );
+        }
+        
+        $this->sameSite = $sameSite;
+    }
+    
+    /**
+     * 
+     * @return bool
+     */
+    public function hasSameSiteValue(): bool {
+        return empty($this->getSameSite()) === FALSE;
+    }
+
+    
     /**
      * @param boolean $secure
      */
@@ -523,19 +563,20 @@ class Zend_Http_Header_SetCookie
 
     public function isValidForRequest($requestDomain, $path, $isSecure = false)
     {
-        if ($this->getDomain() && (strrpos((string) $requestDomain, $this->getDomain()) !== false)) {
+        if ($this->getDomain() && (strrpos($requestDomain, $this->getDomain()) !== false)) {
             return false;
         }
 
-        if ($this->getPath() && (strpos((string) $path, $this->getPath()) !== 0)) {
+        if ($this->getPath() && (strpos($path, $this->getPath()) !== 0)) {
             return false;
         }
 
-        if ($this->secure && $this->isSecure() !== $isSecure) {
+        if ($this->secure && $this->isSecure()!==$isSecure) {
             return false;
         }
 
         return true;
+
     }
 
     public function toString()
@@ -551,7 +592,7 @@ class Zend_Http_Header_SetCookie
     public function toStringMultipleHeaders(array $headers)
     {
         $headerLine = $this->toString();
-        /* @var $header SetCookie */
+        /* @var SetCookie $header */
         foreach ($headers as $header) {
             if (!$header instanceof Zend_Http_Header_SetCookie) {
                 throw new Zend_Http_Header_Exception_RuntimeException(
@@ -562,4 +603,6 @@ class Zend_Http_Header_SetCookie
         }
         return $headerLine;
     }
+
+
 }

--- a/application/helpers/Zend/Http/Response.php
+++ b/application/helpers/Zend/Http/Response.php
@@ -44,7 +44,7 @@ class Zend_Http_Response
      *
      * @var array
      */
-    protected static $messages = array(
+    protected static $messages = [
         // Informational 1xx
         100 => 'Continue',
         101 => 'Switching Protocols',
@@ -96,7 +96,7 @@ class Zend_Http_Response
         504 => 'Gateway Timeout',
         505 => 'HTTP Version Not Supported',
         509 => 'Bandwidth Limit Exceeded'
-    );
+    ];
 
     /**
      * The HTTP version (1.0, 1.1)
@@ -125,7 +125,7 @@ class Zend_Http_Response
      *
      * @var array
      */
-    protected $headers = array();
+    protected $headers = [];
 
     /**
      * The HTTP response body
@@ -165,8 +165,9 @@ class Zend_Http_Response
 
         foreach ($headers as $name => $value) {
             if (is_int($name)) {
-                $header = explode(":", (string) $value, 2);
-                if (count($header) != 2) {
+                $header = explode(':', $value, 2);
+
+                if (count($header) !== 2) {
                     require_once 'Zend/Http/Exception.php';
                     throw new Zend_Http_Exception("'{$value}' is not a valid HTTP header");
                 }
@@ -182,7 +183,7 @@ class Zend_Http_Response
         $this->body = $body;
 
         // Set the HTTP version
-        if (! preg_match('|^\d\.\d$|', $version)) {
+        if (! preg_match('|^\d(\.\d)?$|', $version)) {
             require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception("Invalid HTTP response version: $version");
         }
@@ -206,11 +207,8 @@ class Zend_Http_Response
     public function isError()
     {
         $restype = floor($this->code / 100);
-        if ($restype == 4 || $restype == 5) {
-            return true;
-        }
 
-        return false;
+        return $restype == 4 || $restype == 5;
     }
 
     /**
@@ -221,11 +219,8 @@ class Zend_Http_Response
     public function isSuccessful()
     {
         $restype = floor($this->code / 100);
-        if ($restype == 2 || $restype == 1) { // Shouldn't 3xx count as success as well ???
-            return true;
-        }
 
-        return false;
+        return $restype == 2 || $restype == 1; // Shouldn't 3xx count as success as well ???
     }
 
     /**
@@ -236,11 +231,8 @@ class Zend_Http_Response
     public function isRedirect()
     {
         $restype = floor($this->code / 100);
-        if ($restype == 3) {
-            return true;
-        }
 
-        return false;
+        return $restype == 3;
     }
 
     /**
@@ -260,7 +252,8 @@ class Zend_Http_Response
         $body = '';
 
         // Decode the body if it was transfer-encoded
-        switch (strtolower($this->getHeader('transfer-encoding'))) {
+        switch (strtolower((string) $this->getHeader('transfer-encoding'))) {
+
             // Handle chunked body
             case 'chunked':
                 $body = self::decodeChunkedBody($this->body);
@@ -274,7 +267,8 @@ class Zend_Http_Response
         }
 
         // Decode any content-encoding (gzip or deflate) if needed
-        switch (strtolower($this->getHeader('content-encoding'))) {
+        switch (strtolower((string) $this->getHeader('content-encoding'))) {
+
             // Handle gzip encoding
             case 'gzip':
                 $body = self::decodeGzip($body);
@@ -355,9 +349,7 @@ class Zend_Http_Response
     public function getHeader($header)
     {
         $header = ucwords(strtolower($header));
-        if (! is_string($header) || ! isset($this->headers[$header])) {
-            return null;
-        }
+        if (! is_string($header) || ! isset($this->headers[$header])) return null;
 
         return $this->headers[$header];
     }
@@ -378,10 +370,12 @@ class Zend_Http_Response
         }
 
         // Iterate over the headers and stringify them
-        foreach ($this->headers as $name => $value) {
-            if (is_string($value)) {
+        foreach ($this->headers as $name => $value)
+        {
+            if (is_string($value))
                 $str .= "{$name}: {$value}{$br}";
-            } elseif (is_array($value)) {
+
+            elseif (is_array($value)) {
                 foreach ($value as $subval) {
                     $str .= "{$name}: {$subval}{$br}";
                 }
@@ -427,9 +421,7 @@ class Zend_Http_Response
     public static function responseCodeAsText($code = null, $http11 = true)
     {
         $messages = self::$messages;
-        if (! $http11) {
-            $messages[302] = 'Moved Temporarily';
-        }
+        if (! $http11) $messages[302] = 'Moved Temporarily';
 
         if ($code === null) {
             return $messages;
@@ -499,7 +491,7 @@ class Zend_Http_Response
      */
     public static function extractHeaders($response_str)
     {
-        $headers = array();
+        $headers = [];
 
         // First, split body and headers. Headers are separated from the
         // message at exactly the sequence "\r\n\r\n"
@@ -513,8 +505,8 @@ class Zend_Http_Response
         unset($parts);
         $last_header = null;
 
-        foreach ($lines as $index => $line) {
-            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+) [1-5]\d+#', $line)) {
+        foreach($lines as $index => $line) {
+            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+)? [1-5]\d+#', $line)) {
                 // Status line; ignore
                 continue;
             }
@@ -533,7 +525,7 @@ class Zend_Http_Response
 
                 if (isset($headers[$h_name])) {
                     if (! is_array($headers[$h_name])) {
-                        $headers[$h_name] = array($headers[$h_name]);
+                        $headers[$h_name] = [$headers[$h_name]];
                     }
 
                     $headers[$h_name][] = ltrim($h_value);
@@ -599,27 +591,30 @@ class Zend_Http_Response
     public static function decodeChunkedBody($body)
     {
         $decBody = '';
+        $offset = 0;
 
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
-        if (
-            function_exists('mb_internal_encoding') &&
-            ((int) ini_get('mbstring.func_overload')) & 2
-        ) {
+        if (function_exists('mb_internal_encoding') &&
+           ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbIntEnc = mb_internal_encoding();
             mb_internal_encoding('ASCII');
         }
 
-        while (trim($body)) {
-            if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m)) {
-                require_once 'Zend/Http/Exception.php';
-                throw new Zend_Http_Exception("Error parsing body - doesn't seem to be a chunked message");
+        while (true) {
+            if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m, 0, $offset)) {
+                if (trim(substr($body, $offset))) {
+                    require_once 'Zend/Http/Exception.php';
+                    throw new Zend_Http_Exception("Error parsing body - doesn't seem to be a chunked message");
+                }
+                // Message was consumed completely
+                break;
             }
 
-            $length = hexdec(trim($m[1]));
-            $cut = strlen($m[0]);
-            $decBody .= substr($body, $cut, $length);
-            $body = substr($body, $cut + $length + 2);
+            $length   = hexdec(trim($m[1]));
+            $cut      = strlen($m[0]);
+            $decBody .= substr($body, $offset + $cut, $length);
+            $offset += $cut + $length + 2;
         }
 
         if (isset($mbIntEnc)) {
@@ -678,11 +673,12 @@ class Zend_Http_Response
          * @link http://framework.zend.com/issues/browse/ZF-6040
          */
         $zlibHeader = unpack('n', substr($body, 0, 2));
-        if ($zlibHeader[1] % 31 == 0 && ord($body[0]) == 0x78 && in_array(ord($body[1]), array(0x01, 0x5e, 0x9c, 0xda))) {
+
+        if ($zlibHeader[1] % 31 == 0 && ord($body[0]) == 0x78 && in_array(ord($body[1]), [0x01, 0x5e, 0x9c, 0xda])) {
             return gzuncompress($body);
-        } else {
-            return gzinflate($body);
         }
+
+        return gzinflate($body);
     }
 
     /**

--- a/application/helpers/Zend/Http/Response/Stream.php
+++ b/application/helpers/Zend/Http/Response/Stream.php
@@ -59,7 +59,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
     /**
      * Get the response as stream
      *
-     * @return resourse
+     * @return resource
      */
     public function getStream()
     {
@@ -83,8 +83,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      *
      * @return boolean
      */
-    public function getCleanup()
-    {
+    public function getCleanup() {
         return $this->_cleanup;
     }
 
@@ -93,8 +92,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      *
      * @param bool $cleanup Set cleanup trigger
      */
-    public function setCleanup($cleanup = true)
-    {
+    public function setCleanup($cleanup = true) {
         $this->_cleanup = $cleanup;
     }
 
@@ -103,8 +101,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      *
      * @return string
      */
-    public function getStreamName()
-    {
+    public function getStreamName() {
         return $this->stream_name;
     }
 
@@ -114,8 +111,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      * @param string $stream_name Name to set
      * @return Zend_Http_Response_Stream
      */
-    public function setStreamName($stream_name)
-    {
+    public function setStreamName($stream_name) {
         $this->stream_name = $stream_name;
         return $this;
     }
@@ -143,7 +139,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
     public function __construct($code, $headers, $body = null, $version = '1.1', $message = null)
     {
 
-        if (is_resource($body)) {
+        if(is_resource($body)) {
             $this->setStream($body);
             $body = '';
         }
@@ -181,7 +177,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      */
     public function getBody()
     {
-        if ($this->stream != null) {
+        if($this->stream != null) {
             $this->readStream();
         }
         return parent::getBody();
@@ -197,7 +193,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      */
     public function getRawBody()
     {
-        if ($this->stream) {
+        if($this->stream) {
             $this->readStream();
         }
         return $this->body;
@@ -212,11 +208,11 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
      */
     protected function readStream()
     {
-        if (!is_resource($this->stream)) {
+        if(!is_resource($this->stream)) {
             return '';
         }
 
-        if (isset($headers['content-length'])) {
+        if(isset($headers['content-length'])) {
             $this->body = stream_get_contents($this->stream, $headers['content-length']);
         } else {
             $this->body = stream_get_contents($this->stream);
@@ -227,12 +223,13 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
 
     public function __destruct()
     {
-        if (is_resource($this->stream)) {
+        if(is_resource($this->stream)) {
             fclose($this->stream);
             $this->stream = null;
         }
-        if ($this->_cleanup) {
+        if($this->_cleanup && is_string($this->stream_name) && file_exists($this->stream_name)) {
             @unlink($this->stream_name);
         }
     }
+
 }

--- a/application/helpers/Zend/Http/UserAgent.php
+++ b/application/helpers/Zend/Http/UserAgent.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -81,7 +80,7 @@ class Zend_Http_UserAgent implements Serializable
      *
      * @var array
      */
-    protected $_browserTypeClass = array();
+    protected $_browserTypeClass = [];
 
     /**
      * Array to store config
@@ -91,12 +90,12 @@ class Zend_Http_UserAgent implements Serializable
      *
      * @var array
      */
-    protected $_config = array(
+    protected $_config = [
         'identification_sequence' => self::DEFAULT_IDENTIFICATION_SEQUENCE,
-        'storage'                 => array(
+        'storage'                 => [
             'adapter'             => self::DEFAULT_PERSISTENT_STORAGE_ADAPTER,
-        ),
-    );
+        ],
+    ];
 
     /**
      * Identified device
@@ -123,20 +122,20 @@ class Zend_Http_UserAgent implements Serializable
      * Plugin loaders
      * @var array
      */
-    protected $_loaders = array();
+    protected $_loaders = [];
 
     /**
      * Valid plugin loader types
      * @var array
      */
-    protected $_loaderTypes = array('storage', 'device');
+    protected $_loaderTypes = ['storage', 'device'];
 
     /**
      * Trace of items matched to identify the browser type
      *
      * @var array
      */
-    protected $_matchLog = array();
+    protected $_matchLog = [];
 
     /**
      * Server variable
@@ -170,18 +169,23 @@ class Zend_Http_UserAgent implements Serializable
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): ?string
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
     {
         $device = $this->getDevice();
-        $spec = array(
+        $spec = [
             'browser_type' => $this->_browserType,
             'config'       => $this->_config,
             'device_class' => get_class($device),
             'device'       => $device->serialize(),
             'user_agent'   => $this->getServerValue('http_user_agent'),
             'http_accept'  => $this->getServerValue('http_accept'),
-        );
-        return serialize($spec);
+        ];
+        return $spec;
     }
 
     /**
@@ -190,10 +194,13 @@ class Zend_Http_UserAgent implements Serializable
      * @param  string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
 
+    public function __unserialize(array $spec): void
+    {
         $this->setOptions($spec);
 
         // Determine device class and ensure the class is loaded
@@ -221,8 +228,7 @@ class Zend_Http_UserAgent implements Serializable
             $options = $options->toArray();
         }
 
-        if (
-            !is_array($options)
+        if (!is_array($options)
             && !$options instanceof ArrayAccess
             && !$options instanceof Traversable
         ) {
@@ -251,9 +257,9 @@ class Zend_Http_UserAgent implements Serializable
         }
 
         // And then loop through the remaining options
-        $config = array();
+        $config = [];
         foreach ($options as $key => $value) {
-            switch (strtolower((string) $key)) {
+            switch (strtolower($key)) {
                 case 'browser_type':
                     $this->setBrowserType($value);
                     break;
@@ -298,7 +304,7 @@ class Zend_Http_UserAgent implements Serializable
 
         // Call match method on device class
         return call_user_func(
-            array($deviceClass, 'match'),
+            [$deviceClass, 'match'],
             $userAgent,
             $this->getServer()
         );
@@ -318,8 +324,7 @@ class Zend_Http_UserAgent implements Serializable
             return $this->_browserTypeClass[$browserType];
         }
 
-        if (
-            isset($this->_config[$browserType])
+        if (isset($this->_config[$browserType])
             && isset($this->_config[$browserType]['device'])
         ) {
             $deviceConfig = $this->_config[$browserType]['device'];
@@ -336,7 +341,7 @@ class Zend_Http_UserAgent implements Serializable
             } elseif (is_array($deviceConfig) && isset($deviceConfig['path'])) {
                 $loader = $this->getPluginLoader('device');
                 $path   = $deviceConfig['path'];
-                $prefix = $deviceConfig['prefix'] ?? 'Zend_Http_UserAgent';
+                $prefix = isset($deviceConfig['prefix']) ? $deviceConfig['prefix'] : 'Zend_Http_UserAgent';
                 $loader->addPrefixPath($prefix, $path);
 
                 $device = $loader->load($browserType);
@@ -435,7 +440,7 @@ class Zend_Http_UserAgent implements Serializable
                 $adapter = $loader->load($adapter);
                 $loader = $this->getPluginLoader('storage');
             }
-            $options = array('browser_type' => $browser);
+            $options = ['browser_type' => $browser];
             if (isset($config['options'])) {
                 $options = array_merge($options, $config['options']);
             }
@@ -503,7 +508,7 @@ class Zend_Http_UserAgent implements Serializable
      * @param  mixed $config (option) Config array
      * @return Zend_Http_UserAgent
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
@@ -519,7 +524,7 @@ class Zend_Http_UserAgent implements Serializable
         }
 
         if ($config instanceof Traversable) {
-            $tmp = array();
+            $tmp = [];
             foreach ($config as $key => $value) {
                 $tmp[$key] = $value;
             }
@@ -628,7 +633,7 @@ class Zend_Http_UserAgent implements Serializable
      * data that will be introspected.
      *
      * @param  array|ArrayAccess $server
-     * @return void
+     * @return Zend_Http_UserAgent
      * @throws Zend_Http_UserAgent_Exception on invalid parameter
      */
     public function setServer($server)
@@ -652,7 +657,7 @@ class Zend_Http_UserAgent implements Serializable
         if ($server instanceof ArrayObject) {
             $server = $server->getArrayCopy();
         } elseif ($server instanceof Traversable) {
-            $tmp = array();
+            $tmp = [];
             foreach ($server as $key => $value) {
                 $tmp[$key] = $value;
             }
@@ -690,7 +695,7 @@ class Zend_Http_UserAgent implements Serializable
      *
      * @param  string|int|float $key
      * @param  mixed $value
-     * @return void
+     * @return Zend_Http_UserAgent
      */
     public function setServerValue($key, $value)
     {
@@ -802,7 +807,7 @@ class Zend_Http_UserAgent implements Serializable
      * Run the identification sequence to match the right browser type according to the
      * user agent
      *
-     * @return Zend_Http_UserAgent_Result
+     * @return string
      */
     protected function _matchUserAgent()
     {
@@ -814,7 +819,7 @@ class Zend_Http_UserAgent implements Serializable
         }
 
         // Get sequence against which to match
-        $sequence = explode(',', (string) $this->_config['identification_sequence']);
+        $sequence = explode(',', $this->_config['identification_sequence']);
 
         // If a browser type is already configured, push that to the front of the list
         if (null !== ($browserType = $this->getBrowserType())) {

--- a/application/helpers/Zend/Http/UserAgent/AbstractDevice.php
+++ b/application/helpers/Zend/Http/UserAgent/AbstractDevice.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -31,8 +30,13 @@ require_once 'Zend/Http/UserAgent/Device.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent_Device
+abstract class Zend_Http_UserAgent_AbstractDevice
+    implements Zend_Http_UserAgent_Device
 {
+    public $device_os;
+
+    public $list;
+
     /**
      * Browser signature
      *
@@ -73,28 +77,28 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
      *
      * @var array
      */
-    protected $_images = array(
+    protected $_images = [
         'jpeg',
         'gif',
         'png',
         'pjpeg',
         'x-png',
         'bmp',
-    );
+    ];
 
     /**
      * Browser/Device features
      *
      * @var array
      */
-    protected $_aFeatures = array();
+    protected $_aFeatures = [];
 
     /**
      * Browser/Device features groups
      *
      * @var array
      */
-    protected $_aGroup = array();
+    protected $_aGroup = [];
 
     /**
      * Constructor
@@ -104,7 +108,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
      * @param  array $config
      * @return void
      */
-    public function __construct($userAgent = null, array $server = array(), array $config = array())
+    public function __construct($userAgent = null, array $server = [], array $config = [])
     {
         if (is_array($userAgent)) {
             // Restoring from serialized array
@@ -124,17 +128,22 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): ?string
     {
-        $spec = array(
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
+        $spec = [
             '_aFeatures'      => $this->_aFeatures,
             '_aGroup'         => $this->_aGroup,
             '_browser'        => $this->_browser,
             '_browserVersion' => $this->_browserVersion,
             '_userAgent'      => $this->_userAgent,
             '_images'         => $this->_images,
-        );
-        return serialize($spec);
+        ];
+        return $spec;
     }
 
     /**
@@ -143,9 +152,13 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
      * @param  string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
+
+    public function __unserialize(array $spec): void
+    {
         $this->_restoreFromArray($spec);
     }
 
@@ -238,7 +251,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     public function setGroup($group, $feature)
     {
         if (!isset($this->_aGroup[$group])) {
-            $this->_aGroup[$group] = array();
+            $this->_aGroup[$group] = [];
         }
         if (!in_array($feature, $this->_aGroup[$group])) {
             $this->_aGroup[$group][] = $feature;
@@ -285,10 +298,10 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
      */
     protected function _getDefaultFeatures()
     {
-        $server = array();
+        $server = [];
 
         // gets info from user agent chain
-        $uaExtract = $this->extractFromUserAgent($this->getUserAgent());
+        $uaExtract = static::extractFromUserAgent($this->getUserAgent());
 
         if (is_array($uaExtract)) {
             foreach ($uaExtract as $key => $info) {
@@ -322,8 +335,8 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         if (isset($this->list) && empty($this->_browser)) {
             $lowerUserAgent = strtolower($this->getUserAgent());
             foreach ($this->list as $browser_signature) {
-                if (strpos($lowerUserAgent, (string) $browser_signature) !== false) {
-                    $this->_browser = strtolower((string) $browser_signature);
+                if (strpos($lowerUserAgent, $browser_signature) !== false) {
+                    $this->_browser = strtolower($browser_signature);
                     $this->setFeature('browser_name', $this->_browser, 'product_info');
                 }
             }
@@ -340,30 +353,30 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
 
         /* sets the server infos */
         if (isset($this->_server['server_software'])) {
-            if (strpos((string) $this->_server['server_software'], 'Apache') !== false || strpos((string) $this->_server['server_software'], 'LiteSpeed') !== false) {
+            if (strpos($this->_server['server_software'], 'Apache') !== false || strpos($this->_server['server_software'], 'LiteSpeed') !== false) {
                 $server['version'] = 1;
-                if (strpos((string) $this->_server['server_software'], 'Apache/2') !== false) {
+                if (strpos($this->_server['server_software'], 'Apache/2') !== false) {
                     $server['version'] = 2;
                 }
                 $server['server'] = 'apache';
             }
 
-            if (strpos((string) $this->_server['server_software'], 'Microsoft-IIS') !== false) {
+            if (strpos($this->_server['server_software'], 'Microsoft-IIS') !== false) {
                 $server['server'] = 'iis';
             }
 
-            if (strpos((string) $this->_server['server_software'], 'Unix') !== false) {
+            if (strpos($this->_server['server_software'], 'Unix') !== false) {
                 $server['os'] = 'unix';
                 if (isset($_ENV['MACHTYPE'])) {
-                    if (strpos((string) $_ENV['MACHTYPE'], 'linux') !== false) {
+                    if (strpos($_ENV['MACHTYPE'], 'linux') !== false) {
                         $server['os'] = 'linux';
                     }
                 }
-            } elseif (strpos((string) $this->_server['server_software'], 'Win') !== false) {
+            } elseif (strpos($this->_server['server_software'], 'Win') !== false) {
                 $server['os'] = 'windows';
             }
 
-            if (preg_match('/Apache\/([0-9\.]*)/', (string) $this->_server['server_software'], $arr)) {
+            if (preg_match('/Apache\/([0-9\.]*)/', $this->_server['server_software'], $arr)) {
                 if ($arr[1]) {
                     $server['version'] = $arr[1];
                     $server['server']  = 'apache';
@@ -393,7 +406,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     }
 
     /**
-     * Extract and sets information from the User Agent chain
+     * Extract and sets informations from the User Agent chain
      *
      * @param  string $userAgent User Agent chain
      * @return array
@@ -408,7 +421,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         $pattern =  "(([^/\s]*)(/(\S*))?)(\s*\[[a-zA-Z][a-zA-Z]\])?\s*(\\((([^()]|(\\([^()]*\\)))*)\\))?\s*";
         preg_match("#^$pattern#", $userAgent, $match);
 
-        $comment = array();
+        $comment = [];
         if (isset($match[7])) {
             $comment = explode(';', $match[7]);
         }
@@ -419,7 +432,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
             $result['others']['full'] = $end;
         }
 
-        $match2 = array();
+        $match2 = [];
         if (isset($result['others'])) {
             preg_match_all('/(([^\/\s]*)(\/)?([^\/\(\)\s]*)?)(\s\((([^\)]*)*)\))?/i', $result['others']['full'], $match2);
         }
@@ -448,23 +461,23 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         if ($match2) {
             $i = 0;
             $max = count($match2[0]);
-            for ($i = 0; $i < $max; $i++) {
+            for ($i = 0; $i < $max; $i ++) {
                 if (!empty($match2[0][$i])) {
-                    $result['others']['detail'][] = array(
+                    $result['others']['detail'][] = [
                         $match2[0][$i],
                         $match2[2][$i],
                         $match2[4][$i],
-                    );
+                    ];
                 }
             }
         }
 
         /** Security level */
-        $security = array(
+        $security = [
             'N' => 'no security',
             'U' => 'strong security',
             'I' => 'weak security',
-        );
+        ];
         if (!empty($result['browser_token'])) {
             if (isset($security[$result['browser_token']])) {
                 $result['security_level'] = $security[$result['browser_token']];
@@ -492,6 +505,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                         $real[1][0]               = "Internet Explorer";
                         $temp                     = explode(' ', trim($v));
                         $real[3][0]               = $temp[1];
+
                     }
                     if (strpos($v, 'Win') !== false) {
                         $result['device_os_token'] = trim($v);
@@ -503,13 +517,12 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                 $result['browser_name']    = $real[1][0];
                 $result['browser_version'] = $real[3][0];
             } else {
-                if (isset($result['browser_token'])) {
+                if(isset($result['browser_token'])) {
                     $result['browser_name']    = $result['browser_token'];
                 }
                 $result['browser_version'] = '??';
             }
-        } elseif (
-            $product == 'mozilla' && isset($result['browser_version'])
+        } elseif ($product == 'mozilla' && isset($result['browser_version'])
                   && $result['browser_version'] < 5.0
         ) {
             // handles the real Mozilla (or old Netscape if version < 5.0)
@@ -523,7 +536,8 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         }
         if (isset($result['device_os_token'])) {
             if (strpos($result['device_os_token'], 'Win') !== false) {
-                $windows = array(
+
+                $windows = [
                     'Windows NT 6.1'          => 'Windows 7',
                     'Windows NT 6.0'          => 'Windows Vista',
                     'Windows NT 5.2'          => 'Windows Server 2003',
@@ -538,7 +552,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                     'Windows 95'              => 'Windows 95',
                     'Win95'                   => 'Windows 95',
                     'Windows CE'              => 'Windows CE',
-                );
+                ];
                 if (isset($windows[$result['device_os_token']])) {
                     $result['device_os_name'] = $windows[$result['device_os_token']];
                 } else {
@@ -548,11 +562,11 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         }
 
         // iphone
-        $apple_device = array(
+        $apple_device = [
             'iPhone',
             'iPod',
             'iPad',
-        );
+        ];
         if (isset($result['compatibility_flag'])) {
             if (in_array($result['compatibility_flag'], $apple_device)) {
                 $result['device']           = strtolower($result['compatibility_flag']);
@@ -612,10 +626,10 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                 }
 
                 // For Safari < 2.2, AppleWebKit version gives the Safari version
-                if (strpos((string) $result['browser_version'], '.') > 2 || (int) $result['browser_version'] > 20) {
-                    $temp = explode('.', (string) $result['browser_version']);
+                if (strpos($result['browser_version'], '.') > 2 || (int) $result['browser_version'] > 20) {
+                    $temp = explode('.', $result['browser_version']);
                     $build = (int) $temp[0];
-                    $awkVersion = array(
+                    $awkVersion = [
                         48  => '0.8',
                         73  => '0.9',
                         85  => '1.0',
@@ -623,7 +637,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                         124 => '1.2',
                         300 => '1.3',
                         400 => '2.0',
-                    );
+                    ];
                     foreach ($awkVersion as $k => $v) {
                         if ($build >= $k) {
                             $result['browser_version'] = $v;
@@ -646,17 +660,15 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                     // exception : if the version of the last information is
                     // empty we take the previous one
                     if (empty($result['others']['detail'][$last][2])) {
-                        $last--;
+                        $last --;
                     }
 
                     // exception : if the last one is 'Red Hat' or 'Debian' =>
                     // use rv: to find browser_version */
-                    if (
-                        in_array($result['others']['detail'][$last][1], array(
+                    if (in_array($result['others']['detail'][$last][1], [
                         'Debian',
                         'Hat',
-                        ))
-                    ) {
+                    ])) {
                         $searchRV = true;
                     }
                     $result['browser_name']    = $result['others']['detail'][$last][1];
@@ -767,7 +779,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         $config      = $this->_config;
         $browserType = $this->getType();
         if (!isset($config[$browserType]) || !isset($config[$browserType]['features'])) {
-            return array();
+            return [];
         }
         $config = $config[$browserType]['features'];
 
@@ -785,13 +797,13 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
                 throw new Zend_Http_UserAgent_Exception('The ' . $this->getType() . ' features adapter must have a "path" config parameter defined');
             }
 
-            if (false === include_once($path)) {
+            if (false === include_once ($path)) {
                 require_once 'Zend/Http/UserAgent/Exception.php';
                 throw new Zend_Http_UserAgent_Exception('The ' . $this->getType() . ' features adapter path that does not exist');
             }
         }
 
-        return call_user_func(array($className, 'getFromRequest'), $this->_server, $this->_config);
+        return call_user_func([$className, 'getFromRequest'], $this->_server, $this->_config);
     }
 
     /**
@@ -807,7 +819,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     /**
      * Get maximum image height supported by this device
      *
-     * @return int
+     * @return string|null
      */
     public function getMaxImageHeight()
     {
@@ -817,7 +829,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     /**
      * Get maximum image width supported by this device
      *
-     * @return int
+     * @return string|null
      */
     public function getMaxImageWidth()
     {
@@ -827,7 +839,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     /**
      * Get physical screen height of this device
      *
-     * @return int
+     * @return string|null
      */
     public function getPhysicalScreenHeight()
     {
@@ -837,7 +849,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     /**
      * Get physical screen width of this device
      *
-     * @return int
+     * @return string|null
      */
     public function getPhysicalScreenWidth()
     {
@@ -935,7 +947,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
     }
 
     /**
-     * @return the $_images
+     * @return array|string[] $_images
      */
     public function getImages()
     {
@@ -987,7 +999,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice implements Zend_Http_UserAgent
         $userAgent = strtolower($userAgent);
         foreach ($signatures as $signature) {
             if (!empty($signature)) {
-                if (strpos($userAgent, (string) $signature) !== false) {
+                if (strpos($userAgent, $signature) !== false) {
                     // Browser signature was found in user agent string
                     return true;
                 }

--- a/application/helpers/Zend/Http/UserAgent/Bot.php
+++ b/application/helpers/Zend/Http/UserAgent/Bot.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -19,7 +18,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-
 require_once 'Zend/Http/UserAgent/AbstractDevice.php';
 
 /**
@@ -40,7 +38,7 @@ class Zend_Http_UserAgent_Bot extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         // The most common ones.
         'googlebot',
         'msnbot',
@@ -105,7 +103,7 @@ class Zend_Http_UserAgent_Bot extends Zend_Http_UserAgent_AbstractDevice
         'yahoo! slurp',
         'yandex',
         'zyborg',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and browser signatures

--- a/application/helpers/Zend/Http/UserAgent/Checker.php
+++ b/application/helpers/Zend/Http/UserAgent/Checker.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -19,7 +18,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-
 require_once 'Zend/Http/UserAgent/Desktop.php';
 
 /**
@@ -40,7 +38,7 @@ class Zend_Http_UserAgent_Checker extends Zend_Http_UserAgent_Desktop
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'abilogic',
         'checklink',
         'checker',
@@ -52,7 +50,7 @@ class Zend_Http_UserAgent_Checker extends Zend_Http_UserAgent_Desktop
         'sitebar',
         'xenu',
         'sleuth',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures

--- a/application/helpers/Zend/Http/UserAgent/Console.php
+++ b/application/helpers/Zend/Http/UserAgent/Console.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,11 +37,11 @@ class Zend_Http_UserAgent_Console extends Zend_Http_UserAgent_Desktop
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'playstation',
         'wii',
         'libnup',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures

--- a/application/helpers/Zend/Http/UserAgent/Desktop.php
+++ b/application/helpers/Zend/Http/UserAgent/Desktop.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/UserAgent/Device.php
+++ b/application/helpers/Zend/Http/UserAgent/Device.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -43,7 +42,7 @@ interface Zend_Http_UserAgent_Device extends Serializable
      * @param  array $config
      * @return void
      */
-    public function __construct($userAgent = null, array $server = array(), array $config = array());
+    public function __construct($userAgent = null, array $server = [], array $config = []);
 
     /**
      * Attempt to match the user agent

--- a/application/helpers/Zend/Http/UserAgent/Email.php
+++ b/application/helpers/Zend/Http/UserAgent/Email.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,9 +37,9 @@ class Zend_Http_UserAgent_Email extends Zend_Http_UserAgent_Desktop
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'thunderbird',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures

--- a/application/helpers/Zend/Http/UserAgent/Exception.php
+++ b/application/helpers/Zend/Http/UserAgent/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/UserAgent/Features/Adapter.php
+++ b/application/helpers/Zend/Http/UserAgent/Features/Adapter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/UserAgent/Features/Adapter/Browscap.php
+++ b/application/helpers/Zend/Http/UserAgent/Features/Adapter/Browscap.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -36,7 +35,8 @@ require_once 'Zend/Http/UserAgent/Features/Adapter.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Http_UserAgent_Features_Adapter_Browscap implements Zend_Http_UserAgent_Features_Adapter
+class Zend_Http_UserAgent_Features_Adapter_Browscap
+    implements Zend_Http_UserAgent_Features_Adapter
 {
     /**
      * Constructor
@@ -67,7 +67,7 @@ class Zend_Http_UserAgent_Features_Adapter_Browscap implements Zend_Http_UserAge
     public static function getFromRequest($request, array $config)
     {
         $browscap = get_browser($request['http_user_agent'], true);
-        $features = array();
+        $features = [];
 
         if (is_array($browscap)) {
             foreach ($browscap as $key => $value) {

--- a/application/helpers/Zend/Http/UserAgent/Features/Adapter/DeviceAtlas.php
+++ b/application/helpers/Zend/Http/UserAgent/Features/Adapter/DeviceAtlas.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -61,7 +60,7 @@ class Zend_Http_UserAgent_Features_Adapter_DeviceAtlas implements Zend_Http_User
             }
 
             // Include the Device Atlas file from the specified lib_dir
-            require_once($config['deviceatlas_lib_dir'] . '/Mobi/Mtld/DA/Api.php');
+            require_once ($config['deviceatlas_lib_dir'] . '/Mobi/Mtld/DA/Api.php');
         }
 
         if (empty($config['deviceatlas_data'])) {
@@ -72,8 +71,6 @@ class Zend_Http_UserAgent_Features_Adapter_DeviceAtlas implements Zend_Http_User
         //load the device data-tree : e.g. 'json/DeviceAtlas.json
         $tree = Mobi_Mtld_DA_Api::getTreeFromFile($config['deviceatlas_data']);
 
-        $properties = Mobi_Mtld_DA_Api::getProperties($tree, $request['http_user_agent']);
-
-        return $properties;
+        return Mobi_Mtld_DA_Api::getProperties($tree, $request['http_user_agent']);
     }
 }

--- a/application/helpers/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
+++ b/application/helpers/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -57,14 +56,14 @@ class Zend_Http_UserAgent_Features_Adapter_TeraWurfl implements Zend_Http_UserAg
 
             $config = $config['terawurfl'];
 
-            if (empty($config['terawurfl_lib_dir'])) {
+             if (empty($config['terawurfl_lib_dir'])) {
                 // No lib_dir given
                 require_once 'Zend/Http/UserAgent/Features/Exception.php';
                 throw new Zend_Http_UserAgent_Features_Exception('The "terawurfl_lib_dir" parameter is not defined');
             }
 
             // Include the Tera-WURFL file
-            require_once($config['terawurfl_lib_dir'] . '/TeraWurfl.php');
+            require_once ($config['terawurfl_lib_dir'] . '/TeraWurfl.php');
         }
 
 
@@ -89,7 +88,7 @@ class Zend_Http_UserAgent_Features_Adapter_TeraWurfl implements Zend_Http_UserAg
             if (!is_array($group)) {
                 continue;
             }
-            while (list ($key, $value) = each($group)) {
+            foreach ($group as $key => $value) {
                 if (is_bool($value)) {
                     // to have the same type than the official WURFL API
                     $features[$key] = ($value ? 'true' : 'false');

--- a/application/helpers/Zend/Http/UserAgent/Features/Exception.php
+++ b/application/helpers/Zend/Http/UserAgent/Features/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/UserAgent/Feed.php
+++ b/application/helpers/Zend/Http/UserAgent/Feed.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,12 +37,12 @@ class Zend_Http_UserAgent_Feed extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'bloglines',
         'everyfeed',
         'feedfetcher',
         'gregarius',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures
@@ -70,12 +69,12 @@ class Zend_Http_UserAgent_Feed extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Look for features
      *
-     * @return string
+     * @return array|null
      */
     protected function _defineFeatures()
     {
-        $this->setFeature('iframes', false, 'product_capability');
-        $this->setFeature('frames', false, 'product_capability');
+        $this->setFeature('iframes',    false, 'product_capability');
+        $this->setFeature('frames',     false, 'product_capability');
         $this->setFeature('javascript', false, 'product_capability');
         return parent::_defineFeatures();
     }

--- a/application/helpers/Zend/Http/UserAgent/Mobile.php
+++ b/application/helpers/Zend/Http/UserAgent/Mobile.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -43,7 +42,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'iphone',
         'ipod',
         'ipad',
@@ -163,25 +162,25 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
         'j2me',
         'klondike',
         'kbrowser'
-    );
+    ];
 
     /**
      * @var array
      */
-    protected static $_haTerms = array(
+    protected static $_haTerms = [
         'midp',
         'wml',
         'vnd.rim',
         'vnd.wap',
         'j2me',
-    );
+    ];
 
     /**
      * first 4 letters of mobile User Agent chains
      *
      * @var array
      */
-    protected static $_uaBegin = array(
+    protected static $_uaBegin = [
         'w3c ',
         'acs-',
         'alav',
@@ -267,7 +266,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
         'winw',
         'xda',
         'xda-',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures
@@ -280,7 +279,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     {
         //  To have a quick identification, try light-weight tests first
         if (isset($server['all_http'])) {
-            if (strpos(strtolower(str_replace(' ', '', (string) $server['all_http'])), 'operam') !== false) {
+            if (strpos(strtolower(str_replace(' ', '', $server['all_http'])), 'operam') !== false) {
                 // Opera Mini or Opera Mobi
                 return true;
             }
@@ -311,7 +310,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
      * Retrieve beginning clause of user agent
      *
      * @param  string $userAgent
-     * @return string
+     * @return bool
      */
     public static function userAgentStart($userAgent)
     {
@@ -326,7 +325,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
      *
      * @return void
      */
-    public function __construct($userAgent = null, array $server = array(), array $config = array())
+    public function __construct($userAgent = null, array $server = [], array $config = [])
     {
         // For mobile detection, an adapter must be defined
         if (empty($config['mobile']['features'])) {
@@ -349,7 +348,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Look for features
      *
-     * @return string
+     * @return array
      */
     protected function _defineFeatures()
     {
@@ -367,8 +366,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
         }
 
         // markup
-        if (
-            $this->getFeature('device_os') == 'iPhone OS'
+        if ($this->getFeature('device_os') == 'iPhone OS'
             || $this->getFeature('device_os_token') == 'iPhone OS'
         ) {
             $this->setFeature('markup', 'iphone');
@@ -377,7 +375,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
         }
 
         // image format
-        $this->_images = array();
+        $this->_images = [];
 
         if ($this->getFeature('png')) {
             $this->_images[] = 'png';
@@ -399,7 +397,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
      * Determine markup language expected
      *
      * @access public
-     * @return __TYPE__
+     * @return string
      */
     public function getMarkupLanguage($preferredMarkup = null)
     {
@@ -439,7 +437,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Determine maximum image height supported
      *
-     * @return int
+     * @return string|null
      */
     public function getMaxImageHeight()
     {
@@ -449,7 +447,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Determine maximum image width supported
      *
-     * @return int
+     * @return string|null
      */
     public function getMaxImageWidth()
     {
@@ -459,7 +457,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Determine physical screen height
      *
-     * @return int
+     * @return string|null
      */
     public function getPhysicalScreenHeight()
     {
@@ -469,7 +467,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Determine physical screen width
      *
-     * @return int
+     * @return string|null
      */
     public function getPhysicalScreenWidth()
     {
@@ -489,7 +487,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Determine X/HTML support level
      *
-     * @return int
+     * @return string|null
      */
     public function getXhtmlSupportLevel()
     {
@@ -499,7 +497,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Does the device support Flash?
      *
-     * @return bool
+     * @return string|null
      */
     public function hasFlashSupport()
     {
@@ -509,7 +507,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Does the device support PDF?
      *
-     * @return bool
+     * @return string|null
      */
     public function hasPdfSupport()
     {
@@ -519,7 +517,7 @@ class Zend_Http_UserAgent_Mobile extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Does the device have an associated phone number?
      *
-     * @return bool
+     * @return string|null
      */
     public function hasPhoneNumber()
     {

--- a/application/helpers/Zend/Http/UserAgent/Offline.php
+++ b/application/helpers/Zend/Http/UserAgent/Offline.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,14 +37,14 @@ class Zend_Http_UserAgent_Offline extends Zend_Http_UserAgent_Desktop
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'wget',
         'webzip',
         'webcopier',
         'downloader',
         'superbot',
         'offline',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures

--- a/application/helpers/Zend/Http/UserAgent/Probe.php
+++ b/application/helpers/Zend/Http/UserAgent/Probe.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,10 +37,10 @@ class Zend_Http_UserAgent_Probe extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'witbe',
         'netvigie',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures
@@ -69,7 +68,7 @@ class Zend_Http_UserAgent_Probe extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Look for features
      *
-     * @return string
+     * @return array|null
      */
     protected function _defineFeatures()
     {

--- a/application/helpers/Zend/Http/UserAgent/Spam.php
+++ b/application/helpers/Zend/Http/UserAgent/Spam.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,9 +37,9 @@ class Zend_Http_UserAgent_Spam extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         '',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures
@@ -67,7 +66,7 @@ class Zend_Http_UserAgent_Spam extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Look for features
      *
-     * @return string
+     * @return array|null
      */
     protected function _defineFeatures()
     {

--- a/application/helpers/Zend/Http/UserAgent/Storage.php
+++ b/application/helpers/Zend/Http/UserAgent/Storage.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Http/UserAgent/Storage/Exception.php
+++ b/application/helpers/Zend/Http/UserAgent/Storage/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -19,6 +18,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+
 
 /**
  * @see Zend_Http_UserAgent_Exception

--- a/application/helpers/Zend/Http/UserAgent/Storage/NonPersistent.php
+++ b/application/helpers/Zend/Http/UserAgent/Storage/NonPersistent.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -21,6 +20,7 @@
  * @version    $Id: NonPersistent.php 20096 2010-01-06 02:05:09Z bkarwin $
  */
 
+
 /**
  * @see Zend_Http_UserAgent_Storage_Interface
  */
@@ -39,7 +39,8 @@ require_once 'Zend/Http/UserAgent/Storage.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Http_UserAgent_Storage_NonPersistent implements Zend_Http_UserAgent_Storage
+class Zend_Http_UserAgent_Storage_NonPersistent
+    implements Zend_Http_UserAgent_Storage
 {
     /**
      * Holds the actual Browser data

--- a/application/helpers/Zend/Http/UserAgent/Storage/Session.php
+++ b/application/helpers/Zend/Http/UserAgent/Storage/Session.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -97,8 +96,10 @@ class Zend_Http_UserAgent_Storage_Session implements Zend_Http_UserAgent_Storage
 
         // add '.' to prevent the message ''Session namespace must not start with a number'
         $this->_namespace = '.'
-                          . ($options['browser_type'] ?? self::NAMESPACE_DEFAULT);
-        $this->_member    = $options['member'] ?? self::MEMBER_DEFAULT;
+                          . (isset($options['browser_type'])
+                             ? $options['browser_type']
+                             : self::NAMESPACE_DEFAULT);
+        $this->_member    = isset($options['member']) ? $options['member'] : self::MEMBER_DEFAULT;
         $this->_session   = new Zend_Session_Namespace($this->_namespace);
     }
 

--- a/application/helpers/Zend/Http/UserAgent/Text.php
+++ b/application/helpers/Zend/Http/UserAgent/Text.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,11 +37,11 @@ class Zend_Http_UserAgent_Text extends Zend_Http_UserAgent_AbstractDevice
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'lynx',
         'retawq',
         'w3m',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures
@@ -69,7 +68,7 @@ class Zend_Http_UserAgent_Text extends Zend_Http_UserAgent_AbstractDevice
     /**
      * Look for features
      *
-     * @return string
+     * @return array|null
      */
     protected function _defineFeatures()
     {

--- a/application/helpers/Zend/Http/UserAgent/Validator.php
+++ b/application/helpers/Zend/Http/UserAgent/Validator.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -38,7 +37,7 @@ class Zend_Http_UserAgent_Validator extends Zend_Http_UserAgent_Desktop
      *
      * @var array
      */
-    protected static $_uaSignatures = array(
+    protected static $_uaSignatures = [
         'htmlvalidator',
         'csscheck',
         'cynthia',
@@ -48,7 +47,7 @@ class Zend_Http_UserAgent_Validator extends Zend_Http_UserAgent_Desktop
         'jigsaw',
         'w3c_validator',
         'wdg_validator',
-    );
+    ];
 
     /**
      * Comparison of the UserAgent chain and User Agent signatures

--- a/application/helpers/Zend/Loader.php
+++ b/application/helpers/Zend/Loader.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -73,7 +72,7 @@ class Zend_Loader
                 if ($dir == '.') {
                     $dirs[$key] = $dirPath;
                 } else {
-                    $dir = rtrim((string) $dir, '\\/');
+                    $dir = rtrim($dir, '\\/');
                     $dirs[$key] = $dir . DIRECTORY_SEPARATOR . $dirPath;
                 }
             }
@@ -131,10 +130,20 @@ class Zend_Loader
         /**
          * Try finding for the plain filename in the include_path.
          */
+        // "@":
+        // - Avoid error-logs full of PHP Warnings due to autoloads from class-exists()-checks.
+        // - If a class does not exist that we really need, error will be thrown anyway.
+        // - Fatal errors from the included files are still thrown anyway.
+        // Since PHP 8.0 @ doesn't mute the errors, which makes for a lot of clutter on the error log when you are using class_exists() and it doesn't
+        // Added stream_resolve_include_path to avoid it.
         if ($once) {
-            include_once $filename;
+            if(stream_resolve_include_path($filename)) {
+                @include_once $filename;
+            }
         } else {
-            include $filename;
+            if(stream_resolve_include_path($filename)) {
+                @include $filename;
+            }
         }
 
         /**
@@ -168,8 +177,7 @@ class Zend_Loader
             return true;
         }
 
-        if (
-            strtoupper(substr(PHP_OS, 0, 3)) == 'WIN'
+        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN'
             && preg_match('/^[a-z]:/i', $filename)
         ) {
             // If on windows, and path provided is clearly an absolute path,
@@ -266,7 +274,7 @@ class Zend_Loader
                 throw new Zend_Exception("The class \"$class\" does not have an autoload() method");
             }
 
-            $callback = array($class, 'autoload');
+            $callback = [$class, 'autoload'];
 
             if ($enabled) {
                 $autoloader->pushAutoloader($callback);

--- a/application/helpers/Zend/README.md
+++ b/application/helpers/Zend/README.md
@@ -1,0 +1,3 @@
+Moved from original ZF1 to "ZF1 Future" (https://github.com/Shardj/zf1-future/) because original project is unmaintained.
+
+Still had to fix Zend_XmlRpc_Server::setResponseClass() as it was failing.

--- a/application/helpers/Zend/Registry.php
+++ b/application/helpers/Zend/Registry.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -191,20 +190,9 @@ class Zend_Registry extends ArrayObject
      * @param array $array data array
      * @param integer $flags ArrayObject flags
      */
-    public function __construct($array = array(), $flags = parent::ARRAY_AS_PROPS)
+    public function __construct($array = [], $flags = parent::ARRAY_AS_PROPS)
     {
         parent::__construct($array, $flags);
     }
 
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
 }

--- a/application/helpers/Zend/Server/Abstract.php
+++ b/application/helpers/Zend/Server/Abstract.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -52,9 +51,9 @@ require_once 'Zend/Server/Method/Parameter.php';
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Abstract.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 abstract class Zend_Server_Abstract implements Zend_Server_Interface
 {
@@ -62,7 +61,7 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
      * @deprecated
      * @var array List of PHP magic methods (lowercased)
      */
-    protected static $magic_methods = array(
+    protected static $magic_methods = [
         '__call',
         '__clone',
         '__construct',
@@ -75,7 +74,7 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
         '__tostring',
         '__unset',
         '__wakeup',
-    );
+    ];
 
     /**
      * @var bool Flag; whether or not overwriting existing methods is allowed
@@ -112,7 +111,21 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
         return $this->_table;
     }
 
-
+    /**
+     * Lowercase a string
+     *
+     * Lowercase's a string by reference
+     *
+     * @deprecated
+     * @param  string $string value
+     * @param  string $key
+     * @return string Lower cased string
+     */
+    public static function lowerCase(&$value, &$key)
+    {
+        trigger_error(__CLASS__ . '::' . __METHOD__ . '() is deprecated and will be removed in a future version', E_USER_NOTICE);
+        return $value = strtolower($value);
+    }
 
     /**
      * Build callback for method signature
@@ -125,11 +138,11 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
         $callback = new Zend_Server_Method_Callback();
         if ($reflection instanceof Zend_Server_Reflection_Method) {
             $callback->setType($reflection->isStatic() ? 'static' : 'instance')
-                        ->setClass($reflection->getDeclaringClass()->getName())
-                        ->setMethod($reflection->getName());
+                     ->setClass($reflection->getDeclaringClass()->getName())
+                     ->setMethod($reflection->getName());
         } elseif ($reflection instanceof Zend_Server_Reflection_Function) {
             $callback->setType('function')
-                        ->setFunction($reflection->getName());
+                     ->setFunction($reflection->getName());
         }
         return $callback;
     }
@@ -155,19 +168,19 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
 
         $definition = new Zend_Server_Method_Definition();
         $definition->setName($method)
-                    ->setCallback($this->_buildCallback($reflection))
-                    ->setMethodHelp($reflection->getDescription())
-                    ->setInvokeArguments($reflection->getInvokeArguments());
+                   ->setCallback($this->_buildCallback($reflection))
+                   ->setMethodHelp($reflection->getDescription())
+                   ->setInvokeArguments($reflection->getInvokeArguments());
 
         foreach ($reflection->getPrototypes() as $proto) {
             $prototype = new Zend_Server_Method_Prototype();
             $prototype->setReturnType($this->_fixType($proto->getReturnType()));
             foreach ($proto->getParameters() as $parameter) {
-                $param = new Zend_Server_Method_Parameter(array(
+                $param = new Zend_Server_Method_Parameter([
                     'type'     => $this->_fixType($parameter->getType()),
                     'name'     => $parameter->getName(),
                     'optional' => $parameter->isOptional(),
-                ));
+                ]);
                 if ($parameter->isDefaultValueAvailable()) {
                     $param->setDefaultValue($parameter->getDefaultValue());
                 }
@@ -203,7 +216,7 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
         $method = $callback->getMethod();
 
         if ('static' == $type) {
-            return call_user_func_array(array($class, $method), $params);
+            return call_user_func_array([$class, $method], $params);
         }
 
         $object = $invocable->getObject();
@@ -213,10 +226,10 @@ abstract class Zend_Server_Abstract implements Zend_Server_Interface
                 $reflection = new ReflectionClass($class);
                 $object     = $reflection->newInstanceArgs($invokeArgs);
             } else {
-                $object = new $class();
+                $object = new $class;
             }
         }
-        return call_user_func_array(array($object, $method), $params);
+        return call_user_func_array([$object, $method], $params);
     }
 
     /**

--- a/application/helpers/Zend/Server/Cache.php
+++ b/application/helpers/Zend/Server/Cache.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,9 +14,9 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Cache.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -25,7 +24,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Cache
@@ -33,7 +32,7 @@ class Zend_Server_Cache
     /**
      * @var array Methods to skip when caching server
      */
-    protected static $_skipMethods = array();
+    protected static $_skipMethods = [];
 
     /**
      * Cache a file containing the dispatch list.
@@ -50,10 +49,9 @@ class Zend_Server_Cache
      */
     public static function save($filename, Zend_Server_Interface $server)
     {
-        if (
-            !is_string($filename)
-            || (!file_exists($filename) && !is_writable(dirname($filename)))
-        ) {
+        if (!is_string($filename)
+            || (!file_exists($filename) && !is_writable(dirname($filename))))
+        {
             return false;
         }
 
@@ -110,11 +108,10 @@ class Zend_Server_Cache
      */
     public static function get($filename, Zend_Server_Interface $server)
     {
-        if (
-            !is_string($filename)
+        if (!is_string($filename)
             || !file_exists($filename)
-            || !is_readable($filename)
-        ) {
+            || !is_readable($filename))
+        {
             return false;
         }
 

--- a/application/helpers/Zend/Server/Definition.php
+++ b/application/helpers/Zend/Server/Definition.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,9 +14,9 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Definition.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -26,7 +25,7 @@
  * @todo       Implement iterator
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Definition implements Countable, Iterator
@@ -34,7 +33,7 @@ class Zend_Server_Definition implements Countable, Iterator
     /**
      * @var array Array of Zend_Server_Method_Definition objects
      */
-    protected $_methods = array();
+    protected $_methods = [];
 
     /**
      * @var bool Whether or not overwriting existing methods is allowed
@@ -57,7 +56,7 @@ class Zend_Server_Definition implements Countable, Iterator
     /**
      * Set flag indicating whether or not overwriting existing methods is allowed
      *
-     * @param boolean $flag
+     * @param mixed $flag
      * @return Zend_Server_Definition
      */
     public function setOverwriteExistingMethods($flag)
@@ -147,7 +146,7 @@ class Zend_Server_Definition implements Countable, Iterator
      * Get a given method definition
      *
      * @param  string $method
-     * @return bool|null|Zend_Server_Method_Definition
+     * @return null|Zend_Server_Method_Definition
      */
     public function getMethod($method)
     {
@@ -188,7 +187,7 @@ class Zend_Server_Definition implements Countable, Iterator
      */
     public function clearMethods()
     {
-        $this->_methods = array();
+        $this->_methods = [];
         return $this;
     }
 
@@ -199,7 +198,7 @@ class Zend_Server_Definition implements Countable, Iterator
      */
     public function toArray()
     {
-        $methods = array();
+        $methods = [];
         foreach ($this->getMethods() as $key => $method) {
             $methods[$key] = $method->toArray();
         }
@@ -211,8 +210,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->_methods);
     }
@@ -266,8 +264,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->current();
     }

--- a/application/helpers/Zend/Server/Exception.php
+++ b/application/helpers/Zend/Server/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,7 +28,7 @@ require_once 'Zend/Exception.php';
  *
  * @package Zend_Server
  * @subpackage Reflection
- * @version $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Exception extends Zend_Exception
 {

--- a/application/helpers/Zend/Server/Interface.php
+++ b/application/helpers/Zend/Server/Interface.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -24,9 +23,9 @@
  *
  * @category Zend
  * @package  Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Interface.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 interface Zend_Server_Interface
 {
@@ -103,6 +102,7 @@ interface Zend_Server_Interface
      *
      * Used for persistence; loads a construct as returned by {@link getFunctions()}.
      *
+     * @param array $array
      * @return void
      */
     public function loadFunctions($definition);

--- a/application/helpers/Zend/Server/Method/Callback.php
+++ b/application/helpers/Zend/Server/Method/Callback.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Callback.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Method_Callback
@@ -55,7 +54,7 @@ class Zend_Server_Method_Callback
     /**
      * @var array Valid callback types
      */
-    protected $_types = array('function', 'static', 'instance');
+    protected $_types = ['function', 'static', 'instance'];
 
     /**
      * Constructor
@@ -65,7 +64,7 @@ class Zend_Server_Method_Callback
      */
     public function __construct($options = null)
     {
-        if ((null !== $options) && is_array($options)) {
+        if ((null !== $options) && is_array($options))  {
             $this->setOptions($options);
         }
     }
@@ -192,9 +191,9 @@ class Zend_Server_Method_Callback
     public function toArray()
     {
         $type = $this->getType();
-        $array = array(
+        $array = [
             'type' => $type,
-        );
+        ];
         if ('function' == $type) {
             $array['function'] = $this->getFunction();
         } else {

--- a/application/helpers/Zend/Server/Method/Definition.php
+++ b/application/helpers/Zend/Server/Method/Definition.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Definition.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Method_Definition
@@ -40,7 +39,7 @@ class Zend_Server_Method_Definition
     /**
      * @var array
      */
-    protected $_invokeArguments = array();
+    protected $_invokeArguments = [];
 
     /**
      * @var string
@@ -60,7 +59,7 @@ class Zend_Server_Method_Definition
     /**
      * @var array Array of Zend_Server_Method_Prototype objects
      */
-    protected $_prototypes = array();
+    protected $_prototypes = [];
 
     /**
      * Constructor
@@ -117,7 +116,7 @@ class Zend_Server_Method_Definition
     /**
      * Set method callback
      *
-     * @param  Zend_Server_Method_Callback $callback
+     * @param  array|Zend_Server_Method_Callback $callback
      * @return Zend_Server_Method_Definition
      */
     public function setCallback($callback)
@@ -184,7 +183,7 @@ class Zend_Server_Method_Definition
      */
     public function setPrototypes(array $prototypes)
     {
-        $this->_prototypes = array();
+        $this->_prototypes = [];
         $this->addPrototypes($prototypes);
         return $this;
     }
@@ -277,18 +276,18 @@ class Zend_Server_Method_Definition
     public function toArray()
     {
         $prototypes = $this->getPrototypes();
-        $signatures = array();
+        $signatures = [];
         foreach ($prototypes as $prototype) {
             $signatures[] = $prototype->toArray();
         }
 
-        return array(
+        return [
             'name'            => $this->getName(),
             'callback'        => $this->getCallback()->toArray(),
             'prototypes'      => $signatures,
             'methodHelp'      => $this->getMethodHelp(),
             'invokeArguments' => $this->getInvokeArguments(),
             'object'          => $this->getObject(),
-        );
+        ];
     }
 }

--- a/application/helpers/Zend/Server/Method/Parameter.php
+++ b/application/helpers/Zend/Server/Method/Parameter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Parameter.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Method_Parameter
@@ -61,7 +60,7 @@ class Zend_Server_Method_Parameter
      * Constructor
      *
      * @param  null|array $options
-     * @return string
+     * @return void
      */
     public function __construct($options = null)
     {
@@ -204,12 +203,12 @@ class Zend_Server_Method_Parameter
      */
     public function toArray()
     {
-        return array(
+        return [
             'type'         => $this->getType(),
             'name'         => $this->getName(),
             'optional'     => $this->isOptional(),
             'defaultValue' => $this->getDefaultValue(),
             'description'  => $this->getDescription(),
-        );
+        ];
     }
 }

--- a/application/helpers/Zend/Server/Method/Prototype.php
+++ b/application/helpers/Zend/Server/Method/Prototype.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Prototype.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Method
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Method_Prototype
@@ -40,12 +39,12 @@ class Zend_Server_Method_Prototype
     /**
      * @var array Map parameter names to parameter index
      */
-    protected $_parameterNameMap = array();
+    protected $_parameterNameMap = [];
 
     /**
      * @var array Method parameters
      */
-    protected $_parameters = array();
+    protected $_parameters = [];
 
     /**
      * Constructor
@@ -97,9 +96,9 @@ class Zend_Server_Method_Prototype
             }
         } else {
             require_once 'Zend/Server/Method/Parameter.php';
-            $parameter = new Zend_Server_Method_Parameter(array(
+            $parameter = new Zend_Server_Method_Parameter([
                 'type' => (string) $parameter,
-            ));
+            ]);
             $this->_parameters[] = $parameter;
         }
         return $this;
@@ -108,7 +107,7 @@ class Zend_Server_Method_Prototype
     /**
      * Add parameters
      *
-     * @param  array $parameters
+     * @param  array $parameter
      * @return Zend_Server_Method_Prototype
      */
     public function addParameters(array $parameters)
@@ -127,8 +126,8 @@ class Zend_Server_Method_Prototype
      */
     public function setParameters(array $parameters)
     {
-        $this->_parameters       = array();
-        $this->_parameterNameMap = array();
+        $this->_parameters       = [];
+        $this->_parameterNameMap = [];
         $this->addParameters($parameters);
         return $this;
     }
@@ -140,7 +139,7 @@ class Zend_Server_Method_Prototype
      */
     public function getParameters()
     {
-        $types = array();
+        $types = [];
         foreach ($this->_parameters as $parameter) {
             $types[] = $parameter->getType();
         }
@@ -201,9 +200,9 @@ class Zend_Server_Method_Prototype
      */
     public function toArray()
     {
-        return array(
+        return [
             'returnType' => $this->getReturnType(),
             'parameters' => $this->getParameters(),
-        );
+        ];
     }
 }

--- a/application/helpers/Zend/Server/Reflection.php
+++ b/application/helpers/Zend/Server/Reflection.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -35,9 +34,9 @@ require_once 'Zend/Server/Reflection/Class.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Reflection.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection
 {

--- a/application/helpers/Zend/Server/Reflection/Class.php
+++ b/application/helpers/Zend/Server/Reflection/Class.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,9 +32,9 @@ require_once 'Zend/Server/Reflection/Method.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Class.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Class
 {
@@ -44,13 +43,13 @@ class Zend_Server_Reflection_Class
      * {@link __set()}
      * @var array
      */
-    protected $_config = array();
+    protected $_config = [];
 
     /**
      * Array of {@link Zend_Server_Reflection_Method}s
      * @var array
      */
-    protected $_methods = array();
+    protected $_methods = [];
 
     /**
      * Namespace
@@ -103,7 +102,7 @@ class Zend_Server_Reflection_Class
     public function __call($method, $args)
     {
         if (method_exists($this->_reflection, $method)) {
-            return call_user_func_array(array($this->_reflection, $method), $args);
+            return call_user_func_array([$this->_reflection, $method], $args);
         }
 
         require_once 'Zend/Server/Reflection/Exception.php';

--- a/application/helpers/Zend/Server/Reflection/Exception.php
+++ b/application/helpers/Zend/Server/Reflection/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,9 +29,9 @@ require_once 'Zend/Server/Exception.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Exception extends Zend_Server_Exception
 {

--- a/application/helpers/Zend/Server/Reflection/Function.php
+++ b/application/helpers/Zend/Server/Reflection/Function.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,9 +30,9 @@ require_once 'Zend/Server/Reflection/Function/Abstract.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Function.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Function extends Zend_Server_Reflection_Function_Abstract
 {

--- a/application/helpers/Zend/Server/Reflection/Method.php
+++ b/application/helpers/Zend/Server/Reflection/Method.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -31,9 +30,9 @@ require_once 'Zend/Server/Reflection/Function/Abstract.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Method.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abstract
 {
@@ -58,7 +57,7 @@ class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abst
      * @param array $argv
      * @return void
      */
-    public function __construct(Zend_Server_Reflection_Class $class, ReflectionMethod $r, $namespace = null, $argv = array())
+    public function __construct(Zend_Server_Reflection_Class $class, ReflectionMethod $r, $namespace = null, $argv = [])
     {
         $this->_classReflection = $class;
         $this->_reflection      = $r;
@@ -107,4 +106,5 @@ class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abst
         $this->_classReflection = new Zend_Server_Reflection_Class(new ReflectionClass($this->_class), $this->getNamespace(), $this->getInvokeArguments());
         $this->_reflection = new ReflectionMethod($this->_classReflection->getName(), $this->getName());
     }
+
 }

--- a/application/helpers/Zend/Server/Reflection/Node.php
+++ b/application/helpers/Zend/Server/Reflection/Node.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -25,8 +24,8 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @version $Id: Node.php 23775 2011-03-01 17:25:24Z ralph $
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @version $Id$
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Server_Reflection_Node
@@ -41,7 +40,7 @@ class Zend_Server_Reflection_Node
      * Array of child nodes (if any)
      * @var array
      */
-    protected $_children = array();
+    protected $_children = [];
 
     /**
      * Parent node (if any)
@@ -93,9 +92,7 @@ class Zend_Server_Reflection_Node
      */
     public function createChild($value)
     {
-        $child = new self($value, $this);
-
-        return $child;
+        return new self($value, $this);
     }
 
     /**
@@ -175,7 +172,7 @@ class Zend_Server_Reflection_Node
      */
     public function getEndPoints()
     {
-        $endPoints = array();
+        $endPoints = [];
         if (!$this->hasChildren()) {
             return $endPoints;
         }
@@ -185,10 +182,9 @@ class Zend_Server_Reflection_Node
 
             if (null === $value) {
                 $endPoints[] = $this;
-            } elseif (
-                (null !== $value)
-                && $child->hasChildren()
-            ) {
+            } elseif ((null !== $value)
+                && $child->hasChildren())
+            {
                 $childEndPoints = $child->getEndPoints();
                 if (!empty($childEndPoints)) {
                     $endPoints = array_merge($endPoints, $childEndPoints);

--- a/application/helpers/Zend/Server/Reflection/Parameter.php
+++ b/application/helpers/Zend/Server/Reflection/Parameter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,9 +26,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Parameter.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Parameter
 {
@@ -80,7 +79,7 @@ class Zend_Server_Reflection_Parameter
     public function __call($method, $args)
     {
         if (method_exists($this->_reflection, $method)) {
-            return call_user_func_array(array($this->_reflection, $method), $args);
+            return call_user_func_array([$this->_reflection, $method], $args);
         }
 
         require_once 'Zend/Server/Reflection/Exception.php';

--- a/application/helpers/Zend/Server/Reflection/Prototype.php
+++ b/application/helpers/Zend/Server/Reflection/Prototype.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -37,12 +36,22 @@ require_once 'Zend/Server/Reflection/Parameter.php';
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Prototype.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_Prototype
 {
+    /**
+     * @var array | null
+     */
+    protected $_params;
+
+    /**
+     * @var Zend_Server_Reflection_ReturnValue
+     */
+    protected $_return;
+
     /**
      * Constructor
      *

--- a/application/helpers/Zend/Server/Reflection/ReturnValue.php
+++ b/application/helpers/Zend/Server/Reflection/ReturnValue.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -27,9 +26,9 @@
  * @category   Zend
  * @package    Zend_Server
  * @subpackage Reflection
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: ReturnValue.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_Server_Reflection_ReturnValue
 {

--- a/application/helpers/Zend/Stdlib/CallbackHandler.php
+++ b/application/helpers/Zend/Stdlib/CallbackHandler.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -31,6 +30,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Stdlib_CallbackHandler
 {
     /**
@@ -58,7 +58,7 @@ class Zend_Stdlib_CallbackHandler
      * @param  array $options Options used by the callback handler (e.g., priority)
      * @return void
      */
-    public function __construct($callback, array $metadata = array())
+    public function __construct($callback, array $metadata = [])
     {
         $this->metadata  = $metadata;
         $this->registerCallback($callback);
@@ -93,7 +93,7 @@ class Zend_Stdlib_CallbackHandler
      */
     protected function registerCallback($callback)
     {
-        set_error_handler(array($this, 'errorHandler'), E_STRICT);
+        set_error_handler([$this, 'errorHandler'], E_STRICT);
         $callable = is_callable($callback);
         restore_error_handler();
         if (!$callable || $this->error) {
@@ -102,7 +102,7 @@ class Zend_Stdlib_CallbackHandler
         }
 
         // If pecl/weakref is not installed, simply store the callback and return
-        set_error_handler(array($this, 'errorHandler'), E_WARNING);
+        set_error_handler([$this, 'errorHandler'], E_WARNING);
         $callable = class_exists('WeakRef');
         restore_error_handler();
         if (!$callable || $this->error) {
@@ -137,7 +137,7 @@ class Zend_Stdlib_CallbackHandler
         // We have an array callback with an object as the first argument;
         // pass it to WeakRef, and then register the new callback
         $target = new WeakRef($target);
-        $this->callback = array($target, $method);
+        $this->callback = [$target, $method];
     }
 
     /**
@@ -168,7 +168,7 @@ class Zend_Stdlib_CallbackHandler
         // then return
         list($target, $method) = $callback;
         if ($target instanceof WeakRef) {
-            return array($target->get(), $method);
+            return [$target->get(), $method];
         }
 
         // Otherwise, return it
@@ -181,7 +181,7 @@ class Zend_Stdlib_CallbackHandler
      * @param  array $args Arguments to pass to callback
      * @return mixed
      */
-    public function call(array $args = array())
+    public function call(array $args = [])
     {
         $callback = $this->getCallback();
 

--- a/application/helpers/Zend/Stdlib/Exception/InvalidCallbackException.php
+++ b/application/helpers/Zend/Stdlib/Exception/InvalidCallbackException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -29,6 +28,8 @@ require_once 'Zend/Stdlib/Exception.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Stdlib_Exception_InvalidCallbackException extends DomainException implements Zend_Stdlib_Exception
+class Zend_Stdlib_Exception_InvalidCallbackException
+    extends DomainException
+    implements Zend_Stdlib_Exception
 {
 }

--- a/application/helpers/Zend/Stdlib/PriorityQueue.php
+++ b/application/helpers/Zend/Stdlib/PriorityQueue.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -55,7 +54,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      * with keys "data" and "priority".
      * @var array
      */
-    protected $items      = array();
+    protected $items      = [];
 
     /**
      * Inner queue object
@@ -75,10 +74,10 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
     public function insert($data, $priority = 1)
     {
         $priority = (int) $priority;
-        $this->items[] = array(
+        $this->items[] = [
             'data'     => $data,
             'priority' => $priority,
-        );
+        ];
         $this->getQueue()->insert($data, $priority);
         return $this;
     }
@@ -135,7 +134,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->items);
     }
@@ -172,7 +171,8 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return SplPriorityQueue
      */
-    public function getIterator()
+    #[\ReturnTypeWillChange]
+    public function getIterator(): \Traversable
     {
         $queue = $this->getQueue();
         return clone $queue;
@@ -183,9 +183,14 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): ?string
     {
-        return serialize($this->items);
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
+        return $this->items;
     }
 
     /**
@@ -196,9 +201,14 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      * @param  string $data
      * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }
@@ -219,10 +229,10 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
             case self::EXTR_BOTH:
                 return $this->items;
             case self::EXTR_PRIORITY:
-                return array_map(array($this, 'returnPriority'), $this->items);
+                return array_map([$this, 'returnPriority'], $this->items);
             case self::EXTR_DATA:
             default:
-                return array_map(array($this, 'returnData'), $this->items);
+                return array_map([$this, 'returnData'], $this->items);
         }
     }
 

--- a/application/helpers/Zend/Stdlib/SplPriorityQueue.php
+++ b/application/helpers/Zend/Stdlib/SplPriorityQueue.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -19,360 +18,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-    /**
-     * SplPriorityQueue
-     *
-     * PHP 5.2.X userland implementation of PHP's SplPriorityQueue
-     */
-    class SplPriorityQueue implements Iterator, Countable
-    {
-        /**
-         * Extract data only
-         */
-        const EXTR_DATA = 0x00000001;
-
-        /**
-         * Extract priority only
-         */
-        const EXTR_PRIORITY = 0x00000002;
-
-        /**
-         * Extract an array of ('data' => $value, 'priority' => $priority)
-         */
-        const EXTR_BOTH = 0x00000003;
-
-        /**
-         * Count of items in the queue
-         * @var int
-         */
-        protected $count = 0;
-
-        /**
-         * Flag indicating what should be returned when iterating or extracting
-         * @var int
-         */
-        protected $extractFlags = self::EXTR_DATA;
-
-        /**
-         * @var bool|array
-         */
-        protected $preparedQueue = false;
-
-        /**
-         * All items in the queue
-         * @var array
-         */
-        protected $queue = array();
-
-        /**
-         * Constructor
-         *
-         * Creates a new, empty queue
-         *
-         * @return void
-         */
-        public function __construct()
-        {
-        }
-
-        /**
-         * Compare two priorities
-         *
-         * Returns positive integer if $priority1 is greater than $priority2, 0
-         * if equal, negative otherwise.
-         *
-         * Unused internally, and only included in order to retain the same
-         * interface as PHP's SplPriorityQueue.
-         *
-         * @param  mixed $priority1
-         * @param  mixed $priority2
-         * @return int
-         */
-        public function compare($priority1, $priority2)
-        {
-            if ($priority1 > $priority2) {
-                return 1;
-            }
-            if ($priority1 == $priority2) {
-                return 0;
-            }
-
-            return -1;
-        }
-
-        /**
-         * Countable: return number of items composed in the queue
-         *
-         * @return int
-         */
-        public function count()
-        {
-            return $this->count;
-        }
-
-        /**
-         * Iterator: return current item
-         *
-         * @return mixed
-         */
-        public function current()
-        {
-            if (!$this->preparedQueue) {
-                $this->rewind();
-            }
-            if (!$this->count) {
-                throw new OutOfBoundsException('Cannot iterate SplPriorityQueue; no elements present');
-            }
-
-            if (!is_array($this->preparedQueue)) {
-                throw new DomainException(sprintf(
-                    "Queue was prepared, but is empty?\n    PreparedQueue: %s\n    Internal Queue: %s\n",
-                    var_export($this->preparedQueue, 1),
-                    var_export($this->queue, 1)
-                ));
-            }
-
-            $return      = array_shift($this->preparedQueue);
-            $priority    = $return['priority'];
-            $priorityKey = $return['priorityKey'];
-            $key         = $return['key'];
-            unset($return['key']);
-            unset($return['priorityKey']);
-            unset($this->queue[$priorityKey][$key]);
-
-            switch ($this->extractFlags) {
-                case self::EXTR_DATA:
-                    return $return['data'];
-                case self::EXTR_PRIORITY:
-                    return $return['priority'];
-                case self::EXTR_BOTH:
-                default:
-                    return $return;
-            };
-        }
-
-        /**
-         * Extract a node from top of the heap and sift up
-         *
-         * Returns either the value, the priority, or both, depending on the extract flag.
-         *
-         * @return mixed;
-         */
-        public function extract()
-        {
-            if (!$this->count) {
-                return null;
-            }
-
-            if (!$this->preparedQueue) {
-                $this->prepareQueue();
-            }
-
-            if (empty($this->preparedQueue)) {
-                return null;
-            }
-
-            $return      = array_shift($this->preparedQueue);
-            $priority    = $return['priority'];
-            $priorityKey = $return['priorityKey'];
-            $key         = $return['key'];
-            unset($return['key']);
-            unset($return['priorityKey']);
-            unset($this->queue[$priorityKey][$key]);
-            $this->count--;
-
-            switch ($this->extractFlags) {
-                case self::EXTR_DATA:
-                    return $return['data'];
-                case self::EXTR_PRIORITY:
-                    return $return['priority'];
-                case self::EXTR_BOTH:
-                default:
-                    return $return;
-            };
-        }
-
-        /**
-         * Insert a value into the heap, at the specified priority
-         *
-         * @param  mixed $value
-         * @param  mixed $priority
-         * @return void
-         */
-        public function insert($value, $priority)
-        {
-            if (!is_scalar($priority)) {
-                $priority = serialize($priority);
-            }
-            if (!isset($this->queue[$priority])) {
-                $this->queue[$priority] = array();
-            }
-            $this->queue[$priority][] = $value;
-            $this->count++;
-            $this->preparedQueue = false;
-        }
-
-        /**
-         * Is the queue currently empty?
-         *
-         * @return bool
-         */
-        public function isEmpty()
-        {
-            return (0 == $this->count);
-        }
-
-        /**
-         * Iterator: return current key
-         *
-         * @return mixed Usually an int or string
-         */
-        public function key()
-        {
-            return $this->count;
-        }
-
-        /**
-         * Iterator: Move pointer forward
-         *
-         * @return void
-         */
-        public function next()
-        {
-            $this->count--;
-        }
-
-        /**
-         * Recover from corrupted state and allow further actions on the queue
-         *
-         * Unimplemented, and only included in order to retain the same interface as PHP's
-         * SplPriorityQueue.
-         *
-         * @return void
-         */
-        public function recoverFromCorruption()
-        {
-        }
-
-        /**
-         * Iterator: Move pointer to first item
-         *
-         * @return void
-         */
-        public function rewind()
-        {
-            if (!$this->preparedQueue) {
-                $this->prepareQueue();
-            }
-        }
-
-        /**
-         * Set the extract flags
-         *
-         * Defines what is extracted by SplPriorityQueue::current(),
-         * SplPriorityQueue::top() and SplPriorityQueue::extract().
-         *
-         * - SplPriorityQueue::EXTR_DATA (0x00000001): Extract the data
-         * - SplPriorityQueue::EXTR_PRIORITY (0x00000002): Extract the priority
-         * - SplPriorityQueue::EXTR_BOTH (0x00000003): Extract an array containing both
-         *
-         * The default mode is SplPriorityQueue::EXTR_DATA.
-         *
-         * @param  int $flags
-         * @return void
-         */
-        public function setExtractFlags($flags)
-        {
-            $expected = array(
-                self::EXTR_DATA => true,
-                self::EXTR_PRIORITY => true,
-                self::EXTR_BOTH => true,
-            );
-            if (!isset($expected[$flags])) {
-                throw new InvalidArgumentException(sprintf('Expected an EXTR_* flag; received %s', $flags));
-            }
-            $this->extractFlags = $flags;
-        }
-
-        /**
-         * Return the value or priority (or both) of the top node, depending on
-         * the extract flag
-         *
-         * @return mixed
-         */
-        public function top()
-        {
-            $this->sort();
-            $keys = array_keys($this->queue);
-            $key  = array_shift($keys);
-            if (preg_match('/^(a|O):/', $key)) {
-                $key = unserialize($key);
-            }
-
-            if ($this->extractFlags == self::EXTR_PRIORITY) {
-                return $key;
-            }
-
-            if ($this->extractFlags == self::EXTR_DATA) {
-                return $this->queue[$key][0];
-            }
-
-            return array(
-                'data'     => $this->queue[$key][0],
-                'priority' => $key,
-            );
-        }
-
-        /**
-         * Iterator: is the current position valid for the queue
-         *
-         * @return bool
-         */
-        public function valid()
-        {
-            return (bool) $this->count;
-        }
-
-        /**
-         * Sort the queue
-         *
-         * @return void
-         */
-        protected function sort()
-        {
-            krsort($this->queue);
-        }
-
-        /**
-         * Prepare the queue for iteration and/or extraction
-         *
-         * @return void
-         */
-        protected function prepareQueue()
-        {
-            $this->sort();
-            $count = $this->count;
-            $queue = array();
-            foreach ($this->queue as $priority => $values) {
-                $priorityKey = $priority;
-                if (preg_match('/^(a|O):/', $priority)) {
-                    $priority = unserialize($priority);
-                }
-                foreach ($values as $key => $value) {
-                    $queue[$count] = array(
-                        'data'        => $value,
-                        'priority'    => $priority,
-                        'priorityKey' => $priorityKey,
-                        'key'         => $key,
-                    );
-                    $count--;
-                }
-            }
-            $this->preparedQueue = $queue;
-        }
-    }
-}
 
 /**
  * Serializable version of SplPriorityQueue
@@ -393,21 +38,6 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
     protected $serial = PHP_INT_MAX;
 
     /**
-     * @var bool
-     */
-    protected $isPhp53;
-
-    /**
-     * Constructor
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->isPhp53 = version_compare(PHP_VERSION, '5.3', '>=');
-    }
-
-    /**
      * Insert a value with a given priority
      *
      * Utilizes {@var $serial} to ensure that values of equal priority are
@@ -423,10 +53,8 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
         // hack around it to ensure that items registered at the same priority
         // return in the order registered. In the userland version, this is not
         // necessary.
-        if ($this->isPhp53) {
-            if (!is_array($priority)) {
-                $priority = array($priority, $this->serial--);
-            }
+        if (!is_array($priority)) {
+            $priority = [$priority, $this->serial--];
         }
         parent::insert($datum, $priority);
     }
@@ -441,7 +69,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
     public function toArray()
     {
         $this->setExtractFlags(self::EXTR_BOTH);
-        $array = array();
+        $array = [];
         while ($this->valid()) {
             $array[] = $this->current();
             $this->next();
@@ -454,7 +82,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
         }
 
         // Return only the data
-        $return = array();
+        $return = [];
         foreach ($array as $item) {
             $return[] = $item['data'];
         }
@@ -467,9 +95,14 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): ?string
     {
-        $data = array();
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
+        $data = [];
         $this->setExtractFlags(self::EXTR_BOTH);
         while ($this->valid()) {
             $data[] = $this->current();
@@ -482,7 +115,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
             $this->insert($item['data'], $item['priority']);
         }
 
-        return serialize($data);
+        return $data;
     }
 
     /**
@@ -491,9 +124,14 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  string $data
      * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/application/helpers/Zend/Uri.php
+++ b/application/helpers/Zend/Uri.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -42,9 +41,9 @@ abstract class Zend_Uri
      *
      * @var array
      */
-    protected static $_config = array(
+    static protected $_config = [
         'allow_unwise' => false
-    );
+    ];
 
     /**
      * Return a string representation of this URI.
@@ -97,7 +96,7 @@ abstract class Zend_Uri
     public static function factory($uri = 'http', $className = null)
     {
         // Separate the scheme from the scheme-specific parts
-        $uri            = explode(':', $uri, 2);
+        $uri            = explode(':', (string) $uri, 2);
         $scheme         = strtolower($uri[0]);
         $schemeSpecific = isset($uri[1]) === true ? $uri[1] : '';
 
@@ -170,7 +169,7 @@ abstract class Zend_Uri
      *
      * @param Zend_Config|array $config
      */
-    public static function setConfig($config)
+    static public function setConfig($config)
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();

--- a/application/helpers/Zend/Uri/Exception.php
+++ b/application/helpers/Zend/Uri/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *

--- a/application/helpers/Zend/Uri/Http.php
+++ b/application/helpers/Zend/Uri/Http.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -104,7 +103,7 @@ class Zend_Uri_Http extends Zend_Uri
      *
      * @var array
      */
-    protected $_regex = array();
+    protected $_regex = [];
 
     /**
      * Constructor accepts a string $scheme (e.g., http, https) and a scheme-specific part of the URI
@@ -179,13 +178,12 @@ class Zend_Uri_Http extends Zend_Uri
         $scheme         = strtolower($uri[0]);
         $schemeSpecific = isset($uri[1]) === true ? $uri[1] : '';
 
-        if (in_array($scheme, array('http', 'https')) === false) {
+        if (in_array($scheme, ['http', 'https']) === false) {
             require_once 'Zend/Uri/Exception.php';
             throw new Zend_Uri_Exception("Invalid scheme: '$scheme'");
         }
 
-        $schemeHandler = new Zend_Uri_Http($scheme, $schemeSpecific);
-        return $schemeHandler;
+        return new Zend_Uri_Http($scheme, $schemeSpecific);
     }
 
     /**
@@ -270,16 +268,17 @@ class Zend_Uri_Http extends Zend_Uri
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         // Return true if and only if all parts of the URI have passed validation
         return $this->validateUsername()
-           and $this->validatePassword()
-           and $this->validateHost()
-           and $this->validatePort()
-           and $this->validatePath()
-           and $this->validateQuery()
-           and $this->validateFragment();
+           && $this->validatePassword()
+           && $this->validateHost()
+           && $this->validatePort()
+           && $this->validatePath()
+           && $this->validateQuery()
+           && $this->validateFragment();
     }
 
     /**
@@ -375,7 +374,7 @@ class Zend_Uri_Http extends Zend_Uri
         }
 
         // If the password is nonempty, but there is no username, then it is considered invalid
-        if (strlen($password) > 0 and strlen($this->_username) === 0) {
+        if (strlen($password) > 0 && strlen($this->_username) === 0) {
             return false;
         }
 
@@ -495,7 +494,7 @@ class Zend_Uri_Http extends Zend_Uri
         }
 
         // Check the port against the allowed values
-        return ctype_digit((string) $port) and 1 <= $port and $port <= 65535;
+        return ctype_digit((string) $port) && 1 <= $port && $port <= 65535;
     }
 
     /**
@@ -555,7 +554,7 @@ class Zend_Uri_Http extends Zend_Uri
             throw new Zend_Uri_Exception('Internal error: path validation failed');
         }
 
-        return (bool) $status;
+        return (boolean) $status;
     }
 
     /**
@@ -598,7 +597,7 @@ class Zend_Uri_Http extends Zend_Uri
     public function getQueryAsArray()
     {
         $query = $this->getQuery();
-        $querryArray = array();
+        $querryArray = [];
         if ($query !== false) {
             parse_str($query, $querryArray);
         }
@@ -741,7 +740,7 @@ class Zend_Uri_Http extends Zend_Uri
             throw new Zend_Uri_Exception('Internal error: fragment validation failed');
         }
 
-        return (bool) $status;
+        return (boolean) $status;
     }
 
     /**

--- a/application/helpers/Zend/Xml/Exception.php
+++ b/application/helpers/Zend/Xml/Exception.php
@@ -13,19 +13,24 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Stdlib
+ * @package    Zend_Xml
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
  */
 
+
 /**
- * Marker interface for Stdlib exceptions
- *
+ * @see Zend_Exception
+ */
+require_once 'Zend/Exception.php';
+
+
+/**
  * @category   Zend
- * @package    Zend_Stdlib
+ * @package    Zend_Xml
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Zend_Stdlib_Exception
-{
-}
+class Zend_Xml_Exception extends Zend_Exception
+{}

--- a/application/helpers/Zend/Xml/Security.php
+++ b/application/helpers/Zend/Xml/Security.php
@@ -1,0 +1,494 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Xml
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+
+/**
+ * @category   Zend
+ * @package    Zend_Xml_SecurityScan
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Xml_Security
+{
+    const ENTITY_DETECT = 'Detected use of ENTITY in XML, disabled to prevent XXE/XEE attacks';
+
+    /**
+     * Heuristic scan to detect entity in XML
+     *
+     * @param  string $xml
+     * @throws Zend_Xml_Exception If entity expansion or external entity declaration was discovered.
+     */
+    protected static function heuristicScan($xml)
+    {
+        foreach (self::getEntityComparison($xml) as $compare) {
+            if (strpos($xml, $compare) !== false) {
+                throw new Zend_Xml_Exception(self::ENTITY_DETECT);
+            }
+        }
+    }
+
+    /**
+     * @param integer $errno
+     * @param string $errstr
+     * @param string $errfile
+     * @param integer $errline
+     * @return bool
+     */
+    public static function loadXmlErrorHandler($errno, $errstr, $errfile, $errline)
+    {
+        if (substr_count($errstr, 'DOMDocument::loadXML()') > 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Scan XML string for potential XXE and XEE attacks
+     *
+     * @param   string $xml
+     * @param   DomDocument $dom
+     * @throws  Zend_Xml_Exception
+     * @return  SimpleXMLElement|DomDocument|boolean
+     */
+    public static function scan($xml, DOMDocument $dom = null)
+    {
+        // If running with PHP-FPM we perform an heuristic scan
+        // We cannot use libxml_disable_entity_loader because of this bug
+        // @see https://bugs.php.net/bug.php?id=64938
+        if (self::isPhpFpm()) {
+            self::heuristicScan($xml);
+        }
+
+        if (null === $dom) {
+            $simpleXml = true;
+            $dom = new DOMDocument();
+        }
+
+        if (!self::isPhpFpm()) {
+            if (LIBXML_VERSION < 20900) {
+                $loadEntities = libxml_disable_entity_loader(true);
+            }
+            $useInternalXmlErrors = libxml_use_internal_errors(true);
+        }
+
+        // Load XML with network access disabled (LIBXML_NONET)
+        // error disabled with @ for PHP-FPM scenario
+        set_error_handler(['Zend_Xml_Security', 'loadXmlErrorHandler'], E_WARNING);
+
+        $result = $dom->loadXML($xml, LIBXML_NONET);
+        restore_error_handler();
+
+        if (!$result) {
+            // Entity load to previous setting
+            if (!self::isPhpFpm()) {
+                if (LIBXML_VERSION < 20900) {
+                    libxml_disable_entity_loader($loadEntities);
+                }
+                libxml_use_internal_errors($useInternalXmlErrors);
+            }
+            return false;
+        }
+
+        // Scan for potential XEE attacks using ENTITY, if not PHP-FPM
+        if (!self::isPhpFpm()) {
+            foreach ($dom->childNodes as $child) {
+                if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
+                    if ($child->entities->length > 0) {
+                        require_once 'Exception.php';
+                        throw new Zend_Xml_Exception(self::ENTITY_DETECT);
+                    }
+                }
+            }
+        }
+
+        // Entity load to previous setting
+        if (!self::isPhpFpm()) {
+            if (LIBXML_VERSION < 20900) {
+                libxml_disable_entity_loader($loadEntities);
+            }
+            libxml_use_internal_errors($useInternalXmlErrors);
+        }
+
+        if (isset($simpleXml)) {
+            $result = simplexml_import_dom($dom);
+            if (!$result instanceof SimpleXMLElement) {
+                return false;
+            }
+            return $result;
+        }
+        return $dom;
+    }
+
+    /**
+     * Scan XML file for potential XXE/XEE attacks
+     *
+     * @param  string $file
+     * @param  DOMDocument $dom
+     * @throws Zend_Xml_Exception
+     * @return SimpleXMLElement|DomDocument
+     */
+    public static function scanFile($file, DOMDocument $dom = null)
+    {
+        if (!file_exists($file)) {
+            require_once 'Exception.php';
+            throw new Zend_Xml_Exception(
+                "The file $file specified doesn't exist"
+            );
+        }
+        return self::scan(file_get_contents($file), $dom);
+    }
+
+    /**
+     * Return true if PHP is running with PHP-FPM
+     *
+     * This method is mainly used to determine whether or not heuristic checks
+     * (vs libxml checks) should be made, due to threading issues in libxml;
+     * under php-fpm, threading becomes a concern.
+     *
+     * However, PHP versions 5.5.22+ and 5.6.6+ contain a patch to the
+     * libxml support in PHP that makes the libxml checks viable; in such
+     * versions, this method will return false to enforce those checks, which
+     * are more strict and accurate than the heuristic checks.
+     *
+     * @return boolean
+     */
+    public static function isPhpFpm()
+    {
+        $isVulnerableVersion = (
+            version_compare(PHP_VERSION, '5.5.22', 'lt')
+            || (
+                version_compare(PHP_VERSION, '5.6', 'ge')
+                && version_compare(PHP_VERSION, '5.6.6', 'lt')
+            )
+        );
+
+        if (substr(php_sapi_name(), 0, 3) === 'fpm' && $isVulnerableVersion) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Determine and return the string(s) to use for the <!ENTITY comparison.
+     *
+     * @param string $xml
+     * @return string[]
+     */
+    protected static function getEntityComparison($xml)
+    {
+        $encodingMap = self::getAsciiEncodingMap();
+        return array_map(
+            [__CLASS__, 'generateEntityComparison'],
+            self::detectXmlEncoding($xml, self::detectStringEncoding($xml))
+        );
+    }
+
+    /**
+     * Determine the string encoding.
+     *
+     * Determines string encoding from either a detected BOM or a
+     * heuristic.
+     *
+     * @param string $xml
+     * @return string File encoding
+     */
+    protected static function detectStringEncoding($xml)
+    {
+        $encoding = self::detectBom($xml);
+        return ($encoding) ? $encoding : self::detectXmlStringEncoding($xml);
+    }
+
+    /**
+     * Attempt to match a known BOM.
+     *
+     * Iterates through the return of getBomMap(), comparing the initial bytes
+     * of the provided string to the BOM of each; if a match is determined,
+     * it returns the encoding.
+     *
+     * @param string $string
+     * @return false|string Returns encoding on success.
+     */
+    protected static function detectBom($string)
+    {
+        foreach (self::getBomMap() as $criteria) {
+            if (0 === strncmp($string, $criteria['bom'], $criteria['length'])) {
+                return $criteria['encoding'];
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Attempt to detect the string encoding of an XML string.
+     *
+     * @param string $xml
+     * @return string Encoding
+     */
+    protected static function detectXmlStringEncoding($xml)
+    {
+        foreach (self::getAsciiEncodingMap() as $encoding => $generator) {
+            $prefix = call_user_func($generator, '<' . '?xml');
+            if (0 === strncmp($xml, $prefix, strlen($prefix))) {
+                return $encoding;
+            }
+        }
+
+        // Fallback
+        return 'UTF-8';
+    }
+
+    /**
+     * Attempt to detect the specified XML encoding.
+     *
+     * Using the file's encoding, determines if an "encoding" attribute is
+     * present and well-formed in the XML declaration; if so, it returns a
+     * list with both the ASCII representation of that declaration and the
+     * original file encoding.
+     *
+     * If not, a list containing only the provided file encoding is returned.
+     *
+     * @param string $xml
+     * @param string $fileEncoding
+     * @return string[] Potential XML encodings
+     */
+    protected static function detectXmlEncoding($xml, $fileEncoding)
+    {
+        $encodingMap = self::getAsciiEncodingMap();
+        $generator   = $encodingMap[$fileEncoding];
+        $encAttr     = call_user_func($generator, 'encoding="');
+        $quote       = call_user_func($generator, '"');
+        $close       = call_user_func($generator, '>');
+
+        $closePos    = strpos($xml, $close);
+        if (false === $closePos) {
+            return [$fileEncoding];
+        }
+
+        $encPos = strpos($xml, $encAttr);
+        if (false === $encPos
+            || $encPos > $closePos
+        ) {
+            return [$fileEncoding];
+        }
+
+        $encPos   += strlen($encAttr);
+        $quotePos = strpos($xml, $quote, $encPos);
+        if (false === $quotePos) {
+            return [$fileEncoding];
+        }
+
+        $encoding = self::substr($xml, $encPos, $quotePos);
+        return [
+            // Following line works because we're only supporting 8-bit safe encodings at this time.
+            str_replace('\0', '', $encoding), // detected encoding
+            $fileEncoding,                    // file encoding
+        ];
+    }
+
+    /**
+     * Return a list of BOM maps.
+     *
+     * Returns a list of common encoding -> BOM maps, along with the character
+     * length to compare against.
+     *
+     * @link https://en.wikipedia.org/wiki/Byte_order_mark
+     * @return array
+     */
+    protected static function getBomMap()
+    {
+        return [
+            [
+                'encoding' => 'UTF-32BE',
+                'bom'      => pack('CCCC', 0x00, 0x00, 0xfe, 0xff),
+                'length'   => 4,
+            ],
+            [
+                'encoding' => 'UTF-32LE',
+                'bom'      => pack('CCCC', 0xff, 0xfe, 0x00, 0x00),
+                'length'   => 4,
+            ],
+            [
+                'encoding' => 'GB-18030',
+                'bom'      => pack('CCCC', 0x84, 0x31, 0x95, 0x33),
+                'length'   => 4,
+            ],
+            [
+                'encoding' => 'UTF-16BE',
+                'bom'      => pack('CC', 0xfe, 0xff),
+                'length'   => 2,
+            ],
+            [
+                'encoding' => 'UTF-16LE',
+                'bom'      => pack('CC', 0xff, 0xfe),
+                'length'   => 2,
+            ],
+            [
+                'encoding' => 'UTF-8',
+                'bom'      => pack('CCC', 0xef, 0xbb, 0xbf),
+                'length'   => 3,
+            ],
+        ];
+    }
+
+    /**
+     * Return a map of encoding => generator pairs.
+     *
+     * Returns a map of encoding => generator pairs, where the generator is a
+     * callable that accepts a string and returns the appropriate byte order
+     * sequence of that string for the encoding.
+     *
+     * @return array
+     */
+    protected static function getAsciiEncodingMap()
+    {
+        return [
+            'UTF-32BE'   => [__CLASS__, 'encodeToUTF32BE'],
+            'UTF-32LE'   => [__CLASS__, 'encodeToUTF32LE'],
+            'UTF-32odd1' => [__CLASS__, 'encodeToUTF32odd1'],
+            'UTF-32odd2' => [__CLASS__, 'encodeToUTF32odd2'],
+            'UTF-16BE'   => [__CLASS__, 'encodeToUTF16BE'],
+            'UTF-16LE'   => [__CLASS__, 'encodeToUTF16LE'],
+            'UTF-8'      => [__CLASS__, 'encodeToUTF8'],
+            'GB-18030'   => [__CLASS__, 'encodeToUTF8'],
+        ];
+    }
+
+    /**
+     * Binary-safe substr.
+     *
+     * substr() is not binary-safe; this method loops by character to ensure
+     * multi-byte characters are aggregated correctly.
+     *
+     * @param string $string
+     * @param int $start
+     * @param int $end
+     * @return string
+     */
+    protected static function substr($string, $start, $end)
+    {
+        $substr = '';
+        for ($i = $start; $i < $end; $i += 1) {
+            $substr .= $string[$i];
+        }
+        return $substr;
+    }
+
+    /**
+     * Generate an entity comparison based on the given encoding.
+     *
+     * This patch is internal only, and public only so it can be used as a
+     * callable to pass to array_map.
+     *
+     * @internal
+     * @param string $encoding
+     * @return string
+     */
+    public static function generateEntityComparison($encoding)
+    {
+        $encodingMap = self::getAsciiEncodingMap();
+        $generator   = isset($encodingMap[$encoding]) ? $encodingMap[$encoding] : $encodingMap['UTF-8'];
+        return call_user_func($generator, '<!ENTITY');
+    }
+
+    /**
+     * Encode an ASCII string to UTF-32BE
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF32BE($ascii)
+    {
+        return preg_replace('/(.)/', "\0\0\0\\1", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-32LE
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF32LE($ascii)
+    {
+        return preg_replace('/(.)/', "\\1\0\0\0", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-32odd1
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF32odd1($ascii)
+    {
+        return preg_replace('/(.)/', "\0\\1\0\0", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-32odd2
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF32odd2($ascii)
+    {
+        return preg_replace('/(.)/', "\0\0\\1\0", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-16BE
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF16BE($ascii)
+    {
+        return preg_replace('/(.)/', "\0\\1", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-16LE
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF16LE($ascii)
+    {
+        return preg_replace('/(.)/', "\\1\0", $ascii);
+    }
+
+    /**
+     * Encode an ASCII string to UTF-8
+     *
+     * @internal
+     * @param string $ascii
+     * @return string
+     */
+    public static function encodeToUTF8($ascii)
+    {
+        return $ascii;
+    }
+}

--- a/application/helpers/Zend/XmlRpc/Client/Exception.php
+++ b/application/helpers/Zend/XmlRpc/Client/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Exception
@@ -33,9 +33,8 @@ require_once 'Zend/XmlRpc/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_Exception extends Zend_XmlRpc_Exception
-{
-}
+{}

--- a/application/helpers/Zend/XmlRpc/Client/FaultException.php
+++ b/application/helpers/Zend/XmlRpc/Client/FaultException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: FaultException.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /** Zend_XmlRpc_Client_Exception */
 require_once 'Zend/XmlRpc/Client/Exception.php';
@@ -31,9 +31,8 @@ require_once 'Zend/XmlRpc/Client/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_FaultException extends Zend_XmlRpc_Client_Exception
-{
-}
+{}

--- a/application/helpers/Zend/XmlRpc/Client/HttpException.php
+++ b/application/helpers/Zend/XmlRpc/Client/HttpException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: HttpException.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Exception
@@ -34,9 +34,8 @@ require_once 'Zend/XmlRpc/Client/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_HttpException extends Zend_XmlRpc_Client_Exception
-{
-}
+{}

--- a/application/helpers/Zend/XmlRpc/Client/IntrospectException.php
+++ b/application/helpers/Zend/XmlRpc/Client/IntrospectException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: IntrospectException.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Client_Exception
@@ -33,9 +33,8 @@ require_once 'Zend/XmlRpc/Client/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_IntrospectException extends Zend_XmlRpc_Client_Exception
-{
-}
+{}

--- a/application/helpers/Zend/XmlRpc/Client/ServerIntrospection.php
+++ b/application/helpers/Zend/XmlRpc/Client/ServerIntrospection.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: ServerIntrospection.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_ServerIntrospection
@@ -85,15 +84,15 @@ class Zend_XmlRpc_Client_ServerIntrospection
             $methods = $this->listMethods();
         }
 
-        $multicallParams = array();
+        $multicallParams = [];
         foreach ($methods as $method) {
-            $multicallParams[] = array('methodName' => 'system.methodSignature',
-                                        'params'     => array($method));
+            $multicallParams[] = ['methodName' => 'system.methodSignature',
+                                       'params'     => [$method]];
         }
 
         $serverSignatures = $this->_system->multicall($multicallParams);
 
-        if (!is_array($serverSignatures)) {
+        if (! is_array($serverSignatures)) {
             $type = gettype($serverSignatures);
             $error = "Multicall return is malformed.  Expected array, got $type";
             require_once 'Zend/XmlRpc/Client/IntrospectException.php';
@@ -107,7 +106,7 @@ class Zend_XmlRpc_Client_ServerIntrospection
         }
 
         // Create a new signatures array with the methods name as keys and the signature as value
-        $signatures = array();
+        $signatures = [];
         foreach ($serverSignatures as $i => $signature) {
             $signatures[$methods[$i]] = $signature;
         }
@@ -128,7 +127,7 @@ class Zend_XmlRpc_Client_ServerIntrospection
             $methods = $this->listMethods();
         }
 
-        $signatures = array();
+        $signatures = [];
         foreach ($methods as $method) {
             $signatures[$method] = $this->getMethodSignature($method);
         }
@@ -156,10 +155,12 @@ class Zend_XmlRpc_Client_ServerIntrospection
     /**
      * Call system.listMethods()
      *
+     * @param  array  $method
      * @return array  array(method, method, method...)
      */
     public function listMethods()
     {
         return $this->_system->listMethods();
     }
+
 }

--- a/application/helpers/Zend/XmlRpc/Client/ServerProxy.php
+++ b/application/helpers/Zend/XmlRpc/Client/ServerProxy.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: ServerProxy.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 
@@ -30,7 +29,7 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Client
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Client_ServerProxy
@@ -49,7 +48,7 @@ class Zend_XmlRpc_Client_ServerProxy
     /**
      * @var array of Zend_XmlRpc_Client_ServerProxy
      */
-    private $_cache = array();
+    private $_cache = [];
 
 
     /**
@@ -68,6 +67,7 @@ class Zend_XmlRpc_Client_ServerProxy
     /**
      * Get the next successive namespace
      *
+     * @param string $name
      * @return Zend_XmlRpc_Client_ServerProxy
      */
     public function __get($namespace)
@@ -83,7 +83,7 @@ class Zend_XmlRpc_Client_ServerProxy
     /**
      * Call a method in this namespace.
      *
-     * @param  string $method
+     * @param  string $methodN
      * @param  array $args
      * @return mixed
      */

--- a/application/helpers/Zend/XmlRpc/Exception.php
+++ b/application/helpers/Zend/XmlRpc/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,10 +14,11 @@
  *
  * @category   Zend
  * @package    Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_Exception
@@ -29,9 +29,9 @@ require_once 'Zend/Exception.php';
 /**
  * @category   Zend
  * @package    Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Exception extends Zend_Exception
-{
-}
+{}
+

--- a/application/helpers/Zend/XmlRpc/Fault.php
+++ b/application/helpers/Zend/XmlRpc/Fault.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,9 +14,9 @@
  *
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Fault.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -37,7 +36,7 @@ require_once 'Zend/XmlRpc/Value.php';
  *
  * @category   Zend
  * @package    Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Fault
@@ -64,7 +63,7 @@ class Zend_XmlRpc_Fault
      * Internal fault codes => messages
      * @var array
      */
-    protected $_internal = array(
+    protected $_internal = [
         404 => 'Unknown Error',
 
         // 610 - 619 reflection errors
@@ -96,12 +95,12 @@ class Zend_XmlRpc_Fault
         651 => 'Failed to parse response',
         652 => 'Invalid response',
         653 => 'Invalid XMLRPC value in response',
-    );
+    ];
 
     /**
      * Constructor
      *
-     * @return Zend_XmlRpc_Fault
+     * @return void
      */
     public function __construct($code = 404, $message = '')
     {
@@ -141,7 +140,7 @@ class Zend_XmlRpc_Fault
     /**
      * Retrieve fault message
      *
-     * @param string
+     * @param string $message
      * @return Zend_XmlRpc_Fault
      */
     public function setMessage($message)
@@ -204,7 +203,7 @@ class Zend_XmlRpc_Fault
         } catch (Exception $e) {
             // Not valid XML
             require_once 'Zend/XmlRpc/Exception.php';
-            throw new Zend_XmlRpc_Exception('Failed to parse XML fault: ' . $e->getMessage(), 500, $e);
+            throw new Zend_XmlRpc_Exception('Failed to parse XML fault: ' .  $e->getMessage(), 500, $e);
         }
 
         // Check for fault
@@ -280,18 +279,18 @@ class Zend_XmlRpc_Fault
     public function saveXml()
     {
         // Create fault value
-        $faultStruct = array(
+        $faultStruct = [
             'faultCode'   => $this->getCode(),
             'faultString' => $this->getMessage()
-        );
+        ];
         $value = Zend_XmlRpc_Value::getXmlRpcValue($faultStruct);
 
         $generator = Zend_XmlRpc_Value::getGenerator();
         $generator->openElement('methodResponse')
-                    ->openElement('fault');
+                  ->openElement('fault');
         $value->generateXml();
         $generator->closeElement('fault')
-                    ->closeElement('methodResponse');
+                  ->closeElement('methodResponse');
 
         return $generator->flush();
     }
@@ -303,6 +302,6 @@ class Zend_XmlRpc_Fault
      */
     public function __toString()
     {
-        return $this->saveXML();
+        return $this->saveXml();
     }
 }

--- a/application/helpers/Zend/XmlRpc/Generator/DomDocument.php
+++ b/application/helpers/Zend/XmlRpc/Generator/DomDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,13 +15,13 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Generator
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: DomDocument.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
- * @var Zend_XmlRpc_Generator_GeneratorAbstract
+ * @see Zend_XmlRpc_Generator_GeneratorAbstract
  */
 require_once 'Zend/XmlRpc/Generator/GeneratorAbstract.php';
 
@@ -86,7 +85,7 @@ class Zend_XmlRpc_Generator_DomDocument extends Zend_XmlRpc_Generator_GeneratorA
      */
     public function saveXml()
     {
-        return $this->_dom->saveXml();
+        return $this->_dom->saveXML();
     }
 
     /**

--- a/application/helpers/Zend/XmlRpc/Generator/GeneratorAbstract.php
+++ b/application/helpers/Zend/XmlRpc/Generator/GeneratorAbstract.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Generator
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: GeneratorAbstract.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -51,7 +50,7 @@ abstract class Zend_XmlRpc_Generator_GeneratorAbstract
      *
      * @param string $name XML tag name
      * @param string $value Optional value of the XML tag
-     * @return self Fluent interface
+     * @return $this
      */
     public function openElement($name, $value = null)
     {
@@ -69,7 +68,7 @@ abstract class Zend_XmlRpc_Generator_GeneratorAbstract
      * Method marks the end of an XML element
      *
      * @param string $name XML tag name
-     * @return self Fluent interface
+     * @return $this
      */
     public function closeElement($name)
     {

--- a/application/helpers/Zend/XmlRpc/Generator/XmlWriter.php
+++ b/application/helpers/Zend/XmlRpc/Generator/XmlWriter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,13 +15,13 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Generator
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: XmlWriter.php 24479 2011-09-26 20:10:08Z matthew $
+ * @version    $Id$
  */
 
 /**
- * @var Zend_XmlRpc_Generator_GeneratorAbstract
+ * @see Zend_XmlRpc_Generator_GeneratorAbstract
  */
 require_once 'Zend/XmlRpc/Generator/GeneratorAbstract.php';
 
@@ -77,7 +76,7 @@ class Zend_XmlRpc_Generator_XmlWriter extends Zend_XmlRpc_Generator_GeneratorAbs
      * Close an previously opened XML element
      *
      * @param string $name
-     * @return self
+     * @return Zend_XmlRpc_Generator_XmlWriter
      */
     protected function _closeElement($name)
     {
@@ -88,7 +87,6 @@ class Zend_XmlRpc_Generator_XmlWriter extends Zend_XmlRpc_Generator_GeneratorAbs
 
     public function saveXml()
     {
-        $xml = $this->_xmlWriter->flush(false);
-        return $xml;
+        return $this->_xmlWriter->flush(false);
     }
 }

--- a/application/helpers/Zend/XmlRpc/Request.php
+++ b/application/helpers/Zend/XmlRpc/Request.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Controller
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -28,6 +27,12 @@ require_once 'Zend/XmlRpc/Value.php';
  * Zend_XmlRpc_Fault
  */
 require_once 'Zend/XmlRpc/Fault.php';
+
+/** @see Zend_Xml_Security */
+require_once 'Zend/Xml/Security.php';
+
+/** @see Zend_Xml_Exception */
+require_once 'Zend/Xml/Exception.php';
 
 /**
  * XmlRpc Request object
@@ -42,9 +47,9 @@ require_once 'Zend/XmlRpc/Fault.php';
  *
  * @category Zend
  * @package  Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Request.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_XmlRpc_Request
 {
@@ -70,7 +75,7 @@ class Zend_XmlRpc_Request
      * Method parameters
      * @var array
      */
-    protected $_params = array();
+    protected $_params = [];
 
     /**
      * Fault object, if any
@@ -82,13 +87,13 @@ class Zend_XmlRpc_Request
      * XML-RPC type for each param
      * @var array
      */
-    protected $_types = array();
+    protected $_types = [];
 
     /**
      * XML-RPC request params
      * @var array
      */
-    protected $_xmlRpcParams = array();
+    protected $_xmlRpcParams = [];
 
     /**
      * Create a new XML-RPC request
@@ -181,8 +186,8 @@ class Zend_XmlRpc_Request
                 $type        = $xmlRpcValue->getType();
             }
         }
-        $this->_types[] = $type;
-        $this->_xmlRpcParams[] = array('value' => $value, 'type' => $type);
+        $this->_types[]  = $type;
+        $this->_xmlRpcParams[] = ['value' => $value, 'type' => $type];
     }
 
     /**
@@ -215,8 +220,8 @@ class Zend_XmlRpc_Request
         }
 
         if ((1 == $argc) && is_array($argv[0])) {
-            $params     = array();
-            $types      = array();
+            $params     = [];
+            $types      = [];
             $wellFormed = true;
             foreach ($argv[0] as $arg) {
                 if (!is_array($arg) || !isset($arg['value'])) {
@@ -237,8 +242,8 @@ class Zend_XmlRpc_Request
                 $this->_types  = $types;
             } else {
                 $this->_params = $argv[0];
-                $this->_types  = array();
-                $xmlRpcParams  = array();
+                $this->_types  = [];
+                $xmlRpcParams  = [];
                 foreach ($argv[0] as $arg) {
                     if ($arg instanceof Zend_XmlRpc_Value) {
                         $type = $arg->getType();
@@ -246,7 +251,7 @@ class Zend_XmlRpc_Request
                         $xmlRpcValue = Zend_XmlRpc_Value::getXmlRpcValue($arg);
                         $type        = $xmlRpcValue->getType();
                     }
-                    $xmlRpcParams[] = array('value' => $arg, 'type' => $type);
+                    $xmlRpcParams[] = ['value' => $arg, 'type' => $type];
                     $this->_types[] = $type;
                 }
                 $this->_xmlRpcParams = $xmlRpcParams;
@@ -255,8 +260,8 @@ class Zend_XmlRpc_Request
         }
 
         $this->_params = $argv;
-        $this->_types  = array();
-        $xmlRpcParams  = array();
+        $this->_types  = [];
+        $xmlRpcParams  = [];
         foreach ($argv as $arg) {
             if ($arg instanceof Zend_XmlRpc_Value) {
                 $type = $arg->getType();
@@ -264,7 +269,7 @@ class Zend_XmlRpc_Request
                 $xmlRpcValue = Zend_XmlRpc_Value::getXmlRpcValue($arg);
                 $type        = $xmlRpcValue->getType();
             }
-            $xmlRpcParams[] = array('value' => $arg, 'type' => $type);
+            $xmlRpcParams[] = ['value' => $arg, 'type' => $type];
             $this->_types[] = $type;
         }
         $this->_xmlRpcParams = $xmlRpcParams;
@@ -305,8 +310,8 @@ class Zend_XmlRpc_Request
         }
 
         try {
-            $xml = new SimpleXMLElement($request);
-        } catch (Exception $e) {
+            $xml = Zend_Xml_Security::scan($request);
+        } catch (Zend_Xml_Exception $e) {
             // Not valid XML
             $this->_fault = new Zend_XmlRpc_Fault(631);
             $this->_fault->setEncoding($this->getEncoding());
@@ -325,8 +330,8 @@ class Zend_XmlRpc_Request
 
         // Check for parameters
         if (!empty($xml->params)) {
-            $types = array();
-            $argv  = array();
+            $types = [];
+            $argv  = [];
             foreach ($xml->params->children() as $param) {
                 if (!isset($param->value)) {
                     $this->_fault = new Zend_XmlRpc_Fault(633);
@@ -382,11 +387,11 @@ class Zend_XmlRpc_Request
      */
     protected function _getXmlRpcParams()
     {
-        $params = array();
+        $params = [];
         if (is_array($this->_xmlRpcParams)) {
             foreach ($this->_xmlRpcParams as $param) {
                 $value = $param['value'];
-                $type  = $param['type'] ?? Zend_XmlRpc_Value::AUTO_DETECT_TYPE;
+                $type  = isset($param['type']) ? $param['type'] : Zend_XmlRpc_Value::AUTO_DETECT_TYPE;
 
                 if (!$value instanceof Zend_XmlRpc_Value) {
                     $value = Zend_XmlRpc_Value::getXmlRpcValue($value, $type);
@@ -410,8 +415,8 @@ class Zend_XmlRpc_Request
 
         $generator = Zend_XmlRpc_Value::getGenerator();
         $generator->openElement('methodCall')
-                    ->openElement('methodName', $method)
-                    ->closeElement('methodName');
+                  ->openElement('methodName', $method)
+                  ->closeElement('methodName');
 
         if (is_array($args) && count($args)) {
             $generator->openElement('params');
@@ -435,6 +440,6 @@ class Zend_XmlRpc_Request
      */
     public function __toString()
     {
-        return $this->saveXML();
+        return $this->saveXml();
     }
 }

--- a/application/helpers/Zend/XmlRpc/Request/Http.php
+++ b/application/helpers/Zend/XmlRpc/Request/Http.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Controller
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,9 +32,9 @@ require_once 'Zend/XmlRpc/Request.php';
  *
  * @category Zend
  * @package  Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Http.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_XmlRpc_Request_Http extends Zend_XmlRpc_Request
 {
@@ -94,7 +93,7 @@ class Zend_XmlRpc_Request_Http extends Zend_XmlRpc_Request
     public function getHeaders()
     {
         if (null === $this->_headers) {
-            $this->_headers = array();
+            $this->_headers = [];
             foreach ($_SERVER as $key => $value) {
                 if ('HTTP_' == substr($key, 0, 5)) {
                     $header = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));

--- a/application/helpers/Zend/XmlRpc/Request/Stdin.php
+++ b/application/helpers/Zend/XmlRpc/Request/Stdin.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Controller
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -33,9 +32,9 @@ require_once 'Zend/XmlRpc/Request.php';
  *
  * @category Zend
  * @package  Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Stdin.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_XmlRpc_Request_Stdin extends Zend_XmlRpc_Request
 {

--- a/application/helpers/Zend/XmlRpc/Response.php
+++ b/application/helpers/Zend/XmlRpc/Response.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Controller
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -29,6 +28,12 @@ require_once 'Zend/XmlRpc/Value.php';
  */
 require_once 'Zend/XmlRpc/Fault.php';
 
+/** @see Zend_Xml_Security */
+require_once 'Zend/Xml/Security.php';
+
+/** @see Zend_Xml_Exception */
+require_once 'Zend/Xml/Exception.php';
+
 /**
  * XmlRpc Response
  *
@@ -36,9 +41,9 @@ require_once 'Zend/XmlRpc/Fault.php';
  *
  * @category Zend
  * @package  Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Response.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_XmlRpc_Response
 {
@@ -178,11 +183,8 @@ class Zend_XmlRpc_Response
         }
 
         try {
-            $useInternalXmlErrors = libxml_use_internal_errors(true);
-            $xml = new SimpleXMLElement($response);
-            libxml_use_internal_errors($useInternalXmlErrors);
-        } catch (Exception $e) {
-            libxml_use_internal_errors($useInternalXmlErrors);
+            $xml = Zend_Xml_Security::scan($response);
+        } catch (Zend_Xml_Exception $e) {
             // Not valid XML
             $this->_fault = new Zend_XmlRpc_Fault(651);
             $this->_fault->setEncoding($this->getEncoding());
@@ -206,6 +208,7 @@ class Zend_XmlRpc_Response
 
         try {
             if (!isset($xml->params) || !isset($xml->params->param) || !isset($xml->params->param->value)) {
+                require_once 'Zend/XmlRpc/Value/Exception.php';
                 throw new Zend_XmlRpc_Value_Exception('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();
@@ -230,12 +233,12 @@ class Zend_XmlRpc_Response
         $value = $this->_getXmlRpcReturn();
         $generator = Zend_XmlRpc_Value::getGenerator();
         $generator->openElement('methodResponse')
-                    ->openElement('params')
-                    ->openElement('param');
+                  ->openElement('params')
+                  ->openElement('param');
         $value->generateXml();
         $generator->closeElement('param')
-                    ->closeElement('params')
-                    ->closeElement('methodResponse');
+                  ->closeElement('params')
+                  ->closeElement('methodResponse');
 
         return $generator->flush();
     }
@@ -247,6 +250,6 @@ class Zend_XmlRpc_Response
      */
     public function __toString()
     {
-        return $this->saveXML();
+        return $this->saveXml();
     }
 }

--- a/application/helpers/Zend/XmlRpc/Response/Http.php
+++ b/application/helpers/Zend/XmlRpc/Response/Http.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -15,7 +14,7 @@
  *
  * @category   Zend
  * @package    Zend_Controller
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
@@ -30,9 +29,9 @@ require_once 'Zend/XmlRpc/Response.php';
  * @uses Zend_XmlRpc_Response
  * @category Zend
  * @package  Zend_XmlRpc
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version $Id: Http.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version $Id$
  */
 class Zend_XmlRpc_Response_Http extends Zend_XmlRpc_Response
 {

--- a/application/helpers/Zend/XmlRpc/Server.php
+++ b/application/helpers/Zend/XmlRpc/Server.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Server.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -112,11 +111,16 @@ require_once 'Zend/Server/Reflection/Method.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Server extends Zend_Server_Abstract
 {
+    /**
+     * @var mixed|\Zend_XmlRpc_Server_System
+     */
+    protected $_system;
+
     /**
      * Character encoding
      * @var string
@@ -145,7 +149,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      * PHP types => XML-RPC types
      * @var array
      */
-    protected $_typeMap = array(
+    protected $_typeMap = [
         'i4'                         => 'i4',
         'int'                        => 'int',
         'integer'                    => 'int',
@@ -165,6 +169,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         'dateTime.iso8601'           => 'dateTime.iso8601',
         'date'                       => 'dateTime.iso8601',
         'time'                       => 'dateTime.iso8601',
+        'time'                       => 'dateTime.iso8601',
         'Zend_Date'                  => 'dateTime.iso8601',
         'DateTime'                   => 'dateTime.iso8601',
         'array'                      => 'array',
@@ -174,7 +179,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         'ex:nil'                     => 'nil',
         'void'                       => 'void',
         'mixed'                      => 'struct',
-    );
+    ];
 
     /**
      * Send arguments to all methods or just constructor?
@@ -211,7 +216,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
             require_once 'Zend/XmlRpc/Server/Exception.php';
             throw new Zend_XmlRpc_Server_Exception('Unknown instance method called on server: ' . $method);
         }
-        return call_user_func_array(array($system, $method), $params);
+        return call_user_func_array([$system, $method], $params);
     }
 
     /**
@@ -278,13 +283,13 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
             throw new Zend_XmlRpc_Server_Exception('Invalid method class', 610);
         }
 
-        $argv = null;
+        $args = null;
         if (2 < func_num_args()) {
-            $argv = func_get_args();
-            $argv = array_slice($argv, 2);
+            $args = func_get_args();
+            $args = array_slice($args, 2);
         }
 
-        $dispatchable = Zend_Server_Reflection::reflectClass($class, $argv, $namespace);
+        $dispatchable = Zend_Server_Reflection::reflectClass($class, $args, $namespace);
         foreach ($dispatchable->getMethods() as $reflection) {
             $this->_buildSignature($reflection, $class);
         }
@@ -320,8 +325,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
     public function handle($request = false)
     {
         // Get request
-        if (
-            (!$request || !$request instanceof Zend_XmlRpc_Request)
+        if ((!$request || !$request instanceof Zend_XmlRpc_Request)
             && (null === ($request = $this->getRequest()))
         ) {
             require_once 'Zend/XmlRpc/Request/Http.php';
@@ -460,10 +464,9 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      */
     public function setResponseClass($class)
     {
-        if (
-            !class_exists($class) or
-            ($c = new ReflectionClass($class) and !$c->isSubclassOf('Zend_XmlRpc_Response'))
-        ) {
+        if (!class_exists($class) ||
+            ($c = new ReflectionClass($class) && !$c->isSubclassOf('Zend_XmlRpc_Response'))) {
+
             require_once 'Zend/XmlRpc/Server/Exception.php';
             throw new Zend_XmlRpc_Server_Exception('Invalid response class');
         }
@@ -521,7 +524,6 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      * how to handle arguments. If set to true, all methods including constructor
      * will receive the arguments. If set to false, only constructor will receive the
      * arguments
-     * @param boolean $flag
      */
     public function sendArgumentsToAllMethods($flag = null)
     {
@@ -529,7 +531,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
             return $this->_sendArgumentsToAllMethods;
         }
 
-        $this->_sendArgumentsToAllMethods = (bool) $flag;
+        $this->_sendArgumentsToAllMethods = (bool)$flag;
         return $this;
     }
 
@@ -552,7 +554,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      *
      * @param Zend_XmlRpc_Request $request
      * @return Zend_XmlRpc_Response
-     * @throws Zend_XmlRpc_Server_Exception|Exception
+     * @throws Zend_XmlRpcServer_Exception|Exception
      * Zend_XmlRpcServer_Exceptions are thrown for internal errors; otherwise,
      * any other exception may be thrown by the callback
      */
@@ -569,7 +571,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         $info     = $this->_table->getMethod($method);
         $params   = $request->getParams();
         $argv     = $info->getInvokeArguments();
-        if (0 < count($argv) and $this->sendArgumentsToAllMethods()) {
+        if (0 < count($argv) && $this->sendArgumentsToAllMethods()) {
             $params = array_merge($params, $argv);
         }
 

--- a/application/helpers/Zend/XmlRpc/Server.php
+++ b/application/helpers/Zend/XmlRpc/Server.php
@@ -464,8 +464,11 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      */
     public function setResponseClass($class)
     {
+        /**
+         * IMPORTANT: The if condition has been fixed in LimeSurvey as it was failing without the parenthesis in the assignment.
+         */
         if (!class_exists($class) ||
-            ($c = new ReflectionClass($class) && !$c->isSubclassOf('Zend_XmlRpc_Response'))) {
+            (($c = new ReflectionClass($class)) && !$c->isSubclassOf('Zend_XmlRpc_Response'))) {
 
             require_once 'Zend/XmlRpc/Server/Exception.php';
             throw new Zend_XmlRpc_Server_Exception('Invalid response class');

--- a/application/helpers/Zend/XmlRpc/Server/Cache.php
+++ b/application/helpers/Zend/XmlRpc/Server/Cache.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Cache.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /** Zend_Server_Cache */
@@ -30,7 +29,7 @@ require_once 'Zend/Server/Cache.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Server_Cache extends Zend_Server_Cache
@@ -38,10 +37,10 @@ class Zend_XmlRpc_Server_Cache extends Zend_Server_Cache
     /**
      * @var array Skip system methods when caching XML-RPC server
      */
-    protected static $_skipMethods = array(
+    protected static $_skipMethods = [
         'system.listMethods',
         'system.methodHelp',
         'system.methodSignature',
         'system.multicall',
-    );
+    ];
 }

--- a/application/helpers/Zend/XmlRpc/Server/Exception.php
+++ b/application/helpers/Zend/XmlRpc/Server/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Exception
@@ -33,9 +33,10 @@ require_once 'Zend/XmlRpc/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Server_Exception extends Zend_XmlRpc_Exception
 {
 }
+

--- a/application/helpers/Zend/XmlRpc/Server/Fault.php
+++ b/application/helpers/Zend/XmlRpc/Server/Fault.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Fault.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -45,7 +44,7 @@ require_once 'Zend/XmlRpc/Fault.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Server_Fault extends Zend_XmlRpc_Fault
@@ -58,24 +57,25 @@ class Zend_XmlRpc_Server_Fault extends Zend_XmlRpc_Fault
     /**
      * @var array Array of exception classes that may define xmlrpc faults
      */
-    protected static $_faultExceptionClasses = array('Zend_XmlRpc_Server_Exception' => true);
+    protected static $_faultExceptionClasses = ['Zend_XmlRpc_Server_Exception' => true];
 
     /**
      * @var array Array of fault observers
      */
-    protected static $_observers = array();
+    protected static $_observers = [];
 
     /**
      * Constructor
      *
      * @param Exception $e
-     * @return Zend_XmlRpc_Server_Fault
+     * @return void
      */
     public function __construct(Exception $e)
     {
         $this->_exception = $e;
         $code             = 404;
         $message          = 'Unknown error';
+        $exceptionClass   = get_class($e);
 
         foreach (array_keys(self::$_faultExceptionClasses) as $class) {
             if ($e instanceof $class) {
@@ -90,7 +90,7 @@ class Zend_XmlRpc_Server_Fault extends Zend_XmlRpc_Fault
         // Notify exception observers, if present
         if (!empty(self::$_observers)) {
             foreach (array_keys(self::$_observers) as $observer) {
-                call_user_func(array($observer, 'observe'), $this);
+                call_user_func([$observer, 'observe'], $this);
             }
         }
     }
@@ -158,11 +158,10 @@ class Zend_XmlRpc_Server_Fault extends Zend_XmlRpc_Fault
      */
     public static function attachObserver($class)
     {
-        if (
-            !is_string($class)
+        if (!is_string($class)
             || !class_exists($class)
-            || !is_callable(array($class, 'observe'))
-        ) {
+            || !is_callable([$class, 'observe']))
+        {
             return false;
         }
 

--- a/application/helpers/Zend/XmlRpc/Server/System.php
+++ b/application/helpers/Zend/XmlRpc/Server/System.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,9 +15,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: System.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -27,7 +26,7 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Server
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Server_System
@@ -114,7 +113,7 @@ class Zend_XmlRpc_Server_System
      */
     public function multicall($methods)
     {
-        $responses = array();
+        $responses = [];
         foreach ($methods as $method) {
             $fault = false;
             if (!is_array($method)) {
@@ -138,8 +137,7 @@ class Zend_XmlRpc_Server_System
                     $request->setMethod($method['methodName']);
                     $request->setParams($method['params']);
                     $response = $this->_server->handle($request);
-                    if (
-                        $response instanceof Zend_XmlRpc_Fault
+                    if ($response instanceof Zend_XmlRpc_Fault
                         || $response->isFault()
                     ) {
                         $fault = $response;
@@ -152,10 +150,10 @@ class Zend_XmlRpc_Server_System
             }
 
             if ($fault) {
-                $responses[] = array(
+                $responses[] = [
                     'faultCode'   => $fault->getCode(),
                     'faultString' => $fault->getMessage()
-                );
+                ];
             }
         }
 

--- a/application/helpers/Zend/XmlRpc/Value/Array.php
+++ b/application/helpers/Zend/XmlRpc/Value/Array.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Array.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Collection
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Collection.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Array extends Zend_XmlRpc_Value_Collection
@@ -57,8 +57,8 @@ class Zend_XmlRpc_Value_Array extends Zend_XmlRpc_Value_Collection
     {
         $generator = $this->getGenerator();
         $generator->openElement('value')
-                    ->openElement('array')
-                    ->openElement('data');
+                  ->openElement('array')
+                  ->openElement('data');
 
         if (is_array($this->_value)) {
             foreach ($this->_value as $val) {
@@ -66,7 +66,8 @@ class Zend_XmlRpc_Value_Array extends Zend_XmlRpc_Value_Collection
             }
         }
         $generator->closeElement('data')
-                    ->closeElement('array')
-                    ->closeElement('value');
+                  ->closeElement('array')
+                  ->closeElement('value');
     }
 }
+

--- a/application/helpers/Zend/XmlRpc/Value/Base64.php
+++ b/application/helpers/Zend/XmlRpc/Value/Base64.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Base64.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Base64 extends Zend_XmlRpc_Value_Scalar
@@ -42,15 +42,15 @@ class Zend_XmlRpc_Value_Base64 extends Zend_XmlRpc_Value_Scalar
      * We keep this value in base64 encoding
      *
      * @param string $value
-     * @param bool $alreadyEncoded If set, it means that the given string is already base64 encoded
+     * @param bool $already_encoded If set, it means that the given string is already base64 encoded
      */
     public function __construct($value, $alreadyEncoded = false)
     {
         $this->_type = self::XMLRPC_TYPE_BASE64;
 
-        $value = (string) $value; // Make sure this value is string
+        $value = (string)$value;    // Make sure this value is string
         if (!$alreadyEncoded) {
-            $value = base64_encode($value); // We encode it in base64
+            $value = base64_encode($value);     // We encode it in base64
         }
         $this->_value = $value;
     }
@@ -63,6 +63,6 @@ class Zend_XmlRpc_Value_Base64 extends Zend_XmlRpc_Value_Scalar
      */
     public function getValue()
     {
-        return base64_decode((string) $this->_value);
+        return base64_decode($this->_value);
     }
 }

--- a/application/helpers/Zend/XmlRpc/Value/BigInteger.php
+++ b/application/helpers/Zend/XmlRpc/Value/BigInteger.php
@@ -16,9 +16,9 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: BigInteger.php 23969 2011-05-03 14:48:31Z ralph $
+ * @version    $Id$
  */
 
 /**
@@ -30,7 +30,7 @@ require_once 'Zend/XmlRpc/Value/Integer.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_BigInteger extends Zend_XmlRpc_Value_Integer
@@ -41,7 +41,7 @@ class Zend_XmlRpc_Value_BigInteger extends Zend_XmlRpc_Value_Integer
     public function __construct($value)
     {
         require_once 'Zend/Crypt/Math/BigInteger.php';
-        $integer = new Zend_Crypt_Math_BigInteger();
+        $integer = new Zend_Crypt_Math_BigInteger;
         $this->_value = $integer->init($value);
         $this->_type = self::XMLRPC_TYPE_I8;
     }

--- a/application/helpers/Zend/XmlRpc/Value/Boolean.php
+++ b/application/helpers/Zend/XmlRpc/Value/Boolean.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Boolean.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Boolean extends Zend_XmlRpc_Value_Scalar
@@ -48,7 +48,7 @@ class Zend_XmlRpc_Value_Boolean extends Zend_XmlRpc_Value_Scalar
         $this->_type = self::XMLRPC_TYPE_BOOLEAN;
         // Make sure the value is boolean and then convert it into a integer
         // The double convertion is because a bug in the ZendOptimizer in PHP version 5.0.4
-        $this->_value = (int) (bool) $value;
+        $this->_value = (int)(bool)$value;
     }
 
     /**
@@ -58,6 +58,6 @@ class Zend_XmlRpc_Value_Boolean extends Zend_XmlRpc_Value_Scalar
      */
     public function getValue()
     {
-        return (bool) $this->_value;
+        return (bool)$this->_value;
     }
 }

--- a/application/helpers/Zend/XmlRpc/Value/Collection.php
+++ b/application/helpers/Zend/XmlRpc/Value/Collection.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Collection.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 abstract class Zend_XmlRpc_Value_Collection extends Zend_XmlRpc_Value
@@ -44,7 +44,7 @@ abstract class Zend_XmlRpc_Value_Collection extends Zend_XmlRpc_Value
      */
     public function __construct($value)
     {
-        $values = (array) $value; // Make sure that the value is an array
+        $values = (array)$value;   // Make sure that the value is an array
         foreach ($values as $key => $value) {
             // If the elements of the given array are not Zend_XmlRpc_Value objects,
             // we need to convert them as such (using auto-detection from PHP value)
@@ -63,9 +63,9 @@ abstract class Zend_XmlRpc_Value_Collection extends Zend_XmlRpc_Value
      */
     public function getValue()
     {
-        $values = (array) $this->_value;
+        $values = (array)$this->_value;
         foreach ($values as $key => $value) {
-            /* @var $value Zend_XmlRpc_Value */
+            /* @var Zend_XmlRpc_Value $value */
             $values[$key] = $value->getValue();
         }
         return $values;

--- a/application/helpers/Zend/XmlRpc/Value/DateTime.php
+++ b/application/helpers/Zend/XmlRpc/Value/DateTime.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: DateTime.php 24292 2011-07-28 21:25:22Z matthew $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_DateTime extends Zend_XmlRpc_Value_Scalar
@@ -66,15 +66,13 @@ class Zend_XmlRpc_Value_DateTime extends Zend_XmlRpc_Value_Scalar
             $this->_value = $value->toString($this->_isoFormatString);
         } elseif ($value instanceof DateTime) {
             $this->_value = $value->format($this->_phpFormatString);
-        } elseif (is_numeric($value)) {
-// The value is numeric, we make sure it is an integer
-            $this->_value = date($this->_phpFormatString, (int) $value);
+        } elseif (is_numeric($value)) { // The value is numeric, we make sure it is an integer
+            $this->_value = date($this->_phpFormatString, (int)$value);
         } else {
             $timestamp = new DateTime($value);
-            if ($timestamp === false) {
-// cannot convert the value to a timestamp
+            if ($timestamp === false) { // cannot convert the value to a timestamp
                 require_once 'Zend/XmlRpc/Value/Exception.php';
-                throw new Zend_XmlRpc_Value_Exception('Cannot convert given value \'' . $value . '\' to a timestamp');
+                throw new Zend_XmlRpc_Value_Exception('Cannot convert given value \''. $value .'\' to a timestamp');
             }
 
             $this->_value = $timestamp->format($this->_phpFormatString); // Convert the timestamp to iso8601 format
@@ -84,7 +82,7 @@ class Zend_XmlRpc_Value_DateTime extends Zend_XmlRpc_Value_Scalar
     /**
      * Return the value of this object as iso8601 dateTime value
      *
-     * @return int As a Unix timestamp
+     * @return string As a Unix timestamp
      */
     public function getValue()
     {

--- a/application/helpers/Zend/XmlRpc/Value/Double.php
+++ b/application/helpers/Zend/XmlRpc/Value/Double.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Double.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Double extends Zend_XmlRpc_Value_Scalar
@@ -45,9 +45,9 @@ class Zend_XmlRpc_Value_Double extends Zend_XmlRpc_Value_Scalar
     public function __construct($value)
     {
         $this->_type = self::XMLRPC_TYPE_DOUBLE;
-        $precision = (int) ini_get('precision');
+        $precision = (int)ini_get('precision');
         $formatString = '%1.' . $precision . 'F';
-        $this->_value = rtrim(sprintf($formatString, (float) $value), '0');
+        $this->_value = rtrim(sprintf($formatString, (float)$value), '0');
     }
 
     /**
@@ -57,6 +57,6 @@ class Zend_XmlRpc_Value_Double extends Zend_XmlRpc_Value_Scalar
      */
     public function getValue()
     {
-        return (float) $this->_value;
+        return (float)$this->_value;
     }
 }

--- a/application/helpers/Zend/XmlRpc/Value/Exception.php
+++ b/application/helpers/Zend/XmlRpc/Value/Exception.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Exception.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Exception
@@ -31,9 +31,9 @@ require_once 'Zend/XmlRpc/Exception.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Exception extends Zend_XmlRpc_Exception
-{
-}
+{}
+

--- a/application/helpers/Zend/XmlRpc/Value/Integer.php
+++ b/application/helpers/Zend/XmlRpc/Value/Integer.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Integer.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Integer extends Zend_XmlRpc_Value_Scalar
@@ -50,7 +50,7 @@ class Zend_XmlRpc_Value_Integer extends Zend_XmlRpc_Value_Scalar
         }
 
         $this->_type = self::XMLRPC_TYPE_INTEGER;
-        $this->_value = (int) $value; // Make sure this value is integer
+        $this->_value = (int)$value;    // Make sure this value is integer
     }
 
     /**

--- a/application/helpers/Zend/XmlRpc/Value/Nil.php
+++ b/application/helpers/Zend/XmlRpc/Value/Nil.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Nil.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Nil extends Zend_XmlRpc_Value_Scalar
@@ -57,3 +57,4 @@ class Zend_XmlRpc_Value_Nil extends Zend_XmlRpc_Value_Scalar
         return null;
     }
 }
+

--- a/application/helpers/Zend/XmlRpc/Value/Scalar.php
+++ b/application/helpers/Zend/XmlRpc/Value/Scalar.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Scalar.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 abstract class Zend_XmlRpc_Value_Scalar extends Zend_XmlRpc_Value
@@ -46,8 +46,8 @@ abstract class Zend_XmlRpc_Value_Scalar extends Zend_XmlRpc_Value
         $generator = $this->getGenerator();
 
         $generator->openElement('value')
-                    ->openElement($this->_type, $this->_value)
-                    ->closeElement($this->_type)
-                    ->closeElement('value');
+                  ->openElement($this->_type, $this->_value)
+                  ->closeElement($this->_type)
+                  ->closeElement('value');
     }
 }

--- a/application/helpers/Zend/XmlRpc/Value/String.php
+++ b/application/helpers/Zend/XmlRpc/Value/String.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: String.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Scalar
@@ -29,7 +29,7 @@ require_once 'Zend/XmlRpc/Value/Scalar.php';
 /**
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_String extends Zend_XmlRpc_Value_Scalar
@@ -45,7 +45,7 @@ class Zend_XmlRpc_Value_String extends Zend_XmlRpc_Value_Scalar
         $this->_type = self::XMLRPC_TYPE_STRING;
 
         // Make sure this value is string and all XML characters are encoded
-        $this->_value = (string) $value;
+        $this->_value = (string)$value;
     }
 
     /**
@@ -55,6 +55,6 @@ class Zend_XmlRpc_Value_String extends Zend_XmlRpc_Value_Scalar
      */
     public function getValue()
     {
-        return (string) $this->_value;
+        return (string)$this->_value;
     }
 }

--- a/application/helpers/Zend/XmlRpc/Value/Struct.php
+++ b/application/helpers/Zend/XmlRpc/Value/Struct.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework
  *
@@ -16,10 +15,11 @@
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @version    $Id: Struct.php 23775 2011-03-01 17:25:24Z ralph $
+ * @version    $Id$
  */
+
 
 /**
  * Zend_XmlRpc_Value_Collection
@@ -31,7 +31,7 @@ require_once 'Zend/XmlRpc/Value/Collection.php';
  * @category   Zend
  * @package    Zend_XmlRpc
  * @subpackage Value
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_XmlRpc_Value_Struct extends Zend_XmlRpc_Value_Collection
@@ -57,19 +57,19 @@ class Zend_XmlRpc_Value_Struct extends Zend_XmlRpc_Value_Collection
     {
         $generator = $this->getGenerator();
         $generator->openElement('value')
-                    ->openElement('struct');
+                  ->openElement('struct');
 
         if (is_array($this->_value)) {
             foreach ($this->_value as $name => $val) {
-                /* @var $val Zend_XmlRpc_Value */
+                /* @var Zend_XmlRpc_Value $val */
                 $generator->openElement('member')
-                            ->openElement('name', $name)
-                            ->closeElement('name');
+                          ->openElement('name', $name)
+                          ->closeElement('name');
                 $val->generateXml();
                 $generator->closeElement('member');
             }
         }
         $generator->closeElement('struct')
-                    ->closeElement('value');
+                  ->closeElement('value');
     }
 }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3647,7 +3647,7 @@ function cleanLanguagesFromSurvey($iSurveyID, $availlangs, $baselang = '')
     $iSurveyID = (int) $iSurveyID;
     $baselang = sanitize_languagecode($baselang);
     if (empty($baselang)) {
-        $baselang = Survey::model()->findByPk($sid)->language;
+        $baselang = Survey::model()->findByPk($iSurveyID)->language;
     }
     $aLanguages = [];
     if (!empty($availlangs) && $availlangs != " ") {

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -407,7 +407,7 @@ class remotecontrol_handle
      * @access public
      * @param string $sSessionKey Auth credentials
      * @param integer $iSurveyID - ID of the Survey
-     * @param array $aSurveyData - An array with the particular fieldnames as keys and their values to set on that particular Survey
+     * @param struct $aSurveyData - An array with the particular fieldnames as keys and their values to set on that particular Survey
      * @return array Of succeeded and failed nodifications according to internal validation
      */
     public function set_survey_properties($sSessionKey, $iSurveyID, $aSurveyData)
@@ -955,7 +955,7 @@ class remotecontrol_handle
      * @access public
      * @param string $sSessionKey Auth credentials
      * @param integer $iSurveyID  - ID of the Survey
-     * @param array $aSurveyLocaleData - An array with the particular fieldnames as keys and their values to set on that particular survey
+     * @param struct $aSurveyLocaleData - An array with the particular fieldnames as keys and their values to set on that particular survey
      * @param string $sLanguage - Optional - Language to update  - if not given the base language of the particular survey is used
      * @return array in case of success 'status'=>'OK', when save successful otherwise error text.
      */

--- a/tests/functional/backend/RemoteControlXmlrpcTest.php
+++ b/tests/functional/backend/RemoteControlXmlrpcTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ls\tests;
+
+use Yii;
+
+class RemoteControlXmlrpcTest extends TestBaseClassWeb
+{
+    private static $tmpBaseUrl;
+    private static $tmpRPCType;
+
+    private static $client;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $urlMan = Yii::app()->urlManager;
+        self::$tmpBaseUrl = $urlMan->getBaseUrl();
+        $urlMan->setBaseUrl('http://' . self::$domain . '/index.php');
+        //$serverUrl = App()->createAbsoluteUrl('/admin/remotecontrol');
+        $serverUrl = $urlMan->createUrl('/admin/remotecontrol');
+
+        self::$tmpRPCType = Yii::app()->getConfig('RPCInterface');
+
+        if (self::$tmpRPCType !== 'xml') {
+            \SettingGlobal::setSetting('RPCInterface', 'xml');
+            $RPCType = 'xml';
+        }
+
+        $cur_path = get_include_path();
+        set_include_path($cur_path . PATH_SEPARATOR . APPPATH . 'helpers');
+        require_once('Zend/XmlRpc/Client.php');
+
+        self::$client = new \Zend_XmlRpc_Client($serverUrl);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        $urlMan = Yii::app()->urlManager;
+        $urlMan->setBaseUrl(self::$tmpBaseUrl);
+
+        \SettingGlobal::setSetting('RPCInterface', self::$tmpRPCType);
+    }
+
+    public function testGetSessionKey()
+    {
+        $username = getenv('ADMINUSERNAME');
+        if (!$username) {
+            $username = 'admin';
+        }
+
+        $password = getenv('PASSWORD');
+        if (!$password) {
+            $password = 'password';
+        }
+        $sessionKey = self::$client->call('get_session_key', [$username, $password]);
+        $this->assertIsString($sessionKey);
+
+        self::$client->call('release_session_key', [$sessionKey]);
+    }
+
+    public function testCredentialsError()
+    {
+        /* generate a random string to get an invalid user, no restriction on users_name */
+        $sessionKey = self::$client->call('get_session_key', [Yii::app()->securityManager->generateRandomString(64), Yii::app()->securityManager->generateRandomString(64)]);
+        $this->assertIsArray($sessionKey);
+        $this->assertSame("Invalid user name or password", $sessionKey['status']);
+
+        self::$client->call('release_session_key', [$sessionKey]);
+    }
+}


### PR DESCRIPTION
I encountered compatibility issues with Zend Framework 1 (ZF1) when using newer PHP versions. 
After some investigation, I found the following solutions:

Original Source (zendframework/zf1):
The original ZF1 project reached its end-of-life in 2016. The repository contains a conversion of the ZF1 subversion repo to Git, starting from version 15234 onward. However, Lime (another context) seems to use only a subset of the library/Zend files from this repository.

ZF1 Future (Shardj’s Fork):
I discovered a fork called “ZF1 Future” on GitHub, maintained by Shardj. This fork aims to create a PHP 8.1-compatible version of ZF1.
While it almost worked for me, I still had to apply a manual fix.
If you’re interested, consider contributing by submitting a pull request (PR) to the “ZF1 Future” repository. The last update was about two weeks ago.

Testing and Compatibility:
I tested the solution with the RemoteControl controller. Interestingly, it failed in the same place as it did with PHP 7.4.
So no new issues introduced here.