### PR TITLE
Fixed issue #19810: Error loading survey participants using LDAPv3 (AD)

### DIFF
--- a/application/helpers/ldap_helper.php
+++ b/application/helpers/ldap_helper.php
@@ -28,7 +28,7 @@ function ldap_getCnx($server_id = null)
     } else {
         $ds = false;
         if ($ldap_server[$server_id]['protoversion'] == 'ldapv3' && $ldap_server[$server_id]['encrypt'] != 'ldaps') {
-            $ds = ldap_connect("{$ldap_server[$server_id]['server']}:{$ldap_server[$server_id]['port']}");
+            $ds = ldap_connect("ldap://" . "{$ldap_server[$server_id]['server']}:{$ldap_server[$server_id]['port']}");
             ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
 
             if (!$ldap_server[$server_id]['referrals']) {
@@ -40,9 +40,9 @@ function ldap_getCnx($server_id = null)
             }
         } elseif ($ldap_server[$server_id]['protoversion'] == 'ldapv2') {
             if ($ldap_server[$server_id]['encrypt'] == 'ldaps') {
-                $ds = ldap_connect("ldaps://" . $ldap_server[$server_id]['server'] . ':' . $ldap_server[$server_id]['port']);
+                $ds = ldap_connect("ldaps://" . "{$ldap_server[$server_id]['server']}:{$ldap_server[$server_id]['port']}");
             } else {
-                $ds = ldap_connect("{$ldap_server[$server_id]['server']}:{$ldap_server[$server_id]['port']}");
+                $ds = ldap_connect("ldap://" . "{$ldap_server[$server_id]['server']}:{$ldap_server[$server_id]['port']}");
             }
 
             if (!$ldap_server[$server_id]['referrals']) {


### PR DESCRIPTION
Fixing an error connecting to the Active DIrectory LDAP v3 server. (https://bugs.limesurvey.org/view.php?id=19810)

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

