### PR TITLE
QE0-1153 Open editor

### DIFF
--- a/application/core/TopbarConfiguration.php
+++ b/application/core/TopbarConfiguration.php
@@ -215,10 +215,6 @@ class TopbarConfiguration
             'editorLink/index',
             ['route' => 'survey/' . $sid]
         );
-        App()->getClientScript()->registerScriptFile(
-            App()->getConfig('adminscripts') . 'newQuestionEditor.js',
-            CClientScript::POS_END
-        );
 
         return array(
             'sid' => $sid,

--- a/application/core/TopbarConfiguration.php
+++ b/application/core/TopbarConfiguration.php
@@ -211,11 +211,9 @@ class TopbarConfiguration
             $enableEditorButton = false;
         }
 
-        $editorUrl = Yii::app()->request->getUrlReferrer(
-            Yii::app()->createUrl(
-                'editorLink/index',
-                ['route' => 'survey/' . $sid]
-            )
+        $editorUrl = Yii::app()->createUrl(
+            'editorLink/index',
+            ['route' => 'survey/' . $sid]
         );
         App()->getClientScript()->registerScriptFile(
             App()->getConfig('adminscripts') . 'newQuestionEditor.js',

--- a/application/views/surveyAdministration/partial/topbar/_newQuestionEditorBtn.php
+++ b/application/views/surveyAdministration/partial/topbar/_newQuestionEditorBtn.php
@@ -22,7 +22,7 @@ if (isset($editorEnabled) && $editorEnabled && $editorUrl) {
                 'text' => gT('Open in Limesurvey editor'),
                 'link' => '',
                 'htmlOptions' => [
-                    'class' => 'btn btn-info',
+                    'class' => 'btn btn-info editor-link-button',
                     'role' => 'button',
                     'disabled' => $disabled,
                     'data-url' => $editorUrl,

--- a/assets/scripts/admin/newQuestionEditor.js
+++ b/assets/scripts/admin/newQuestionEditor.js
@@ -1,6 +1,0 @@
-$(document).on('ready pjax:scriptcomplete', function () {
-    $('#editor-link-button').on('click', function(e){
-        window.location.assign(this.getAttribute('data-url'));
-        window.open(newUrl, '_top');
-    });
-});

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -52,6 +52,11 @@ var LS = LS || {};
 // TODO: Use component for quick-add
 // TODO: Use component for label sets
 $(document).on('ready pjax:scriptcomplete', function () {
+
+  $('#editor-link-button').on('click', function (e) {
+    window.location.assign(this.getAttribute('data-url'));
+  });
+
   // TODO: Routing?
   if (window.location.href.indexOf('questionAdministration') === -1) {
     return;


### PR DESCRIPTION
- Fix 'open in new editor' URL generation (its not a referer URL)
- Support rendering multiple 'open in new editor' buttons on a single page (target via class instead of id)