### PR TITLE
New feature MW-1407: Add check for database size before download

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -78,6 +78,7 @@ $config['timeadjust']                = 0; // Number of hours to adjust between y
 $config['maxdumpdbrecords']          = 500; // The maximum number of records that would be ouput in one go during a database backup. Reduce this number if you're getting errors while backing up the entire database.
 $config['maxdbsizeforbackup']        = 0; // The maximum database size in MB that is backed up up by ComfortUpdate - 0 for no limit
 $config['allowexportalldb']          = 0; // Default 0 will only export prefixed tables when doing a database dump. If set to 1 ALL tables in the database will be exported (use carefully)
+$config['maxDatabaseSizeForDump']    = 256; // Maximum database size in megabytes to be able to download without errors
 
 $config['deletenonvalues']           = 1; // By default, LimeSurvey does not save responses to conditional questions that haven't been answered/shown. To have LimeSurvey save these responses change this value to 0.
 $config['stringcomparizonoperators'] = 0; // By default, LimeSurvey assumes the numrical order for comparizon operators in conditions. If you need string comparizon operators, set this parameter to 1

--- a/application/controllers/admin/dumpdb.php
+++ b/application/controllers/admin/dumpdb.php
@@ -86,6 +86,16 @@ class Dumpdb extends SurveyCommonAction
 
     public function outPutDatabase()
     {
+        // Check if it's a POST request
+        if (!Yii::app()->request->isPostRequest) {
+            throw new CHttpException(405, gT("Invalid action"));
+        }
+
+        // Check if user has necessary permissions
+        if (!Permission::model()->hasGlobalPermission('superadmin', 'read')) {
+            throw new CHttpException(403, gT("You do not have permission to access this page."));
+        }
+
         Yii::app()->loadHelper("admin/backupdb");
         $sDbName = _getDbName();
         $sFileName = 'LimeSurvey_' . $sDbName . '_dump_' . dateShift(date('Y-m-d H:i:s'), 'Y-m-d', Yii::app()->getConfig('timeadjust')) . '.sql';

--- a/application/controllers/admin/dumpdb.php
+++ b/application/controllers/admin/dumpdb.php
@@ -51,12 +51,12 @@ class Dumpdb extends SurveyCommonAction
      */
     public function index()
     {
-        Yii::app()->loadHelper("admin/backupdb");
-        $sDbName = _getDbName();
-        $sFileName = 'LimeSurvey_' . $sDbName . '_dump_' . dateShift(date('Y-m-d H:i:s'), 'Y-m-d', Yii::app()->getConfig('timeadjust')) . '.sql';
-        $this->outputHeaders($sFileName);
-        outputDatabase();
-        exit;
+        $data = $this->getData();
+
+        $data['topbar']['title'] = gT('Backup entire database');
+        $data['topbar']['backLink'] = App()->createUrl('admin/index');
+
+        $this->renderWrappedTemplate('dumpdb', 'dumpdb_view', $data);
     }
 
     /**
@@ -68,5 +68,29 @@ class Dumpdb extends SurveyCommonAction
         header('Content-type: application/octet-stream');
         header('Content-Disposition: attachment; filename=' . $sFileName);
         header("Cache-Control: no-store, no-cache, must-revalidate");  // Don't store in cache because it is sensitive data
+    }
+
+    private function getData()
+    {
+        Yii::app()->loadHelper("admin/backupdb");
+        $dbSize = getDatabaseSize();
+        $downloadable = true;
+        if ($dbSize > Yii::app()->getConfig('maxDatabaseSizeForDump')) {
+            $downloadable = false;
+        }
+        return [
+            'downloadable' => $downloadable,
+            'dbSize' => $dbSize,
+        ];
+    }
+
+    public function outPutDatabase()
+    {
+        Yii::app()->loadHelper("admin/backupdb");
+        $sDbName = _getDbName();
+        $sFileName = 'LimeSurvey_' . $sDbName . '_dump_' . dateShift(date('Y-m-d H:i:s'), 'Y-m-d', Yii::app()->getConfig('timeadjust')) . '.sql';
+        $this->outputHeaders($sFileName);
+        outputDatabase();
+        return;
     }
 }

--- a/application/helpers/admin/backupdb_helper.php
+++ b/application/helpers/admin/backupdb_helper.php
@@ -201,3 +201,31 @@ function _getDbName()
 
     return $sDbName;
 }
+
+/**
+ * Get database size in MB
+ */
+function getDatabaseSize()
+{
+    $dbName = _getDbName();
+
+    // Run the query using Yii's DB component
+    $result = Yii::app()->db->createCommand("
+        SELECT 
+            table_schema AS `Database`, 
+            ROUND(SUM(data_length + index_length) / 1024 / 1024, 2) AS `Size (MB)`
+        FROM 
+            information_schema.tables 
+        WHERE 
+            table_schema = :dbName
+        GROUP BY 
+            table_schema;
+    ")->bindValue(':dbName', $dbName)->queryRow();
+
+    if ($result) {
+        // echo "Database: " . $result['Database'] . "<br>";
+        return $result['Size (MB)']; // Size in MB
+    } else {
+        return null;
+    }
+}

--- a/application/views/admin/dumpdb/dumpdb_view.php
+++ b/application/views/admin/dumpdb/dumpdb_view.php
@@ -1,0 +1,46 @@
+<?php
+/* @var $this AdminController */
+/* @var $dataProvider CActiveDataProvider */
+
+// DO NOT REMOVE This is for automated testing to validate we see that page
+echo viewHelper::getViewTestTag('dumpdb');
+?>
+
+<div class="row">
+    <div class="col-12">
+        <!-- Data redundancy check -->
+        <div class="jumbotron message-box">
+            <h2><?php eT("Database size check"); ?></h2>
+            <p class="lead">
+                <?php eT("This check evaluates the database size to determine if an immediate download is possible or if a manual backup is necessary."); ?>
+            </p>
+            <p>
+                <?php echo "DB Size: MB " . $dbSize; ?>
+                <?php if ($downloadable) { // todo: remove testing boolean ?>
+                    <?php
+                    $this->widget('ext.AlertWidget.AlertWidget', [
+                        'text' => gT("Your database can be downloaded now!"),
+                        'type' => 'success',
+                    ]);
+                    ?>
+                    <?php echo CHtml::form(["admin/dumpdb", "sa" => 'outPutDatabase'], 'post'); ?>
+                    <button
+                        type='submit'
+                        value='Y'
+                        name='ok'
+                        class="btn btn-info">
+                        <?php eT("Yes - Download now!"); ?>
+                    </button>
+                    </form>
+                <?php } else { ?>
+                    <?php
+                        $this->widget('ext.AlertWidget.AlertWidget', [
+                            'text' => gT("Your database is too large for immediate download. Please use your database client to perform a manual backup."),
+                            'type' => 'warning',
+                        ]);
+                    ?>
+                <?php } ?>
+            </p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
LimeSurvey includes a built-in feature to download the database as an SQL file. However, for instances with large databases, this process is slow and resource-intensive, often failing due to long execution times and high memory usage.

Solution: This PR introduces a pre-check mechanism to assess the database size before initiating the backup process.

If the database is within the size limit (default: 250 MB), the user can proceed with the download by pressing a button.
If the database exceeds the limit, the user is shown a message advising them to perform a manual backup using the appropriate database client for their instance.
Changes Made:

Added logic to calculate the database size beforehand.
Introduced a new view (dumpdb_view) to display appropriate messages to users.
Configured the size limit via application/config/config-defaults.php in 'maxDatabaseSizeForDump'. 
Testing Instructions:

Check out the branch and navigate to Configuration > Advanced > Backup Entire Database in the admin panel.
Expected Results:
For databases smaller than the configured size limit (default: 250 MB), a message and a green button is displayed, allowing the user to proceed with the download.
For larger databases, a message suggests performing a manual backup.
To simulate the message for large databases, reduce the size limit in config-defaults.php to a value smaller than your current database size.