### PR TITLE
Fixed issue #13732: Twig strip_tags function didn't work

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -289,6 +289,7 @@ $internalConfig = array(
                 'empty'                   => 'empty',
                 'count'                   => 'LS_Twig_Extension::safecount',
                 'reset'                   => 'reset',
+                'strip_tags'              => 'strip_tags',
                 'in_array'                => 'in_array',
                 'in_multiarray'           => 'LS_Twig_Extension::in_multiarray',
                 'array_search'            => 'array_search',

--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -350,7 +350,7 @@ $internalConfig = array(
                     'capitalize',
                     'lower',
                     'upper',
-                    'strip_tags',
+                    'striptags',
                     'number_format',
                     'isAbsoluteUrl'
                 ),


### PR DESCRIPTION
New feature #13732: Twig - add "striptags" filters
Dev: flatString do near the same thing 
