### PR TITLE
19661: Data inconsistency in responses after importing LSA files

### DIFF
--- a/tests/unit/helpers/remotecontrol/ExportStatisticsArrayQuestionsTest.php
+++ b/tests/unit/helpers/remotecontrol/ExportStatisticsArrayQuestionsTest.php
@@ -41,13 +41,13 @@ class RemoteControlExportStatisticsArrayQuestionsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($questionData[2][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($questionData[2][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($questionData[2][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($questionData[2][1], '3', 'The Count is incorrect for this option.');
+        $this->assertSame($questionData[2][2], '30.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($questionData[3][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($questionData[3][1], '3', 'The Count is incorrect for this option.');
-        $this->assertSame($questionData[3][2], '30.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($questionData[3][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($questionData[3][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($questionData[4], 'This row should be empty.');
@@ -72,13 +72,13 @@ class RemoteControlExportStatisticsArrayQuestionsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($questionData[8][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($questionData[8][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($questionData[8][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($questionData[8][1], '3', 'The Count is incorrect for this option.');
+        $this->assertSame($questionData[8][2], '30.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($questionData[9][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($questionData[9][1], '3', 'The Count is incorrect for this option.');
-        $this->assertSame($questionData[9][2], '30.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($questionData[9][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($questionData[9][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($questionData[10], 'This row should be empty.');

--- a/tests/unit/helpers/remotecontrol/ExportStatisticsTest.php
+++ b/tests/unit/helpers/remotecontrol/ExportStatisticsTest.php
@@ -49,13 +49,13 @@ class RemoteControlExportStatisticsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($q1Data[3][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[3][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[3][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[3][1], '2', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[3][2], '20.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($q1Data[4][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[4][1], '2', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[4][2], '20.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[4][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[4][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($q1Data[5], 'This row should be empty.');
@@ -98,13 +98,13 @@ class RemoteControlExportStatisticsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($q1Data[3][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[3][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[3][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[3][1], '3', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[3][2], '30.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($q1Data[4][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[4][1], '3', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[4][2], '30.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[4][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[4][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($q1Data[5], 'This row should be empty.');
@@ -149,13 +149,13 @@ class RemoteControlExportStatisticsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($q1Data[6][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[6][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[6][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[6][1], '2', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[6][2], '20.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($q1Data[7][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[7][1], '2', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[7][2], '20.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[7][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[7][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($q1Data[8], 'This row should be empty.');
@@ -185,13 +185,13 @@ class RemoteControlExportStatisticsTest extends BaseTest
 
         // No answer row.
         $this->assertSame($q1Data[3][0], 'No answer', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[3][1], '0', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[3][2], '0.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[3][1], '2', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[3][2], '20.00%', 'The Percentage is incorrect for this option.');
 
         // Not completed row.
         $this->assertSame($q1Data[4][0], 'Not completed or Not displayed', 'The Answer text is incorrect for this option.');
-        $this->assertSame($q1Data[4][1], '2', 'The Count is incorrect for this option.');
-        $this->assertSame($q1Data[4][2], '20.00%', 'The Percentage is incorrect for this option.');
+        $this->assertSame($q1Data[4][1], '0', 'The Count is incorrect for this option.');
+        $this->assertSame($q1Data[4][2], '0.00%', 'The Percentage is incorrect for this option.');
 
         // A row is left empty.
         $this->assertEmpty($q1Data[5], 'This row should be empty.');


### PR DESCRIPTION
- RemoteControlExportStatisticsArrayQuestionsTest and RemoteControlExportStatisticsTest expected zero 'No answer' responses and a number of 'Not completed or Not displayed' responses on surveys where it's impossible to have not completed/not displayed questions/subquestions. Tests worked because LSA import was broken