### PR TITLE
Fixed issue #19883: PHP8.3 + debug : potential home page broken

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -28,8 +28,8 @@ class SurveysController extends LSYii_Controller
         } else {
             $lang = App()->getConfig('defaultlang');
         }
-            App()->setLanguage($lang);
-
+        App()->setLanguage($lang);
+        LimeExpressionManager::SetSurveyId(0);
 
         $oTemplate       = Template::model()->getInstance(getGlobalSetting('defaulttheme'));
         $this->sTemplate = $oTemplate->sTemplateName;


### PR DESCRIPTION
Dev: disable Expression Manager in home page without reset existing survey session (only expression)

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
