### PR TITLE
CT-1121: Creating timings table when activating back a survey

### DIFF
--- a/application/models/SurveyActivator.php
+++ b/application/models/SurveyActivator.php
@@ -417,7 +417,8 @@ class SurveyActivator
      */
     protected function createTimingsTable()
     {
-        if ($this->survey->isSaveTimings) {
+        $prow = $this->survey->find('sid = :sid', array(':sid' => $this->survey->sid));
+        if ($prow->savetimings == "Y") {
             $this->prepareTimingsTable();
             $sTableName = $this->survey->timingsTableName;
             try {

--- a/application/models/SurveyActivator.php
+++ b/application/models/SurveyActivator.php
@@ -417,6 +417,12 @@ class SurveyActivator
      */
     protected function createTimingsTable()
     {
+        /**
+         * CT-1121: Needed a fix because $this->survey->isSaveTimings is incorrectly N even if it's Y in the database
+         * We will need to look into that problem later and restore the earlier code changed in 28bdcc3fde1e758756d2f4a4984e29a4105d3950
+         * once $this->survey->isSaveTimings becomes reliable again
+         * The idea for the fix was to load this value from the database for the time being until the session creation at the Question Editor is fixed
+         */
         $prow = $this->survey->find('sid = :sid', array(':sid' => $this->survey->sid));
         if ($prow->savetimings == "Y") {
             $this->prepareTimingsTable();


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
