### PR TITLE
QE-1394 allow jpeg upload

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -96,7 +96,7 @@ $config['createsample']              = true;
 $config['customassetversionnumber']  = 1;        // Used to generate the path of tmp assets (see: LSYii_AssetManager::generatePath()  )
 
 // Please be very careful if you want to allow SVG files - there are several XSS dangerous security issues
-$config['allowedthemeimageformats'] = 'gif,ico,jpg,png'; // Image file types allowed to be uploaded in the themes section.
+$config['allowedthemeimageformats'] = 'gif,ico,jpg,jpeg,png'; // Image file types allowed to be uploaded in the themes section.
 $config['allowedthemeuploads'] = 'css,js,map,json,eot,otf,ttf,woff,txt,md,xml,woff2,twig,lss,lsa,lsq,lsg'; // Other file types allowed to be uploaded in the themes section.
 $config['allowedfileuploads'] = [
     //Documents


### PR DESCRIPTION
Question editor image upload functionality introduced FileUploadService which handles upload functionality. It makes use of LSYii_ImageValidato::validateImage(). The validation limits image upload to the types defined in allowedthemeimageformats but this list does not include ‘jpeg' by default even though it does include ‘jpg’. This sure if there is a good reason for this or if it is an oversight. This PR just adds 'jpeg’ to that list.

