### PR TITLE
Fix .gitattributes typo and missing files for psalm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,7 @@ package.json            export-ignore
 phpci.yml               export-ignore
 phpcs.ruleset.xml       export-ignore
 phpunit.xml             export-ignore
-palm.xml                export-ignore
+psalm*.xml              export-ignore
 tests                   export-ignore
 yarn.lock               export-ignore
 vendor/khaled.alshamaa/ar-php/examples export-ignore


### PR DESCRIPTION
Run `git archive HEAD --format zip --output=repo.zip` to test it

After this fix the 3 files present in the released tarballs will go away 

```
-rw-rw-r--   1 www-data www-data 2.2K Jan 27 14:10 psalm-all.xml
-rw-rw-r--   1 www-data www-data 1.1K Jan 27 14:10 psalm-strict.xml
-rw-rw-r--   1 www-data www-data 1.1K Jan 27 14:10 psalm.xml
```

The typo was not spotted 2 years ago in https://github.com/LimeSurvey/LimeSurvey/commit/d47fe8a9736b2f3ce4d3ad7d016f7f9f5970a1c8 and introduced by #2230 in https://github.com/LimeSurvey/LimeSurvey/commit/d03b30022e346999f8261d02cacc2158c4ae47f0
/cc @c-schmitz 

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
