### PR TITLE
Fixed issue #19909: Issues with font handling in the custom configuration of the survey theme - Fonts styles not showed in dropdown

### DIFF
--- a/application/views/themeOptions/options_core.php
+++ b/application/views/themeOptions/options_core.php
@@ -190,6 +190,19 @@ $aOptionAttributes['optionAttributes']['brandlogofile']['dropdownoptions'] = $br
                                     $classes[] = 'selector_image_selector';
                                 }
                                 $classValue = implode(' ', $classes);
+
+                                if ($attributeKey === 'font') {
+                                    // Register font packages
+                                    // All fonts are displayed in the dropdowns, so we need to register the packages for font preview to work.
+                                    // Packages are separated in two groups: core and user.
+                                    foreach (Yii::app()->getClientScript()->fontPackages as $fontPackages) {
+                                        foreach (array_keys($fontPackages) as $fontKey) {
+                                            Yii::app()->getClientScript()->registerPackage('font-' . $fontKey);
+                                        }
+                                    }
+                                    // Websafe fonts are on a separate package
+                                    Yii::app()->getClientScript()->registerPackage('font-websafe');
+                                }
                                 ?>
 
                                 <div class="col-12">


### PR DESCRIPTION
Fix for issue 2 described in ticket 19909: Fonts styles not showed in dropdown

Looks like a bug as in 3.x styles are effectively showed and now it doesn't. Think it's simply because before the Theme Options were rendered with the options.twig file of each theme, and in that file the packages were registered with the CSS of each font. Now the options are rendered with options_core.html, and the packages are not registered there.
What the fix does is register all the necessary packages.

Stil, although it seems like a porting issue, it is also likely this could be a decision to abandon the preview function of the sources, so as not to have to load so many packages, its impact in performance and number of requests.