### PR TITLE
Fixed Issue #19743 : Copy survey button was too small

### DIFF
--- a/application/views/surveyAdministration/tabCopy_view.php
+++ b/application/views/surveyAdministration/tabCopy_view.php
@@ -33,7 +33,7 @@
                             <?= gT("If the new survey ID is already used, a random one will be assigned."); ?> </span>
                 <!-- Submit -->
                 <div class="mt-3">
-                    <input type='submit' class='btn btn-primary col-4' value='<?php eT("Copy survey"); ?>' />
+                    <input type='submit' class='btn btn-primary col-6' value='<?php eT("Copy survey"); ?>' />
                     <?php if (isset($surveyid)) echo '<input type="hidden" name="sid" value="' . $surveyid . '" />'; ?>
                     <input type='hidden' name='action' value='copysurvey' />
                 </div>


### PR DESCRIPTION
Dev: On the survey creation page, in the Copy tab, the Copy a Survey button was smaller than its counterparts in the Create and Import tabs. I have changed the button class so it matches the other buttons and make it a bit bigger.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #19743:
Dev: On the survey creation page, in the Copy tab, the Copy a Survey button was smaller than its counterparts in the Create and Import tabs. I have changed the button class so it matches the other buttons and make it a bit bigger.
