### PR TITLE
Fixed Issue #19742: Label set export anomaly

### DIFF
--- a/assets/scripts/admin/labels.js
+++ b/assets/scripts/admin/labels.js
@@ -33,6 +33,12 @@ $(document).on('ready  pjax:scriptcomplete', function(){
         }
     });
 
+    // Use window focus trick to ensure loading spinner is hidden after export
+    $('#exportlabelset').on('submit', function(){
+        $(window).one('focus', function(){ $('#ls-loading').hide(); });
+    });
+
+
     const answersTable = $(".answertable tbody");
     if (answersTable.length && answersTable.children().length == 0) {
         add_label(undefined);


### PR DESCRIPTION
Dev: After exporting a label set, the page would be stuck on the loading screen. I added an focus event listener to the export button handler in order to ensure that the loading screen is hidden.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #19742: Label set export anomaly
Dev: After exporting a label set, the page would be stuck on the loading screen. I added an focus event listener to the export button handler in order to ensure that the loading screen is hidden.
