### PR TITLE
New feature #20002: Create 2FA enforcement setting for 2FA plugin

### DIFF
--- a/application/core/plugins/TwoFactorAdminLogin/config.xml
+++ b/application/core/plugins/TwoFactorAdminLogin/config.xml
@@ -4,10 +4,10 @@
         <name>TwoFactorAdminLogin</name>
         <type>plugin</type>
         <creationDate>2019-03-10</creationDate>
-        <lastUpdate>2021-03-25</lastUpdate>
+        <lastUpdate>2025-03-14</lastUpdate>
         <author>LimeSurvey GmbH</author>
         <authorUrl>https://www.limesurvey.org</authorUrl>
-        <version>1.2.5</version>
+        <version>1.3.0</version>
         <license>GNU General Public License version 2 or later</license>
         <description><![CDATA[Use a TOTP based 2 factor authentication on logging in into the admin portal.]]></description>
         <supportUrl>https://www.limesurvey.org</supportUrl>

--- a/application/core/plugins/TwoFactorAdminLogin/views/userindex.php
+++ b/application/core/plugins/TwoFactorAdminLogin/views/userindex.php
@@ -14,18 +14,18 @@ echo viewHelper::getViewTestTag('2faUsersIndex');
     <div class="h1 pagetitle">
     <?=gT("Two-factor authentication (2FA)");?>
     </div>
-    <?php if ($oTFAModel == null ) { ?>
+    <?php if ($oTFAModel == null) { ?>
     <div class="jumbotron">
         <div class="col-12">
             <h2>
             <?=gT("You don't have two-factor authentication (2FA) activated.");?> <br/>
-                <?=($force2FA == true ? gT("Please activate it now.") : gT("Do you want to activate it now?"))?>
+                <?=($force2FA > 1 ? gT("Please activate it now.") : gT("Do you want to activate it now?"))?>
             </h2>
             <p>
                 <a role="button" class="btn btn-outline-secondary TFA--actionopenmodal TFA--excludefromlock" data-href="<?=App()->createUrl("plugins/direct/plugin/TwoFactorAdminLogin/function/directCallCreateNewKey")?>" data-bs-toggle="modal" id="TFA--register2fa">
                     <?=gT("Activate 2FA now");?>
                 </a>
-            <?php if ($force2FA == true) { ?>
+            <?php if ($force2FA < 2) { ?>
                 <a role="button" class="btn btn-danger TFA--excludefromlock" href="<?=App()->createUrl("admin")?>" id="TFA--excludeNotNow">
                     <?=gT("Not now");?>
                 </a>
@@ -33,20 +33,22 @@ echo viewHelper::getViewTestTag('2faUsersIndex');
             </p>
         </div>
     </div>
-<?php } else { ?>
+    <?php } else { ?>
     <div class="col-12">
         <p><?=sprintf(gT("Currently activated two-factor authentication: %s"), $oTFAModel->authTypeDescription);?> </p>
-        <p><?=gT("Do you want to remove/renew it?");?></p>
+        <p><?=($force2FA > 1 ? gT("Do you want to renew it?") : gT("Do you want to remove/renew it?"))?>
         <p>
-            <a
-                class="btn btn-outline-secondary TFA--actionconfirm"
-                data-href="<?=App()->createUrl("plugins/direct/plugin/TwoFactorAdminLogin/function/directCallDeleteKey")?>"
-                id="TFA--unset2fa"
-                data-confirmtext="<?=gT('Are you sure you want to disable two-factor authentication (2FA) for your account?')?>"
-                data-buttons='{"confirm_cancel": "<?=gT('No, cancel', 'js')?>", "confirm_ok": "<?=gT('Yes, I am sure', 'js')?>"}'
-                data-uid="<?=$oTFAModel->uid?>"
-                data-errortext="<?=gT('An error has occurred, and the key could not be deleted.')?>"
-            ><?=gT("Remove 2FA")?></a>
+            <?php if ($force2FA < 2) { ?>
+                <a
+                    class="btn btn-outline-secondary TFA--actionconfirm"
+                    data-href="<?=App()->createUrl("plugins/direct/plugin/TwoFactorAdminLogin/function/directCallDeleteKey")?>"
+                    id="TFA--unset2fa"
+                    data-confirmtext="<?=gT('Are you sure you want to disable two-factor authentication (2FA) for your account?')?>"
+                    data-buttons='{"confirm_cancel": "<?=gT('No, cancel', 'js')?>", "confirm_ok": "<?=gT('Yes, I am sure', 'js')?>"}'
+                    data-uid="<?=$oTFAModel->uid?>"
+                    data-errortext="<?=gT('An error has occurred, and the key could not be deleted.')?>"
+                ><?=gT("Remove 2FA")?></a>
+            <?php } ?>
             <a
                 class="btn btn-outline-secondary TFA--actionopenmodal"
                 data-href="<?=App()->createUrl("plugins/direct/plugin/TwoFactorAdminLogin/function/directCallCreateNewKey", ['uid' => $oTFAModel->uid])?>"
@@ -61,7 +63,7 @@ echo viewHelper::getViewTestTag('2faUsersIndex');
         </div>
     </div>
 </div>
-<?php if($force2FA == true && $oTFAModel == null ) { 
+<?php if ($force2FA > 1 && $oTFAModel == null) {
        echo "<style>.navbar {visibility: hidden;} .footer {visibility:hidden;}</style>";
        App()->getClientScript()->registerScript('TFA-User-Lock', 'window.TFAUser.restrictAccess();', LSYii_ClientScript::POS_POSTSCRIPT);
 }?>


### PR DESCRIPTION
Dev: attach to beforeAdminMenuRender, call for all GUI.

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
