### PR TITLE
QE-1495: fix TransformerInputAnswer, aid can be string

### DIFF
--- a/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputAnswer.php
+++ b/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputAnswer.php
@@ -10,7 +10,7 @@ class TransformerInputAnswer extends Transformer
         TransformerInputAnswerL10ns $transformerInputAnswerL10ns
     ) {
         $this->setDataMap([
-            'aid' => ['type' => 'int', 'required' => 'update'],
+            'aid' => ['required' => 'update'], // can be a string temp id or an int
             'qid' => ['type' => 'int'],
             'oldCode' => 'oldcode',
             'code' => [


### PR DESCRIPTION
TransformerInputAnswer was casting aid to an INT but it can also be a STRING temp id.