### PR TITLE
APE-98: access mode toggle

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '6.13.0';
-$config['dbversionnumber'] = 629;
+$config['dbversionnumber'] = 630;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/helpers/update/updates/Update_630.php
+++ b/application/helpers/update/updates/Update_630.php
@@ -2,7 +2,8 @@
 
 namespace LimeSurvey\Helpers\Update;
 
-class Update_630 extends DatabaseUpdateBase {
+class Update_630 extends DatabaseUpdateBase
+{
     public function up()
     {
         addColumn('{{surveys}}', 'access_mode', "string(1) DEFAULT 'O'");

--- a/application/helpers/update/updates/Update_630.php
+++ b/application/helpers/update/updates/Update_630.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+class Update_630 extends DatabaseUpdateBase {
+    public function up()
+    {
+        addColumn('{{surveys}}', 'access_mode', "string(1) DEFAULT 'O'");
+        $sids = [];
+        foreach (dbGetTablesLike('%token%') as $table) {
+            if (strpos($table, "old") === false) {
+                $split = explode("_", $table);
+                $sids[] = $split[count($split) - 1];
+            }
+        }
+        if (count($sids)) {
+            $this->db->createCommand()->update("{{surveys}}", ["access_mode" => "C"], "sid in (" . implode(",", $sids) . ")");
+        }
+    }
+
+    public function down()
+    {
+        dropColumn('{{surveys}}', 'access_mode');
+    }
+}

--- a/application/helpers/update/updates/Update_630.php
+++ b/application/helpers/update/updates/Update_630.php
@@ -18,9 +18,4 @@ class Update_630 extends DatabaseUpdateBase
             $this->db->createCommand()->update("{{surveys}}", ["access_mode" => "C"], "sid in (" . implode(",", $sids) . ")");
         }
     }
-
-    public function down()
-    {
-        dropColumn('{{surveys}}', 'access_mode');
-    }
 }

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
@@ -41,7 +41,7 @@ class OpHandlerSurveyAccessMode implements OpHandlerInterface
         return ($op->getEntityType() === $this->entity) && ($op->getType()->getId() === OpTypeUpdate::ID);
     }
 
-    public function handle(OpInterface $op)
+    public function handle(OpInterface $op): void
     {
         $this->surveyAccessModeService->changeAccessMode((int)$op->getEntityId(), $op->getProps()['accessMode'], $op->getProps()['archive'] ?? true);
     }
@@ -51,7 +51,7 @@ class OpHandlerSurveyAccessMode implements OpHandlerInterface
         if (!($sid = intval($op->getEntityId()))) {
             throw new NotFoundException('sid is not a number');
         }
-        if (!$this->surveyAccessModeService->hasPermission((int)$sid, $op->getProps()['accessMode'])) {
+        if (!$this->surveyAccessModeService->hasPermission($sid, $op->getProps()['accessMode'])) {
             throw new PermissionDeniedException(
                 'Access denied'
             );

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
@@ -59,7 +59,7 @@ class OpHandlerSurveyAccessMode implements OpHandlerInterface
      *            "accessMode": "D"
      *        }
      *   }
-     * 
+     *
      * Access mode can be:
      * - O: open access mode: no table, survey can be filled anonymously
      * - C: closed access mode: tokens table exists, survey can be filled with token

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
@@ -16,7 +16,6 @@ use LimeSurvey\Models\Services\Exception\{
     NotFoundException,
     PermissionDeniedException
 };
-
 use LimeSurvey\Models\Services\SurveyAccessModeService;
 use Permission;
 

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace LimeSurvey\Api\Command\V1\SurveyPatch;
+
+use LimeSurvey\ObjectPatch\{
+    Op\OpInterface,
+    OpHandler\OpHandlerInterface,
+    OpType\OpTypeUpdate
+};
+use LimeSurvey\Api\Command\V1\SurveyPatch\Traits\{
+    OpHandlerExceptionTrait,
+    OpHandlerSurveyTrait,
+    OpHandlerValidationTrait
+};
+use LimeSurvey\Models\Services\Exception\{
+    NotFoundException,
+    PermissionDeniedException
+};
+
+use LimeSurvey\Models\Services\SurveyAccessModeService;
+use Permission;
+
+class OpHandlerSurveyAccessMode implements OpHandlerInterface
+{
+    use OpHandlerExceptionTrait;
+    use OpHandlerSurveyTrait;
+    use OpHandlerValidationTrait;
+
+    protected string $entity;
+
+    protected SurveyAccessModeService $surveyAccessModeService;
+
+    public function __construct(
+        SurveyAccessModeService $surveyAccessModeService
+    ) {
+        $this->surveyAccessModeService = $surveyAccessModeService;
+        $this->entity = 'accessMode';
+    }
+
+    public function canHandle(OpInterface $op): bool
+    {
+        return ($op->getEntityType() === $this->entity) && ($op->getType()->getId() === OpTypeUpdate::ID);
+    }
+
+    public function handle(OpInterface $op)
+    {
+        $this->surveyAccessModeService->changeAccessMode((int)$op->getEntityId(), $op->getProps()['accessMode'], $op->getProps()['archive'] ?? true);
+    }
+
+    public function validateOperation(OpInterface $op): array
+    {
+        if (!($sid = intval($op->getEntityId()))) {
+            throw new NotFoundException('sid is not a number');
+        }
+        if (!$this->surveyAccessModeService->hasPermission((int)$sid, $op->getProps()['accessMode'])) {
+            throw new PermissionDeniedException(
+                'Access denied'
+            );
+        }
+        return [];
+    }
+}

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSurveyAccessMode.php
@@ -36,11 +36,40 @@ class OpHandlerSurveyAccessMode implements OpHandlerInterface
         $this->entity = 'accessMode';
     }
 
+    /**
+     * Checks whether the operation can be handled
+     * @param \LimeSurvey\ObjectPatch\Op\OpInterface $op
+     * @return bool
+     */
     public function canHandle(OpInterface $op): bool
     {
         return ($op->getEntityType() === $this->entity) && ($op->getType()->getId() === OpTypeUpdate::ID);
     }
 
+    /**
+     * Handle survey access mode update.
+     *
+     *   Expects a patch structure like this:
+     *   {
+     *        "id": 571271,
+     *        "op": "update",
+     *        "entity": "accessMode",
+     *        "error": false,
+     *        "props": {
+     *            "accessMode": "D"
+     *        }
+     *   }
+     * 
+     * Access mode can be:
+     * - O: open access mode: no table, survey can be filled anonymously
+     * - C: closed access mode: tokens table exists, survey can be filled with token
+     * - D: dual access mode: tokens table exists, survey can be filled with token or anonymously
+     * - A: anyone with the link: tokens table exists, survey can be filled anonymously
+     * Optionally an archive parameter can be passed besides the accessMode parameter, which may be true or false, depending on whether we want to
+     * archive or remove the tokens table if switching to O
+     * @param \LimeSurvey\ObjectPatch\Op\OpInterface $op
+     * @return void
+     */
     public function handle(OpInterface $op): void
     {
         $this->surveyAccessModeService->changeAccessMode((int)$op->getEntityId(), $op->getProps()['accessMode'], $op->getProps()['archive'] ?? true);

--- a/application/libraries/Api/Command/V1/SurveyPatch/PatcherSurvey.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/PatcherSurvey.php
@@ -50,6 +50,7 @@ class PatcherSurvey extends Patcher
             OpHandlerSurveyStatus::class,
             OpHandlerImport::class,
             OpHandlerThemeSettings::class,
+            OpHandlerSurveyAccessMode::class,
         ];
 
         foreach ($classes as $class) {

--- a/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurvey.php
+++ b/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurvey.php
@@ -165,7 +165,8 @@ class TransformerOutputSurvey extends TransformerOutputActiveRecord
                 'type' => 'int'
             ],
             'template' => true,
-            'format' => true
+            'format' => true,
+            'access_mode' => 'access_mode'
         ]);
     }
 

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace LimeSurvey\Models\Services;
+
+use Permission;
+use Survey;
+use Token;
+use LimeExpressionManager;
+use LSYii_Application;
+use ArchivedTableSettings;
+
+use LimeSurvey\Models\Services\Exception\{
+    PersistErrorException,
+    NotFoundException,
+    PermissionDeniedException
+};
+
+class SurveyAccessModeService
+{
+    protected Permission $permission;
+
+    protected Survey $survey;
+    protected LSYii_Application $app;
+
+    public static $ACCESS_TYPE_OPEN = 'O';
+    public static $ACCESS_TYPE_CLOSED = 'C';
+    public static $ACCESS_TYPE_DUAL = 'D';
+    public static $ACCESS_TYPE_ANYONE_WITH_LINK = 'A';
+
+    protected static $supportedAccessModes = null;
+
+    public function __construct(
+        Permission $permission,
+        Survey $survey,
+        LSYii_Application $app
+    )
+    {
+        $this->permission = $permission;
+        $this->survey = $survey;
+        $this->app = $app;
+        if (!self::$supportedAccessModes) {
+            self::$supportedAccessModes = [
+                self::$ACCESS_TYPE_OPEN,
+                self::$ACCESS_TYPE_CLOSED,
+                self::$ACCESS_TYPE_DUAL,
+                self::$ACCESS_TYPE_ANYONE_WITH_LINK
+            ];
+        }
+    }
+
+    /**
+     * Checks whether the issuer has the necessary permissions for the action
+     * @param int $surveyID the id of the survey
+     * @param string $oldMode the access mode we intend to change
+     * @param string $newMode the access mode we intend to set
+     * @return bool whether all the permissions necessary are present
+     */
+    protected function hasPermission(int $surveyID, string $oldMode, string $newMode)
+    {
+        $permissions = [
+            'surveysettings' => 'update'
+        ];
+        if (($oldMode !== self::$ACCESS_TYPE_CLOSED) && ($newMode === self::$ACCESS_TYPE_CLOSED)) {
+            $permissions['tokens'] = 'delete';
+        } else if (($oldMode === self::$ACCESS_TYPE_CLOSED) && ($newMode !== self::$ACCESS_TYPE_CLOSED)) {
+            $permissions['tokens'] = 'create';
+        }
+        foreach ($permissions as $name => $perm) {
+            if (!$this->permission->hasSurveyPermission($surveyID, $name, $perm)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Creates a token table for the survey if it does not already exist
+     * @param \Survey $survey
+     * @return bool
+     */
+    protected function newTokenTable(Survey $survey)
+    {
+        $surveyInfo = getSurveyInfo($survey->sid);
+        if ($survey->hasTokensTable) {
+            return false; //Tokens table already exists, nothing to do here
+        }
+        $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
+        $tokenencryptionoptions['enabled'] = 'Y';
+        $survey->tokenencryptionoptions = ls_json_encode($tokenencryptionoptions);
+        Token::createTable($survey->sid);
+        LimeExpressionManager::setDirtyFlag();
+        return true;
+    }
+
+    /**
+     * Drops token table if it exists
+     * @param \Survey $survey the survey whose participant table is to be dropped
+     * @param bool $archive whether we archive the tokens, or remove them
+     * @return void
+     */
+    protected function dropTokenTable(Survey $survey, bool $archive = true)
+    {
+        $datestamp = time();
+        $date = date('YmdHis', $datestamp);
+        $DBDate = "date('Y-m-d H:i:s', $datestamp)";
+        $oldTable = "tokens_" . $survey->sid;
+        $newTable = "old_tokens_" . $survey->sid . "_" . $date;
+        $userID = $this->app->user->getId();
+
+        if ($archive) {
+            $surveyInfo = getSurveyInfo($survey->sid);
+            $this->app->db->createCommand()->renameTable("{{" . $oldTable . "}}", "{{" . $newTable . "}}");
+            $archivedTokenSettings = new ArchivedTableSettings();
+            $archivedTokenSettings->survey_id = $survey->sid;
+            $archivedTokenSettings->user_id = $userID;
+            $archivedTokenSettings->tbl_name = $newTable;
+            $archivedTokenSettings->tbl_type = 'token';
+            $archivedTokenSettings->created = $DBDate;
+            $archivedTokenSettings->properties = $surveyInfo['tokenencryptionoptions'];
+            $archivedTokenSettings->attributes = json_encode($surveyInfo['attributedescriptions']);
+            $archivedTokenSettings->save();
+        } else {
+            $this->app->db->createCommand()->dropTable("{{" . $oldTable . "}}");
+        }
+    }
+
+    /**
+     * Changes the access mode of the survey
+     * @param int $surveyID the id of the survey whose access mode is to be changed
+     * @param string $accessMode the access mode we desire to have
+     * @param bool $archive whether we intend to archive the tokens table or not
+     * @throws \LimeSurvey\Models\Services\Exception\PersistErrorException
+     * @throws \LimeSurvey\Models\Services\Exception\PermissionDeniedException
+     * @return bool whether the change was done
+     */
+    public function changeAccessMode(int $surveyID, string $accessMode, bool $archive = true)
+    {
+        $survey = Survey::model()->findByPk($surveyID);
+        $oldAccessMode = $survey->access_mode;
+        if ($oldAccessMode === $accessMode) {
+            return false; //Nothing to change
+        }
+        if (!in_array($accessMode, self::$supportedAccessModes)) {
+            throw new PersistErrorException(
+                'The access mode given is not supported'
+            );
+        }
+        if (!$this->hasPermission($surveyID, $oldAccessMode, $accessMode)) {
+            throw new PermissionDeniedException(
+                'Access denied'
+            );
+        }
+        $survey->access_mode = $accessMode;
+        if ($oldAccessMode === self::$ACCESS_TYPE_OPEN) {
+            $this->newTokenTable($survey);
+        } else if ($accessMode === self::$ACCESS_TYPE_OPEN) {
+            $this->dropTokenTable($survey, $archive);
+        }
+        $survey->save();
+        return true;
+    }
+}

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -79,7 +79,6 @@ class SurveyAccessModeService
      */
     protected function newTokenTable(Survey $survey)
     {
-        $surveyInfo = getSurveyInfo($survey->sid);
         if ($survey->hasTokensTable) {
             return false; //Tokens table already exists, nothing to do here
         }

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -8,7 +8,6 @@ use Token;
 use LimeExpressionManager;
 use LSYii_Application;
 use ArchivedTableSettings;
-
 use LimeSurvey\Models\Services\Exception\{
     PersistErrorException,
     NotFoundException,
@@ -33,8 +32,7 @@ class SurveyAccessModeService
         Permission $permission,
         Survey $survey,
         LSYii_Application $app
-    )
-    {
+    ) {
         $this->permission = $permission;
         $this->survey = $survey;
         $this->app = $app;
@@ -63,7 +61,7 @@ class SurveyAccessModeService
         ];
         if (($oldMode !== self::$ACCESS_TYPE_CLOSED) && ($newMode === self::$ACCESS_TYPE_CLOSED)) {
             $permissions['tokens'] = 'delete';
-        } else if (($oldMode === self::$ACCESS_TYPE_CLOSED) && ($newMode !== self::$ACCESS_TYPE_CLOSED)) {
+        } elseif (($oldMode === self::$ACCESS_TYPE_CLOSED) && ($newMode !== self::$ACCESS_TYPE_CLOSED)) {
             $permissions['tokens'] = 'create';
         }
         foreach ($permissions as $name => $perm) {
@@ -154,7 +152,7 @@ class SurveyAccessModeService
         $survey->access_mode = $accessMode;
         if ($oldAccessMode === self::$ACCESS_TYPE_OPEN) {
             $this->newTokenTable($survey);
-        } else if ($accessMode === self::$ACCESS_TYPE_OPEN) {
+        } elseif ($accessMode === self::$ACCESS_TYPE_OPEN) {
             $this->dropTokenTable($survey, $archive);
         }
         $survey->save();

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -106,20 +106,22 @@ class SurveyAccessModeService
         $newTable = "old_tokens_" . $survey->sid . "_" . $date;
         $userID = $this->app->user->getId();
 
-        if ($archive) {
-            $surveyInfo = getSurveyInfo($survey->sid);
-            $this->app->db->createCommand()->renameTable("{{" . $oldTable . "}}", "{{" . $newTable . "}}");
-            $archivedTokenSettings = new ArchivedTableSettings();
-            $archivedTokenSettings->survey_id = $survey->sid;
-            $archivedTokenSettings->user_id = $userID;
-            $archivedTokenSettings->tbl_name = $newTable;
-            $archivedTokenSettings->tbl_type = 'token';
-            $archivedTokenSettings->created = $DBDate;
-            $archivedTokenSettings->properties = $surveyInfo['tokenencryptionoptions'];
-            $archivedTokenSettings->attributes = json_encode($surveyInfo['attributedescriptions']);
-            $archivedTokenSettings->save();
-        } else {
-            $this->app->db->createCommand()->dropTable("{{" . $oldTable . "}}");
+        if ($survey->active === 'Y') {
+            if ($archive) {
+                $surveyInfo = getSurveyInfo($survey->sid);
+                $this->app->db->createCommand()->renameTable("{{" . $oldTable . "}}", "{{" . $newTable . "}}");
+                $archivedTokenSettings = new ArchivedTableSettings();
+                $archivedTokenSettings->survey_id = $survey->sid;
+                $archivedTokenSettings->user_id = $userID;
+                $archivedTokenSettings->tbl_name = $newTable;
+                $archivedTokenSettings->tbl_type = 'token';
+                $archivedTokenSettings->created = $DBDate;
+                $archivedTokenSettings->properties = $surveyInfo['tokenencryptionoptions'];
+                $archivedTokenSettings->attributes = json_encode($surveyInfo['attributedescriptions']);
+                $archivedTokenSettings->save();
+            } else {
+                $this->app->db->createCommand()->dropTable("{{" . $oldTable . "}}");
+            }
         }
     }
 

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -79,8 +79,8 @@ class SurveyAccessModeService
      */
     protected function newTokenTable(Survey $survey)
     {
-        if (($survey->active === 'Y') && ($survey->hasTokensTable)) {
-            return false; //Tokens table already exists, nothing to do here
+        if (($survey->active !== 'Y') || ($survey->hasTokensTable)) {
+            return false; //Tokens table already exists or the survey is not active, nothing to do here
         }
         $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
         $tokenencryptionoptions['enabled'] = 'Y';

--- a/application/models/services/SurveyAccessModeService.php
+++ b/application/models/services/SurveyAccessModeService.php
@@ -51,12 +51,13 @@ class SurveyAccessModeService
     /**
      * Checks whether the issuer has the necessary permissions for the action
      * @param int $surveyID the id of the survey
-     * @param string $oldMode the access mode we intend to change
      * @param string $newMode the access mode we intend to set
      * @return bool whether all the permissions necessary are present
      */
-    protected function hasPermission(int $surveyID, string $oldMode, string $newMode)
+    public function hasPermission(int $surveyID, string $newMode)
     {
+        $survey = $this->survey->findByPk($surveyID);
+        $oldMode = $survey->access_mode;
         $permissions = [
             'surveysettings' => 'update'
         ];
@@ -145,7 +146,7 @@ class SurveyAccessModeService
                 'The access mode given is not supported'
             );
         }
-        if (!$this->hasPermission($surveyID, $oldAccessMode, $accessMode)) {
+        if (!$this->hasPermission($surveyID, $accessMode)) {
             throw new PermissionDeniedException(
                 'Access denied'
             );

--- a/application/models/services/SurveyActivate.php
+++ b/application/models/services/SurveyActivate.php
@@ -126,7 +126,13 @@ class SurveyActivate
             recoverSurveyResponses($surveyId, $archives["survey"], $preserveIDs, $dynamicColumns);
             if (isset($archives["tokens"])) {
                 $tokenTable = $this->app->db->tablePrefix . "tokens_" . $surveyId;
-                createTableFromPattern($tokenTable, $archives["tokens"]);
+                try {
+                    createTableFromPattern($tokenTable, $archives["tokens"]);
+                } catch (\CDbException $ex) {
+                    if (strpos($ex->getMessage(), "Base table or view already exists") === false) {
+                        throw $ex;
+                    }
+                }
                 copyFromOneTableToTheOther($archives["tokens"], $tokenTable);
             }
             if (isset($archives["timings"])) {

--- a/application/models/services/SurveyActivate.php
+++ b/application/models/services/SurveyActivate.php
@@ -124,7 +124,9 @@ class SurveyActivate
             $sTimestamp = $sParts[count($sParts) - 1];
             $dynamicColumns = getUnchangedColumns($surveyId, $sTimestamp, $qTimestamp);
             recoverSurveyResponses($surveyId, $archives["survey"], $preserveIDs, $dynamicColumns);
-            if (isset($archives["tokens"])) {
+            $survey = Survey::model()->findByPk($surveyId);
+            //If it's not open access mode, then we import the surveys from the archive if they exist
+            if (($survey->access_mode !== 'O') && isset($archives["tokens"])) {
                 $tokenTable = $this->app->db->tablePrefix . "tokens_" . $surveyId;
                 try {
                     createTableFromPattern($tokenTable, $archives["tokens"]);

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -678,6 +678,7 @@ function populateDatabase($oDB)
             'googleanalyticsstyle' => "string(1) NULL",
             'googleanalyticsapikey' => "string(25) NULL",
             'tokenencryptionoptions' => "text NULL",
+            'access_mode' => "string(1) DEFAULT 'O'"
         ), $options);
 
         $oDB->createCommand()->addPrimaryKey('{{surveys_pk}}', '{{surveys}}', 'sid');


### PR DESCRIPTION
This PR is about:

- creation of the access_mode field in the surveys table
- creation of a service which allows access_mode changes
- creation of an API that exposes the service to API use

access_mode values supported:

- O: open to all -> when changing to this access mode, we archive or remove the tokens table (more on that later) and it is for filling the survey anonymously
- C: closed access mode -> when changing to this access mode, we create a tokens table if we switched from O, access is expected to happen with tokens only
- D: dual access mode -> when changing to this access mode, we are to allow open and closed access mode alike and we are to create a tokens table if the access mode was O
- A: allow all -> when changing to this access mode, we create a tokens table if we switched from O, access is only allowed anonymously, but we keep track of past tokens