### PR TITLE
Fixed issue #20080: Disable plugins without way to alert administrator

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -1,4 +1,6 @@
-<?php if (!defined('BASEPATH')) {
+<?php
+
+if (!defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
 
@@ -186,6 +188,15 @@ $internalConfig = array(
                     'levels' => 'trace, info, error, warning',
                     'logFile' => 'plugin.log',
                     'categories' => 'plugin.*'  // The category will be the name of the plugin
+                ),
+                // Plugin error happen, plugin was disable : send email using CLogRoute
+                'pluginError' => array(
+                    'class' => 'CEmailLogRoute', // https://www.yiiframework.com/doc/api/1.1/CEmailLogRoute
+                    'categories' => 'application.model.plugin.setLoadError', // A plugin was disable
+                    'subject' => '[ERROR] Plugin deactivated',
+                    'emails' => ['webmaster@example.org'],
+                    'sentFrom' => 'noreply@example.org',
+                    'enabled' => 0, // disable here
                 )
             )
         ),

--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -189,10 +189,10 @@ $internalConfig = array(
                     'logFile' => 'plugin.log',
                     'categories' => 'plugin.*'  // The category will be the name of the plugin
                 ),
-                // Plugin error happen, plugin was disable : send email using CLogRoute
+                // Plugin error happens, plugin was disabled : send email using CLogRoute
                 'pluginError' => array(
                     'class' => 'CEmailLogRoute', // https://www.yiiframework.com/doc/api/1.1/CEmailLogRoute
-                    'categories' => 'application.model.plugin.setLoadError', // A plugin was disable
+                    'categories' => 'application.model.plugin.setLoadError', // A plugin was disabled
                     'subject' => '[ERROR] Plugin deactivated',
                     'emails' => ['webmaster@example.org'],
                     'sentFrom' => 'noreply@example.org',

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -78,7 +78,11 @@ class Plugin extends LSActiveRecord
             "UPDATE {{plugins}} SET load_error = 1, load_error_message = '%s' WHERE id = " . $this->id,
             addslashes($error['message'] . ' ' . $error['file'])
         );
-        Yii::log("Plugin {$this->name} ({$this->id}) deactivated with error '{$error['message']}'", CLogger::LEVEL_ERROR, 'application.model.plugin.setLoadError');
+        Yii::log(
+            "Plugin $this->name} ({$this->id}) deactivated with error '" . CHtml::encode($error['message']) . "' at file '" . CHtml::encode($error['file']) . "'",
+            CLogger::LEVEL_ERROR,
+            'application.model.plugin.setLoadError'
+        );
         return \Yii::app()->db->createCommand($sql)->execute();
     }
 

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -74,12 +74,13 @@ class Plugin extends LSActiveRecord
         // NB: Don't use ActiveRecord here, since it will trigger events and
         // load the plugin system all over again.
         // TODO: Works on all SQL systems?
-        $sql = sprintf(
-            "UPDATE {{plugins}} SET load_error = 1, load_error_message = '%s' WHERE id = " . $this->id,
-            addslashes($error['message'] . ' ' . $error['file'])
-        );
+        $sql = "UPDATE {{plugins}} SET load_error = 1, load_error_message = :error_message WHERE id = :id";
+        $params = [
+            ':error_message' => $error['message'] . ' ' . $error['file'],
+            ':id' => $this->id
+        ];
         Yii::log(
-            "Plugin {$this->name} ({$this->id}) deactivated with error '" . CHtml::encode($error['message']) . "' at file '" . CHtml::encode($error['file']) . "'",
+            "Plugin {$this->name} ({$this->id}) deactivated with error " . htmlspecialchars($error['message'], ENT_COMPAT) . " at file " . htmlspecialchars($error['file'], ENT_COMPAT),
             CLogger::LEVEL_ERROR,
             'application.model.plugin.setLoadError'
         );

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -78,6 +78,7 @@ class Plugin extends LSActiveRecord
             "UPDATE {{plugins}} SET load_error = 1, load_error_message = '%s' WHERE id = " . $this->id,
             addslashes($error['message'] . ' ' . $error['file'])
         );
+        Yii::log("Plugin {$this->name} ({$this->id}) deactivated with error '{$error['message']}'", CLogger::LEVEL_ERROR, 'application.model.plugin.setLoadError');
         return \Yii::app()->db->createCommand($sql)->execute();
     }
 

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -79,7 +79,7 @@ class Plugin extends LSActiveRecord
             addslashes($error['message'] . ' ' . $error['file'])
         );
         Yii::log(
-            "Plugin $this->name} ({$this->id}) deactivated with error '" . CHtml::encode($error['message']) . "' at file '" . CHtml::encode($error['file']) . "'",
+            "Plugin {$this->name} ({$this->id}) deactivated with error '" . CHtml::encode($error['message']) . "' at file '" . CHtml::encode($error['file']) . "'",
             CLogger::LEVEL_ERROR,
             'application.model.plugin.setLoadError'
         );

--- a/application/models/Plugin.php
+++ b/application/models/Plugin.php
@@ -80,11 +80,17 @@ class Plugin extends LSActiveRecord
             ':id' => $this->id
         ];
         Yii::log(
-            "Plugin {$this->name} ({$this->id}) deactivated with error " . htmlspecialchars($error['message'], ENT_COMPAT) . " at file " . htmlspecialchars($error['file'], ENT_COMPAT),
+            sprintf(
+                "Plugin %s (%s) deactivated with error “%s” at file %s",
+                $this->name,
+                $this->id,
+                $error['message'],
+                $error['file']
+            ),
             CLogger::LEVEL_ERROR,
             'application.model.plugin.setLoadError'
         );
-        return \Yii::app()->db->createCommand($sql)->execute();
+        return \Yii::app()->db->createCommand($sql)->bindValues($params)->execute();
     }
 
     /**


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Log plugin deactivation errors for administrator awareness

- Enhance error visibility when disabling faulty plugins


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Plugin.php</strong><dd><code>Add error logging for plugin deactivation on load error</code>&nbsp; &nbsp; </dd></summary>
<hr>

application/models/Plugin.php

<li>Added logging when a plugin is deactivated due to a load error<br> <li> Log includes plugin name, ID, and error message


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4253/files#diff-5f787603f1077bc68ff25da8e0175c9c6665b365783845ef4f3aa109a611a1e6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>