### PR TITLE
APE-100: Applied access mode logic to survey filling

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '6.13.0';
-$config['dbversionnumber'] = 629;
+$config['dbversionnumber'] = 630;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -1578,6 +1578,7 @@ class SurveyRuntimeHelper
     private function showTokenOrCaptchaFormsIfNeeded()
     {
         $this->iSurveyid   = $this->aSurveyInfo['sid'];
+        $accessMode        = $this->aSurveyInfo['access_mode'];
         $preview           = $this->preview;
 
         // Template settings
@@ -1600,7 +1601,7 @@ class SurveyRuntimeHelper
          */
 
         $scenarios = array(
-            "tokenRequired"   => ($tokensexist == 1),
+            "tokenRequired"   => (($accessMode === 'C') || ($accessMode === 'D')),
             "captchaRequired" => (isCaptchaEnabled('surveyaccessscreen', $this->aSurveyInfo['usecaptcha']) && !isset($_SESSION['survey_' . $this->iSurveyid]['captcha_surveyaccessscreen']))
         );
 

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1348,6 +1348,9 @@ function importSurveyFile($sFullFilePath, $bTranslateLinksFields, $sNewSurveyNam
                     $aImportResults = array_merge_recursive($aTokenImportResults, $aImportResults);
                     $aImportResults['importwarnings'] = array_merge($aImportResults['importwarnings'], $aImportResults['warnings']);
                     unlink(Yii::app()->getConfig('tempdir') . DIRECTORY_SEPARATOR . $filename);
+                    $survey = Survey::model()->findByPk($aImportResults['newsid']);
+                    $survey->access_mode = 'C';
+                    $survey->save();
                     break;
                 }
             }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -376,7 +376,11 @@ function submittokens($quotaexit = false)
     } else {
         $thissurvey = getSurveyInfo($surveyid);
     }
-    $clienttoken = $_SESSION['survey_' . $surveyid]['token'];
+    $clienttoken = $_SESSION['survey_' . $surveyid]['token'] ?? '';
+
+    if (($clienttoken === '') && ($thissurvey['access_mode'] !== 'C')) {
+        return; //optional
+    }
 
     // Shift the date due to global timeadjust setting
     $today = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i", Yii::app()->getConfig("timeadjust"));
@@ -1274,7 +1278,7 @@ function testIfTokenIsValid(array $subscenarios, array $thissurvey, array $aEnte
         $FlashError = sprintf(gT('You have exceeded the number of maximum access code validation attempts. Please wait %d minutes before trying again.'), App()->getConfig('timeOutParticipants') / 60);
         $renderToken = 'main';
     } else {
-        if (!$subscenarios['tokenValid']) {
+        if ((!(($thissurvey['access_mode'] === 'D') && ($_SERVER['REQUEST_METHOD'] !== 'GET') && ((!isset($clienttoken) || $clienttoken == "")))) && (!$subscenarios['tokenValid'])) {
             //Check if there is a clienttoken set
             if ((!isset($clienttoken) || $clienttoken == "")) {
                 if (isset($thissurvey) && $thissurvey['allowregister'] == "Y") {

--- a/application/helpers/update/updates/Update_630.php
+++ b/application/helpers/update/updates/Update_630.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+class Update_630 extends DatabaseUpdateBase
+{
+    public function up()
+    {
+        addColumn('{{surveys}}', 'access_mode', "string(1) DEFAULT 'O'");
+        $sids = [];
+        foreach (dbGetTablesLike('%token%') as $table) {
+            if (strpos($table, "old") === false) {
+                $split = explode("_", $table);
+                $sids[] = $split[count($split) - 1];
+            }
+        }
+        if (count($sids)) {
+            $this->db->createCommand()->update("{{surveys}}", ["access_mode" => "C"], "sid in (" . implode(",", $sids) . ")");
+        }
+    }
+}

--- a/installer/create-database.php
+++ b/installer/create-database.php
@@ -678,6 +678,7 @@ function populateDatabase($oDB)
             'googleanalyticsstyle' => "string(1) NULL",
             'googleanalyticsapikey' => "string(25) NULL",
             'tokenencryptionoptions' => "text NULL",
+            'access_mode' => "string(1) DEFAULT 'O'"
         ), $options);
 
         $oDB->createCommand()->addPrimaryKey('{{surveys_pk}}', '{{surveys}}', 'sid');

--- a/themes/survey/fruity_twentythree/views/subviews/logincomponents/token.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/logincomponents/token.twig
@@ -32,7 +32,11 @@
                         <div class='input-group ls-important-field'>
                             <input
                                 class='{{ aSurveyInfo.class.maincolformdivainput }} form-control' 
-                                {{ aSurveyInfo.attr.maincolformdivainput }}
+                                {% if (aSurveyInfo.access_mode != 'D') %}
+                                    {{ aSurveyInfo.attr.maincolformdivainput }}
+                                {% else %}
+                                    id="token" name="token"
+                                {% endif %}
                                 placeholder="{{ gT("Enter access code") }}"
                             >
                             <button type="button"  class="input-group-text ls-no-js-hidden" id="ls-toggle-token-show" data-passwordstate="hidden">

--- a/themes/survey/vanilla/views/subviews/logincomponents/token.twig
+++ b/themes/survey/vanilla/views/subviews/logincomponents/token.twig
@@ -36,7 +36,13 @@
                     {% if aSurveyInfo.aForm.token == null %}
                         <div class='input-group'>
                             <input
-                                class='{{ aSurveyInfo.class.maincolformdivainput }} form-control' {{ aSurveyInfo.attr.maincolformdivainput }} >
+                                class='{{ aSurveyInfo.class.maincolformdivainput }} form-control' 
+                                {% if (aSurveyInfo.access_mode != 'D') %}
+                                    {{ aSurveyInfo.attr.maincolformdivainput }}
+                                {% else %}
+                                    id="token" name="token"
+                                {% endif %}
+                                 >
                             <button type="button" class="input-group-text ls-no-js-hidden" id="ls-toggle-token-show" data-passwordstate="hidden">
                                 <i class="fa fa-eye ls-password-hidden" aria-hidden="true"></i><span class="visually-hidden ls-password-hidden">gT("Show code")</span>
                                 <i class="fa fa-eye-slash d-none ls-password-shown" aria-hidden="true"></i><span class="visually-hidden d-none ls-password-shown">gT("Hide code")</span>


### PR DESCRIPTION
### **User description**
Survey filling should respond to access mode:

- O: Survey is to be filled anonymously
- A: Survey is to be filled anonymously
- C: Survey is to be filled with token
- D: Survey can be filled anonymously if we click on continue without filling the token, or with token if the token is specified


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented access mode logic for survey filling
  - Differentiates between anonymous, token, and optional token modes
  - Adjusts token and captcha requirements based on access mode

- Updated frontend token input rendering for conditional requirements

- Improved backend token validation to respect access mode


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyRuntimeHelper.php</strong><dd><code>Enforce token requirement based on survey access mode</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/SurveyRuntimeHelper.php

<li>Added access mode check for token requirement<br> <li> Token is now required only for access modes 'C' and 'D'


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4260/files#diff-f2c0610f506dc0397d2efd8d8203a78dc44f2825e26eb0ac70efd87205d2e36e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frontend_helper.php</strong><dd><code>Adjust token submission and validation for access modes</code>&nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/frontend_helper.php

<li>Made token optional for non-'C' access modes in submission<br> <li> Enhanced token validation logic for 'D' (optional token) mode


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4260/files#diff-4b5f6522204521a4e24e45dd60c31295cdc7298b0174dd96cf6c1e7d0334f4ff">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>token.twig</strong><dd><code>Update token input rendering for access mode 'D'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/fruity_twentythree/views/subviews/logincomponents/token.twig

<li>Conditionally set token input attributes based on access mode<br> <li> Ensured correct input rendering for optional token mode ('D')


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4260/files#diff-4c79b9e3486ec50055b9c09c9baf26df6468f67be7078639245ccc7adac7c623">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>token.twig</strong><dd><code>Conditional token input for access mode in vanilla theme</code>&nbsp; </dd></summary>
<hr>

themes/survey/vanilla/views/subviews/logincomponents/token.twig

<li>Applied conditional input attributes for token field<br> <li> Supported optional token entry for access mode 'D'


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4260/files#diff-a1d191182360ecd08d8acb18ea0aa2e66ffedd63f345a1d5814f2a930d013154">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>