### PR TITLE
Fixing Accessibility Issue on "Survey list" Screen

### DIFF
--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -185,7 +185,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                             <div {{ aSurveyInfo.attr.surveylistfootercontp }} class="row">
                                 <div class="col-6 col-md-12">
                                     <a {{ aSurveyInfo.attr.surveylistfootercontpaa }}>
-                                        {{ image("./files/poweredby.png", "proudly powered by LimeSurvey", {class: 'img-fluid'}) }}
+                                        {{ image("./files/poweredby.png", gT("Proudly powered by LimeSurvey"), {class: 'img-fluid'}) }}
                                     </a>
                                 </div>
                                 <div class="col-12 d-block d-sm-none d-md-block text-center">

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -100,9 +100,9 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
 </div>
 
 {# Ajaxify cannot handle an element that is a direct child of body, so => create simple wrapper section #}
-<article>
+<article role="none">
 
-    <div id="{{ aSurveyInfo.id.dynamicreload }}">
+    <div id="{{ aSurveyInfo.id.dynamicreload }}" role="none">
         {% block body %}
             {# Bootstrap Navigation Bar: the top menu #}
             {% block nav_bar %}
@@ -112,10 +112,10 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
 
             {# Replace the content block #}
             {% block content %}
-                <div class="container-md">
+                <div class="container-md" role="none">
                     {{ registerTemplateCssFile('./css/survey-list.css') }}
 
-                    <div class="{{ aSurveyInfo.class.surveylistrow }} row"
+                    <main class="{{ aSurveyInfo.class.surveylistrow }} row"
                          id="{{ aSurveyInfo.id.surveylistrow }}" {{ aSurveyInfo.attr.surveylistrow }}>
                         <div class="col-12">
                             {# include the alert for no JavaScript #}
@@ -176,9 +176,9 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </main>
 
-                    <div id="{{ aSurveyInfo.id.surveylistfooter }}"
+                    <footer id="{{ aSurveyInfo.id.surveylistfooter }}"
                          class="{{ aSurveyInfo.class.surveylistfooter }}" {{ aSurveyInfo.attr.surveylistfooter }}>
                         <div
                             class="{{ aSurveyInfo.class.surveylistfootercont }}" {{ aSurveyInfo.attr.surveylistfootercont }}>
@@ -201,7 +201,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </footer>
                 </div>
             {% endblock %}
 

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -123,7 +123,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                             <div class="row justify-content-center mb-3">
                                 <div
                                     id="{{ aSurveyInfo.id.surveylistrowjumbotron }}" {{ aSurveyInfo.attr.surveylistrowjumbotron }}>
-                                    <div class="img-fluid mx-auto d-block">
+                                    <div class="img-fluid mx-auto d-block" role="img" aria-label="{{gT("LimeSurvey Logo")}}">
                                         {{ include('./ls_logo_svg.twig') }}
                                     </div>
                                     <span class="text-center h3">{{ aSurveyInfo.sSiteName }}</span>
@@ -140,10 +140,10 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                             <div class="row">
                                 <div
                                     class="{{ aSurveyInfo.class.surveylistrowdiva }} col-12" {{ aSurveyInfo.attr.surveylistrowdiva }}>
-                                    <div
-                                        class='{{ aSurveyInfo.class.surveylistrowdivadiv }} form-heading' {{ aSurveyInfo.attr.surveylistrowdivadiv }}>
+                                    <h2
+                                        class='{{ aSurveyInfo.class.surveylistrowdivadiv }} form-heading my-0' {{ aSurveyInfo.attr.surveylistrowdivadiv }}>
                                         {{ gT("The following surveys are available:") }}
-                                    </div>
+                                    </h2>
                                 </div>
                             </div>
 

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -100,7 +100,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
 </div>
 
 {# Ajaxify cannot handle an element that is a direct child of body, so => create simple wrapper section #}
-<article role="none">
+<div>
 
     <div id="{{ aSurveyInfo.id.dynamicreload }}" role="none">
         {% block body %}
@@ -185,7 +185,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                             <div {{ aSurveyInfo.attr.surveylistfootercontp }} class="row">
                                 <div class="col-6 col-md-12">
                                     <a {{ aSurveyInfo.attr.surveylistfootercontpaa }}>
-                                        {{ image("./files/poweredby.png", "proudly powered by LimeSurvey Survey", {class: 'img-fluid'}) }}
+                                        {{ image("./files/poweredby.png", "proudly powered by LimeSurvey", {class: 'img-fluid'}) }}
                                     </a>
                                 </div>
                                 <div class="col-12 d-block d-sm-none d-md-block text-center">
@@ -220,7 +220,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
 
         {% endblock %}
     </div>
-</article>
+</div>
 {% block footer %}
     {{ include('./subviews/footer/footer.twig') }}
 {% endblock %}

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -189,7 +189,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                                     </a>
                                 </div>
                                 <div class="col-12 d-block d-sm-none d-md-block text-center">
-                                    <a {{ aSurveyInfo.attr.surveylistfootercontpab }}>
+                                    <a {{ aSurveyInfo.attr.surveylistfootercontpab }} class="text-decoration-underline">
                                         The Online Survey Tool
                                     </a>
                                     - Free & Open Source

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -115,7 +115,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                 <div class="container-md" role="none">
                     {{ registerTemplateCssFile('./css/survey-list.css') }}
 
-                    <main class="{{ aSurveyInfo.class.surveylistrow }} row"
+                    <main role="main" class="{{ aSurveyInfo.class.surveylistrow }} row"
                          id="{{ aSurveyInfo.id.surveylistrow }}" {{ aSurveyInfo.attr.surveylistrow }}>
                         <div class="col-12">
                             {# include the alert for no JavaScript #}
@@ -178,7 +178,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                         </div>
                     </main>
 
-                    <footer id="{{ aSurveyInfo.id.surveylistfooter }}"
+                    <footer role="contentinfo" id="{{ aSurveyInfo.id.surveylistfooter }}"
                          class="{{ aSurveyInfo.class.surveylistfooter }}" {{ aSurveyInfo.attr.surveylistfooter }}>
                         <div
                             class="{{ aSurveyInfo.class.surveylistfootercont }}" {{ aSurveyInfo.attr.surveylistfootercont }}>

--- a/themes/survey/fruity_twentythree/views/layout_survey_list.twig
+++ b/themes/survey/fruity_twentythree/views/layout_survey_list.twig
@@ -185,7 +185,7 @@ NOTE: Feel free to ask for functions, variables, etc, that you feel are missing 
                             <div {{ aSurveyInfo.attr.surveylistfootercontp }} class="row">
                                 <div class="col-6 col-md-12">
                                     <a {{ aSurveyInfo.attr.surveylistfootercontpaa }}>
-                                        {{ image("./files/poweredby.png", "LimeSurvey Survey Software", {class: 'img-fluid'}) }}
+                                        {{ image("./files/poweredby.png", "proudly powered by LimeSurvey Survey", {class: 'img-fluid'}) }}
                                     </a>
                                 </div>
                                 <div class="col-12 d-block d-sm-none d-md-block text-center">

--- a/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
@@ -18,7 +18,7 @@ For the survey navigator ("Next", "Back", etc.), see: navigation/navigator.twig
 #}
 {% if not aSurveyInfo.popupPreview %}
     <!-- Bootstrap Navigation Bar -->
-    <div id="survey-nav" class="navbar fixed-top">
+    <header id="survey-nav" class="navbar fixed-top">
         <div class="container-fluid col-xl-8">
             {% if( aSurveyInfo.options.brandlogo == "on") %}
                 <div class="navbar-brand logo-container d-none d-md-block">
@@ -53,5 +53,5 @@ For the survey navigator ("Next", "Back", etc.), see: navigation/navigator.twig
             </div>
             <ul id="back-content" class="d-none"></ul>
         </div>
-    </div>
+    </header>
 {% endif %}

--- a/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
@@ -18,7 +18,7 @@ For the survey navigator ("Next", "Back", etc.), see: navigation/navigator.twig
 #}
 {% if not aSurveyInfo.popupPreview %}
     <!-- Bootstrap Navigation Bar -->
-    <header id="survey-nav" class="navbar fixed-top">
+    <header role="banner" id="survey-nav" class="navbar fixed-top">
         <div class="container-fluid col-xl-8">
             {% if( aSurveyInfo.options.brandlogo == "on") %}
                 <div class="navbar-brand logo-container d-none d-md-block">

--- a/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig
@@ -32,10 +32,10 @@ For the survey navigator ("Next", "Back", etc.), see: navigation/navigator.twig
                     aSurveyInfo.options.showclearall == 'on') or
                     aSurveyInfo.aQuestionIndex.bShow == true or
                     aSurveyInfo.alanguageChanger.show == true) %}
-                    <div id="navbar-toggler" class="navbar-toggler" data-bs-toggle="dropdown"
+                    <button id="navbar-toggler" class="navbar-toggler" data-bs-toggle="dropdown"
                         data-bs-auto-close="outside" aria-expanded="false">
                         <span class="ri-more-fill"></span>
-                    </div>
+                    </button>
                     <ul id="main-dropdown" class="dropdown-menu dropdown-menu-end" aria-labelledby="navbar-toggler">
                         {{ include('./subviews/navigation/language_changer_top_menu.twig') }}
                         {% if( aSurveyInfo.aNavigator.load.show == "Y" or

--- a/themes/survey/fruity_twentythree/views/subviews/navigation/language_changer_top_menu.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/navigation/language_changer_top_menu.twig
@@ -31,7 +31,7 @@ The language change is done via javascript
     <!-- Language Changer, top menu version -->
     <li class="dropdown-header text-uppercase">{{ gT("Select language") }}</li>
     <li class="ls-no-js-hidden form-change-lang dropdown nav-item">
-        <a class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdownCustom"
+        <a href='#' class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdownCustom"
            data-bs-target="#language-dropdown" data-navtargetid="language-dropdown">
             {# NOTE:  {{gT( aLCD.aListLang[aLCD.sSelected] )}}: retreives the language name of the selected language and translates it #}
             {{ aLCD.aListLang[aLCD.sSelected] }}


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed Below Accessibility Issue:

1) Elements doesn't supported ARIA attributes, ensure an element's role supports its ARIA attributes.
2) Alternative text is missing for the 'Limesurvey' logo image; it should be announced as 'Limesurvey logo' by screen readers.
3) The screen reader announces the insufficient alternative text as 'LimeSurvey Survey Software', it should announce the sufficient alternative text as 'Proudly powered by Lime survey' for the lime survey logo image..
4) Landmarks are missing on the page, the screen reader should announce the landmarks as follows:- Banner- Main- Content information
5) The screen reader announces the visual heading 'The following surveys are available:' as plain text, it should announce the heading level as 1.
6) The 'The Online Survey Tool' link is distinguished from the surrounding text solely via color. The 'The Online Survey Tool' link should be easily distinguishable from regular text. Styling options can include underlining or some other distinguishable style.
7) The option icon are not focusable by using keyboard. the icon should be focusable by using keyboard.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved accessibility on the "Survey list" screen:
  - Added ARIA roles, labels, and semantic landmarks (header, main, footer)
  - Enhanced alternative text for images, especially the LimeSurvey logo
  - Changed headings and structure for better screen reader support
  - Made menu and language dropdown keyboard accessible
  - Ensured links are visually distinguishable (e.g., underlined)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout_survey_list.twig</strong><dd><code>Add accessibility roles, improve headings and alt text</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/fruity_twentythree/views/layout_survey_list.twig

<li>Added ARIA roles and semantic landmarks (main, footer)<br> <li> Improved alternative text for images (e.g., LimeSurvey logo)<br> <li> Changed survey list heading to <h2> for semantic structure<br> <li> Made links visually distinguishable (underline)<br> <li> Updated structure for better screen reader and keyboard navigation


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4264/files#diff-4490f646064be29b9792456936535bf81069df34234638d338318bc30a70dfb9">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nav_bar.twig</strong><dd><code>Use semantic header and button for navigation bar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/fruity_twentythree/views/subviews/header/nav_bar.twig

<li>Changed navigation bar wrapper from <div> to <header><br> <li> Made menu toggler a <button> for keyboard accessibility


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4264/files#diff-f63c8147b32e2040b2dff0a9baf1e6e5ce7da169ebd49d4430f7cad17a2afb53">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>language_changer_top_menu.twig</strong><dd><code>Improve language dropdown accessibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/fruity_twentythree/views/subviews/navigation/language_changer_top_menu.twig

- Added href attribute to language dropdown anchor for accessibility


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4264/files#diff-8a9c0a1db00807514d7414f1da9a5e3feee719ffa86b4cfe9f3e85ff6cadfb67">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>