### PR TITLE
Fixed issue: If the database is using a different timezone than PHP the created/modified timestamps for certain records would differ

### DIFF
--- a/application/models/LSActiveRecord.php
+++ b/application/models/LSActiveRecord.php
@@ -38,16 +38,11 @@ class LSActiveRecord extends CActiveRecord
         $sCreateFieldName = ($this->hasAttribute('created') ? 'created' : null);
         $sUpdateFieldName = ($this->hasAttribute('modified') ? 'modified' : null);
         $sDriverName = Yii::app()->db->getDriverName();
-        if ($sDriverName == 'sqlsrv' || $sDriverName == 'dblib') {
-            $sTimestampExpression = new CDbExpression('GETDATE()');
-        } else {
-            $sTimestampExpression = new CDbExpression('NOW()');
-        }
         $aBehaviors['CTimestampBehavior'] = [
             'class'               => 'zii.behaviors.CTimestampBehavior',
             'createAttribute'     => $sCreateFieldName,
             'updateAttribute'     => $sUpdateFieldName,
-            'timestampExpression' => $sTimestampExpression
+            'timestampExpression' => "date('Y-m-d H:i:s', time())"
         ];
         // Some tables might not exist/not be up to date during a database upgrade so in that case disconnect plugin events
         if (!Yii::app()->getConfig('Updating')) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes timestamp inconsistency due to database and PHP timezone differences

- Uses PHP-generated timestamps for record creation and modification


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LSActiveRecord.php</strong><dd><code>Use PHP datetime for created/modified timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/LSActiveRecord.php

<li>Replaces database-generated timestamp expressions with PHP-based <br>timestamp<br> <li> Ensures 'created' and 'modified' fields use PHP's current datetime<br> <li> Removes driver-specific timestamp logic for consistency


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4265/files#diff-ebf85ba8a486bce5d44fcf65c87a272498d2a841b68fb535e69db3eaf879ade1">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>