### PR TITLE
QE-1547 activate icon link in box

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -2345,7 +2345,7 @@ class SurveyAdministrationController extends LSBaseController
             }
         }
 
-        if ((App()->getConfig("editorEnabled")) && isset(($aImportResults['newsid']))) {
+        if ((App()->getConfig("editorEnabled")) && isset($aImportResults['newsid'])) {
             if (!isset($oSurvey)) {
                 $oSurvey = Survey::model()->findByPk($aImportResults['newsid']);
             }
@@ -3417,7 +3417,7 @@ class SurveyAdministrationController extends LSBaseController
                 'iconAlter' => $state,
                 'state' => $survey->getState(),
                 'buttons' => $survey->getButtons(),
-                'link' => App()->createUrl('/surveyAdministration/view/surveyid/' . $survey->sid . '?allowRedirect=1'),
+                'link' => App()->createUrl('/surveyAdministration/view/surveyid/' . $survey->sid),
             ];
         }
 

--- a/application/extensions/admin/BoxesWidget/views/box.php
+++ b/application/extensions/admin/BoxesWidget/views/box.php
@@ -74,7 +74,7 @@
                                     && ($item['survey']->getQuestionsCount() > 0)
     ) :
                                     ?>
-                                    <a href="<?= App()->createUrl("/surveyAdministration/view?iSurveyID=" . $item['survey']->sid) ?? '#' ?>"
+                                    <a href="<?= App()->createUrl("/surveyAdministration/rendersidemenulink/subaction/generalsettings/surveyid/" . $item['survey']->sid) ?? '#' ?>"
                                        class="active"
                                        data-bs-toggle="tooltip"
                                        data-bs-original-title="<?= gT('Activate') ?>"

--- a/application/extensions/admin/BoxesWidget/views/box.php
+++ b/application/extensions/admin/BoxesWidget/views/box.php
@@ -64,7 +64,7 @@
                                     && ($item['survey']->getQuestionsCount() > 0)
     ) :
                                     ?>
-                                    <a href="<?= App()->createUrl("/surveyAdministration/rendersidemenulink/subaction/generalsettings/surveyid/" . $item['survey']->sid) ?? '#' ?>"
+                                    <a href="<?= App()->createUrl("/surveyAdministration/view?iSurveyID=" . $item['survey']->sid) ?? '#' ?>"
                                        class="active"
                                        data-bs-toggle="tooltip"
                                        data-bs-original-title="<?= gT('Activate') ?>"

--- a/application/extensions/admin/BoxesWidget/views/box.php
+++ b/application/extensions/admin/BoxesWidget/views/box.php
@@ -55,7 +55,17 @@
                     <div class="box-widget-card-footer">
                         <div class="box-widget-card-footer-items">
                             <div class="box-widget-card-footer-response">
-                                <?php echo $item['survey']->countFullAnswers == 0 ? 'No' : $item['survey']->countFullAnswers ?> responses
+                                <?php
+                                if ($item['survey']->countFullAnswers == 0) {
+                                    $responsesInfo = gT('No responses');
+                                } else {
+                                    $responsesInfo = sprintf(
+                                        gT('%d responses'),
+                                        $item['survey']->countFullAnswers
+                                    );
+                                }
+                                echo $responsesInfo;
+                                ?>
                             </div>
                             <div class="icons">
                                 <?php if (

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1568,16 +1568,6 @@ class Survey extends LSActiveRecord implements PermissionInterface
                 $this->active === "Y"
                 && $permissions['statistics_read'],
         ];
-        if (App()->getConfig('editorEnabled')) {
-            $editorSettings[] = ['url' => App()->createUrl('editorLink/index', ['route' => 'survey/' . $this->sid])];
-            $editorSettings[] = ['url' => App()->createUrl('editorLink/index', ['route' => 'survey/' . $this->sid . '/settings/generalsettings'])];
-            $editorSettings[] = [];
-            foreach ($editorSettings as $key => $editorSetting) {
-                if (isset($editorSetting['url'], $items[$key])) {
-                    $items[$key]['url'] = $editorSetting['url'];
-                }
-            }
-        }
 
         return App()->getController()->widget('ext.admin.grid.BarActionsWidget.BarActionsWidget', ['items' => $items], true);
     }


### PR DESCRIPTION
### **User description**
Preparation for changes in cloud to take effect
- we don't need the hardcoded link substitution in Survey.php anymore


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Updated survey box "Activate" link to "View survey" for consistency.

- Removed hardcoded editor link substitution from Survey model.

- Fixed translation of responses info in dashboard card.

- Cleaned up URL parameters and improved code clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyAdministrationController.php</strong><dd><code>Refined survey view and editor link generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/SurveyAdministrationController.php

<li>Removed unnecessary 'allowRedirect' parameter from survey view link.<br> <li> Fixed isset usage for 'newsid' in editor link logic.


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4266/files#diff-f8c970472fc354612651d57fa98027ecd114f95cf42e4594e0b0b61340ec217f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Survey.php</strong><dd><code>Removed editor link override from action buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/Survey.php

<li>Removed hardcoded editor link substitution logic from action buttons.<br> <li> Simplified action button URL assignment.


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4266/files#diff-0268c3e4648700cef058f99725fd5364a285bd35701d30cfda885a81ce1c86a4">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>box.php</strong><dd><code>Improved translation for dashboard responses info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/admin/BoxesWidget/views/box.php

<li>Made responses info in dashboard card translatable.<br> <li> Used proper translation function for "No responses" and count.


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4266/files#diff-b5e70849a6ba19dc1177b66f228845399e674928036aa5b6600b8382f0f8248b">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>