### PR TITLE
APE-34: Adjusted the participants feature at the core

### DIFF
--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -645,14 +645,9 @@ class Tokens extends SurveyCommonAction
         $request = App()->request;
         $subAction = $request->getPost('subaction');
         if ($subAction == 'inserttoken') {
-            if (!$survey->hasTokensTable) {
-                $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
-                $tokenencryptionoptions['enabled'] = 'Y';
-                $survey->tokenencryptionoptions = ls_json_encode($tokenencryptionoptions);
-                Token::createTable($survey->sid);
-                LimeExpressionManager::setDirtyFlag();
-            }
-                // TODO: This part could be refactored into function like "insertToken()"
+            $this->verifyAndCreateTokenTable($survey);
+
+            // TODO: This part could be refactored into function like "insertToken()"
             Yii::import('application.libraries.Date_Time_Converter');
 
             // Fix up dates and match to database format
@@ -1001,13 +996,8 @@ class Tokens extends SurveyCommonAction
         );
 
         if (!empty($subaction) && $subaction == 'add') {
-            if (!$survey->hasTokensTable) {
-                $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
-                $tokenencryptionoptions['enabled'] = 'Y';
-                $survey->tokenencryptionoptions = ls_json_encode($tokenencryptionoptions);
-                Token::createTable($survey->sid);
-                LimeExpressionManager::setDirtyFlag();
-            }
+            $this->verifyAndCreateTokenTable($survey);
+
             $message = '';
             $this->getController()->loadLibrary('Date_Time_Converter');
             $dateformatdetails = getDateFormatData(Yii::app()->session['dateformat']);
@@ -2224,13 +2214,8 @@ class Tokens extends SurveyCommonAction
         $aEncodings = aEncodingsArray();
 
         if (Yii::app()->request->isPostRequest) {
-            if (!$survey->hasTokensTable) {
-                $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
-                $tokenencryptionoptions['enabled'] = 'Y';
-                $survey->tokenencryptionoptions = ls_json_encode($tokenencryptionoptions);
-                Token::createTable($survey->sid);
-                LimeExpressionManager::setDirtyFlag();
-            }
+            $this->verifyAndCreateTokenTable($survey);
+
             $sUploadCharset = Yii::app()->request->getPost('csvcharset');
             if (!array_key_exists($sUploadCharset, $aEncodings)) {
                 // Validate sUploadCharset
@@ -3271,5 +3256,23 @@ class Tokens extends SurveyCommonAction
         );
 
         return $aResult;
+    }
+
+    /**
+     * Verifies and creates token table if it didn't exist
+     * @param Survey $survey
+     * @return void
+     */
+    protected function verifyAndCreateTokenTable($survey)
+    {
+        if ($survey->hasTokensTable) {
+            return;
+        }
+
+        $tokenencryptionoptions = $survey->getTokenEncryptionOptions();
+        $tokenencryptionoptions['enabled'] = 'Y';
+        $survey->tokenencryptionoptions = ls_json_encode($tokenencryptionoptions);
+        Token::createTable($survey->sid);
+        LimeExpressionManager::setDirtyFlag();
     }
 }

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -133,7 +133,6 @@ class Tokens extends SurveyCommonAction
             if ($filterForm) {
                 $model->setAttributes($filterForm, false);
             }
-    
         }
         $aData['model'] = $model;
 
@@ -2984,7 +2983,7 @@ class Tokens extends SurveyCommonAction
                     }
                     $aData['oldlist'] = $oldlist;
                 }
-    
+
                 $aData['tcount'] = $tcount;
                 $aData['databasetype'] = Yii::app()->db->getDriverName();
                 $aData['sidemenu']["token_menu"] = true;

--- a/application/core/TopbarConfiguration.php
+++ b/application/core/TopbarConfiguration.php
@@ -352,6 +352,7 @@ class TopbarConfiguration
             'hasTokensUpdatePermission' => $hasTokensUpdatePermission,
             'hasTokensDeletePermission' => $hasTokensDeletePermission,
             'hasSurveySettingsUpdatePermission' => $hasSurveySettingsUpdatePermission,
+            'tokenexists' => $survey->hasTokensTable
         );
     }
 

--- a/application/models/services/SurveyActivate.php
+++ b/application/models/services/SurveyActivate.php
@@ -136,7 +136,7 @@ class SurveyActivate
             $dynamicColumns = getUnchangedColumns($surveyId, $sTimestamp, $qTimestamp);
             recoverSurveyResponses($surveyId, $archives["survey"], $preserveIDs, $dynamicColumns);
             //If it's not open access mode, then we import the surveys from the archive if they exist
-            if ($survey->access_mode !== SurveyAccessModeService::$ACCESS_TYPE_OPEN) {
+            if ($survey->access_mode !== $this->surveyAccessModeService::$ACCESS_TYPE_OPEN) {
                 if (isset($archives["tokens"])) {
                     $tokenTable = $this->app->db->tablePrefix . "tokens_" . $surveyId;
                     try {

--- a/application/models/services/SurveyActivate.php
+++ b/application/models/services/SurveyActivate.php
@@ -85,7 +85,7 @@ class SurveyActivate
         if ($params['restore'] ?? false) {
             $result['restored'] = $this->restoreData($surveyId);
         }
-        if ($survey->access_mode !== $this->surveyAccessModeService::$ACCESS_TYPE_OPEN) {
+        if ($survey->access_mode !== SurveyAccessModeService::$ACCESS_TYPE_OPEN) {
             if (!$survey->hasTokensTable) {
                 $this->surveyAccessModeService->newTokenTable($survey, true);
             }
@@ -136,7 +136,7 @@ class SurveyActivate
             $dynamicColumns = getUnchangedColumns($surveyId, $sTimestamp, $qTimestamp);
             recoverSurveyResponses($surveyId, $archives["survey"], $preserveIDs, $dynamicColumns);
             //If it's not open access mode, then we import the surveys from the archive if they exist
-            if ($survey->access_mode !== $this->surveyAccessModeService::$ACCESS_TYPE_OPEN) {
+            if ($survey->access_mode !== SurveyAccessModeService::$ACCESS_TYPE_OPEN) {
                 if (isset($archives["tokens"])) {
                     $tokenTable = $this->app->db->tablePrefix . "tokens_" . $surveyId;
                     try {

--- a/application/views/admin/token/surveyParticipantView.php
+++ b/application/views/admin/token/surveyParticipantView.php
@@ -86,13 +86,13 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
             </div>
         </div>
     </div>
-    <h2 class="summary-title mt-4 pb-2 mb-3"><?php eT("All participants"); ?></h2>
+    <h2 class="summary-title mt-4 pb-2 mb-3"><?php $model && eT("All participants"); ?></h2>
     <div class='side-body'>
         <input type='hidden' id="dateFormatDetails" name='dateFormatDetails' value='<?php echo json_encode($dateformatdetails); ?>' />
         <input type="hidden" id="locale" name="locale" value="<?= convertLStoDateTimePickerLocale(Yii::app()->session['adminlang']) ?>" />
         <input type='hidden' name='rtl' value='<?php echo getLanguageRTL($_SESSION['adminlang']) ? '1' : '0'; ?>' />
         <?php
-        $this->widget('ext.AlertWidget.AlertWidget', [
+        $model && $this->widget('ext.AlertWidget.AlertWidget', [
             'tag'  => 'p',
             'text' => gT(
                 "You can use operators in the search filters (eg: >, <, >=, <=, = )"
@@ -113,7 +113,7 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
         <div class="row">
             <div class="content-right">
                 <?php
-                $this->widget('application.extensions.admin.grid.CLSGridView', [
+                $model && $this->widget('application.extensions.admin.grid.CLSGridView', [
                     'dataProvider'          => $model->search(),
                     'filter'                => $model,
                     'id'                    => 'token-grid',
@@ -138,6 +138,39 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
         </div>
 
         <?php
+        if ($tcount > 0 && (Permission::model()->hasSurveyPermission($oSurvey->sid, 'surveysettings', 'update') || Permission::model()->hasSurveyPermission($oSurvey->sid, 'tokens','create'))):
+            echo eT("No survey participants found.");
+        ?>
+                <input class="btn btn-large btn-block btn-outline-secondary" type='button' value='<?php eT("Add participants"); ?>' onclick="window.open('<?php echo $this->createUrl("admin/tokens/sa/addnew/surveyid/" . $surveyid); ?>', '_top')" />
+                <div class="col-12 content-right">
+                    <div class="card card-primary">
+                        <h2><?php eT("Restore options"); ?></h2>
+                        <p class="text-info">
+                            <?php eT("Please be aware that tables including encryption should not be restored if they have been created in LimeSurvey 4 before version 4.6.1")?>
+                        </p>
+                        <p class="lead text-success">
+                            <strong>
+                                <?php eT("The following old survey participants tables could be restored:"); ?>
+                            </strong>
+                        </p>
+                        <p>
+                            <?php echo CHtml::form(array("admin/tokens/sa/index/surveyid/{$oSurvey->sid}"), 'post'); ?>
+                                <select size='4' name='oldtable' required>
+                                    <?php
+                                        foreach ($oldlist as $ol) {
+                                            echo "<option>" . $ol . "</option>\n";
+                                        }
+                                    ?>
+                                </select><br /><br />
+                                <input type='submit' value='<?php eT("Restore"); ?>' class="btn btn-outline-secondary btn-lg"/>
+                                <input type='hidden' name='restoretable' value='Y' />
+                                <input type='hidden' name='sid' value='<?php echo $oSurvey->sid; ?>' />
+                            <?php echo CHtml::endForm() ?>
+                        </p>
+                    </div>
+                </div>
+        <?php endif;?>
+<?php
         // To update rows per page via ajax
         App()->getClientScript()->registerScript(
             "Tokens:neccesaryVars",

--- a/application/views/admin/token/surveyParticipantView.php
+++ b/application/views/admin/token/surveyParticipantView.php
@@ -142,7 +142,7 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
             echo eT("No survey participants found.");
         ?>
                 <input class="btn btn-large btn-block btn-outline-secondary" type='button' value='<?php eT("Add participants"); ?>' onclick="window.open('<?php echo $this->createUrl("admin/tokens/sa/addnew/surveyid/" . $surveyid); ?>', '_top')" />
-                <div class="col-12 content-right">
+                <div class="col-12 content-right mt-4">
                     <div class="card card-primary">
                         <h2><?php eT("Restore options"); ?></h2>
                         <p class="text-info">

--- a/application/views/surveyAdministration/partial/topbar_tokens/leftSideButtons.php
+++ b/application/views/surveyAdministration/partial/topbar_tokens/leftSideButtons.php
@@ -23,91 +23,94 @@ if ($hasTokensCreatePermission || $hasTokensImportPermission) {
     <?php
 }
 
-if ($hasTokensUpdatePermission || $hasSurveySettingsUpdatePermission) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'tokens-manage-attributes',
-            'id' => 'tokens-manage-attributes',
-            'text' => gT('Manage attributes'),
-            'icon' => 'ri-server-fill',
-            'link' => Yii::App()->createUrl("admin/tokens/sa/managetokenattributes/surveyid/$oSurvey->sid"),
+if ($tokenexists) {
+    if ($hasTokensUpdatePermission || $hasSurveySettingsUpdatePermission) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'tokens-manage-attributes',
+                'id' => 'tokens-manage-attributes',
+                'text' => gT('Manage attributes'),
+                'icon' => 'ri-server-fill',
+                'link' => Yii::App()->createUrl("admin/tokens/sa/managetokenattributes/surveyid/$oSurvey->sid"),
+                'htmlOptions' => [
+                    'class' => 'btn btn-outline-secondary',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    }
+    
+    if ($hasTokensExportPermission) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'tokens-export-attributes',
+                'id' => 'tokens-export-attributes',
+                'text' => gT('Export'),
+                'icon' => 'ri-upload-2-fill',
+                'link' => Yii::App()->createUrl("admin/tokens/sa/exportdialog/surveyid/$oSurvey->sid"),
+                'htmlOptions' => [
+                    'class' => 'btn btn-outline-secondary',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    }
+    
+    if ($hasTokensUpdatePermission) {
+        $invRemDropDownItems = $this->renderPartial(
+            '/surveyAdministration/partial/topbar_tokens/tokensInvRemDropdownItems',
+            get_defined_vars(),
+            true
+        );
+    
+    
+        $this->widget('ext.ButtonWidget.ButtonWidget', [
+            'name' => 'ls-inv-rem-button',
+            'id' => 'ls-inv-rem-button',
+            'text' => gT('Invite & remind'),
+            'icon' => 'ri-mail-settings-line',
+            'isDropDown' => true,
+            'dropDownContent' => $invRemDropDownItems,
             'htmlOptions' => [
                 'class' => 'btn btn-outline-secondary',
-                'role' => 'button'
             ],
-        ]
-    );
-}
-
-if ($hasTokensExportPermission) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'tokens-export-attributes',
-            'id' => 'tokens-export-attributes',
-            'text' => gT('Export'),
-            'icon' => 'ri-upload-2-fill',
-            'link' => Yii::App()->createUrl("admin/tokens/sa/exportdialog/surveyid/$oSurvey->sid"),
-            'htmlOptions' => [
-                'class' => 'btn btn-outline-secondary',
-                'role' => 'button'
-            ],
-        ]
-    );
-}
-
-if ($hasTokensUpdatePermission) {
-    $invRemDropDownItems = $this->renderPartial(
-        '/surveyAdministration/partial/topbar_tokens/tokensInvRemDropdownItems',
-        get_defined_vars(),
-        true
-    );
-
-
-    $this->widget('ext.ButtonWidget.ButtonWidget', [
-        'name' => 'ls-inv-rem-button',
-        'id' => 'ls-inv-rem-button',
-        'text' => gT('Invite & remind'),
-        'icon' => 'ri-mail-settings-line',
-        'isDropDown' => true,
-        'dropDownContent' => $invRemDropDownItems,
-        'htmlOptions' => [
-            'class' => 'btn btn-outline-secondary',
-        ],
-    ]);
-
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'tokens-access-codes',
-            'id' => 'tokens-access-codes',
-            'text' => gT('Generate access codes'),
-            'icon' => 'ri-settings-5-fill',
-            'link' => Yii::App()->createUrl("admin/tokens/sa/tokenify/surveyid/$oSurvey->sid"),
-            'htmlOptions' => [
-                'class' => 'btn btn-outline-secondary',
-                'role' => 'button'
-            ],
-        ]
-    );
-
-    $url = Yii::App()->createUrl("/admin/participants/sa/displayParticipants");
-
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'tokens-cpdb',
-            'id' => 'tokens-cpdb',
-            'text' => gT('View in CPDB'),
-            'icon' => 'ri-group-fill',
-            'htmlOptions' => [
-                'class' => 'btn btn-outline-secondary',
-                'role' => 'button',
-                'onclick' => "window.LS.sendPost('$url',false,{'searchcondition': 'surveyid||equal|| $oSurvey->sid '});"
-            ],
-        ]
-    );
+        ]);
+    
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'tokens-access-codes',
+                'id' => 'tokens-access-codes',
+                'text' => gT('Generate access codes'),
+                'icon' => 'ri-settings-5-fill',
+                'link' => Yii::App()->createUrl("admin/tokens/sa/tokenify/surveyid/$oSurvey->sid"),
+                'htmlOptions' => [
+                    'class' => 'btn btn-outline-secondary',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    
+        $url = Yii::App()->createUrl("/admin/participants/sa/displayParticipants");
+    
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'tokens-cpdb',
+                'id' => 'tokens-cpdb',
+                'text' => gT('View in CPDB'),
+                'icon' => 'ri-group-fill',
+                'htmlOptions' => [
+                    'class' => 'btn btn-outline-secondary',
+                    'role' => 'button',
+                    'onclick' => "window.LS.sendPost('$url',false,{'searchcondition': 'surveyid||equal|| $oSurvey->sid '});"
+                ],
+            ]
+        );
+    }
+    
 }
 /* --> btn not necessary because it is already a side menu link (entry)
 $this->widget(

--- a/application/views/surveyAdministration/partial/topbar_tokens/rightSideButtons.php
+++ b/application/views/surveyAdministration/partial/topbar_tokens/rightSideButtons.php
@@ -1,72 +1,74 @@
 <?php
 
-if (!empty($showDelButton) && ($hasSurveySettingsUpdatePermission || $hasTokensDeletePermission)) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'delete-token-table',
-            'id' => 'delete-token-table',
-            'text' => gT('Delete participants table'),
-            'icon' => '',
-            'link' => Yii::App()->createUrl("admin/tokens/sa/kill/surveyid/$oSurvey->sid"),
-            'htmlOptions' => [
-                'class' => 'btn btn-danger',
-                'role' => 'button'
-            ],
-        ]
-    );
-}
-
-// Include the default buttons
-$this->renderPartial('/surveyAdministration/partial/topbar/surveyTopbarRight_view', get_defined_vars());
-
-if (!empty($showDownloadButton)) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'export-button',
-            'id' => 'export-button',
-            'text' => gT('Download CSV file'),
-            'icon' => 'ri-download-fill',
-            'htmlOptions' => [
-                'class' => 'btn btn-primary',
-                'role' => 'button',
-                'data-submit-form' => 1,
-            ],
-        ]
-    );
-}
-
-if (!empty($showSendInvitationButton)) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'send-invitation-button',
-            'id' => 'send-invitation-button',
-            'text' => gT('Send invitations'),
-            'icon' => 'ri-mail-send-fill',
-            'htmlOptions' => [
-                'class' => 'btn btn-primary',
-                'role' => 'button'
-            ],
-        ]
-    );
-}
-
-if (!empty($showSendReminderButton)) {
-    $this->widget(
-        'ext.ButtonWidget.ButtonWidget',
-        [
-            'name' => 'send-reminders-button',
-            'id' => 'send-reminders-button',
-            'text' => gT('Send reminders'),
-            'icon' => 'ri-mail-send-fill',
-            'htmlOptions' => [
-                'class' => 'btn btn-primary',
-                'role' => 'button'
-            ],
-        ]
-    );
+if ($tokenexists) {
+    if (!empty($showDelButton) && ($hasSurveySettingsUpdatePermission || $hasTokensDeletePermission)) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'delete-token-table',
+                'id' => 'delete-token-table',
+                'text' => gT('Delete participants table'),
+                'icon' => '',
+                'link' => Yii::App()->createUrl("admin/tokens/sa/kill/surveyid/$oSurvey->sid"),
+                'htmlOptions' => [
+                    'class' => 'btn btn-danger',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    }
+    
+    // Include the default buttons
+    $this->renderPartial('/surveyAdministration/partial/topbar/surveyTopbarRight_view', get_defined_vars());
+    
+    if (!empty($showDownloadButton)) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'export-button',
+                'id' => 'export-button',
+                'text' => gT('Download CSV file'),
+                'icon' => 'ri-download-fill',
+                'htmlOptions' => [
+                    'class' => 'btn btn-primary',
+                    'role' => 'button',
+                    'data-submit-form' => 1,
+                ],
+            ]
+        );
+    }
+    
+    if (!empty($showSendInvitationButton)) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'send-invitation-button',
+                'id' => 'send-invitation-button',
+                'text' => gT('Send invitations'),
+                'icon' => 'ri-mail-send-fill',
+                'htmlOptions' => [
+                    'class' => 'btn btn-primary',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    }
+    
+    if (!empty($showSendReminderButton)) {
+        $this->widget(
+            'ext.ButtonWidget.ButtonWidget',
+            [
+                'name' => 'send-reminders-button',
+                'id' => 'send-reminders-button',
+                'text' => gT('Send reminders'),
+                'icon' => 'ri-mail-send-fill',
+                'htmlOptions' => [
+                    'class' => 'btn btn-primary',
+                    'role' => 'button'
+                ],
+            ]
+        );
+    }
 }
 
 ?>

--- a/tests/functional/backend/ImportResponsesTest.php
+++ b/tests/functional/backend/ImportResponsesTest.php
@@ -2,10 +2,9 @@
 
 namespace ls\tests;
 
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverExpectedCondition;
 use LimeSurvey\Models\Services\SurveyActivate;
 use LimeSurvey\Models\Services\SurveyDeactivate;
+use LimeSurvey\Models\Services\SurveyAccessModeService;
 
 class ImportResponsesTest extends TestBaseClass
 {
@@ -46,7 +45,12 @@ class ImportResponsesTest extends TestBaseClass
                 $survey,
                 $permission,
                 new \SurveyActivator($survey),
-                App()
+                App(),
+                new SurveyAccessModeService(
+                    $permission,
+                    $survey,
+                    App()
+                )
             );
             $surveyActivator->activate($survey->sid, ['restore' => true], true);
             $responses2 = App()->db->createCommand($query)->queryAll();


### PR DESCRIPTION
### **User description**
Please refer to the spec at https://limesurvey.atlassian.net/browse/APE-34


___

### **PR Type**
Enhancement


___

### **Description**
- Improved handling of surveys without a tokens table
  - Conditional creation and restoration of tokens table
  - Graceful fallback and UI for missing tokens table

- Updated UI to reflect tokens table existence
  - Conditional rendering of participant grid and buttons
  - Added restore options for old tokens tables

- Refactored backend logic for token operations
  - Avoid unnecessary table creation
  - Default values for missing token data

- Enhanced topbar and button logic for participants page


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tokens.php</strong><dd><code>Improved tokens table handling and restoration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/admin/Tokens.php

<li>Conditional creation/restoration of tokens table based on POST and <br>survey state<br> <li> Avoid unnecessary tokens table creation in add/import/dummy actions<br> <li> Provide default token data if table is missing<br> <li> Adjust queries, model, and UI data for missing tokens table<br> <li> Add restore options and old table listing logic


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4267/files#diff-af8e690b7162e715acc4d95c2dd74fb97479066cf40a03d33de4c393df0250e3">+105/-41</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TopbarConfiguration.php</strong><dd><code>Add token existence flag to topbar configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/core/TopbarConfiguration.php

- Added `tokenexists` flag to topbar data for UI logic


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4267/files#diff-c3b923244ce56d8af1826f283438a5eed15ec4117c2693c104558f16763c030d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>surveyParticipantView.php</strong><dd><code>Conditional participant grid and restore UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/admin/token/surveyParticipantView.php

<li>Conditional rendering of participant grid and alerts based on tokens <br>table<br> <li> Added UI for restoring old tokens tables if available<br> <li> Hide participant grid if no tokens table exists


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4267/files#diff-88b9c567a016f4b684f2b3ee3d537b801e9f4491d5ce98588ea2726c39df1601">+36/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>leftSideButtons.php</strong><dd><code>Conditional left-side buttons based on tokens table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/surveyAdministration/partial/topbar_tokens/leftSideButtons.php

<li>Only show attribute, export, invite/remind, and CPDB buttons if tokens <br>table exists<br> <li> Refactored button rendering logic for clarity and conditionality


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4267/files#diff-1cbea067a26e034e2675248f7754496a0741b42ae127ca4084d466928f0af066">+85/-82</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rightSideButtons.php</strong><dd><code>Conditional right-side buttons based on tokens table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/surveyAdministration/partial/topbar_tokens/rightSideButtons.php

<li>Only show delete, export, invitation, and reminder buttons if tokens <br>table exists<br> <li> Wrapped button rendering in token existence check


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4267/files#diff-f8d0120a8bcf3b80cad192a40c7547326391e7e2a7c6b893bf002f2e2819bf51">+69/-67</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 🔍 To retrieve JIRA tickets as context to your PR description, please [register](https://qodo-merge-docs.qodo.ai/core-abilities/fetching_ticket_context/#jira-cloud) your organization.