### PR TITLE
custom criteria from a plugin

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1847,7 +1847,10 @@ class Survey extends LSActiveRecord implements PermissionInterface
         $event = new PluginEvent('beforeSurveySearch');
         $event->set('criteria', $criteria);
         App()->getPluginManager()->dispatchEvent($event);
-        $criteria = $event->get('criteria');
+        $returnedCriteria = $event->get('criteria');
+        if ($returnedCriteria instanceof LSDbCriteria) {
+            $criteria = $returnedCriteria;
+        }
 
         // $criteria->addCondition("t.blabla == 'blub'");
         $dataProvider = new CActiveDataProvider('Survey', array(


### PR DESCRIPTION
### **User description**
Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Enhancement


___

### **Description**
- Added plugin hook for custom survey search criteria.

- Enables plugins to modify search criteria before execution.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Survey.php</strong><dd><code>Add plugin event for customizing survey search criteria</code>&nbsp; &nbsp; </dd></summary>
<hr>

application/models/Survey.php

<li>Introduced <code>beforeSurveySearch</code> plugin event before search execution.<br> <li> Allows plugins to modify or extend the search criteria.


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4269/files#diff-0268c3e4648700cef058f99725fd5364a285bd35701d30cfda885a81ce1c86a4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Survey search functionality now supports plugin-level customization through extensible event handling, allowing plugins to modify search queries after permission criteria are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->