### PR TITLE
Fixed issue #20087: Modal content not shown inside a modal but as a page itself with no style

### DIFF
--- a/application/controllers/SurveyPermissionsController.php
+++ b/application/controllers/SurveyPermissionsController.php
@@ -144,8 +144,12 @@ class SurveyPermissionsController extends LSBaseController
     {
         $surveyid = sanitize_int($surveyid);
         if (!Permission::model()->hasSurveyPermission($surveyid, 'surveysecurity', 'create')) {
-            Yii::app()->user->setFlash('error', gT("No permission or survey does not exist."));
-            $this->redirect(Yii::app()->request->urlReferrer);
+            return Yii::app()->getController()->renderPartial('/admin/super/_renderJson', [
+                "data" => [
+                    'success' => false,
+                    'message' => gT("No permission or survey does not exist."),
+                ]
+            ]);
         }
         $oSurvey = Survey::model()->findByPk($surveyid);
         $userGroupId = (int)Yii::app()->request->getPost('ugid');
@@ -155,16 +159,26 @@ class SurveyPermissionsController extends LSBaseController
         );
         $amountUsersAdded = $surveyPermissions->addUserGroupToSurveyPermissions($userGroupId);
         if ($amountUsersAdded == 0) {
-            Yii::app()->user->setFlash('error', gT("No users from group could be added."));
-            $this->redirect(['surveyPermissions/index', 'surveyid' => $surveyid]);
+            return Yii::app()->getController()->renderPartial('/admin/super/_renderJson', [
+                "data" => [
+                    'success' => false,
+                    'message' => gT("No users from group could be added."),
+                ]
+            ]);
         } else {
-            Yii::app()->user->setFlash('success', sprintf(gT("%s users from group were added."), $amountUsersAdded));
-            $this->redirect(array(
-                'surveyPermissions/settingsPermissions',
-                'surveyid' => $surveyid,
-                'action' => 'usergroup',
-                'id' => $userGroupId
-            ));
+            $data = [
+                'success' => true,
+                'message' => sprintf(gT("%s users from group were added."), $amountUsersAdded),
+                'href' => Yii::app()->getController()->createUrl('surveyPermissions/settingsPermissions', [
+                    'surveyid' => $surveyid,
+                    'action' => 'usergroup',
+                    'id' => $userGroupId
+                ]),
+                'modalsize' => 'modal-lg',
+            ];
+            return Yii::app()->getController()->renderPartial('/admin/super/_renderJson', [
+                "data" => $data
+            ]);
         }
     }
 

--- a/application/controllers/SurveyPermissionsController.php
+++ b/application/controllers/SurveyPermissionsController.php
@@ -147,7 +147,7 @@ class SurveyPermissionsController extends LSBaseController
             return Yii::app()->getController()->renderPartial('/admin/super/_renderJson', [
                 "data" => [
                     'success' => false,
-                    'message' => gT("No permission or survey does not exist."),
+                    'errors' => gT("No permission or survey does not exist."),
                 ]
             ]);
         }
@@ -162,7 +162,7 @@ class SurveyPermissionsController extends LSBaseController
             return Yii::app()->getController()->renderPartial('/admin/super/_renderJson', [
                 "data" => [
                     'success' => false,
-                    'message' => gT("No users from group could be added."),
+                    'errors' => gT("No users from group could be added."),
                 ]
             ]);
         } else {

--- a/application/views/surveyPermissions/index.php
+++ b/application/views/surveyPermissions/index.php
@@ -52,7 +52,7 @@
                 echo CHtml::form(
                     ["surveyPermissions/addusergroup/surveyid/{$surveyid}"],
                     'post',
-                    ['class' => "form44"]
+                    ["id" => "SurveyPermissions-addusergroup-form"]
                 ); ?>
                 <div class="row justify-content-md-end">
                     <label class='col-2 text-end control-label' for='ugidselect'>
@@ -73,7 +73,7 @@
                         </select>
                     </div>
                     <div class="col-3">
-                    <input class='btn btn-outline-secondary w-100' type='submit' value='<?= gT("Add group users") ?>'/>
+                    <button id="SurveyPermissions-addusergroup-submit" class='btn btn-outline-secondary w-100' type='submit'><?= gT("Add group users") ?></button>
                     <input type='hidden' name='action' value='addusergroupsurveysecurity'/>
                     </div>
                 </div>

--- a/assets/packages/usermanagement/js/usermanagement.js
+++ b/assets/packages/usermanagement/js/usermanagement.js
@@ -374,6 +374,7 @@ var UserManagement = function () {
         wirePermissions: wirePermissions,
         wireMassPermissions: wireMassPermissions,
         wireForm: wireForm,
+        openModal: openModal,
     };
 };
 

--- a/assets/scripts/admin/surveypermissions.js
+++ b/assets/scripts/admin/surveypermissions.js
@@ -197,17 +197,16 @@ var addUserGroupToSurvey = function (form) {
                 return;
             }
             $("#usermanagement-modal-doalog").offset({ top: 10 });
-            //$('#UserManagement--errors').html(result.errors).removeClass('d-none').addClass('alert alert-danger');
+            window.LS.ajaxAlerts(result.errors, 'danger', {showCloseButton: true, timeout: 10000});
         },
         error: function (request, status, error) {
+            stopAddUserGroupSubmit();
             if (request && request.responseJSON && request.responseJSON.message) {
-                $('#UserManagement--errors').html(
-                    LS.LsGlobalNotifier.createAlert(
-                        request.responseJSON.message,
-                        'danger',
-                        {showCloseButton: true, timeout: 10000}
-                    )
-                ).removeClass('d-none');
+                window.LS.ajaxAlerts(
+                    request.responseJSON.message,
+                    'danger',
+                    {showCloseButton: true, timeout: 10000}
+                );
             } else {
                 alert('An error occured while trying to save, please reload the page Code:1571926261195');
             }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored user group addition to surveys to use AJAX modal flow
  - Controller now returns JSON responses instead of redirects
  - Frontend handles form submission and modal updates dynamically

- Improved user feedback and error handling for group addition
  - Loading spinner and button disabling during submission
  - Success and error messages shown in modal or as alerts

- Updated form markup and JavaScript wiring for new modal behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyPermissionsController.php</strong><dd><code>Refactor controller to return JSON for group addition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/SurveyPermissionsController.php

<li>Changed <code>actionAddUserGroup</code> to return JSON responses instead of <br>redirects<br> <li> Provided success/failure messages and next modal URL in JSON<br> <li> Improved permission error handling for AJAX flow


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4270/files#diff-fc510db939b5afc725e1e6f3d5ce9ac31c56bb3b978865297e34d621c38b2691">+25/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>surveypermissions.js</strong><dd><code>Add AJAX modal logic for user group addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/scripts/admin/surveypermissions.js

<li>Added AJAX form submission for adding user groups to surveys<br> <li> Handles loading spinner, disables submit, and processes JSON responses<br> <li> Updates modal content or triggers modal close and alerts on success<br> <li> Improved error handling and feedback for users


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4270/files#diff-277448e501cbde9015885355e834ad9b47979e2b163634699a0a7175a2de74a2">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.php</strong><dd><code>Update form markup for AJAX/modal submission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/surveyPermissions/index.php

<li>Updated user group addition form to use new ID and button markup<br> <li> Changed submit input to button with specific ID for JS handling<br> <li> Prepared form for AJAX/modal-based submission


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4270/files#diff-016cedda7ae1749c1aff0d25f7b8e63336bf5cd8a809c3dbab44d4422683e2d0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usermanagement.js</strong><dd><code>Expose openModal for external modal triggering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/packages/usermanagement/js/usermanagement.js

<li>Exposed <code>openModal</code> method in UserManagement JS module for external use


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4270/files#diff-c6afc487b7a7aa392fce36b32fb1fe58db49269a2a3bdc70d4058ca10a337415">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>