### PR TITLE
Fixed issue QE-1572: 2 typeErrors reported on sentry

### DIFF
--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerAnswer.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerAnswer.php
@@ -169,7 +169,7 @@ class OpHandlerAnswer implements OpHandlerInterface
         $this->questionAggregateService->checkUpdatePermission($surveyId);
         $question = $this->questionService->getQuestionBySidAndQid(
             $surveyId,
-            $op->getEntityId()
+            (int)$op->getEntityId()
         );
 
         $data = $this->transformer->transformAll(

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionAttributeUpdate.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionAttributeUpdate.php
@@ -100,7 +100,7 @@ class OpHandlerQuestionAttributeUpdate implements OpHandlerInterface
         $this->attributesService->saveAdvanced(
             $this->questionService->getQuestionBySidAndQid(
                 $surveyId,
-                $questionId
+                (int)$questionId
             ),
             $preparedData
         );

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroup.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroup.php
@@ -168,7 +168,7 @@ class OpHandlerQuestionGroup implements OpHandlerInterface
         }
         $questionGroup = $this->questionGroupService->getQuestionGroupForUpdate(
             $surveyId,
-            $op->getEntityId()
+            (int)$op->getEntityId()
         );
         if (!empty($transformedProps['questionGroup'])) {
             $this->questionGroupService->updateQuestionGroup(

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroupL10n.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroupL10n.php
@@ -88,7 +88,7 @@ class OpHandlerQuestionGroupL10n implements OpHandlerInterface
         $questionGroupService->checkUpdatePermission($surveyId);
         $questionGroup = $questionGroupService->getQuestionGroupForUpdate(
             $surveyId,
-            $op->getEntityId()
+            (int)$op->getEntityId()
         );
         $transformedProps = $this->transformer->transformAll(
             $op->getProps(),

--- a/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSubQuestion.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSubQuestion.php
@@ -170,7 +170,7 @@ class OpHandlerSubQuestion implements OpHandlerInterface
         $questionId = $op->getEntityId();
         $question = $this->questionService->getQuestionBySidAndQid(
             $surveyId,
-            $questionId
+            (int)$questionId
         );
         $this->subQuestionsService->save(
             $question,


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Bug fix


___

### **Description**
- Fix TypeError by casting entity IDs to integers

- Update multiple OpHandler classes for type safety

- Prevent runtime errors in question and group update operations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OpHandlerAnswer.php</strong><dd><code>Ensure integer type for question ID in OpHandlerAnswer</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyPatch/OpHandlerAnswer.php

<li>Cast <code>getEntityId()</code> to integer in <code>getQuestionBySidAndQid</code> call<br> <li> Prevents TypeError when entity ID is not an integer


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4271/files#diff-8b6427a001e58bb4b498896924d77b1cc88da6e0e2575e11ccfd60ade8732ce9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpHandlerQuestionAttributeUpdate.php</strong><dd><code>Fix TypeError in question attribute update handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionAttributeUpdate.php

<li>Cast <code>questionId</code> to integer in <code>getQuestionBySidAndQid</code> call<br> <li> Prevents TypeError when updating question attributes


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4271/files#diff-843a2301b9752125da6fdaead840847d416def8143dda80d3d0960432036cad9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpHandlerQuestionGroup.php</strong><dd><code>Enforce integer type for group ID in OpHandlerQuestionGroup</code></dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroup.php

<li>Cast <code>getEntityId()</code> to integer in <code>getQuestionGroupForUpdate</code> call<br> <li> Ensures type safety for question group updates


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4271/files#diff-bac5f01b3c9ab081270d393e507c6d5439cab9bb608eae7c9411afb6fde854ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpHandlerQuestionGroupL10n.php</strong><dd><code>Fix TypeError in localized question group update handler</code>&nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyPatch/OpHandlerQuestionGroupL10n.php

<li>Cast <code>getEntityId()</code> to integer in <code>getQuestionGroupForUpdate</code> call<br> <li> Prevents TypeError in localized question group updates


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4271/files#diff-af8bb01a08afa1e750f6c76260d465fb53036ff4f9724975d3d0ac8e870f78fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpHandlerSubQuestion.php</strong><dd><code>Enforce integer type for subquestion ID in OpHandlerSubQuestion</code></dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyPatch/OpHandlerSubQuestion.php

<li>Cast <code>questionId</code> to integer in <code>getQuestionBySidAndQid</code> call<br> <li> Ensures type safety for subquestion updates


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4271/files#diff-97d9ad8f5a1fdc27447ded0596243d6753f14e376482b815284f6f69da8e1fc0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>