### PR TITLE
APE-29: sideMenu widget redirect to react themeOptions

### DIFF
--- a/application/extensions/admin/survey/SurveySidemenuWidget/SurveySidemenuWidget.php
+++ b/application/extensions/admin/survey/SurveySidemenuWidget/SurveySidemenuWidget.php
@@ -132,7 +132,11 @@ class SurveySidemenuWidget extends WhSelect2
                 ]
             ),
             'presentation' => array(
-                [ 'name' => 'theme_options' ],
+                [
+                    'name' => 'theme_options',
+                    'route' => 'editorLink/index',
+                    'params' =>  array('route' => 'survey/' . $this->sid . '/presentation/theme_options'),
+                ],
                 [
                     'name' => 'presentation',
                     'route' => 'editorLink/index',

--- a/application/extensions/admin/survey/SurveySidemenuWidget/views/sidemenu.php
+++ b/application/extensions/admin/survey/SurveySidemenuWidget/views/sidemenu.php
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div class="sidebar-icons-item">
-                <div class="sidebar-icon" data-target="#survey-presentation-panel" onclick="window.location='<?php echo App()->createUrl('themeOptions/updateSurvey', array('surveyid' => $sid)); ?>'">
+                <div class="sidebar-icon" data-target="#survey-presentation-panel" onclick="window.location='<?php echo App()->createUrl('editorLink/index', ['route' => 'survey/' .  $sid . '/presentation/theme_options']); ?>'">
                     <div data-bs-toggle="tooltip"
                          title="<?php echo gT('Survey presentation'); ?>"
                          data-bs-offset="0, 20"


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Enhancement


___

### **Description**
- Updated side menu widget to redirect theme options to React route

- Modified presentation menu item to use new editorLink route

- Adjusted sidebar icon click handler for theme options redirection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveySidemenuWidget.php</strong><dd><code>Redirect theme options menu to React route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/admin/survey/SurveySidemenuWidget/SurveySidemenuWidget.php

<li>Updated 'theme_options' menu item to use 'editorLink/index' route<br> <li> Added parameters for React-based theme options redirection


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4278/files#diff-91de4551918b06969c33ec6be2d97ba4ca63746a308f7c59f9f0787a8d433a8a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidemenu.php</strong><dd><code>Update sidebar icon to redirect to React theme options</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/admin/survey/SurveySidemenuWidget/views/sidemenu.php

<li>Changed sidebar icon click handler for theme options<br> <li> Now redirects to 'editorLink/index' with React route parameters


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4278/files#diff-887d634d7e7a3d24c177fbda1fbc7c5b2c2c249c3b34b14d52aac1348927536c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>