### PR TITLE
APE-112: Created new archive endpoint to support base table too

### DIFF
--- a/application/config/rest/v1/survey.php
+++ b/application/config/rest/v1/survey.php
@@ -166,4 +166,26 @@ $rest['v1/survey-archives/$id'] = [
     ]
 ];
 
+$rest['v1/action/survey-archives/id/$id/basetable/$basetable'] = [
+    'GET' => [
+        'tag' => 'survey',
+        'description' => 'Survey archives',
+        'commandClass' => SurveyArchive::class,
+        'auth' => true,
+        'responses' => [
+            'success' => [
+                'code' => 200,
+                'description' => 'Success',
+                'content' => null,
+                'schema' => (new SchemaFactorySurveyArchive())->make()
+            ],
+            'not-found' => [
+                'code' => 404,
+                'description' => 'Not Found',
+                'schema' => $errorSchema
+            ]
+        ]
+    ]
+];
+
 return $rest;

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1198,9 +1198,10 @@ function finalizeSurveyImportFile($newsid, $baselang)
 /**
  * Returns the tables which
  * @param int $sid
+ * @param string $baseTable
  * @return array
  */
-function getTableArchivesAndTimestamps(int $sid)
+function getTableArchivesAndTimestamps(int $sid, string $baseTable = 'old_survey')
 {
     switch (Yii::app()->db->getDriverName()) {
         case 'mysqli':
@@ -1210,7 +1211,7 @@ function getTableArchivesAndTimestamps(int $sid)
                 FROM information_schema.tables t1
                 JOIN information_schema.tables t2
                 ON t1.TABLE_SCHEMA = t2.TABLE_SCHEMA AND
-                   t2.TABLE_NAME LIKE CONCAT('%old_survey_{$sid}_', SUBSTRING_INDEX(t1.TABLE_NAME, '_', -1))
+                   t2.TABLE_NAME LIKE CONCAT('%{$baseTable}_{$sid}_', SUBSTRING_INDEX(t1.TABLE_NAME, '_', -1))
                 WHERE t1.TABLE_SCHEMA = DATABASE() AND
                       t1.TABLE_NAME LIKE '%old%' AND
                       t1.TABLE_NAME LIKE '%{$sid}%'
@@ -1223,7 +1224,7 @@ function getTableArchivesAndTimestamps(int $sid)
             FROM information_schema.tables t1
             JOIN information_schema.tables t2
             ON t1.TABLE_CATALOG = t2.TABLE_CATALOG AND
-               t2.TABLE_NAME LIKE CONCAT('%old_survey_{$sid}_', SUBSTRING_INDEX(t1.TABLE_NAME, '_', -1))
+               t2.TABLE_NAME LIKE CONCAT('%{$baseTable}_{$sid}_', SUBSTRING_INDEX(t1.TABLE_NAME, '_', -1))
             WHERE t1.TABLE_CATALOG = current_database() AND
                   t1.TABLE_NAME LIKE '%old%' AND
                   t1.TABLE_NAME LIKE '%{$sid}%'
@@ -1243,7 +1244,7 @@ function getTableArchivesAndTimestamps(int $sid)
                 FROM information_schema.tables t1
                 JOIN information_schema.tables t2
                 ON t1.TABLE_CATALOG = t2.TABLE_CATALOG AND
-                   t2.TABLE_NAME LIKE CONCAT('%old_survey_{$sid}_', substring(t1.TABLE_NAME, len(t1.TABLE_NAME) - charindex('_', reverse(t1.TABLE_NAME)) + 2, 2000))
+                   t2.TABLE_NAME LIKE CONCAT('%{$baseTable}_{$sid}_', substring(t1.TABLE_NAME, len(t1.TABLE_NAME) - charindex('_', reverse(t1.TABLE_NAME)) + 2, 2000))
                 WHERE t1.TABLE_CATALOG = db_name() AND
                       t1.TABLE_NAME LIKE '%old%' AND
                       t1.TABLE_NAME LIKE '%{$sid}%'

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -46,7 +46,8 @@ class SurveyArchive implements CommandInterface
      * @param array $rawData
      * @return []
      */
-    protected function processData(Survey $survey, array $rawData) {
+    protected function processData(Survey $survey, array $rawData)
+    {
         try {
             $hasTokens = ($survey->isActive && (Token::model($survey->sid)->find('1=1') !== null));
         } catch (\Exception $ex) {

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -46,13 +46,15 @@ class SurveyArchive implements CommandInterface
      * @param array $rawData
      * @return []
      */
-    protected function processData(Survey $survey, array $rawData)
+    protected function processData(Survey $survey, array $rawData): array
     {
+        $hasTokens = false;
         try {
             $hasTokens = ($survey->isActive && (Token::model($survey->sid)->find('1=1') !== null));
         } catch (\Exception $ex) {
             //Tokens table exists, proceed
         }
+        $data = [];
         for ($index = 0; $index < count($rawData); $index++) {
             $newData = ['newformat' => false];
             $split = explode(",", $rawData[$index]['tables']);
@@ -94,9 +96,9 @@ class SurveyArchive implements CommandInterface
     {
         $surveyId = (int)$request->getData('_id');
         if (!$surveyId) {
-            $surveyId = (int)$_GET['id'];
+            $surveyId = intval($_GET['id']);
         }
-        $rawBaseTable = $_GET['basetable'] ?? 'survey';
+        $rawBaseTable = (string)($_GET['basetable'] ?? 'survey');
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -91,6 +91,8 @@ class SurveyArchive implements CommandInterface
     /**
      * Processes the request
      * @param \LimeSurvey\Api\Command\Request\Request $request
+     * @SuppressWarnings(PHPMD.PossiblyInvalidOperand)
+     * @SuppressWarnings(PHPMD.InvalidArgument)
      */
     public function run(Request $request)
     {
@@ -99,10 +101,6 @@ class SurveyArchive implements CommandInterface
             $surveyId = intval($_GET['id']);
         }
         $rawBaseTable = ($_GET['basetable'] ?? 'survey') . "";
-        $rawBaseTable = 'survey';
-        if (isset($_GET['basetable'])) {
-            $rawBaseTable = (is_array($_GET['basetable']) ? implode("", $_GET['basetable']) : $_GET['basetable']);
-        }
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -44,7 +44,7 @@ class SurveyArchive implements CommandInterface
      * Processes data and returns aggregate summary of the archives
      * @param \Survey $survey
      * @param array $rawData
-     * @return []
+     * @return array
      */
     protected function processData(Survey $survey, array $rawData): array
     {
@@ -98,7 +98,7 @@ class SurveyArchive implements CommandInterface
         if (!$surveyId) {
             $surveyId = intval($_GET['id']);
         }
-        $rawBaseTable = (string)($_GET['basetable'] ?? 'survey');
+        $rawBaseTable = ($_GET['basetable'] ?? 'survey') . "";
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -47,6 +47,14 @@ class SurveyArchive implements CommandInterface
     public function run(Request $request)
     {
         $surveyId = (int)$request->getData('_id');
+        if (!$surveyId) {
+            $surveyId = (int)$_GET['id'];
+        }
+        $rawBaseTable = $_GET['basetable'] ?? 'survey';
+        if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
+            throw new \Exception("Incorrect base table");
+        }
+        $baseTable = "old_{$rawBaseTable}";
         if ($response = $this->ensurePermissions($surveyId)) {
             return $response;
         }
@@ -61,7 +69,7 @@ class SurveyArchive implements CommandInterface
             );
         }
         require_once "application/helpers/admin/import_helper.php";
-        $rawData = getTableArchivesAndTimestamps($surveyId);
+        $rawData = getTableArchivesAndTimestamps($surveyId, $baseTable);
         $data = [];
         $hasTokens = false;
         try {

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -98,7 +98,7 @@ class SurveyArchive implements CommandInterface
         if (!$surveyId) {
             $surveyId = intval($_GET['id']);
         }
-        $rawBaseTable = (json_encode($_GET['basetable']) ?? 'survey');
+        $rawBaseTable = (json_encode($_GET['basetable'] ?? 'survey'));
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -91,8 +91,6 @@ class SurveyArchive implements CommandInterface
     /**
      * Processes the request
      * @param \LimeSurvey\Api\Command\Request\Request $request
-     * @SuppressWarnings(PHPMD.PossiblyInvalidOperand)
-     * @SuppressWarnings(PHPMD.InvalidArgument)
      */
     public function run(Request $request)
     {
@@ -100,7 +98,7 @@ class SurveyArchive implements CommandInterface
         if (!$surveyId) {
             $surveyId = intval($_GET['id']);
         }
-        $rawBaseTable = ($_GET['basetable'] ?? 'survey') . "";
+        $rawBaseTable = (json_encode($_GET['basetable']) ?? 'survey');
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }

--- a/application/libraries/Api/Command/V1/SurveyArchive.php
+++ b/application/libraries/Api/Command/V1/SurveyArchive.php
@@ -99,6 +99,10 @@ class SurveyArchive implements CommandInterface
             $surveyId = intval($_GET['id']);
         }
         $rawBaseTable = ($_GET['basetable'] ?? 'survey') . "";
+        $rawBaseTable = 'survey';
+        if (isset($_GET['basetable'])) {
+            $rawBaseTable = (is_array($_GET['basetable']) ? implode("", $_GET['basetable']) : $_GET['basetable']);
+        }
         if (!in_array($rawBaseTable, ['survey', 'tokens'])) {
             throw new \Exception("Incorrect base table");
         }


### PR DESCRIPTION
Requests like

```
curl 'http://ls-ce-6x/index.php/rest/v1/survey-archives/157447
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Authorization: Bearer tjnMybaErFOt~a1yMO8kv4hlEAxcBhi0' \
  -H 'ClientApplication: limesurvey-editor@1.0.5@f0ab50b4bff61eaed8f6962d224a884cb08c93a7' \
  -H 'Connection: keep-alive' \
  -H 'Origin: http://ls-ce-6x:3000' \
  -H 'Referer: http://ls-ce-6x:3000/' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36' \
  -H 'mode: cors' \
  --insecure
```

should work as they were working before, whereas we should be able to tell what tables should be the main items of the archives we retrieve, like

```
curl 'http://ls-ce-6x/index.php/rest/v1/action/survey-archives/id/157447/basetable/tokens' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Authorization: Bearer tjnMybaErFOt~a1yMO8kv4hlEAxcBhi0' \
  -H 'ClientApplication: limesurvey-editor@1.0.5@f0ab50b4bff61eaed8f6962d224a884cb08c93a7' \
  -H 'Connection: keep-alive' \
  -H 'Origin: http://ls-ce-6x:3000' \
  -H 'Referer: http://ls-ce-6x:3000/' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36' \
  -H 'mode: cors' \
  --insecure
```

For example if there is a token archive at a certain date, but no responses on that date, then the first example will not retrieve that given archive.