### PR TITLE
Fixed Issue #20120: Advanced ranking height and width are set to 0 wh…

### DIFF
--- a/themes/question/ranking_advanced/survey/questions/answer/ranking/assets/scripts/advanced_ranking.js
+++ b/themes/question/ranking_advanced/survey/questions/answer/ranking/assets/scripts/advanced_ranking.js
@@ -228,10 +228,43 @@ var AdvancedRankingQuestion = function (options) {
         });
     };
 
+    /**
+     * Observe visibility changes on the question element
+     *  fix height when there is conditional display logic.
+     */
+    var observeVisibilityChange = function() {
+
+        // Get the DOM element corresponding to the question using its ID
+        var target = document.getElementById('question' + questionId);
+        if (!target) return;
+
+        // Create a MutationObserver to watch for changes to the element's attributes
+        var observer = new MutationObserver(function(mutations) {
+
+            mutations.forEach(function(mutation) {
+                // We're only interested in attribute changes, specifically the "class" attribute
+                if ( mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    // Check if the "hidden" class was removed (i.e., the element became visible)
+                    if (!target.classList.contains('hidden')) {
+                        fixChoiceListHeight();
+                    }
+                }
+            });
+
+        });
+
+        // Start observing the target element for changes to its class attribute
+        observer.observe(target, {
+            attributes: true, // Watch for attribute changes
+            attributeFilter: ['class'] // Only care about the "class" attribute
+        });
+    };
+
     return {
         init : function(){
             doDragDropRank();
             triggerEmRelevanceSortable();
+            observeVisibilityChange();
         }
     }
 


### PR DESCRIPTION
…en conditional display is applied.


Fixed issue #20120: Advanced ranking height and width are set to 0 when conditional display is applied.

I added a mutation observer on the question to trigger fixChoiceListHeight() when hidden class is removed so the dimensions are recalculated.
