### PR TITLE
Fixed bug #20121: Wrong alert on failed authentication with access code

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1295,7 +1295,7 @@ function testIfTokenIsValid(array $subscenarios, array $thissurvey, array $aEnte
                 }
             } else {
                 //token was wrong
-                $errorMsg    = gT("The access code you have provided is either not valid, or has already been used.");
+                $errorMsg    = gT("The access code you have provided is incorrect.");
                 $FlashError .= $errorMsg;
                 $renderToken = 'main';
                 FailedLoginAttempt::model()->addAttempt(FailedLoginAttempt::TYPE_TOKEN);


### PR DESCRIPTION
**Steps to reproduce**
Start a new survey with closed participants list. Enter a wrong access code.
**Expected result**
The user should see an alert that inform him that the code is not correct
**Actual result**
The alert "The access code you have provided is either not valid, or has already been used" is shown. It could lead to misunderstanding since the error is provided only when a wrong access code is used.

<!-- Keep one of the below lines. -->

Fixed issue #20121: Wrong alert on failed authentication with access code