### PR TITLE
Fixed issue #20096: Confirmation email is not sent if multiple participants/email addresses are used, also applies to admin notifications

### DIFF
--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -1007,7 +1007,7 @@ class LimeMailer extends PHPMailer
      * Validate a list of email addresses - either as array or as comma or semicolon-limited text
      * @param string|string[] $aEmailAddressList  Email address to check
      * @param string|callable $patternselect Which pattern to use (default to static::$validator)
-     * @return string List with valid email addresses - invalid email addresses are filtered - false if none of the email addresses are valid
+     * @return string[]|false List with valid email addresses - invalid email addresses are filtered - false if none of the email addresses are valid
      */
     public static function validateAddresses($aEmailAddressList, $patternselect = null)
     {


### PR DESCRIPTION
Update code documentation