### PR TITLE
Fixed issue #20055: Missing save confirmation with validation errors

### DIFF
--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -910,7 +910,7 @@ class SurveyRuntimeHelper
      */
     private function setPrevStep()
     {
-        if (isset($this->sMove) && $this->sMove != "") {
+        if (isset($this->sMove) && $this->sMove !== "") {
             if (!in_array($this->sMove, array("clearall", "changelang", "saveall", "reload"))) {
                 $_SESSION[$this->LEMsessid]['prevstep'] = $_SESSION[$this->LEMsessid]['step'];
             } else {


### PR DESCRIPTION
Seems sometimes `$this->sMove ` may be blank.
Ex: https://github.com/LimeSurvey/LimeSurvey/pull/2889/files#diff-f2c0610f506dc0397d2efd8d8203a78dc44f2825e26eb0ac70efd87205d2e36eR1136