### PR TITLE
Fixed issue #20127: Dump when browsing responses, with DEBUG enabled

### DIFF
--- a/application/models/Answer.php
+++ b/application/models/Answer.php
@@ -167,6 +167,7 @@ class Answer extends LSActiveRecord
                 return null;
             }
             if (!isset($aAnswer->answerl10ns[$sLanguage])) {
+                Yii::log("AnswerL10n record missing for language \"{$sLanguage}\" and aid {$aAnswer->aid}", 'warning', 'application.models.Answer.getAnswerFromCode');
                 return null;
             }
             $answerCache[$qid][$code][$sLanguage][$iScaleID] = $aAnswer->answerl10ns[$sLanguage]->answer;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added check for missing `AnswerL10n` records in `getAnswerFromCode`

- Logged warning when language-specific answer is missing

- Prevented PHP dump when browsing responses with DEBUG enabled


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Answer.php</strong><dd><code>Add missing AnswerL10n check and warning in getAnswerFromCode</code></dd></summary>
<hr>

application/models/Answer.php

<li>Added check for existence of <code>AnswerL10n</code> for requested language<br> <li> Logged a warning if the language-specific answer is missing<br> <li> Returned null instead of causing a dump when missing


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4307/files#diff-61d68b10b263b0a1a9a974c41ad98d3b676b88ced72e79b35cb428b00c74d63d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>