### PR TITLE
Fixed issue #20129: Dump when accesing 2FA Admin screen, with DEBUG enabled

### DIFF
--- a/application/core/plugins/TwoFactorAdminLogin/models/TFAUser.php
+++ b/application/core/plugins/TwoFactorAdminLogin/models/TFAUser.php
@@ -130,7 +130,7 @@ class TFAUser extends User
             [
                 "name"   => 'userkeys.authType',
                 "header" => gT("2FA method"),
-                "value"  => 'TFAUserKey::$authTypeOptions[$data->userkeys->authType]',
+                "value"  => '$data->hasAuthSet==1 ? TFAUserKey::$authTypeOptions[$data->userkeys->authType] : ""',
                 "filter" => TbHtml::dropDownList('userkeys_authType', Yii::app()->request->getParam('userkeys_authType'), array_merge(['' => ''], TFAUserKey::$authTypeOptions)),
             ],
             [


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes crash on 2FA Admin screen with DEBUG enabled

- Adds conditional check for `authType` display logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TFAUser.php</strong><dd><code>Add conditional check for 2FA method display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/core/plugins/TwoFactorAdminLogin/models/TFAUser.php

<li>Adds conditional to only display 2FA method if <code>hasAuthSet</code> is true<br> <li> Prevents accessing undefined array index when no 2FA is set


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4308/files#diff-e36baa84d1f37320c92cd4a353155874821bd8b634f0e50ec82f4440932d8d80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>