### PR TITLE
Fixed issue #20098: Sensitive information exposed to public in session errors

### DIFF
--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -157,7 +157,7 @@ class SurveysController extends LSYii_Controller
 
         // For CDbException, we clear the message in order to avoid showing sensitive information to the user.
         // This method is not usually executed when debug is enabled, but check anyway to be sure to only
-        // suppress the error is debug is disabled.
+        // suppress the error if debug is disabled.
         if (!YII_DEBUG && isset($error['type']) && $error['type'] == 'CDbException') {
             $error['message'] = gT('Database error!');
         }

--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -154,6 +154,12 @@ class SurveysController extends LSYii_Controller
                 $message = gT('The above error occurred when the Web server was processing your request.');
                 break;
         }
+
+        // For CDbException, we clear the message in order to avoid showing sensitive information to the user.
+        if (isset($error['type']) && $error['type'] == 'CDbException') {
+            $error['message'] = "";
+        }
+
         $aError['type'] = $error['code'];
         $aError['error'] = $title;
         if (!empty($error['message'])) {

--- a/application/controllers/SurveysController.php
+++ b/application/controllers/SurveysController.php
@@ -156,8 +156,10 @@ class SurveysController extends LSYii_Controller
         }
 
         // For CDbException, we clear the message in order to avoid showing sensitive information to the user.
-        if (isset($error['type']) && $error['type'] == 'CDbException') {
-            $error['message'] = "";
+        // This method is not usually executed when debug is enabled, but check anyway to be sure to only
+        // suppress the error is debug is disabled.
+        if (!YII_DEBUG && isset($error['type']) && $error['type'] == 'CDbException') {
+            $error['message'] = gT('Database error!');
         }
 
         $aError['type'] = $error['code'];


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevents exposure of sensitive information in session errors

- Clears error messages for `CDbException` before displaying to users

- Enhances security by sanitizing error output


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveysController.php</strong><dd><code>Sanitize error messages to avoid sensitive data exposure</code>&nbsp; </dd></summary>
<hr>

application/controllers/SurveysController.php

<li>Adds check for <code>CDbException</code> to clear error message<br> <li> Prevents sensitive database error details from being shown to users<br> <li> Improves error handling for internal server errors


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4309/files#diff-5798c5cc16dea303442851aa6e7659ecb0387f59f54fa3a274fde4b70645c133">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>