### PR TITLE
Fixed issue #20132: With debug=2 I am getting an error when exporting responses to SPSS

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -83,7 +83,7 @@ function strSplitUnicode($str, $l = 0)
 */
 function quoteSPSS($sText, $sQuoteChar, $aField)
 {
-    $sText = trim($sText);
+    $sText = trim((string) $sText);
     if ($sText == '') {
         return '';
     }

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -77,7 +77,7 @@ function strSplitUnicode($str, $l = 0)
 /**
 * Quotes a string with surrounding quotes and masking inside quotes by doubling them
 *
-* @param string $sText Text to quote
+* @param string|null $sText Text to quote
 * @param string $sQuoteChar The quote character (Use ' for SPSS and " for R)
 * @param string $aField General field information from SPSSFieldmap
 */


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes error when exporting responses to SPSS with debug=2

- Ensures `quoteSPSS` handles non-string input safely


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export_helper.php</strong><dd><code>Safely handle non-string input in `quoteSPSS` function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/export_helper.php

<li>Casts <code>$sText</code> to string before trimming in <code>quoteSPSS</code><br> <li> Prevents errors when non-string values are passed


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4310/files#diff-1aecd900cde469d4c2ba64ab989062a075ed3ff9378180051d812b127a929dfe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>