### PR TITLE
Fixed issue #20047: Unable to open survey on new tab in Survey listing

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -1585,7 +1585,8 @@ class Survey extends LSActiveRecord implements PermissionInterface
             [
                 'header'            => gT('Survey ID'),
                 'name'              => 'survey_id',
-                'value'             => '$data->sid',
+                'value'             => 'CHtml::link($data->sid, Yii::app()->createUrl("surveyAdministration/view", ["surveyid" => $data->sid]))',
+                'type'              => 'raw',
                 'headerHtmlOptions' => ['class' => 'd-none d-sm-table-cell text-nowrap'],
                 'htmlOptions'       => ['class' => 'd-none d-sm-table-cell has-link'],
             ],
@@ -1600,7 +1601,8 @@ class Survey extends LSActiveRecord implements PermissionInterface
             [
                 'header'            => gT('Title'),
                 'name'              => 'title',
-                'value'             => '$data->defaultlanguage->surveyls_title ?? null',
+                'value'             => 'isset($data->defaultlanguage) ? CHtml::link(flattenText($data->defaultlanguage->surveyls_title), Yii::app()->createUrl("surveyAdministration/view", ["surveyid" => $data->sid])) : ""',
+                'type'              => 'raw',
                 'htmlOptions'       => ['class' => 'has-link'],
                 'headerHtmlOptions' => ['class' => 'text-nowrap'],
             ],


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes inability to open surveys in new tab from survey listing.

- Makes Survey ID and Title columns clickable links.

- Ensures links use raw HTML for proper rendering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Survey.php</strong><dd><code>Make Survey ID and Title columns clickable links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/Survey.php

<li>Changed Survey ID column to render as a clickable link to survey view.<br> <li> Changed Title column to render as a clickable link if default language <br>exists.<br> <li> Set both columns to use raw HTML type for proper link rendering.


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4313/files#diff-0268c3e4648700cef058f99725fd5364a285bd35701d30cfda885a81ce1c86a4">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>