### PR TITLE
Fixed issue #20083: Pre-Installation check: Session writable re-check is impossible - Attempt II

### DIFF
--- a/application/controllers/InstallerController.php
+++ b/application/controllers/InstallerController.php
@@ -192,8 +192,13 @@ class InstallerController extends CController
      */
     private function stepPreInstallationCheckPrepare()
     {
-        // Unset the cookie if present
+        // Unset the LS_PRECHECK_SHOWN cookie if present
+        // It is used in the next step to check if the request comes from this step or not.
         setcookie("LS_PRECHECK_SHOWN", "", time() - 3600, "/");
+
+        // Set the LS_COOKIES_ALLOWED cookie
+        // It is used for checking if cookies are enabled
+        setcookie("LS_COOKIES_ALLOWED", "1", time() + 3600, "/");
 
         // Set the value to check in the next step
         Yii::app()->session['saveCheck'] = 'save';
@@ -236,6 +241,8 @@ class InstallerController extends CController
         if (!$sessionWritable) {
             $bProceed = false;
         }
+
+        $aData['cookiesAllowed'] = !empty($_COOKIE['LS_COOKIES_ALLOWED']);
 
         // after all check, if flag value is true, show next button and sabe step2 status.
         if ($bProceed) {

--- a/application/views/installer/dbconfig_view.php
+++ b/application/views/installer/dbconfig_view.php
@@ -108,7 +108,7 @@ function checkDbEngine(){
 
         <div class="row">
             <div class="col-lg-4" >
-                <input id="ls-previous" class="btn btn-outline-secondary" type="button" value="<?php eT("Previous"); ?>" onclick="window.open('<?php echo $this->createUrl("installer/precheck"); ?>', '_top')" />
+                <input id="ls-previous" class="btn btn-outline-secondary" type="button" value="<?php eT("Previous"); ?>" onclick="window.open('<?php echo $this->createUrl("installer/precheckprepare"); ?>', '_top')" />
             </div>
             <div class="col-lg-4" style="text-align: center;">
             </div>

--- a/application/views/installer/precheck_view.php
+++ b/application/views/installer/precheck_view.php
@@ -13,6 +13,11 @@ $iconFail = "<span class='ri-error-warning-fill text-danger'></span>";
         <?php $this->renderPartial('/installer/sidebar_view', compact('progressValue', 'classesForStep')); ?>
     </div>
     <div class="col-lg-9">
+        <?php if (empty($next) && empty($cookiesAllowed)): ?>
+            <div class="alert alert-warning" role="alert">
+                <?= gT("Cookies seem to be disabled. Please use the \"Check again\" button instead of refreshing the page."); ?>
+            </div>
+        <?php endif; ?>
         <h2><?php echo $title; ?></h2>
         <p><?php echo $descp; ?></p>
         <legend><?php eT("Minimum requirements"); ?></legend>

--- a/application/views/installer/precheck_view.php
+++ b/application/views/installer/precheck_view.php
@@ -160,7 +160,7 @@ $iconFail = "<span class='ri-error-warning-fill text-danger'></span>";
                 <input id="ls-previous" class="btn btn-outline-secondary" type="button" value="<?php eT('Previous'); ?>" onclick="window.open('<?php echo $this->createUrl("installer/license"); ?>', '_top')" />
             </div>
             <div class="col-lg-4">
-                <input id="ls-check-again" class="btn btn-outline-secondary" type="button" value="<?php eT('Check again'); ?>" onclick="window.open('<?php echo $this->createUrl("installer/precheck"); ?>', '_top')" />
+                <input id="ls-check-again" class="btn btn-outline-secondary" type="button" value="<?php eT('Check again'); ?>" onclick="window.open('<?php echo $this->createUrl("installer/precheckprepare"); ?>', '_top')" />
             </div>
             <div class="col-lg-4">
 

--- a/index.php
+++ b/index.php
@@ -152,8 +152,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 *
 */
 
-ini_set("session.save_path", "sarasa");
-
 require_once BASEPATH . 'yii' . EXT;
 require_once APPPATH . 'core/LSYii_Application' . EXT;
 

--- a/index.php
+++ b/index.php
@@ -152,6 +152,8 @@ require_once __DIR__ . '/vendor/autoload.php';
 *
 */
 
+ini_set("session.save_path", "sarasa");
+
 require_once BASEPATH . 'yii' . EXT;
 require_once APPPATH . 'core/LSYii_Application' . EXT;
 


### PR DESCRIPTION
New Approach.
- Added a Precheck Prepare page where the session is seeded, for later verification of the process.
- When refreshing the precheck page, based on a cookie, we will navigate back to the prepartion page, to seed the session again.

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes session writable re-check in pre-installation step
  - Adds a new `precheckprepare` step to reset session and cookies
  - Ensures session variable is set before precheck runs

- Updates navigation and button actions to use new step
  - Modifies "Previous" and "Check again" buttons to use `precheckprepare`

- Improves reliability of pre-installation session checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InstallerController.php</strong><dd><code>Adds precheckprepare step and improves session/cookie handling</code></dd></summary>
<hr>

application/controllers/InstallerController.php

<li>Introduces <code>stepPreInstallationCheckPrepare</code> to reset session/cookie <br>before precheck<br> <li> Redirects to <code>precheckprepare</code> after license acceptance and on certain <br>conditions<br> <li> Updates session handling logic for pre-installation check<br> <li> Removes redundant session re-setting in precheck step


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4315/files#diff-bb5f8780698b532a1d44456a0d0a3cd597228b690b61adc7969a29deb8ccd77e">+29/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dbconfig_view.php</strong><dd><code>Update navigation to use precheckprepare step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/installer/dbconfig_view.php

<li>Changes "Previous" button to redirect to <code>precheckprepare</code> instead of <br><code>precheck</code>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4315/files#diff-5e9ea3330876664243bf48a61d2f01581d00a0b28f0e3519c9b183339c09b621">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>precheck_view.php</strong><dd><code>Update "Check again" to use precheckprepare step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/installer/precheck_view.php

<li>Changes "Check again" button to redirect to <code>precheckprepare</code> instead of <br><code>precheck</code>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4315/files#diff-44f27929e80679e16218976cbc9e68c5e0eec5d119eeb9e5c8277486787074f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>