### PR TITLE
AT-1663: SurveyDetail output needs to contain othersettings (with inheritance)

### DIFF
--- a/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurvey.php
+++ b/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurvey.php
@@ -165,7 +165,8 @@ class TransformerOutputSurvey extends TransformerOutputActiveRecord
                 'type' => 'int'
             ],
             'template' => true,
-            'format' => true
+            'format' => true,
+            'othersettings' => true,
         ]);
     }
 
@@ -187,6 +188,7 @@ class TransformerOutputSurvey extends TransformerOutputActiveRecord
         $survey['showQNumCode'] = $this->convertShowQNumCode(
             $data['showqnumcode']
         );
+        $survey = $this->addOtherSettings($survey);
         return $this->transformUseCaptcha($survey);
     }
 
@@ -239,6 +241,28 @@ class TransformerOutputSurvey extends TransformerOutputActiveRecord
         $survey['useCaptchaAccess'] = ($threeValues['surveyAccess'] == 'Y');
         $survey['useCaptchaRegistration'] = ($threeValues['registration'] == 'Y');
         $survey['useCaptchaSaveLoad'] = ($threeValues['saveAndLoad'] == 'Y');
+
+        return $survey;
+    }
+
+    /**
+     * Extracts code prefix settings from the othersettings JSON field and adds them to the survey array.
+     *
+     * This function parses the othersettings JSON string from the survey array and extracts
+     * specific prefix settings for questions, subquestions, and answers. These settings are then
+     * added as separate keys to the survey array for easier access.
+     *
+     * @param array $survey The survey array containing the othersettings JSON string
+     * @return array The modified survey array with extracted prefix settings
+     */
+    private function addOtherSettings($survey)
+    {
+        $otherSettingsObj = json_decode($survey['othersettings']);
+        if (is_object($otherSettingsObj)) {
+            $survey['question_code_prefix'] = $otherSettingsObj->question_code_prefix;
+            $survey['subquestion_code_prefix'] = $otherSettingsObj->subquestion_code_prefix;
+            $survey['answer_code_prefix'] = $otherSettingsObj->answer_code_prefix;
+        }
 
         return $survey;
     }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -2659,4 +2659,28 @@ class Survey extends LSActiveRecord implements PermissionInterface
         }
         return (bool)$isValid;
     }
+
+    /**
+     * Retrieves prefix othersettings as an associative array.
+     *
+     * This method collects all the survey's othersettings (prefixes for question codes,
+     * subquestion codes, and answer codes) and returns them as an array.
+     *
+     * @return array An associative array containing the other settings with keys:
+     *               'question_code_prefix', 'subquestion_code_prefix', and 'answer_code_prefix'
+     */
+    public function getOtherSettingsPrefixArray()
+    {
+        $otherSettings['question_code_prefix'] = $this->getOtherSetting(
+            'question_code_prefix'
+        );
+        $otherSettings['subquestion_code_prefix'] = $this->getOtherSetting(
+            'subquestion_code_prefix'
+        );
+        $otherSettings['answer_code_prefix'] = $this->getOtherSetting(
+            'answer_code_prefix'
+        );
+
+        return $otherSettings;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
