### PR TITLE
AT-1609: showing correct menu item on response view

### DIFF
--- a/application/extensions/admin/survey/SurveySidemenuWidget/SideMenuActiveItemMapper.php
+++ b/application/extensions/admin/survey/SurveySidemenuWidget/SideMenuActiveItemMapper.php
@@ -46,6 +46,11 @@ class SideMenuActiveItemMapper extends WhSelect2
                     App()->createUrl("admin/tokens/sa/managetokenattributes/surveyid/$this->surveyid"),
                     App()->createUrl("admin/tokens/sa/exportdialog/surveyid/$this->surveyid")
                 ]
+            ],
+            'responses'=> [
+                'urls' => [
+                    App()->createUrl("responses/browse?surveyId=$this->surveyid")
+                ]
             ]
         );
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Add missing 'responses' menu item to survey side menu
• Fix menu item highlighting for response view pages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SideMenuActiveItemMapper.php</strong><dd><code>Add responses menu item mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/admin/survey/SurveySidemenuWidget/SideMenuActiveItemMapper.php

• Add 'responses' entry to getAllowedSubItems() method<br> • Include URL <br>mapping for responses/browse page<br> • Fix menu item activation for <br>response-related pages


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4325/files#diff-405dd5fa2e5e7d49cd746ca9bcb67a6a01fa34b4cc4d2d2a1145da7bd0b498c4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>