### PR TITLE
Fixed issue #20144: [Security] Unsafe unserialize lead to remote code…

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -862,5 +862,10 @@ $config['reverseProxyIpAddresses'] = [];
 // Works together with "reverseProxyIpAddresses" setting.
 $config['reverseProxyIpHeader'] = 'HTTP_X_FORWARDED_FOR';
 
+// Allow unserialize token attribute when import or read survey object
+// Since LimeSurvey 3 : token attributes data are saved as JSON, if you use older survey file and need get token attibutes, you muts allow this settigs
+// Warning : Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this. 
+$config['allow_unserialize_attributedescriptions'] = false;
+
 return $config;
 //settings deleted

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -862,9 +862,10 @@ $config['reverseProxyIpAddresses'] = [];
 // Works together with "reverseProxyIpAddresses" setting.
 $config['reverseProxyIpHeader'] = 'HTTP_X_FORWARDED_FOR';
 
-// Allow unserialize token attribute when import or read survey object
-// Since LimeSurvey 3 : token attributes data are saved as JSON, if you use older survey file and need get token attibutes, you muts allow this settigs
-// Warning : Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this. 
+// Allow unserializing (with PHP unserialize function) token attributes when importing or reading a survey object
+// Since LimeSurvey 3, token attributes data is saved as JSON. If you use an older survey file and need to get token attributes, you must enable this setting.
+// Warning: Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this.
+// @see https://www.php.net/unserialize
 $config['allow_unserialize_attributedescriptions'] = false;
 
 return $config;

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4838,7 +4838,7 @@ function decodeTokenAttributes(string $tokenAttributeData)
         if (!App()->getConfig('allow_unserialize_attributedescriptions')) {
             return array();
         }
-        // minimal broken securisation, mantis issue #
+        // minimal broken securisation, mantis issue #20144
         $sSerialType = getSerialClass($tokenAttributeData);
         if ($sSerialType == 'array') {
             $aReturnData = unserialize($tokenAttributeData, ["allowed_classes" => false]) ?? [];

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4835,7 +4835,7 @@ function decodeTokenAttributes(string $tokenAttributeData)
         return array();
     }
     if (substr($tokenAttributeData, 0, 1) != '{' && substr($tokenAttributeData, 0, 1) != '[') {
-        if (App()->getConfig('allow_unserialize_attributedescriptions')) {
+        if (!App()->getConfig('allow_unserialize_attributedescriptions')) {
             return array();
         }
         // minimal broken securisation, mantis issue #

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4835,16 +4835,19 @@ function decodeTokenAttributes(string $tokenAttributeData)
         return array();
     }
     if (substr($tokenAttributeData, 0, 1) != '{' && substr($tokenAttributeData, 0, 1) != '[') {
+        if (App()->getConfig('allow_unserialize_attributedescriptions')) {
+            return array();
+        }
+        // minimal broken securisation, mantis issue #
         $sSerialType = getSerialClass($tokenAttributeData);
         if ($sSerialType == 'array') {
-// Safe to decode
-            $aReturnData = unserialize($tokenAttributeData) ?? [];
+            $aReturnData = unserialize($tokenAttributeData, ["allowed_classes" => false]) ?? [];
         } else {
-// Something else, might be unsafe
+            // Something else, sure it's unsafe
             return array();
         }
     } else {
-            $aReturnData = json_decode($tokenAttributeData, true) ?? [];
+        $aReturnData = json_decode($tokenAttributeData, true) ?? [];
     }
     if ($aReturnData === false || $aReturnData === null) {
         return array();


### PR DESCRIPTION
### **User description**
… execution when import survey

Dev: add ["allowed_classes" => false]
Dev: disable unserialize tokenAttributeData by default

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed unsafe unserialize vulnerability in token attributes

- Added configuration option to control unserialize behavior

- Restricted unserialize to only allow basic data types


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config-defaults.php</strong><dd><code>Add security configuration for token attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/config/config-defaults.php

<li>Added new configuration option <code>allow_unserialize_attributedescriptions</code><br> <li> Set default value to false for security<br> <li> Added warning comment about unserialize risks


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4329/files#diff-5e03946ca5722bb02d66c3f94e1b5dc444f3717ab4f3a96d44dba99eac382212">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_helper.php</strong><dd><code>Secure token attribute deserialization process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/common_helper.php

<li>Added configuration check before unserializing token data<br> <li> Restricted unserialize to only allow basic arrays with <code>allowed_classes </code><br><code>=> false</code><br> <li> Fixed code indentation and improved security comments


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4329/files#diff-532cf7aa0d91a79d219e249147cfb29e8d56cdfc691af5754a7587411c48ee0d">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>