### PR TITLE
Fixed issue #20117: Better error return in get_site_settings

### DIFF
--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -128,7 +128,7 @@ class remotecontrol_handle
                     return array('status' => 'Invalid setting');
                 }
             } else {
-                return array('status' => 'Invalid setting');
+                return array('status' => 'No permission');
             }
         } else {
             return array('status' => self::INVALID_SESSION_KEY);


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Bug fix


___

### **Description**
- Improved error message in `get_site_settings` method

- Changed permission error from 'Invalid setting' to 'No permission'


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remotecontrol_handle.php</strong><dd><code>Improve permission error message clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/remotecontrol/remotecontrol_handle.php

<li>Updated error message from 'Invalid setting' to 'No permission' when <br>user lacks superadmin permission


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4330/files#diff-22d09ac4b2de7e29721c3fc14eb239f215498a280b8c37f4b718074646f01f5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>