### PR TITLE
Fixed issue #20118: User creation : use enter key in form close dialog without create user

### DIFF
--- a/application/views/userManagement/partial/addedituser.php
+++ b/application/views/userManagement/partial/addedituser.php
@@ -136,7 +136,7 @@ Yii::app()->getController()->renderPartial(
 </div>
 
 <div class="modal-footer modal-footer-buttons" style="margin-top: 15px;">
-    <button class="btn btn-cancel" id="exitForm" data-bs-dismiss="modal">
+    <button type="button" class="btn btn-cancel" id="exitForm" data-bs-dismiss="modal">
         <?= gT('Cancel') ?>
     </button>
     <button class="btn btn-primary" id="submitForm">


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed form submission issue when pressing Enter key

- Added `type="button"` attribute to Cancel button


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addedituser.php</strong><dd><code>Fix Cancel button form submission behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/userManagement/partial/addedituser.php

<li>Added <code>type="button"</code> attribute to Cancel button to prevent form <br>submission


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4341/files#diff-980d35d2566e3cb9ca8ef6d0859a122602dad3713c157fb6d4d310939a55d518">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>