### PR TITLE
20155: Hotfix for update othersettings input

### DIFF
--- a/application/models/services/SurveyAggregateService/GeneralSettings.php
+++ b/application/models/services/SurveyAggregateService/GeneralSettings.php
@@ -446,10 +446,15 @@ class GeneralSettings
 
     private function updateOtherSettings($input, Survey $survey)
     {
-        // Update other settings, only two for now
-        $survey->setOtherSetting("question_code_prefix", $input['question_code_prefix'] ?? '');
-        $survey->setOtherSetting("subquestion_code_prefix", $input['subquestion_code_prefix'] ?? '');
-        $survey->setOtherSetting("answer_code_prefix", $input['answer_code_prefix'] ?? '');
+        if (isset($input['question_code_prefix'])) {
+            $survey->setOtherSetting("question_code_prefix", $input['question_code_prefix']);
+        }
+        if (isset($input['subquestion_code_prefix'])) {
+            $survey->setOtherSetting("subquestion_code_prefix", $input['subquestion_code_prefix']);
+        }
+        if (isset($input['answer_code_prefix'])) {
+            $survey->setOtherSetting("answer_code_prefix", $input['answer_code_prefix']);
+        }
     }
 
     private function getAdditionalLanguagesArray($input, Survey $survey)


### PR DESCRIPTION
### **User description**
https://bugs.limesurvey.org/view.php?id=20155

Hotfix for 
20155: Cannot change any settings in Presentation section
--


___

### **PR Type**
Bug fix


___

### **Description**
- Fix settings update logic in Presentation section

- Replace null coalescing with proper isset checks

- Prevent overwriting settings with empty values


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GeneralSettings.php</strong><dd><code>Fix other settings update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/services/SurveyAggregateService/GeneralSettings.php

<li>Replace null coalescing operator with <code>isset()</code> checks<br> <li> Prevent setting empty values for prefix settings<br> <li> Fix logic for updating question, subquestion, and answer code prefixes


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4343/files#diff-0843f05e7881262aef9d8f7ad7e1899375a40d69a71440d39120e09e720f166f">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>