### PR TITLE
CT-1247: Changed the return type of getDbTotalSize to int

### DIFF
--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -645,7 +645,7 @@ class UpdateForm extends CFormModel
 
     /**
      * Return the total size of the current database in MB
-     * @return string
+     * @return int
      */
     private function getDbTotalSize()
     {
@@ -657,7 +657,7 @@ class UpdateForm extends CFormModel
             $size += $row["Data_length"] + $row["Index_length"];
         }
 
-        $dbSize = number_format($size / (1024 * 1024), 2);
+        $dbSize = (int)number_format($size / (1024 * 1024), 2);
 
         return $dbSize;
     }


### PR DESCRIPTION
getDbTotalSize previously returned a string, which was compared to maxdbsizeforbackup which is an int, but that's incorrect, as

```
7>"69"
```

is evaluated to false. This PR ensures that we return an int, so at the usage when we do

```
                    if ($dbSize <= $dbChecks->dbSize) {
                        return $this->createDbBackup();
                    } else {
                        $backupDb->result = false;
                        $backupDb->message = 'db_too_big';
                    }
```

we compare them numerically.