### PR TITLE
Fixed issue #AT-1685: Saving general settings in new editor

### DIFF
--- a/application/models/services/SurveyAggregateService/GeneralSettings.php
+++ b/application/models/services/SurveyAggregateService/GeneralSettings.php
@@ -446,10 +446,24 @@ class GeneralSettings
 
     private function updateOtherSettings($input, Survey $survey)
     {
-        // Update other settings, only two for now
-        $survey->setOtherSetting("question_code_prefix", $input['question_code_prefix'] ?? '');
-        $survey->setOtherSetting("subquestion_code_prefix", $input['subquestion_code_prefix'] ?? '');
-        $survey->setOtherSetting("answer_code_prefix", $input['answer_code_prefix'] ?? '');
+        if (isset($input['question_code_prefix'])) {
+            $survey->setOtherSetting(
+                "question_code_prefix",
+                $input['question_code_prefix']
+            );
+        }
+        if (isset($input['subquestion_code_prefix'])) {
+            $survey->setOtherSetting(
+                "subquestion_code_prefix",
+                $input['subquestion_code_prefix']
+            );
+        }
+        if (isset($input['answer_code_prefix'])) {
+            $survey->setOtherSetting(
+                "answer_code_prefix",
+                $input['answer_code_prefix']
+            );
+        }
     }
 
     private function getAdditionalLanguagesArray($input, Survey $survey)


### PR DESCRIPTION
### **User description**
causes problems with new prefixes


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed prefix settings overwrite issue in survey editor

- Added conditional checks to prevent empty value assignments

- Improved code structure with proper formatting


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Input Data"] --> B["Check if prefix exists"]
  B --> C["Set prefix setting"]
  B --> D["Skip if not present"]
  C --> E["Survey Updated"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GeneralSettings.php</strong><dd><code>Add conditional validation for survey prefix settings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/services/SurveyAggregateService/GeneralSettings.php

<li>Replaced direct assignment with conditional checks for prefix settings<br> <li> Added <code>isset()</code> validation before setting survey prefix values<br> <li> Improved code formatting and structure


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4350/files#diff-0843f05e7881262aef9d8f7ad7e1899375a40d69a71440d39120e09e720f166f">+18/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>