### PR TITLE
Applied fixes on access code patterns

### DIFF
--- a/application/core/LSYii_OtherSettingsValidator.php
+++ b/application/core/LSYii_OtherSettingsValidator.php
@@ -48,11 +48,11 @@ class LSYii_OtherSettingsValidator extends CValidator
                 'message' => gT("Question code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 15 characters.")
             ],
             'subquestion_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,4}$/',
+                'pattern' => '/^$|^[A-Za-z0-9]{0,5}$/',
                 'message' => gT("Subquestion code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 5 characters.")
             ],
             'answer_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,1}$/',
+                'pattern' => '/^$|^[A-Za-z0-9]{0,2}$/',
                 'message' => gT("Answer code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 2 characters.")
             ]
         ];


### PR DESCRIPTION
### **User description**
Access code patterns had incorrect upper limits, particularly subquestion_code_prefix and answer_code_prefix was reportedly wrong. This PR copes with this issue


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed regex patterns for access code prefixes

- Corrected maximum length validation for subquestion and answer codes


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Validation Rules"] --> B["Subquestion Prefix"]
  A --> C["Answer Prefix"]
  B --> D["Fixed: 0-4 → 0-5 chars"]
  C --> E["Fixed: 0-1 → 0-2 chars"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LSYii_OtherSettingsValidator.php</strong><dd><code>Fix access code prefix validation limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/core/LSYii_OtherSettingsValidator.php

<li>Updated <code>subquestion_code_prefix</code> regex from <code>{0,4}</code> to <code>{0,5}</code><br> <li> Updated <code>answer_code_prefix</code> regex from <code>{0,1}</code> to <code>{0,2}</code><br> <li> Fixed validation patterns to match documented maximum lengths


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4351/files#diff-6d40dbab6da27b379d335752bbfc528ad80afe06ac5e41193e7abfac16480c58">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>