### PR TITLE
Dev/access code fix

### DIFF
--- a/application/core/LSYii_OtherSettingsValidator.php
+++ b/application/core/LSYii_OtherSettingsValidator.php
@@ -48,11 +48,11 @@ class LSYii_OtherSettingsValidator extends CValidator
                 'message' => gT("Question code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 15 characters.")
             ],
             'subquestion_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,4}$/',
+                'pattern' => '/^$|^[A-Za-z0-9]{0,5}$/',
                 'message' => gT("Subquestion code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 5 characters.")
             ],
             'answer_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,1}$/',
+                'pattern' => '/^$|^[A-Za-z0-9]{0,2}$/',
                 'message' => gT("Answer code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 2 characters.")
             ]
         ];

--- a/application/core/LSYii_OtherSettingsValidator.php
+++ b/application/core/LSYii_OtherSettingsValidator.php
@@ -48,11 +48,11 @@ class LSYii_OtherSettingsValidator extends CValidator
                 'message' => gT("Question code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 15 characters.")
             ],
             'subquestion_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,5}$/',
+                'pattern' => '/^[A-Za-z][A-Za-z0-9]{0,4}$/',
                 'message' => gT("Subquestion code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 5 characters.")
             ],
             'answer_code_prefix' => [
-                'pattern' => '/^$|^[A-Za-z0-9]{0,2}$/',
+                'pattern' => '/^[A-Za-z][A-Za-z0-9]{0,1}$/',
                 'message' => gT("Answer code prefix must start with a letter and can only contain alphanumeric characters. Maximum length is 2 characters.")
             ]
         ];


### PR DESCRIPTION
### **User description**
Applied changes to make it comply to the format


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed regex patterns for code prefixes validation

- Enforced letter-first requirement for subquestion and answer codes

- Removed empty string allowance from validation patterns


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old Pattern"] --> B["Allow Empty OR Alphanumeric"]
  C["New Pattern"] --> D["Require Letter First + Alphanumeric"]
  B --> E["Validation Issue"]
  D --> F["Proper Validation"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LSYii_OtherSettingsValidator.php</strong><dd><code>Fix code prefix validation regex patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/core/LSYii_OtherSettingsValidator.php

<li>Updated <code>subquestion_code_prefix</code> regex to require letter as first <br>character<br> <li> Updated <code>answer_code_prefix</code> regex to require letter as first character<br> <li> Removed empty string allowance from both patterns


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4352/files#diff-6d40dbab6da27b379d335752bbfc528ad80afe06ac5e41193e7abfac16480c58">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for code prefix fields to require starting with a letter character. Code prefixes for subquestions and answers can no longer be empty or begin with numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->