### PR TITLE
LE-280: Fixed timings id discrepancy

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1939,7 +1939,7 @@ function copyFromOneTableToTheOther($source, $destination, $preserveIDs = false)
         $columns[] = Yii::app()->db->quoteColumnName($rawResult['cname']);
     }
     $timings = count($columns) ? Yii::app()->db->createCommand("INSERT INTO " . Yii::app()->db->quoteTableName($destination) . "(" . implode(",", $columns) . ") SELECT " . implode(",", $columns) . " FROM " . Yii::app()->db->quoteTableName($source))->execute() : 0;
-    if (!(($preserveIDs) || (strpos($destination, 'timings') === false))) {
+    if ((!$preserveIDs) && (strpos($destination, 'timings') !== false)) {
         $oldResponsesTable = str_replace('_timings', '', $source);
         $command = "
             SELECT t1.id as rid, t2.id as tid

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1926,9 +1926,9 @@ function copyFromOneTableToTheOther($source, $destination, $preserveIDs = false)
         from information_schema.columns a
         join information_schema.columns b
         on {$filter} and
-           a.TABLE_NAME = '" . $destination . "' and
-           b.TABLE_NAME = '" . $source . "' and
-           a.COLUMN_NAME = b.COLUMN_NAME
+          a.TABLE_NAME = '" . $destination . "' and
+          b.TABLE_NAME = '" . $source . "' and
+          a.COLUMN_NAME = b.COLUMN_NAME
     ";
     if (!$preserveIDs) {
         $command .= " where a.COLUMN_NAME not in ('id', 'tid')";
@@ -1938,7 +1938,40 @@ function copyFromOneTableToTheOther($source, $destination, $preserveIDs = false)
     foreach ($rawResults as $rawResult) {
         $columns[] = Yii::app()->db->quoteColumnName($rawResult['cname']);
     }
-    return count($columns) ? Yii::app()->db->createCommand("INSERT INTO " . Yii::app()->db->quoteTableName($destination) . "(" . implode(",", $columns) . ") SELECT " . implode(",", $columns) . " FROM " . Yii::app()->db->quoteTableName($source))->execute() : 0;
+    $timings = count($columns) ? Yii::app()->db->createCommand("INSERT INTO " . Yii::app()->db->quoteTableName($destination) . "(" . implode(",", $columns) . ") SELECT " . implode(",", $columns) . " FROM " . Yii::app()->db->quoteTableName($source))->execute() : 0;
+    if (!(($preserveIDs) || (strpos($destination, 'timings') === false))) {
+        $oldResponsesTable = str_replace('_timings', '', $source);
+        $command = "
+            SELECT t1.id as rid, t2.id as tid
+            FROM {$oldResponsesTable} t1
+            LEFT JOIN {$source} t2
+            ON t1.id = t2.id
+            order by t1.id
+        ";
+        $newResponsesTable = str_replace('_timings', '', $destination);
+        $rawResults = Yii::app()->db->createCommand($command)->queryAll();
+        $offset = 0;
+        foreach ($rawResults as $rawResult) {
+            if (intval($rawResult['tid']) > 0) {
+                $responseidresult = Yii::app()->db->createCommand()
+                ->select('id ')
+                ->from($newResponsesTable)
+                ->limit(1, $offset)
+                ->query()
+                ->readAll();
+                $newID = $responseidresult[0]['id'];
+                $oldID = $offset + 1;
+                $command = "
+                    UPDATE {$destination}
+                    SET id = {$newID}
+                    WHERE id = {$oldID}
+                ";
+                Yii::app()->db->createCommand($command)->execute();
+            }
+            $offset++;
+        }
+    }
+    return $timings;
 }
 
 /**


### PR DESCRIPTION
### **User description**
How to test:

1. Activate a survey with timings
2. Create fill it at least twice
3. Remove the first
4. Deactivate
5. Activate
6. Check response and timings ids

Expectation: Consistency


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed timing ID discrepancy in survey data copying

- Added ID synchronization logic for timings table

- Ensured consistency between response and timing IDs


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Source Table"] --> B["Copy Data"]
  B --> C["Check Timings Table"]
  C --> D["Map Old/New IDs"]
  D --> E["Update Timing IDs"]
  E --> F["Synchronized Tables"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>import_helper.php</strong><dd><code>Fix timing ID synchronization in table copying</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/admin/import_helper.php

<li>Added ID synchronization logic for timings tables<br> <li> Implemented mapping between old and new response IDs<br> <li> Added conditional update logic to maintain ID consistency<br> <li> Minor formatting improvements to SQL query indentation


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4357/files#diff-4033daa1797e130ed555f4b345ed46387aa79c5eb457adf216ea049b648e5976">+37/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>