### PR TITLE
Fixed issue #20136: Token attributes logic with anonymous survey

### DIFF
--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1883,7 +1883,7 @@ function display_first_page($thissurvey, $aSurveyInfo)
     $thissurvey                 = $aSurveyInfo;
     $thissurvey['aNavigator']   = getNavigatorDatas();
     LimeExpressionManager::StartProcessingPage();
-    LimeExpressionManager::StartProcessingGroup(-1, $thissurvey['anonymized'] != "Y", $surveyid); // start on welcome page
+    LimeExpressionManager::StartProcessingGroup(-1, $thissurvey['anonymized'] != "N", $surveyid); // start on welcome page
 
     // WHY HERE ?????
     $_SESSION['survey_' . $surveyid]['LEMpostKey'] = mt_rand();


### PR DESCRIPTION
### **User description**
Dev: use same logic than elsewher
Dev: 3.X existing bug


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed token attributes logic for anonymous surveys

- Corrected LimeExpressionManager parameter to respect anonymization setting

- Added missing PHPDoc parameters for display_first_page function


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Anonymous Survey Check"] --> B["LimeExpressionManager.StartProcessingGroup"]
  B --> C["Token Attributes Logic"]
  C --> D["Welcome Page Display"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend_helper.php</strong><dd><code>Fix anonymous survey token logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/frontend_helper.php

<li>Fixed LimeExpressionManager parameter to use <code>$thissurvey['anonymized'] </code><br><code>!= "Y"</code> instead of hardcoded <code>false</code><br> <li> Added missing PHPDoc parameters for <code>$thissurvey</code> and <code>$aSurveyInfo</code>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4358/files#diff-4b5f6522204521a4e24e45dd60c31295cdc7298b0174dd96cf6c1e7d0334f4ff">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>