### PR TITLE
Fixed issue #19894: Calling "__tostring" method on a "SimpleXMLElement

### DIFF
--- a/themes/survey/fruity_twentythree/views/layout_global.twig
+++ b/themes/survey/fruity_twentythree/views/layout_global.twig
@@ -74,7 +74,7 @@
     {{ include('./subviews/header/head.twig') }}
     {% endblock %}
     <body class=" {{ aSurveyInfo.class.body }} font-{{  aSurveyInfo.options.font }} lang-{{aSurveyInfo.languagecode}} {{aSurveyInfo.surveyformat}} {% if( aSurveyInfo.options.brandlogo == "on") %}brand-logo{%endif%}" {{ aSurveyInfo.attr.body }} data-thememode="{{ aSurveyInfo.options.thememode ? aSurveyInfo.options.thememode : 'light' }}">
-        {{ dump(aSurveyInfo) }}
+
         {# Notice if emcache is on or off, used by tests. #}
         {% if aSurveyInfo.emcache %}
             <span style="display: none;" id="__emcache_debug" value="on"></span>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Allow `__toString` method calls on `SimpleXMLElement` objects in Twig templates

- Add `TemplateConfiguration` `__toString` method to allowed methods list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Twig Template"] --> B["SimpleXMLElement Object"]
  B -- "__toString method call" --> C["Previously Blocked"]
  C --> D["Now Allowed"]
  E["TemplateConfiguration"] -- "__toString method" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>internal.php</strong><dd><code>Allow __toString methods in Twig configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/config/internal.php

<ul><li>Added <code>TemplateConfiguration</code> class with <code>__toString</code> method to allowed <br>methods<br> <li> Added <code>SimpleXMLElement</code> class with <code>__toString</code> method to allowed methods<br> <li> Extended Twig template security configuration to permit these method <br>calls</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4369/files#diff-8ec9af025be75bc6b064d752cebe2a38352c69ea63f4f87fb75a0d555319aa41">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

