### PR TITLE
bug-20183: Fixed the closed and opened access mode appearance

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -141,6 +141,7 @@ use LimeSurvey\PluginManager\PluginEvent;
  * @property bool $showsurveypolicynotice Show the security notice
  * @property bool $isNoKeyboard Show on-screen keyboard
  * @property bool $isAllowEditAfterCompletion Allow multiple responses or update responses with one token
+ * @property string $access_mode Whether the access mode is open (O) or closed (C), if O token-based participation may be supported, if C, it's enforced
  * @property SurveyLanguageSetting $defaultlanguage
  * @property SurveysGroups $surveygroup
  * @property boolean $isDateExpired Whether survey is expired depending on the current time and survey configuration status

--- a/application/models/SurveyActivator.php
+++ b/application/models/SurveyActivator.php
@@ -488,6 +488,6 @@ class SurveyActivator
      */
     public function isCloseAccessMode()
     {
-        return $this->survey->isAllowRegister || tableExists('tokens_' . $this->survey->sid);
+        return $this->survey->access_mode === 'C';
     }
 }

--- a/application/views/surveyAdministration/surveyActivation/_activateSurveyOptions.php
+++ b/application/views/surveyAdministration/surveyActivation/_activateSurveyOptions.php
@@ -155,9 +155,6 @@ $optionsOnOff = ['Y' => gT('On'), 'N' => gT('Off')];
     </div>
 </div>
 
-<?php
-if (!$closeAccessMode) {
-    ?>
     <div class="row sub_footer">
         <div class="col-12 mt-5 mb-3">
             <div class="sub_footer_border"></div>
@@ -181,9 +178,6 @@ if (!$closeAccessMode) {
         </div>
     </div>
     <?php
-} else {  //transmit input value for "openAccessMode", it's needed to take further steps in action ?>
-    <input type="hidden" name="openAccessMode" value="N">
-<?php }
 ?>
 
 <input type="hidden" name="surveyId" value="<?php echo $aSurveysettings['sid']; ?>">


### PR DESCRIPTION
The old UI has an open and closed access mode chooser on the activation screen which, due to the change on what open and closed access mode means did not always appear, as it was earlier testing whether allow public registration was true or the tokens table existed. Instead, we need to check for the value of access_mode