### PR TITLE
Fixed issue #20180: Double escaping bug

### DIFF
--- a/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
+++ b/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
@@ -46,7 +46,7 @@ class AdvancedSettingWidget extends CWidget
         // Translate options
         if (!empty($this->setting['options'])) {
             foreach ($this->setting['options'] as $optionValue => $optionText) {
-                $this->setting['options'][$optionValue] = is_string($optionText) ? gT($optionText) : $optionText;
+                $this->setting['options'][$optionValue] = is_string($optionText) ? gT($optionText, 'unescaped') : $optionText;
             }
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix

Comment:

We have identified some double gt()
Widget and View

Ex views: 
application\extensions\AdvancedSettingWidget\views\singleselect.php
application\extensions\AdvancedSettingWidget\views\buttongroup.php

For thhese already done on widget. 
Not sure if we should do it on the widget or on the view.

https://github.com/LimeSurvey/LimeSurvey/pull/2456
Here Denis said on the Widget, but I am having second thoughts now.
If implemented on the view, there will be more flexibility.

___

### **Description**
- Fixed double escaping bug in AdvancedSettingWidget options translation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Translation Function"] -- "Add 'unescaped' parameter" --> B["Fixed Options Translation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdvancedSettingWidget.php</strong><dd><code>Fix double escaping in options translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php

<ul><li>Added 'unescaped' parameter to <code>gT()</code> function call for options <br>translation<br> <li> Prevents double escaping of translated option text strings</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4374/files#diff-037352fd9b3c12af0ff6f3d4d27369ea8c38c0c752dfbc0f28df46363835f2ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

