### PR TITLE
AT-1708: changed back the default question type to "Long text"

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -2833,7 +2833,7 @@ class SurveyAdministrationController extends LSBaseController
         $oQuestion = new Question();
         $oQuestion->sid = $iSurveyID;
         $oQuestion->gid = $iGroupID;
-        $oQuestion->type = Question::QT_M_MULTIPLE_CHOICE;
+        $oQuestion->type = Question::QT_T_LONG_FREE_TEXT;
         $oQuestion->title = 'Q00';
         $oQuestion->mandatory = 'N';
         $oQuestion->relevance = '1';


### PR DESCRIPTION
### **User description**
Dev: changed back the default question type to "Long text"


___

### **PR Type**
Bug fix


___

### **Description**
- Changed default question type from multiple choice to long text


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple Choice Question"] -- "reverted to" --> B["Long Text Question"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyAdministrationController.php</strong><dd><code>Reverted default question type to long text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/SurveyAdministrationController.php

<ul><li>Modified <code>createSampleQuestion</code> method to use <code>QT_T_LONG_FREE_TEXT</code> <br>instead of <code>QT_M_MULTIPLE_CHOICE</code></ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4377/files#diff-f8c970472fc354612651d57fa98027ecd114f95cf42e4594e0b0b61340ec217f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

