### PR TITLE
bug-20193: Added start from scratch even for deactivated closed survey

### DIFF
--- a/tests/functional/backend/QuestionGroupEditorTest.php
+++ b/tests/functional/backend/QuestionGroupEditorTest.php
@@ -94,7 +94,6 @@ class QuestionGroupEditorTest extends TestBaseClassWeb
             $germanTab->click();
 
             // Edit group name in German
-            sleep(2);
             $groupNameGerman = self::$webDriver->wait(10)->until(WebDriverExpectedCondition::presenceOfElementLocated(WebDriverBy::id('group_name_de')));
             $groupNameGerman->clear()->sendKeys("German name");
 


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Bug fix


___

### **Description**
- Added "Start from scratch" button for deactivated closed surveys

- Extended functionality to surveys with closed access mode or registration allowed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Survey Token View"] --> B["Check Survey State"]
  B --> C["Active Survey"]
  B --> D["Deactivated Closed/Registration Survey"]
  C --> E["Show Restore & Start from Scratch"]
  D --> F["Show Start from Scratch Only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>surveyParticipantView.php</strong><dd><code>Enable start from scratch for deactivated surveys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/views/admin/token/surveyParticipantView.php

<ul><li>Added conditional block for deactivated surveys with closed access or <br>registration enabled<br> <li> Implemented "Start from scratch" button functionality for these survey <br>types<br> <li> Used inline form styling to maintain UI consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4381/files#diff-88b9c567a016f4b684f2b3ee3d537b801e9f4491d5ce98588ea2726c39df1601">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

