### PR TITLE
Update menu item label to use translation function for consistency

### DIFF
--- a/application/core/SurveyCommonAction.php
+++ b/application/core/SurveyCommonAction.php
@@ -516,7 +516,7 @@ class SurveyCommonAction extends CAction
         $menuItemHeader = [
             'isDivider' => false,
             'isSmallText' => true,
-            'label' => 'Create new',
+            'label' => gT('Create new'),
             'href' => '#',
             'iconClass' => 'ri-add-line',
         ];


### PR DESCRIPTION
Fixed issue #20209: Use translation function on Create new label in new menu.
