### PR TITLE
LE-344: Ensured that register is not supported at closed access mode

### DIFF
--- a/application/controllers/survey/SurveyIndex.php
+++ b/application/controllers/survey/SurveyIndex.php
@@ -93,6 +93,7 @@ class SurveyIndex extends CAction
         // collect all data in this method to pass on later
         $redata = compact(array_keys(get_defined_vars()));
         $redata['popuppreview'] = Yii::app()->request->getParam('popuppreview', false);
+        $redata['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
 
         $canPreviewSurvey = $this->canUserPreviewSurvey($surveyid);
 
@@ -514,6 +515,7 @@ class SurveyIndex extends CAction
             //$oTemplate->registerAssets();
             $thissurvey['include_content'] = 'load';
             $thissurvey['trackUrlPageName'] = 'load';
+            $thissurvey['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
             Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($surveyid), 'aSurveyInfo' => $thissurvey), false);
         }
 

--- a/application/helpers/SurveyRuntimeHelper.php
+++ b/application/helpers/SurveyRuntimeHelper.php
@@ -617,6 +617,7 @@ class SurveyRuntimeHelper
         }
 
         $this->aSurveyInfo['include_content'] = 'main';
+        $this->aSurveyInfo['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
 
         Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array(
             'oSurvey' => Survey::model()->findByPk($this->iSurveyid),
@@ -1196,6 +1197,7 @@ class SurveyRuntimeHelper
 
                 $this->aSurveyInfo['include_content'] = 'save';
                 $this->aSurveyInfo['trackUrlPageName'] = 'save';
+                $this->aSurveyInfo['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
                 Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($this->iSurveyid), 'aSurveyInfo' => $this->aSurveyInfo), false);
             } else {
                 // Intentional retest of all conditions to be true, to make sure we do have tokens and surveyid
@@ -1254,6 +1256,7 @@ class SurveyRuntimeHelper
             if (!empty($aResult['aSaveErrors'])) {
                 $this->aSurveyInfo['aSaveForm'] = $cSave->getSaveFormDatas($this->aSurveyInfo['sid']);
                 $this->aSurveyInfo['include_content'] = 'save';
+                $this->aSurveyInfo['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
                 Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($this->iSurveyid), 'aSurveyInfo' => $this->aSurveyInfo), false);
             }
 
@@ -1422,6 +1425,7 @@ class SurveyRuntimeHelper
             if (!$surveyActive) {
                 $this->aSurveyInfo['include_content'] = 'submit_preview';
             }
+            $this->aSurveyInfo['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
             $sHtml = Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => $oSurvey, 'aSurveyInfo' => $this->aSurveyInfo), true);
             $oTemplate = Template::getLastInstance();
             // kill survey session after doing template : didn't work for all var, but for EM core var : it's OK.
@@ -1603,6 +1607,7 @@ class SurveyRuntimeHelper
 
             $this->aSurveyInfo['surveyUrl'] = $restarturl;
             $this->aSurveyInfo['include_content'] = 'clearall';
+            $this->aSurveyInfo['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
             Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($this->iSurveyid), 'aSurveyInfo' => $this->aSurveyInfo), false);
         }
     }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1283,7 +1283,7 @@ function testIfTokenIsValid(array $subscenarios, array $thissurvey, array $aEnte
         if (!$subscenarios['tokenValid']) {
             //Check if there is a clienttoken set
             if ((!isset($clienttoken) || $clienttoken == "")) {
-                if (isset($thissurvey) && $thissurvey['allowregister'] == "Y") {
+                if (isset($thissurvey) && $thissurvey['allowregister'] == "Y" && (Yii::app()->request->getParam('noregister', 'true') !== 'true')) {
                     $renderToken = 'register';
                 } else {
                     $renderToken = 'main';

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1283,7 +1283,7 @@ function testIfTokenIsValid(array $subscenarios, array $thissurvey, array $aEnte
         if (!$subscenarios['tokenValid']) {
             //Check if there is a clienttoken set
             if ((!isset($clienttoken) || $clienttoken == "")) {
-                if (isset($thissurvey) && $thissurvey['allowregister'] == "Y" && (Yii::app()->request->getParam('noregister', 'true') !== 'true')) {
+                if (isset($thissurvey) && $thissurvey['allowregister'] == "Y" && (Yii::app()->request->getParam('noregister', 'false') !== 'true')) {
                     $renderToken = 'register';
                 } else {
                     $renderToken = 'main';

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1905,7 +1905,7 @@ function display_first_page($thissurvey, $aSurveyInfo)
     $thissurvey['attr']['welcomecontainer'] = $thissurvey['attr']['surveyname'] = $thissurvey['attr']['description'] = $thissurvey['attr']['welcome'] = $thissurvey['attr']['questioncount'] = '';
 
     $thissurvey['include_content'] = 'firstpage';
-    $thissurvey['noregister'] = (Yii::app()->request->getParam('noregister', 'true') === 'true');
+    $thissurvey['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
 
     Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($surveyid), 'aSurveyInfo' => $thissurvey), false);
 }
@@ -2013,6 +2013,7 @@ function getMove()
     if ($move == 'default') {
         $surveyid = Yii::app()->getConfig('surveyID');
         $thissurvey = getsurveyinfo($surveyid);
+        $thissurvey['noregister'] = (Yii::app()->request->getParam('noregister', 'false') === 'true');
         $iSessionStep = $_SESSION['survey_' . $surveyid]['step'] ?? false;
         $iSessionTotalSteps = $_SESSION['survey_' . $surveyid]['totalsteps'] ?? false;
         if ($iSessionStep && ($iSessionStep == $iSessionTotalSteps) || $thissurvey['format'] == 'A') {

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -1905,6 +1905,7 @@ function display_first_page($thissurvey, $aSurveyInfo)
     $thissurvey['attr']['welcomecontainer'] = $thissurvey['attr']['surveyname'] = $thissurvey['attr']['description'] = $thissurvey['attr']['welcome'] = $thissurvey['attr']['questioncount'] = '';
 
     $thissurvey['include_content'] = 'firstpage';
+    $thissurvey['noregister'] = (Yii::app()->request->getParam('noregister', 'true') === 'true');
 
     Yii::app()->twigRenderer->renderTemplateFromFile("layout_global.twig", array('oSurvey' => Survey::model()->findByPk($surveyid), 'aSurveyInfo' => $thissurvey), false);
 }

--- a/application/libraries/Api/Command/V1/SurveyTemplate.php
+++ b/application/libraries/Api/Command/V1/SurveyTemplate.php
@@ -247,7 +247,7 @@ class SurveyTemplate implements CommandInterface
     {
         $root = $this->getRootUrl();
         $token = ($this->token ? "&token=" . $this->token : "");
-        return $root . "/index.php/{$this->surveyId}?lang={$this->language}" . ($this->fillToken ? "&filltoken=true" : "") . $token;
+        return $root . "/index.php/{$this->surveyId}?lang={$this->language}&noregister=true&" . ($this->fillToken ? "&filltoken=true" : "") . $token;
     }
 
     /**
@@ -326,13 +326,8 @@ class SurveyTemplate implements CommandInterface
             $bos[] = $dom->saveHTML($bottomScript);
         }
         $bos = implode("SEPARATOR", $bos);
-        $registration = $xpath->query("//*[@id='register_firstname']");
-        $isRegistration = false;
-        foreach ($registration as $r) {
-            $isRegistration = true;
-        }
         return [
-            'form' => $isRegistration ?  "<form id='limesurvey' class='register'><a class='register' target='_blank'></a></form>" : $form,
+            'form' => $form,
             'hiddenInputs' => $hiddenInputs,
             'head' => $h,
             'beginScripts' => $bes,

--- a/assets/scripts/survey-embed.js
+++ b/assets/scripts/survey-embed.js
@@ -191,6 +191,16 @@ if (typeof lsFormIndex === "undefined") {
             });
         }
 
+        let tokenRedirects = [...surveyRoot.querySelectorAll(".nav-link.ls-link-action")]
+          .filter((el) => el.href.indexOf("filltoken") >= 0);
+        if (tokenRedirects.length) {
+            let tokenRedirect = tokenRedirects[0];
+            tokenRedirect.addEventListener("click", function(evt) {
+                evt.preventDefault();
+                window["lssubmit" + lsFormIndex](lang, true);
+            });
+        }
+
         const headScriptsList = head.split("SEPARATOR");
         const beginScriptList = beginScripts.split("SEPARATOR");
         const bottomScriptsList = bottomScripts.split("SEPARATOR");

--- a/assets/scripts/survey-embed.js
+++ b/assets/scripts/survey-embed.js
@@ -13,7 +13,7 @@ if (typeof lsFormIndex === "undefined") {
     const referer =
         window.location.protocol + "//" + window.location.host + "/";
     function getRequestUrl() {
-        return `${rootUrl}/index.php/rest/v1/survey-template/${surveyId}?lang=${lang}`;
+        return `${rootUrl}/index.php/rest/v1/survey-template/${surveyId}?lang=${lang}&noregister=true`;
     }
     let pageNumber = 0;
 
@@ -189,31 +189,6 @@ if (typeof lsFormIndex === "undefined") {
                 event.preventDefault();
                 window["lssubmit" + lsFormIndex](languageSelector.value);
             });
-        }
-
-        function register() {
-            window.open(`${rootUrl}/index.php/${surveyId}?lang=${lang}&filltoken=true`, "", "popup");
-            let token = prompt("token");
-            if (token) {
-                window["lssubmit" + lsFormIndex](lang, true, token);
-            }
-        }
-        let tokenRedirects = [...surveyRoot.querySelectorAll(".nav-link.ls-link-action")]
-          .filter((el) => el.href.indexOf("filltoken") >= 0);
-        if (tokenRedirects.length) {
-            let tokenRedirect = tokenRedirects[0];
-            tokenRedirect.addEventListener("click", function(evt) {
-                evt.preventDefault();
-                if (tokenRedirect.classList.contains("token")) {
-                    window["lssubmit" + lsFormIndex](lang, true);
-                } else {
-                    register();
-                }
-            });
-        }
-
-        if (form.classList.contains('register')) {
-            register();
         }
 
         const headScriptsList = head.split("SEPARATOR");

--- a/themes/survey/fruity_twentythree/views/subviews/navigation/save_links.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/navigation/save_links.twig
@@ -29,8 +29,8 @@ via survey configuration, at start page, when survey is completed, etc
     <!-- Fill token button -->
     <li class="nav-item ls-no-js-hidden">
         <a href="{{ aSurveyInfo.surveyUrl }}?lang=en&filltoken=true"
-            class="nav-link ls-link-action {% if aSurveyInfo.allowregister == "Y" %}register{% else %}token{% endif %}">
-            {% if aSurveyInfo.allowregister == "Y" %}
+            class="nav-link ls-link-action {% if aSurveyInfo.allowregister == "Y" and not aSurveyInfo.noregister %}register{% else %}token{% endif %}">
+            {% if aSurveyInfo.allowregister == "Y" and not aSurveyInfo.noregister %}
                 {{ gT("Register") }}
             {% else %}
                 {{ gT("Enter access code") }}

--- a/themes/survey/vanilla/views/subviews/navigation/save_links.twig
+++ b/themes/survey/vanilla/views/subviews/navigation/save_links.twig
@@ -31,8 +31,8 @@ via survey configuration, at start page, when survey is completed, etc
     <!-- Fill token button -->
     <li class="nav-item ls-no-js-hidden">
         <a href="{{ aSurveyInfo.surveyUrl }}?lang=en&filltoken=true"
-            class="nav-link ls-link-action {% if aSurveyInfo.allowregister == "Y" %}register{% else %}token{% endif %}">
-            {% if aSurveyInfo.allowregister == "Y" %}
+            class="nav-link ls-link-action {% if aSurveyInfo.allowregister == "Y" and not aSurveyInfo.noregister %}register{% else %}token{% endif %}">
+            {% if aSurveyInfo.allowregister == "Y" and not aSurveyInfo.noregister %}
                 {{ gT("Register") }}
             {% else %}
                 {{ gT("Enter access code") }}


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Enhancement


___

### **Description**
- Disable user registration in embedded survey mode

- Remove registration-related JavaScript functionality from embed script

- Add `noregister=true` parameter to API requests

- Simplify survey template response handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Embed Script"] -- "adds noregister=true" --> B["API Request"]
  B -- "prevents registration" --> C["Survey Template"]
  C -- "removes registration form" --> D["Simplified Response"]
  A -- "removes registration JS" --> E["Clean Embed Experience"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>survey-embed.js</strong><dd><code>Remove registration functionality from embed script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/scripts/survey-embed.js

<ul><li>Add <code>noregister=true</code> parameter to survey template API request<br> <li> Remove entire <code>register()</code> function and related token handling<br> <li> Remove registration form detection and event listeners<br> <li> Simplify embed script by removing registration-related code</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4412/files#diff-20ae70655b37367f01712cbf56dbec6ca26f41f4011328af07cfed5465694840">+1/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frontend_helper.php</strong><dd><code>Add noregister parameter check in token validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/frontend_helper.php

<ul><li>Add check for <code>noregister</code> parameter in token validation<br> <li> Prevent registration render when <code>noregister=true</code> is set</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4412/files#diff-4b5f6522204521a4e24e45dd60c31295cdc7298b0174dd96cf6c1e7d0334f4ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SurveyTemplate.php</strong><dd><code>Disable registration in survey template API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyTemplate.php

<ul><li>Add <code>noregister=true</code> parameter to survey source URL<br> <li> Remove registration form detection logic<br> <li> Simplify survey result response by removing registration checks</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4412/files#diff-0e15de7b4b842eaf111eacf50dfe12629be56b0d8cd87181966a3b55b4aa6673">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

