### PR TITLE
LE-345: add check to prevent API error when tokens table is missing

### DIFF
--- a/application/libraries/Api/Command/V1/SurveyTemplate.php
+++ b/application/libraries/Api/Command/V1/SurveyTemplate.php
@@ -202,16 +202,18 @@ class SurveyTemplate implements CommandInterface
      */
     private function validateAccessToken()
     {
-        $tokenFound = \Token::model($this->surveyId)->findByAttributes(['token' => $this->token]);
-        $step = \Yii::app()->request->getParam('LSEMBED-move', '');
-        if ($this->token && !$tokenFound && $step !== 'movesubmit') {
-            return $this->responseFactory->makeErrorNotFound(
-                (new ResponseDataError(
-                    'TOKEN_NOT_FOUND',
-                    gT("The access code you have provided is either not valid, or has already been used.")
-                )
-                )->toArray()
-            );
+        if ($this->survey->hasTokens()) {
+            $tokenFound = \Token::model($this->surveyId)->findByAttributes(['token' => $this->token]);
+            $step = \Yii::app()->request->getParam('LSEMBED-move', '');
+            if ($this->token && !$tokenFound && $step !== 'movesubmit') {
+                return $this->responseFactory->makeErrorNotFound(
+                    (new ResponseDataError(
+                        'TOKEN_NOT_FOUND',
+                        gT("The access code you have provided is either not valid, or has already been used.")
+                    )
+                    )->toArray()
+                );
+            }
         }
         return false;
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add check to prevent API error when tokens table is missing

- Wrap token validation logic with `hasTokens()` condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validateAccessToken()"] --> B["hasTokens() check"]
  B --> C["Token validation logic"]
  B --> D["Skip validation if no tokens"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyTemplate.php</strong><dd><code>Add tokens table existence check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyTemplate.php

<ul><li>Added <code>hasTokens()</code> check before token validation<br> <li> Wrapped existing token lookup and error handling logic<br> <li> Prevents API errors when tokens table doesn't exist</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4422/files#diff-0e15de7b4b842eaf111eacf50dfe12629be56b0d8cd87181966a3b55b4aa6673">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

