### PR TITLE
Fixed issue #20218: PDF export of the statistics tool does not take the setting 'Show text responses inline' into account

### DIFF
--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -2377,7 +2377,7 @@ class statistics_helper
                     . gT("Browse") . "' id='$sColumnName' />";
                 }
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'pdf') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'pdf') {
                     $headPDF2 = array();
                     $headPDF2[] = array(gT("ID"), gT("Response"));
                     $result2 = $this->_listcolumn($surveyid, $sColumnName);
@@ -2387,7 +2387,7 @@ class statistics_helper
                     }
                 }
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'xls') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'xls') {
                     $headXLS = array();
                     $headXLS[] = array(gT("ID"), gT("Response"));
 
@@ -2427,7 +2427,7 @@ class statistics_helper
                 $bAnswer = true; // For view
                 $bSum    = false;
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'pdf') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'pdf') {
                     $headPDF2 = array();
                     $headPDF2[] = array(gT("ID"), gT("Response"));
                     $tablePDF2 = array();

--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -1610,7 +1610,7 @@ class userstatistics_helper
                     . gT("Browse") . "' id='$sColumnName' />";
                 }
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'pdf') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'pdf') {
                     $headPDF2 = array();
                     $headPDF2[] = array(gT("ID"), gT("Response"));
                     $tablePDF2 = array();
@@ -1621,7 +1621,7 @@ class userstatistics_helper
                     }
                 }
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'xls') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'xls') {
                     $headXLS = array();
                     $tableXLS = array();
                     $headXLS[] = array(gT("ID"), gT("Response"));
@@ -1664,7 +1664,7 @@ class userstatistics_helper
                 . "<strong>" . gT("Percentage") . "</strong></th>\n"
                 . "\t</tr></thead>\n";
 
-                if ($browse === true && isset($_POST['showtextinline']) && $outputType == 'pdf') {
+                if ($browse === true && !empty($_POST['showtextinline']) && $outputType == 'pdf') {
                     $headPDF2 = array();
                     $headPDF2[] = array(gT("ID"), gT("Response"));
                     $tablePDF2 = array();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed PDF export not respecting 'Show text responses inline' setting

- Changed `isset()` to `!empty()` for proper boolean validation

- Applied fix to both admin and user statistics helpers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["POST parameter check"] -- "changed from isset()" --> B["!empty() validation"]
  B --> C["PDF export respects setting"]
  B --> D["XLS export also fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statistics_helper.php</strong><dd><code>Fix POST parameter validation for inline text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/admin/statistics_helper.php

<ul><li>Changed <code>isset($_POST['showtextinline'])</code> to <br><code>!empty($_POST['showtextinline'])</code> in three locations<br> <li> Fixed condition checks for PDF and XLS export inline text display</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4423/files#diff-ae3862a99789eda019e0f1bbec2a94c328502e2998d4f29ee036226cef41e3c1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>userstatistics_helper.php</strong><dd><code>Fix POST parameter validation for inline text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/userstatistics_helper.php

<ul><li>Changed <code>isset($_POST['showtextinline'])</code> to <br><code>!empty($_POST['showtextinline'])</code> in three locations<br> <li> Applied same fix as admin helper for consistent behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4423/files#diff-79cc07186a422dacef1524d0979174fe5d24627ef936483e7575abcc158af99b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

