### PR TITLE
Fixed issue #19812: fruity, bootswatch and vanilla truncate question index dropdown text

### DIFF
--- a/themes/survey/vanilla/views/subviews/navigation/question_index_menu.twig
+++ b/themes/survey/vanilla/views/subviews/navigation/question_index_menu.twig
@@ -34,7 +34,7 @@ There is two possible displays for index, depending on Survey Mode:
                 {{ gT("Question index") }}
                 <span class="caret"></span>
             </a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu dropdown-menu-end">
                 {# TODO: move back this logic to SurveyRuntime, and provide a ready to use indexItem.statusClass #}
                 {% for step, indexItem in aSurveyInfo.aQuestionIndex.items %}
                     {% set statusClass = '' %}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed dropdown menu alignment for question index

- Added `dropdown-menu-end` class to prevent text truncation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Question Index Dropdown"] -- "add dropdown-menu-end class" --> B["Fixed Alignment"]
  B --> C["Prevents Text Truncation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>question_index_menu.twig</strong><dd><code>Fix dropdown menu alignment class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/vanilla/views/subviews/navigation/question_index_menu.twig

<ul><li>Added <code>dropdown-menu-end</code> class to dropdown menu element<br> <li> Fixes text truncation issue in question index dropdown</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4427/files#diff-a9e54ccdf409a0131522384343904e6763e0e541fd0b42d3a82a525968fda8b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

