### PR TITLE
Fixed issue #20229: "Uses left" value is not pre-set when creating a new participant

### DIFF
--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -2769,23 +2769,23 @@ class Tokens extends SurveyCommonAction
         Yii::app()->loadHelper("surveytranslator");
 
         $defaultFields = [
-            'tid',
-            'participant_id',
+            'tid' => null,
+            'participant_id' => null,
             'firstname' => '',
             'lastname' => '',
             'email' => '',
             'emailstatus' => '',
-            'token',
-            'language',
-            'blacklisted',
-            'sent',
-            'remindersent',
-            'remindercount',
-            'completed',
-            'usesleft',
-            'validfrom',
-            'validuntil',
-            'mpid'
+            'token' => null,
+            'language' => null,
+            'blacklisted' => null,
+            'sent' => 'N',
+            'remindersent' => 'N',
+            'remindercount' => null,
+            'completed' => 'N',
+            'usesleft' => 1,
+            'validfrom' => null,
+            'validuntil' => null,
+            'mpid' => null
         ];
 
         if ($iTokenId) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Set default value for `usesleft` field to 1 when creating new participants

- Initialize other token fields with proper default values

- Convert array structure from indexed to associative with defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Token Creation Form"] --> B["Default Fields Array"]
  B --> C["usesleft = 1"]
  C --> D["New Participant"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tokens.php</strong><dd><code>Initialize token fields with proper defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/admin/Tokens.php

<ul><li>Changed <code>defaultFields</code> array from indexed to associative format<br> <li> Set <code>usesleft</code> default value to 1 for new participants<br> <li> Added proper default values for all token fields</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4430/files#diff-af8e690b7162e715acc4d95c2dd74fb97479066cf40a03d33de4c393df0250e3">+13/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

