### PR TITLE
Fixed issue #20256: Date question doesn't show AM/PM correctly

### DIFF
--- a/application/extensions/DateTimePickerWidget/DateTimePicker.php
+++ b/application/extensions/DateTimePickerWidget/DateTimePicker.php
@@ -198,8 +198,15 @@ class DateTimePicker extends CInputWidget
         }
         $localeScript .= "      dayViewHeaderFormat: { month: 'long', year: 'numeric' },\n" .
             "      locale: '$locale',\n" .
-            "      format: '$dateFormat',\n" .
-            "      hourCycle: 'h24'\n";
+            "      format: '$dateFormat',\n";
+
+        // Try to guess the right hour cycle from the format
+        // The old datetimepicker did that, but Tempus Dominus does not (it guesses from the locale, not the format)
+        if (strpos(strtolower($dateFormat), 'a') === false && strpos($dateFormat, 'h') === false) {
+            $localeScript .= "      hourCycle: 'h24',\n";
+        } else {
+            $localeScript .= "      hourCycle: 'h12',\n";
+        }
 
         return "{
           $localeScript


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed AM/PM display in date questions by implementing dynamic hour cycle detection

- Added logic to determine 12-hour vs 24-hour format based on date format string

- Replaced hardcoded 24-hour cycle with conditional hour cycle selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Date Format String"] --> B["Check for 'a' or 'h' characters"]
  B --> C{"Contains AM/PM indicators?"}
  C -->|Yes| D["Set hourCycle: 'h12'"]
  C -->|No| E["Set hourCycle: 'h24'"]
  D --> F["Display with AM/PM"]
  E --> G["Display 24-hour format"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimePicker.php</strong><dd><code>Dynamic hour cycle detection for date picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/DateTimePickerWidget/DateTimePicker.php

<ul><li>Removed hardcoded 24-hour cycle setting<br> <li> Added conditional logic to detect AM/PM format requirements<br> <li> Implemented dynamic hour cycle selection based on format string <br>analysis</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4431/files#diff-9a865812656a53cf70de8228e234a15b85dc8f908f51d6f0be5af7f05b27c628">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

