### PR TITLE
Fixed issue #AT-1745: storing answers from new editor

### DIFF
--- a/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputAnswer.php
+++ b/application/libraries/Api/Command/V1/Transformer/Input/TransformerInputAnswer.php
@@ -38,7 +38,7 @@ class TransformerInputAnswer extends Transformer
     {
         $collection = parent::transformAll($collection, $options);
         $output = [];
-        foreach ($collection as $index => $answer) {
+        foreach ($collection as $answer) {
             // second array index needs to be the scaleId
             $scaleId = array_key_exists(
                 'scale_id',
@@ -47,8 +47,7 @@ class TransformerInputAnswer extends Transformer
             $index = array_key_exists(
                 'aid',
                 $answer
-            ) && (int)$answer['aid'] > 0
-                ? (int)$answer['aid'] : (int)$index;
+            ) ? $answer['aid'] : 'notFound';
             $output[$index][$scaleId] = $answer;
         }
         return $output;

--- a/tests/unit/api/transformer/TransformerInputAnswerTest.php
+++ b/tests/unit/api/transformer/TransformerInputAnswerTest.php
@@ -26,8 +26,8 @@ class TransformerInputAnswerTest extends TestBaseClass
         );
 
         self::assertIsArray($preparedData);
-        self::assertArrayHasKey(0, $preparedData);
-        self::assertArrayHasKey(1, $preparedData);
+        self::assertArrayHasKey('temp__123', $preparedData);
+        self::assertArrayHasKey('temp__456', $preparedData);
         self::assertArrayHasKey(0, $preparedData['temp__123']);
         self::assertArrayHasKey(1, $preparedData['temp__456']);
         self::assertArrayHasKey('code', $preparedData['temp__123'][0]);

--- a/tests/unit/api/transformer/TransformerInputAnswerTest.php
+++ b/tests/unit/api/transformer/TransformerInputAnswerTest.php
@@ -28,21 +28,21 @@ class TransformerInputAnswerTest extends TestBaseClass
         self::assertIsArray($preparedData);
         self::assertArrayHasKey(0, $preparedData);
         self::assertArrayHasKey(1, $preparedData);
-        self::assertArrayHasKey(0, $preparedData[0]);
-        self::assertArrayHasKey(1, $preparedData[1]);
-        self::assertArrayHasKey('code', $preparedData[0][0]);
-        self::assertEquals('AO01', $preparedData[0][0]['code']);
-        self::assertArrayHasKey('answeroptionl10n', $preparedData[0][0]);
-        self::assertIsArray($preparedData[0][0]['answeroptionl10n']);
-        self::assertArrayHasKey('en', $preparedData[0][0]['answeroptionl10n']);
-        self::assertArrayHasKey('de', $preparedData[0][0]['answeroptionl10n']);
+        self::assertArrayHasKey(0, $preparedData['temp__123']);
+        self::assertArrayHasKey(1, $preparedData['temp__456']);
+        self::assertArrayHasKey('code', $preparedData['temp__123'][0]);
+        self::assertEquals('AO01', $preparedData['temp__123'][0]['code']);
+        self::assertArrayHasKey('answeroptionl10n', $preparedData['temp__123'][0]);
+        self::assertIsArray($preparedData['temp__123'][0]['answeroptionl10n']);
+        self::assertArrayHasKey('en', $preparedData['temp__123'][0]['answeroptionl10n']);
+        self::assertArrayHasKey('de', $preparedData['temp__123'][0]['answeroptionl10n']);
         self::assertEquals(
             'answer',
-            $preparedData[0][0]['answeroptionl10n']['en']
+            $preparedData['temp__123'][0]['answeroptionl10n']['en']
         );
         self::assertEquals(
             'answerger',
-            $preparedData[0][0]['answeroptionl10n']['de']
+            $preparedData['temp__123'][0]['answeroptionl10n']['de']
         );
     }
 
@@ -58,7 +58,8 @@ class TransformerInputAnswerTest extends TestBaseClass
             0,
             [
                 '0' => [
-                    'tempId'  => '222',
+                    'aid' => 'temp__123',
+                    'tempId'  => 'temp__123',
                     'code'    => 'AO01',
                     'scaleId' => '0',
                     'l10ns'   => [
@@ -73,7 +74,8 @@ class TransformerInputAnswerTest extends TestBaseClass
                     ]
                 ],
                 '1' => [
-                    'tempId'  => '333',
+                    'aid'  => 'temp__456',
+                    'tempId'  => 'temp__456',
                     'code'    => 'AO01',
                     'scaleId' => '1',
                     'l10ns'   => [

--- a/tests/unit/api/transformer/TransformerInputQuestionAggregateTest.php
+++ b/tests/unit/api/transformer/TransformerInputQuestionAggregateTest.php
@@ -52,12 +52,12 @@ class TransformerInputQuestionAggregateTest extends TestBaseClass
         self::assertIsArray($preparedData);
         self::assertArrayHasKey('answeroptions', $preparedData);
         $answers = $preparedData['answeroptions'];
-        self::assertArrayHasKey(0, $answers);
-        self::assertArrayHasKey(0, $answers[0]);
-        self::assertArrayHasKey('code', $answers[0][0]);
-        self::assertEquals('AO01', $answers[0][0]['code']);
-        self::assertArrayHasKey('answeroptionl10n', $answers[0][0]);
-        $answerL10n = $answers[0][0]['answeroptionl10n'];
+        self::assertArrayHasKey('temp__123', $answers);
+        self::assertArrayHasKey(0, $answers['temp__123']);
+        self::assertArrayHasKey('code', $answers['temp__123'][0]);
+        self::assertEquals('AO01', $answers['temp__123'][0]['code']);
+        self::assertArrayHasKey('answeroptionl10n', $answers['temp__123'][0]);
+        $answerL10n = $answers['temp__123'][0]['answeroptionl10n'];
         self::assertIsArray($answerL10n);
         self::assertArrayHasKey('en', $answerL10n);
         self::assertArrayHasKey('de', $answerL10n);
@@ -156,7 +156,8 @@ class TransformerInputQuestionAggregateTest extends TestBaseClass
     private function getAnswers($operation = 'create'): array
     {
         $answer = [
-            'tempId' => 'XXX124',
+            'tempId' => 'temp__123',
+            'aid' => 'temp__123',
             'code'   => 'AO01',
             'l10ns'  => [
                 'en' => [


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed answer option storage using temporary IDs instead of numeric indices

- Updated transformer to handle `aid` field properly for new editor

- Modified unit tests to reflect new data structure with temp IDs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Index-based Storage"] --> B["TransformerInputAnswer Fix"]
  B --> C["Temp ID-based Storage"]
  C --> D["Updated Unit Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransformerInputAnswer.php</strong><dd><code>Fix answer indexing using aid field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/Transformer/Input/TransformerInputAnswer.php

<ul><li>Removed unused <code>$index</code> variable from foreach loop<br> <li> Changed index logic to use <code>aid</code> field or 'notFound' fallback<br> <li> Simplified conditional logic for answer ID handling</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4433/files#diff-a7d11d5b30d7ee1dd10fd2bf6ecf8f8154f4354ecf83b83279c13c91f580f87a">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransformerInputAnswerTest.php</strong><dd><code>Update tests for temp ID structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/api/transformer/TransformerInputAnswerTest.php

<ul><li>Updated test assertions to use temp IDs (<code>temp__123</code>, <code>temp__456</code>) instead <br>of numeric indices<br> <li> Modified test data structure to include <code>aid</code> field with temp ID values<br> <li> Adjusted all array key assertions to match new data structure</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4433/files#diff-ba0e4c8aee15d3ba9a027ab14860e19d90bc81b7fa5a2c795f23c51fdcdf2f2d">+16/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TransformerInputQuestionAggregateTest.php</strong><dd><code>Align aggregate tests with temp IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/api/transformer/TransformerInputQuestionAggregateTest.php

<ul><li>Changed test assertions to use <code>temp__123</code> instead of numeric index <code>0</code><br> <li> Added <code>aid</code> field to test data with temp ID value<br> <li> Updated array key checks to match new temp ID structure</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4433/files#diff-2eba34c20d09c51aaacdc0a8d767bf7b9cb995df258148e3573bf6a3041c2bd8">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

