### PR TITLE
Fixed issue #20243: Attribute names disappear and automatic mapping breaks when adding CPDB participants to a survey

### DIFF
--- a/application/models/Participant.php
+++ b/application/models/Participant.php
@@ -1598,7 +1598,7 @@ class Participant extends LSActiveRecord
             $aTokenAttributes[$key] = $iIDAttributeCPDB;
         }
 
-        $aTokenAttributes = serialize($aTokenAttributes);
+        $aTokenAttributes = json_encode($aTokenAttributes);
 
         Yii::app()->db
             ->createCommand()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace serialize() with json_encode() for token attributes

- Fix attribute names disappearing when adding CPDB participants

- Resolve automatic mapping issues in survey participant management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CPDB Participants"] --> B["Token Attributes Processing"]
  B --> C["serialize() - OLD"]
  B --> D["json_encode() - NEW"]
  C --> E["Broken Attribute Names"]
  D --> F["Fixed Survey Mapping"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Participant.php</strong><dd><code>Replace serialize with json_encode for attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/Participant.php

<ul><li>Changed serialization method from <code>serialize()</code> to <code>json_encode()</code><br> <li> Fixed token attribute storage in survey database<br> <li> Resolved CPDB participant integration issues</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4439/files#diff-fe7c54eb0759de955cb6dee14f8830b0e08e38c058c15e7708d143d9f7f74873">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

