### PR TITLE
Fixed issue #20264: Bounce processing cannot match encrypted participant email addresses

### DIFF
--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -284,11 +284,11 @@ class Tokens extends SurveyCommonAction
 
                                 if ($iSurveyId == $iSurveyIdBounce[1]) {
                                     $condn  = array('token' => $tokenBounce[1]);
-                                    $record = Token::model($iSurveyId)->findByAttributes($condn)->decrypt();
+                                    $record = Token::model($iSurveyId)->findByAttributes($condn);
 
                                     if (!empty($record) && $record->emailstatus != 'bounced') {
                                         $record->emailstatus = 'bounced';
-                                        $record->encryptSave(true);
+                                        $record->save(true, ['emailstatus']);
                                         $bouncetotal++;
                                     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix bounce processing for encrypted participant email addresses

- Add decryption and encrypted save operations for token records


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Token Record"] --> B["Decrypt Token Data"]
  B --> C["Update Email Status"]
  C --> D["Encrypted Save"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tokens.php</strong><dd><code>Fix encrypted token bounce processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/controllers/admin/Tokens.php

<ul><li>Add <code>decrypt()</code> method call when finding token records<br> <li> Replace <code>save()</code> with <code>encryptSave(true)</code> for encrypted storage</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4440/files#diff-af8e690b7162e715acc4d95c2dd74fb97479066cf40a03d33de4c393df0250e3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

