### PR TITLE
New feature #AT-1418: introducing new option Random A-Z/Z-A for "Answer options order"-setting

### DIFF
--- a/application/helpers/SortHelper.php
+++ b/application/helpers/SortHelper.php
@@ -82,6 +82,27 @@ class SortHelper
     }
 
     /**
+     * Sort array maintaining index association in reverse order
+     * @param string[] $array to sort
+     * @param integer $flags in self::SORT_REGULAR (default or invalid), self::SORT_NUMERIC, self::SORT_STRING
+     * @return boolean, see Collator::asort
+     * @see arsort and Collator::asort
+     */
+    public function arsort(array &$array, int $flags = self::SORT_REGULAR): bool
+    {
+        if (is_null(self::$collator)) {
+            return arsort($array, self::getFlag($flags));
+        }
+
+        // Use our own asort method and then reverse the array
+        $result = $this->asort($array, $flags);
+        if ($result) {
+            $array = array_reverse($array, true); // true preserves keys
+        }
+        return $result;
+    }
+
+    /**
      * Return flag tupe depend on functoion sed
      * @param integer
      * @return integer

--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -34,7 +34,7 @@ class questionHelper
      * Return all the definitions of Question attributes core+extended value
      * @return array[]
      *
-     *@deprecated  used only as fall back method
+     *@deprecated  used only as fall back method and for import/exports of LS v1 and for Survey Logic File
      * use QuestionAttribute::getQuestionAttributesSettings function to get attributes
      */
     public static function getAttributesDefinitions()
@@ -849,11 +849,16 @@ class questionHelper
         );
 
         self::$attributes["answer_order"] = array(
-            "types" => Question::QT_L_LIST . Question::QT_R_RANKING . Question::QT_EXCLAMATION_LIST_DROPDOWN,
+            "types" => Question::QT_L_LIST . Question::QT_R_RANKING . Question::QT_EXCLAMATION_LIST_DROPDOWN . Question::QT_O_LIST_WITH_COMMENT,
             'category' => gT('Display'),
             'sortorder' => 100,
             'inputtype' => 'singleselect',
-            'options' => array('normal' => gT('Normal'), 'random' => gT("Random"), 'alphabetical' => gT("Alphabetical")),
+            'options' => array(
+                'normal' => gT('Normal'),
+                'random' => gT("Random"),
+                'alphabetical' => gT("Alphabetical"),
+                'random_alphabetical' => gT("Random A-Z/Z-A")
+            ),
             //1=>gT('Randomize on each page load')  // Shnoulle : replace by yes till we have only one solution
             //2=>gT('Randomize once on survey start')  //Mdekker: commented out as code to handle this was removed in refactoring
             'default' => 0,

--- a/application/models/Question.php
+++ b/application/models/Question.php
@@ -836,7 +836,23 @@ class Question extends LSActiveRecord
                 foreach ($scaleArray as $key => $answer) {
                     $sorted[$key] = $answer->answerl10ns[$language]->answer;
                 }
-                LimeSurvey\Helpers\SortHelper::getInstance($language)->asort($sorted, LimeSurvey\Helpers\SortHelper::SORT_STRING);
+                // Check if we need to randomize the sort direction (A-Z or Z-A)
+                $answerOrder = $this->getQuestionAttribute('answer_order');
+                if (
+                    $answerOrder == 'random_alphabetical' && mt_rand(0, 1) == 1
+                ) {
+                    // Sort in reverse alphabetical order (Z-A)
+                    LimeSurvey\Helpers\SortHelper::getInstance($language)->arsort(
+                        $sorted,
+                        LimeSurvey\Helpers\SortHelper::SORT_STRING
+                    );
+                } else {
+                    // Sort in alphabetical order (A-Z)
+                    LimeSurvey\Helpers\SortHelper::getInstance($language)->asort(
+                        $sorted,
+                        LimeSurvey\Helpers\SortHelper::SORT_STRING
+                    );
+                }
                 // Now, we create a new array that store the old values of $answerOptions in the order of $sorted
                 $sortedScaleAnswers = array();
                 foreach ($sorted as $key => $answer) {
@@ -884,7 +900,7 @@ class Question extends LSActiveRecord
         // implement the 'answer_order' attribute instead of using separate attributes.
         $answerOrder = $this->getQuestionAttribute('answer_order');
         if (!is_null($answerOrder)) {
-            return $answerOrder == 'alphabetical';
+            return $answerOrder == 'alphabetical' || $answerOrder == 'random_alphabetical';
         }
         return $this->getQuestionAttribute('alphasort') == 1;
     }

--- a/application/views/survey/questions/answer/list_dropdown/config.xml
+++ b/application/views/survey/questions/answer/list_dropdown/config.xml
@@ -90,6 +90,10 @@
                     <value>alphabetical</value>
                     <text>Alphabetical</text>
                 </option>
+                <option>
+                    <value>random_alphabetical</value>
+                    <text>Random A-Z/Z-A</text>
+                </option>
             </options>
             <default>normal</default>
             <help>Present answer options in normal, random or alphabetical order</help>

--- a/application/views/survey/questions/answer/list_with_comment/config.xml
+++ b/application/views/survey/questions/answer/list_with_comment/config.xml
@@ -77,6 +77,10 @@
                     <value>alphabetical</value>
                     <text>Alphabetical</text>
                 </option>
+                <option>
+                    <value>random_alphabetical</value>
+                    <text>Random A-Z/Z-A</text>
+                </option>
             </options>
             <default>normal</default>
             <help>Present answer options in normal, random or alphabetical order</help>

--- a/application/views/survey/questions/answer/listradio/config.xml
+++ b/application/views/survey/questions/answer/listradio/config.xml
@@ -78,6 +78,10 @@
                     <value>alphabetical</value>
                     <text>Alphabetical</text>
                 </option>
+                <option>
+                    <value>random_alphabetical</value>
+                    <text>Random A-Z/Z-A</text>
+                </option>
             </options>
             <default>normal</default>
             <help>Present answer options in normal, random or alphabetical order</help>

--- a/application/views/survey/questions/answer/ranking/config.xml
+++ b/application/views/survey/questions/answer/ranking/config.xml
@@ -364,6 +364,10 @@
                     <value>alphabetical</value>
                     <text>Alphabetical</text>
                 </option>
+                <option>
+                    <value>random_alphabetical</value>
+                    <text>Random A-Z/Z-A</text>
+                </option>
             </options>
             <default>normal</default>
             <help>Present answer options in normal, random or alphabetical order</help>


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:
