### PR TITLE
Fixed issue #20271: Reflected XSS in CSRF token handling

### DIFF
--- a/application/core/LSHttpRequest.php
+++ b/application/core/LSHttpRequest.php
@@ -42,6 +42,8 @@ class LSHttpRequest extends CHttpRequest
     /** @var array<string,mixed>|null the request query parameters (name-value pairs) */
     private $queryParams;
 
+    protected $_csrfToken;
+
     /**
      * Return the referal url,
      * it's used for the "close" buttons, and the "save and close" buttons
@@ -312,5 +314,23 @@ class LSHttpRequest extends CHttpRequest
                  throw new CHttpException(400, gT("The requested hostname is invalid.", 'unescaped'));
             }
         }
+    }
+
+    /**
+     * @inheritdoc
+     * Sanitize the CSRF token to avoid XSS attacks
+     */
+    public function getCsrfToken()
+    {
+        if ($this->_csrfToken === null) {
+            $cookie = $this->getCookies()->itemAt($this->csrfTokenName);
+            if (!$cookie || ($this->_csrfToken = sanitize_base64($cookie->value)) == null) {
+                $cookie = $this->createCsrfCookie();
+                $this->_csrfToken = $cookie->value;
+                $this->getCookies()->add($cookie->name, $cookie);
+            }
+        }
+
+        return $this->_csrfToken;
     }
 }

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -554,3 +554,14 @@ function sanitize_alphanumeric($value)
 {
     return preg_replace("/[^a-zA-Z0-9\-\_]/", "", $value);
 }
+
+/**
+ * Remove all chars from $value that don't belong to a base64 string (doesn't check if the string is a valid base64 string)
+ *
+ * @param string $value
+ * @return string
+ */
+function sanitize_base64($value)
+{
+    return preg_replace("/[^a-zA-Z0-9\/\+=]/", "", $value);
+}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed reflected XSS vulnerability in CSRF token handling

- Added sanitization for base64 CSRF tokens

- Overrode `getCsrfToken()` method with security validation

- Created new `sanitize_base64()` helper function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSRF Token Request"] --> B["getCsrfToken() Override"]
  B --> C["sanitize_base64() Function"]
  C --> D["Clean Base64 Token"]
  D --> E["Secure Token Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LSHttpRequest.php</strong><dd><code>Override CSRF token method with sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/core/LSHttpRequest.php

<ul><li>Added protected <code>$_csrfToken</code> property for token storage<br> <li> Overrode <code>getCsrfToken()</code> method with XSS protection<br> <li> Implemented CSRF token sanitization using <code>sanitize_base64()</code><br> <li> Added proper token validation and cookie handling</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4449/files#diff-51e6b3df6b903a53bafb6ef5152bd9d3b6d150502cb833021ef38a3a349fb795">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanitize_helper.php</strong><dd><code>Add base64 string sanitization helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/sanitize_helper.php

<ul><li>Added new <code>sanitize_base64()</code> function<br> <li> Removes non-base64 characters using regex pattern<br> <li> Accepts string parameter and returns sanitized string</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4449/files#diff-ac66a40bc5e4438b4e825f82a53dbcb0d0d2bd5e617654ee904c1889e9fc1b8e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

