### PR TITLE
Fixed issue #20274: When print survey with empty date question : curr…

### DIFF
--- a/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_date.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_date.twig
@@ -5,7 +5,9 @@
         <div class="col-lg-4 text-end">
         </div>
         <div class="col-lg-8 text-start">
-            {{question.answervalue|date(question.dateformat.phpdate)}}
+            {% if question.answervalue %}
+                {{question.answervalue|date(question.dateformat.phpdate)}}
+            {% endif %}
         </div>
     </div>
 </div>

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_date.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_date.twig
@@ -5,7 +5,9 @@
         <div class="col-lg-4 text-end">
         </div>
         <div class="col-lg-8 text-start">
-            {{question.answervalue|date(question.dateformat.phpdate)}}
+            {% if question.answervalue %}
+                {{question.answervalue|date(question.dateformat.phpdate)}}
+            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
### **User description**
…ent date question is shown as answers


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed empty date question display in survey print view

- Added conditional check to prevent showing current date for empty answers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Empty date question"] --> B["Conditional check added"]
  B --> C["No date displayed when empty"]
  D["Previous behavior"] --> E["Current date shown incorrectly"]
  B --> F["Proper date formatting when value exists"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template_date.twig</strong><dd><code>Add empty date answer validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/survey/vanilla/views/subviews/printanswers/question_types/template_date.twig

<ul><li>Added conditional check around date formatting<br> <li> Prevents display of current date when answer is empty<br> <li> Maintains existing date formatting for valid answers</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4451/files#diff-c39a3f4717778899cb88a8c826b61fc399b8ebc617a44e65a0f1e7d471396ce9">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

