### PR TITLE
LE-428: Fixed the performance issue

### DIFF
--- a/application/models/services/SurveyCondition.php
+++ b/application/models/services/SurveyCondition.php
@@ -22,6 +22,7 @@ class SurveyCondition
     protected array $tokenFieldsAndNames;
     protected string $language;
     protected const X = 'X';
+    protected $processedSurveys = [];
 
     /**
      * Constructor
@@ -1722,8 +1723,11 @@ class SurveyCondition
      */
     protected function renderFormAux(\Question $question)
     {
-        \LimeExpressionManager::SetSurveyId($question->sid);
-        \LimeExpressionManager::StartProcessingPage(false, true);
+        if (!($this->processedSurveys[$question->sid] ?? false)) {
+            \LimeExpressionManager::SetSurveyId($question->sid);
+            \LimeExpressionManager::StartProcessingPage(true, true);
+            $this->processedSurveys[$question->sid] = true;
+        }
         \LimeExpressionManager::ProcessString(
             "{" . trim((string) $question->relevance) . "}",
             $question->qid


### PR DESCRIPTION
### **User description**
Ensured that the condition text generation will not initialize the survey for each question


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed performance issue in survey condition processing

- Added caching to prevent redundant survey initialization

- Optimized LimeExpressionManager calls for repeated questions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Question Processing"] --> B["Check Survey Cache"]
  B --> C{Survey Processed?}
  C -->|No| D["Initialize LimeExpressionManager"]
  C -->|Yes| E["Skip Initialization"]
  D --> F["Mark Survey as Processed"]
  F --> G["Process Question Relevance"]
  E --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyCondition.php</strong><dd><code>Cache survey initialization to improve performance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/models/services/SurveyCondition.php

<ul><li>Added <code>processedSurveys</code> array property to track initialized surveys<br> <li> Modified <code>renderFormAux</code> method to check cache before initializing <br>LimeExpressionManager<br> <li> Changed <code>StartProcessingPage</code> parameter from <code>false</code> to <code>true</code></ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4453/files#diff-5db983baed210365e1d5aed085322682e4cb79090b02e2d58caa6015be94519d">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

