### PR TITLE
Fixed issue #20260: Survey progress bar breaks on back button

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4819,7 +4819,7 @@ class LimeExpressionManager
                         // display new question : Ging backward : maxQuestionSeq>currentQuestionSeq is always true.
                         $message .= $LEM->_UpdateValuesInDatabase();
                         $LEM->runtimeTimings[] = [__METHOD__, (microtime(true) - $now)];
-                        return [
+                        $LEM->lastMoveResult = [
                             'at_start'      => false,
                             'finished'      => false,
                             'message'       => $message,
@@ -4835,6 +4835,7 @@ class LimeExpressionManager
                             'notRelevantSteps'   => $notRelevantSteps,
                             'hiddenSteps'   => $hiddenSteps
                         ];
+                        return $LEM->lastMoveResult;
                     }
                 }
                 break;


### PR DESCRIPTION
### **User description**
Test very carefully as the change could have big impact


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed survey progress bar breaking on back button navigation

- Store navigation result in `$LEM->lastMoveResult` before returning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NavigateBackwards() method"] --> B["Store result in lastMoveResult"] --> C["Return navigation result"] --> D["Progress bar works correctly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>em_manager_helper.php</strong><dd><code>Store navigation result in lastMoveResult property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/helpers/expressions/em_manager_helper.php

<ul><li>Modified <code>NavigateBackwards()</code> method to store navigation result in <br><code>$LEM->lastMoveResult</code><br> <li> Added assignment before return statement to preserve navigation state<br> <li> Maintains same return value while fixing progress bar issue</ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4457/files#diff-fa8d35264aa59c85d37ca2d1756472996499f06fb346865594378102f5f7abc0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

