### PR TITLE
LE-429: Refactor api response type and timestamp format

### DIFF
--- a/application/libraries/Api/Command/V1/SurveyDetail.php
+++ b/application/libraries/Api/Command/V1/SurveyDetail.php
@@ -101,9 +101,9 @@ class SurveyDetail implements CommandInterface
             );
         }
 
-        if ($this->lastLoaded && (strtotime($this->lastLoaded) > strtotime($surveyModel->lastmodified))) {
+        if ($this->lastLoaded && ($this->lastLoaded > strtotime($surveyModel->lastmodified))) {
             return $this->responseFactory
-                ->makeSuccess(['survey' => 'not changed']);
+                ->makeSuccessNoContent();
         }
 
         //set real survey options with inheritance to get value of "inherit" attribute from db

--- a/application/libraries/Api/Command/V1/SurveyPatch/PatcherSurvey.php
+++ b/application/libraries/Api/Command/V1/SurveyPatch/PatcherSurvey.php
@@ -99,7 +99,7 @@ class PatcherSurvey extends Patcher
             }
             $survey = $this->surveyDetailService->getSurveyFromEntityMap($entityMap);
             if ($survey) {
-                $survey->lastmodified = date('Y-m-d h:i:s');
+                $survey->lastmodified = date('Y-m-d H:i:s');
                 $survey->save();
                 $this->surveyDetailService->removeCache($survey->sid);
             }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -145,7 +145,7 @@ use LimeSurvey\PluginManager\PluginEvent;
  * @property SurveyLanguageSetting $defaultlanguage
  * @property SurveysGroups $surveygroup
  * @property boolean $isDateExpired Whether survey is expired depending on the current time and survey configuration status
- * @property string $lastmodified date as SQL datetime (YYYY-MM-DD hh:mm:ss)
+ * @property string $lastmodified date as SQL datetime (YYYY-MM-DD HH:mm:ss)
  * @method mixed active()
  */
 class Survey extends LSActiveRecord implements PermissionInterface


### PR DESCRIPTION
### **User description**
### PR Title
Standardize timestamp format to UNIX for API requests and responses

### Summary
This PR updates the API and frontend to use **UNIX timestamps (in seconds, UTC)** instead of formatted datetime strings (e.g., `YYYY-MM-DD HH:MM:SS`).  
This ensures consistent and timezone-independent timestamp handling across the system.

### Reasons for the Change (Best Practice)
- **Unambiguous and timezone-safe:**  
  UNIX timestamps are always in UTC, eliminating inconsistencies caused by timezone differences between client and server.
- **Easier to compare and process:**  
  Timestamps can be directly compared as integers without parsing or conversion.
- **Lightweight and efficient:**  
  Numeric format reduces payload size and improves parsing performance.
- **Language-agnostic consistency:**  
  Both JavaScript (`Math.floor(Date.now() / 1000)`) and PHP (`time()`) produce compatible UNIX timestamps.
- **Avoids URL encoding issues:**  
  Human-readable timestamps with spaces and colons require encoding (`%20`, `%3A`), while UNIX integers do not.

### Changes Included
- Updated frontend to send timestamps in UNIX format.  
- Modified backend API to return and handle UNIX timestamps consistently.  
- Adjusted timestamp comparison and validation logic.

### Impact
All client requests and responses using timestamps are now standardized on **UNIX seconds (UTC)** format, improving reliability and reducing potential parsing errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor timestamp comparison to use UNIX format

- Replace success response with no-content response


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lastLoaded timestamp"] --> B["Compare with survey.lastmodified"]
  B --> C["Return no-content response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyDetail.php</strong><dd><code>Refactor timestamp handling and response format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/libraries/Api/Command/V1/SurveyDetail.php

<ul><li>Updated timestamp comparison to use UNIX format directly instead of <br>converting both values with <code>strtotime()</code><br> <li> Changed success response from <code>makeSuccess(['survey' => 'not changed'])</code> <br>to <code>makeSuccessNoContent()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/LimeSurvey/LimeSurvey/pull/4468/files#diff-24c066baf5ed2a675b8a58289be8eb3ef534177742d5c676d7abd7810da221e5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

