### PR TITLE
AT-1427: "No answer" should not be pre selected

### DIFF
--- a/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
+++ b/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
@@ -50,7 +50,7 @@ class RenderFivePointChoice extends QuestionBaseRenderer
                 'id'                     => $this->sSGQA,
                 'labelText'              => gT('No answer'),
                 'itemExtraClass'         => 'noanswer-item',
-                'checkedState'           => $this->getIsNoAnswerChecked() ? ' CHECKED ' : '',
+                'checkedState'           => $this->isNoAnswerChecked() ? ' CHECKED ' : '',
                 'checkconditionFunction' => $this->checkconditionFunction,
             );
         }

--- a/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
+++ b/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
@@ -29,6 +29,7 @@ class RenderFivePointChoice extends QuestionBaseRenderer
     public function getRows()
     {
         $aRows = [];
+        $sessionValue = $this->mSessionValue;
         for ($fp = 1; $fp <= 5; $fp++) {
             $aRows[] = array(
                 'name'                   => $this->sSGQA,
@@ -49,7 +50,7 @@ class RenderFivePointChoice extends QuestionBaseRenderer
                 'id'                     => $this->sSGQA,
                 'labelText'              => gT('No answer'),
                 'itemExtraClass'         => 'noanswer-item',
-                'checkedState'           => '',
+                'checkedState'           => $this->getIsNoAnswerChecked() ? ' CHECKED ' : '',
                 'checkconditionFunction' => $this->checkconditionFunction,
             );
         }

--- a/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
+++ b/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
@@ -49,7 +49,7 @@ class RenderFivePointChoice extends QuestionBaseRenderer
                 'id'                     => $this->sSGQA,
                 'labelText'              => gT('No answer'),
                 'itemExtraClass'         => 'noanswer-item',
-                'checkedState'           => (!$this->mSessionValue ? ' CHECKED ' : ''),
+                'checkedState'           => '',
                 'checkconditionFunction' => $this->checkconditionFunction,
             );
         }

--- a/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
+++ b/application/core/QuestionTypes/5PointChoice/RenderFivePointChoice.php
@@ -26,6 +26,22 @@ class RenderFivePointChoice extends QuestionBaseRenderer
         return '/survey/questions/answer/5pointchoice/answer';
     }
 
+    /**
+     * Build the list of option rows for the 5-point choice question (and an optional "No answer" row).
+     *
+     * Each row is an associative array representing a single radio option for values 1 through 5.
+     * If the question is not mandatory and SHOW_NO_ANSWER is enabled, an additional "No answer" row is appended.
+     *
+     * @return array<int, array{name: string, value: mixed, id: string, labelText: mixed, itemExtraClass: string, checkedState: string, checkconditionFunction: mixed}>
+     *         An array of option rows. Each row contains:
+     *         - `name`: form field name (SGQA).
+     *         - `value`: option value (1–5 or empty string for "No answer").
+     *         - `id`: element id (SGQA with numeric suffix for 1–5; SGQA for "No answer").
+     *         - `labelText`: label shown for the option (numeric label for 1–5 or localized "No answer").
+     *         - `itemExtraClass`: additional CSS class for the item (empty or 'noanswer-item').
+     *         - `checkedState`: `' CHECKED '` if the option should be selected, otherwise an empty string.
+     *         - `checkconditionFunction`: condition function used by frontend logic.
+     */
     public function getRows()
     {
         $aRows = [];

--- a/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
+++ b/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
@@ -295,7 +295,7 @@ class RenderArrayFlexibleRow extends QuestionBaseRenderer
                     'ld'                     => '',
                     'code' => $oAnswer->code,
                     'label'                  => gT('No answer'),
-                    'checked' => $this->getIsNoAnswerChecked($myfname) ? 'checked' : '',
+                    'checked' => $this->isNoAnswerChecked($myfname) ? 'checked' : '',
                 );
             }
 

--- a/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
+++ b/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
@@ -295,7 +295,7 @@ class RenderArrayFlexibleRow extends QuestionBaseRenderer
                     'ld'                     => '',
                     'code' => $oAnswer->code,
                     'label'                  => gT('No answer'),
-                    'checked' => '',
+                    'checked' => $this->getIsNoAnswerChecked($myfname) ? 'checked' : '',
                 );
             }
 

--- a/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
+++ b/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
@@ -295,7 +295,7 @@ class RenderArrayFlexibleRow extends QuestionBaseRenderer
                     'ld'                     => '',
                     'code' => $oAnswer->code,
                     'label'                  => gT('No answer'),
-                    'checked'                => (is_null($value) || $value === '') ? 'checked' : '',
+                    'checked' => '',
                 );
             }
 

--- a/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
+++ b/application/core/QuestionTypes/ArrayFlexibleRow/RenderArrayFlexibleRow.php
@@ -246,6 +246,23 @@ class RenderArrayFlexibleRow extends QuestionBaseRenderer
         return $aRows;
     }
 
+    /**
+     * Builds rows for the non-dropdown (radio/table-like) array layout.
+     *
+     * Generates an ordered list of row descriptors for Twig rendering. Each entry is either a repeat-header row
+     * (template `/survey/questions/answer/arrays/array/no_dropdown/rows/repeat_header.twig`) or an answer row
+     * (template `survey/questions/answer/arrays/array/no_dropdown/rows/answer_row.twig`) whose `content` contains
+     * the prepared answer columns, optional "No answer" column, labels, current value, error flag, and layout metadata.
+     * Repeat-section header rows are inserted according to `repeatheadings`/`minrepeatheadings`.
+     *
+     * Side effects: appends each subquestion's input name (`myfname`) to `$this->inputnames`.
+     *
+     * @return array An array of row descriptors suitable for the Twig renderer. Each element has the form:
+     *               [
+     *                 'template' => string,
+     *                 'content'  => array
+     *               ]
+     */
     public function getNonDropdownRows()
     {
         $aRows = [];

--- a/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
+++ b/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
@@ -337,11 +337,11 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
                     // If value is empty, notset should be checked.
                     // string "0" should be considered as valid answer,
                     // so notset should not be checked in that case.
-                    if ($fname0value !== '0' && empty($fname0value)) {
+                    if ($fname0value !== '0' && $this->isNoAnswerChecked($myfname0)) {
                         //$answer .= CHECKED;
                         $aData['aSubQuestions'][$i]['myfname0_notset'] = CHECKED;
                     } else {
-                        $aData['aSubQuestions'][$i]['myfname0_notset'] = '';
+                        $aData['aSubQuestions'][$i]['myfname0_notset'] = "";
                     }
                 }
             }

--- a/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
+++ b/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
@@ -327,7 +327,7 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
                     // If value is empty, notset should be checked.
                     // string "0" should be considered as valid answer,
                     // so notset should not be checked in that case.
-                    if ($fname1value !== '0' && $this->getIsNoAnswerChecked($myfname1)) {
+                    if ($fname1value !== '0' && $this->isNoAnswerChecked($myfname1)) {
                         $aData['aSubQuestions'][$i]['myfname1_notset'] = CHECKED;
                     } else {
                         $aData['aSubQuestions'][$i]['myfname1_notset'] = "";

--- a/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
+++ b/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
@@ -289,7 +289,6 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
                 // if second label set is used
 
                     if (!empty($this->getFromSurveySession($myfname1))) {
-                        //$answer .= $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$myfname1];
                         $aData['aSubQuestions'][$i]['sessionfname1'] = $this->getFromSurveySession($myfname1);
                     } else {
                         $aData['aSubQuestions'][$i]['sessionfname1'] = '';
@@ -302,7 +301,6 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
                         // string "0" should be considered as valid answer,
                         // so notset should not be checked in that case.
                         if ($fname0value !== '0' && empty($fname0value)) {
-                            //$answer .= CHECKED;
                             $aData['aSubQuestions'][$i]['myfname0_notset'] = CHECKED;
                         } else {
                             $aData['aSubQuestions'][$i]['myfname0_notset'] = "";
@@ -329,8 +327,7 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
                     // If value is empty, notset should be checked.
                     // string "0" should be considered as valid answer,
                     // so notset should not be checked in that case.
-                    if ($fname1value !== '0' && empty($fname1value)) {
-                        #$answer .= CHECKED;
+                    if ($fname1value !== '0' && $this->getIsNoAnswerChecked($myfname1)) {
                         $aData['aSubQuestions'][$i]['myfname1_notset'] = CHECKED;
                     } else {
                         $aData['aSubQuestions'][$i]['myfname1_notset'] = "";

--- a/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
+++ b/application/core/QuestionTypes/ArrayMultiscale/RenderArrayMultiscale.php
@@ -201,6 +201,31 @@ class RenderArrayMultiscale extends QuestionBaseRenderer
         }
     }
 
+    /**
+     * Parse and populate non-dropdown subquestions into the view data array.
+     *
+     * Processes scale-0 subquestions, splits dual-scale label text into left/center/right parts,
+     * computes repeat-heading flags, mandatory-violation markers, session-prefilled values,
+     * label-checked states, and "no answer" (notset) states. Appends generated input names
+     * to $this->inputnames and writes per-subquestion entries into $aData['aSubQuestions'].
+     *
+     * Populated keys for each $aData['aSubQuestions'][$i]:
+     * - title, myfname, myfname0, myfid0, myfname1, myfid1
+     * - answertext, answertextcenter, answertextright
+     * - odd
+     * - repeatheadings (bool)
+     * - showmandatoryviolation (bool)
+     * - sDisplayStyle (string)
+     * - sessionfname0, sessionfname1 (strings)
+     * - labelcode0_checked[...] and labelcode1_checked[...] (checked state strings)
+     * - myfname0_notset, myfname1_notset (checked state strings when shownoanswer is enabled)
+     *
+     * Side effects:
+     * - Modifies $aData by reference.
+     * - Appends input names to $this->inputnames.
+     *
+     * @param array &$aData View data array to populate with parsed subquestion information.
+     */
     public function parseSubquestionsNoDropdown(&$aData)
     {
         $repeatheadings     = Yii::app()->getConfig("repeatheadings");

--- a/application/core/QuestionTypes/ListRadio/RenderListRadio.php
+++ b/application/core/QuestionTypes/ListRadio/RenderListRadio.php
@@ -122,7 +122,7 @@ class RenderListRadio extends QuestionBaseRenderer
     {
         return Yii::app()->twigRenderer->renderQuestion($this->getMainView() . '/rows/answer_row_noanswer', array(
             'name' => $this->sSGQA,
-            'check_ans' => '',
+            'check_ans' => $this->getIsNoAnswerChecked() ? CHECKED : '',
             'checkconditionFunction' => $this->checkconditionFunction,
             'iNbCols' => $this->iNbCols,
             'iCountAnswers' => $this->iCountAnswers,

--- a/application/core/QuestionTypes/ListRadio/RenderListRadio.php
+++ b/application/core/QuestionTypes/ListRadio/RenderListRadio.php
@@ -122,7 +122,7 @@ class RenderListRadio extends QuestionBaseRenderer
     {
         return Yii::app()->twigRenderer->renderQuestion($this->getMainView() . '/rows/answer_row_noanswer', array(
             'name' => $this->sSGQA,
-            'check_ans' => $this->getIsNoAnswerChecked() ? CHECKED : '',
+            'check_ans' => $this->isNoAnswerChecked() ? CHECKED : '',
             'checkconditionFunction' => $this->checkconditionFunction,
             'iNbCols' => $this->iNbCols,
             'iCountAnswers' => $this->iCountAnswers,

--- a/application/core/QuestionTypes/ListRadio/RenderListRadio.php
+++ b/application/core/QuestionTypes/ListRadio/RenderListRadio.php
@@ -120,15 +120,9 @@ class RenderListRadio extends QuestionBaseRenderer
 
     public function addNoAnswerRow()
     {
-        if (!isset($this->mSessionValue) || $this->mSessionValue == '' || $this->mSessionValue == ' ') {
-            $check_ans = CHECKED; //Check the "no answer" radio button if there is no answer in session.
-        } else {
-            $check_ans = '';
-        }
-
         return Yii::app()->twigRenderer->renderQuestion($this->getMainView() . '/rows/answer_row_noanswer', array(
             'name' => $this->sSGQA,
-            'check_ans' => $check_ans,
+            'check_ans' => '',
             'checkconditionFunction' => $this->checkconditionFunction,
             'iNbCols' => $this->iNbCols,
             'iCountAnswers' => $this->iCountAnswers,

--- a/application/core/QuestionTypes/ListRadio/RenderListRadio.php
+++ b/application/core/QuestionTypes/ListRadio/RenderListRadio.php
@@ -118,6 +118,13 @@ class RenderListRadio extends QuestionBaseRenderer
         return $sRows;
     }
 
+    / **
+     * Render the "No answer" option row for the question.
+     *
+     * Renders the template row for the "No answer" radio option including its checked state and placement flags.
+     *
+     * @return string The rendered HTML for the "No answer" row; the markup includes the checked attribute when the no-answer option is selected.
+     * /
     public function addNoAnswerRow()
     {
         return Yii::app()->twigRenderer->renderQuestion($this->getMainView() . '/rows/answer_row_noanswer', array(

--- a/application/core/QuestionTypes/ListWithComment/RenderListComment.php
+++ b/application/core/QuestionTypes/ListWithComment/RenderListComment.php
@@ -57,7 +57,7 @@ class RenderListComment extends QuestionBaseRenderer
                 'name' => $this->sSGQA,
                 'id' => 'answer' . $this->sSGQA,
                 'value' => '',
-                'check_ans' => '',
+                'check_ans' => $this->getIsNoAnswerChecked() ? CHECKED : '',
                 'checkconditionFunction' => $this->checkconditionFunction . '(this.value, this.name, this.type)',
                 'labeltext' => gT('No answer'),
             );

--- a/application/core/QuestionTypes/ListWithComment/RenderListComment.php
+++ b/application/core/QuestionTypes/ListWithComment/RenderListComment.php
@@ -57,7 +57,7 @@ class RenderListComment extends QuestionBaseRenderer
                 'name' => $this->sSGQA,
                 'id' => 'answer' . $this->sSGQA,
                 'value' => '',
-                'check_ans' => $this->getIsNoAnswerChecked() ? CHECKED : '',
+                'check_ans' => $this->isNoAnswerChecked() ? CHECKED : '',
                 'checkconditionFunction' => $this->checkconditionFunction . '(this.value, this.name, this.type)',
                 'labeltext' => gT('No answer'),
             );

--- a/application/core/QuestionTypes/ListWithComment/RenderListComment.php
+++ b/application/core/QuestionTypes/ListWithComment/RenderListComment.php
@@ -57,7 +57,7 @@ class RenderListComment extends QuestionBaseRenderer
                 'name' => $this->sSGQA,
                 'id' => 'answer' . $this->sSGQA,
                 'value' => '',
-                'check_ans' => ($this->mSessionValue == '' || $this->mSessionValue == ' ') ? CHECKED : '',
+                'check_ans' => '',
                 'checkconditionFunction' => $this->checkconditionFunction . '(this.value, this.name, this.type)',
                 'labeltext' => gT('No answer'),
             );

--- a/application/core/QuestionTypes/ListWithComment/RenderListComment.php
+++ b/application/core/QuestionTypes/ListWithComment/RenderListComment.php
@@ -34,6 +34,16 @@ class RenderListComment extends QuestionBaseRenderer
         return '/survey/questions/answer/list_with_comment';
     }
 
+    /**
+     * Render the list-style answer options with an associated free-text comment input.
+     *
+     * Renders radio-list rows for each configured answer (including an optional "No answer" choice when allowed),
+     * appends the provided CSS classes to the renderer's core class, registers required assets, and returns the rendered
+     * HTML together with the names of the input fields that were produced.
+     *
+     * @param string $sCoreClasses Additional CSS classes to append to the renderer's base core class.
+     * @return array An array whose first element is the rendered HTML string for the answer list and comment block, and whose second element is an array of input names (the answer SGQA and its comment SGQA).
+     */
     public function renderList($sCoreClasses)
     {
         $sRows = '';

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2522,7 +2522,7 @@ function do_yesno($ia)
     if (($ia[6] != 'Y' && $ia[6] != 'S') && SHOW_NO_ANSWER == 1) {
         $noAnswer = true;
         if (empty($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$ia[1]])) {
-            $naChecked = CHECKED;
+            $naChecked = getIsNoAnswerChecked($ia[1]) ? CHECKED : '';
         }
     }
 
@@ -2565,9 +2565,7 @@ function do_gender($ia)
     $displayType            = (int) $aQuestionAttributes['display_type'];
     if (($ia[6] != 'Y' && $ia[6] != 'S') && SHOW_NO_ANSWER == 1) {
         $noAnswer = true;
-        if ($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$ia[1]] == '') {
-            $naChecked = CHECKED;
-        }
+        $naChecked = getIsNoAnswerChecked($ia[1]) ? CHECKED : '';
     }
 
     $noAnswer = $noAnswer ?? false;
@@ -2770,14 +2768,13 @@ function do_array_5point($ia)
 
         // ==>tds
         if (($isNotYes && $isNotS) && $showNoAnswer) {
-            $CHECKED = (!isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) || $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == '') ? 'CHECKED' : '';
             $answer_tds .= doRender('/survey/questions/answer/arrays/5point/rows/cells/answer_td_input', array(
                 'i' => "",
                 'labelText' => gT('No answer'),
                 'myfname' => $myfname,
                 'basename' => $ia[1],
                 'code' => '',
-                'CHECKED' => $CHECKED,
+                'CHECKED' => getIsNoAnswerChecked($myfname) ? CHECKED : '',
                 'checkconditionFunction' => $checkconditionFunction,
                 'value' => '',
                 ), true);
@@ -2941,7 +2938,6 @@ function do_array_10point($ia)
         }
 
         if ($ia[6] != "Y" && SHOW_NO_ANSWER == 1) {
-            $CHECKED = (!isset($_SESSION['survey_' . $iSurveyId][$myfname]) || $_SESSION['survey_' . $iSurveyId][$myfname] == '') ? 'CHECKED' : '';
             $answer_tds .= doRender(
                 '/survey/questions/answer/arrays/10point/rows/cells/answer_td_input',
                 array(
@@ -2950,7 +2946,7 @@ function do_array_10point($ia)
                     'myfname' => $myfname,
                     'basename' => $ia[1],
                     'code' => '',
-                    'CHECKED' => $CHECKED,
+                    'CHECKED' => getIsNoAnswerChecked($myfname) ? CHECKED : '',
                     'value' => '',
                 ),
                 true
@@ -3062,7 +3058,7 @@ function do_array_yesnouncertain($ia)
             $Ychecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'Y') ? 'CHECKED' : '';
             $Uchecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'U') ? 'CHECKED' : '';
             $Nchecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'N') ? 'CHECKED' : '';
-            $NAchecked = (!isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) || $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == '') ? 'CHECKED' : '';
+            $NAchecked = getIsNoAnswerChecked($myfname) ? 'CHECKED' : '';;
 
             $sRows .= doRender('/survey/questions/answer/arrays/yesnouncertain/rows/answer_row', array(
                 'basename'               => $ia[1],
@@ -3165,7 +3161,7 @@ function do_array_increasesamedecrease($ia)
         $Ichecked       = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'I') ? 'CHECKED' : '';
         $Schecked       = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'S') ? 'CHECKED' : '';
         $Dchecked       = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'D') ? 'CHECKED' : '';
-        $NAchecked      = (!isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) || $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == '') ? 'CHECKED' : '';
+        $NAchecked      = getIsNoAnswerChecked($myfname) ? 'CHECKED' : '';
         $no_answer      = (($ia[6] != 'Y' && $ia[6] != 'S') && SHOW_NO_ANSWER == 1) ? true : false;
 
         $sRows .= doRender('/survey/questions/answer/arrays/increasesamedecrease/rows/answer_row', array(
@@ -4390,7 +4386,6 @@ function do_arraycolumns($ia)
             $aData['labels'] = $labels;
             $aData['checkconditionFunction'] = $checkconditionFunction;
 
-            // TODO: What is this? What is happening here?
             foreach ($labels as $labelIdx => $ansrow) {
 
                 // create the html ids for the table rows, which are
@@ -4407,13 +4402,11 @@ function do_arraycolumns($ia)
                     ) {
                         $aData['checked'][$ansrow['code']][$ld] = CHECKED;
                     } elseif (
-                        !isset($_SESSION['survey_' . App()->getConfig('surveyID')][$myfname]) &&
+                        // no answer
+                        getIsNoAnswerChecked($myfname) &&
                         $ansrow['code'] == ''
                     ) {
                         $aData['checked'][$ansrow['code']][$ld] = CHECKED;
-                    // Humm.. (by lemeur), not sure this section can be reached
-                        // because I think $_SESSION['survey_'.Yii::app()->getConfig('surveyID')][$myfname] is always set (by save.php ??) !
-                        // should remove the !isset part I think !!
                     } else {
                         $aData['checked'][$ansrow['code']][$ld] = "";
                     }
@@ -4932,6 +4925,27 @@ function fillDate($dateString)
         default:
             return '';
     }
+}
+
+/**
+ * Check whether the "No Answer" option is selected for a given survey question.
+ *
+ * This function looks up the current survey session data
+ * and checks whether the given SGQA identifier code
+ * has a non-null value, indicating that the "No Answer" option has been checked.
+ *
+ * @param string $sSGQA The SGQA identifier of the question to check.
+ *
+ * @return bool True if the "No Answer" option is checked (non-null value found), false otherwise.
+ */
+function getIsNoAnswerChecked($sSGQA)
+{
+    $checked = false;
+    $surveySessionArray = @$_SESSION['survey_' . App()->getConfig('surveyID')];
+    if (array_key_exists($sSGQA, $surveySessionArray)) {
+        $checked = $surveySessionArray[$sSGQA] !== null;
+    }
+    return $checked;
 }
 
 /**

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -4940,12 +4940,18 @@ function fillDate($dateString)
  */
 function getIsNoAnswerChecked($sSGQA)
 {
-    $checked = false;
-    $surveySessionArray = @$_SESSION['survey_' . App()->getConfig('surveyID')];
-    if (array_key_exists($sSGQA, $surveySessionArray)) {
-        $checked = $surveySessionArray[$sSGQA] === '';
+    $surveyId = App()->getConfig('surveyID');
+    if (
+        !isset($_SESSION['survey_' . $surveyId])
+        || !is_array($_SESSION['survey_' . $surveyId])
+    ) {
+        return false;
     }
-    return $checked;
+    $surveySessionArray = $_SESSION['survey_' . $surveyId];
+    if (!array_key_exists($sSGQA, $surveySessionArray)) {
+        return false;
+    }
+    return $surveySessionArray[$sSGQA] === '';
 }
 
 /**

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -4932,18 +4932,18 @@ function fillDate($dateString)
  *
  * This function looks up the current survey session data
  * and checks whether the given SGQA identifier code
- * has a non-null value, indicating that the "No Answer" option has been checked.
+ * has a empty string value, indicating that the "No Answer" option has been checked.
  *
  * @param string $sSGQA The SGQA identifier of the question to check.
  *
- * @return bool True if the "No Answer" option is checked (non-null value found), false otherwise.
+ * @return bool True if the "No Answer" option is checked (empty string value found), false otherwise.
  */
 function getIsNoAnswerChecked($sSGQA)
 {
     $checked = false;
     $surveySessionArray = @$_SESSION['survey_' . App()->getConfig('surveyID')];
     if (array_key_exists($sSGQA, $surveySessionArray)) {
-        $checked = $surveySessionArray[$sSGQA] !== null;
+        $checked = $surveySessionArray[$sSGQA] === '';
     }
     return $checked;
 }

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3003,15 +3003,15 @@ function do_array_10point($ia)
 }
 
 
-/ **
+/**
  * Render a "Yes / No / Uncertain" array question and return its rendered HTML and input field names.
  *
  * Renders the question's header, columns and rows according to question attributes and session state.
  * Determines checked states from the survey session, respects mandatory and SHOW_NO_ANSWER settings,
  * and collects the SGQA input names for all subquestions.
  *
- * @param array $ia Question information array (standard LimeSurvey $ia structure: contains QID, field name, question attributes, mandatory flag, etc.).
- * @return array First element is the rendered HTML string for the question; second element is an array of input field names (SGQA) used by the question.
+ * `@param` array $ia Question information array (standard LimeSurvey $ia structure: contains QID, field name, question attributes, mandatory flag, etc.).
+ * `@return` array First element is the rendered HTML string for the question; second element is an array of input field names (SGQA) used by the question.
  */
 function do_array_yesnouncertain($ia)
 {

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2502,10 +2502,14 @@ function do_hugefreetext($ia)
 }
 
 /**
- * Renders Yes/No Question Type.
+ * Render the Yes/No answer control for a question using session state and question attributes.
  *
- * @param array $ia
- * @return array
+ * Determines checked states for Yes, No, and optional No-answer based on the current survey session
+ * and the question's mandatory/settings; selects a button or radio item template according to the
+ * `display_type` question attribute and returns the rendered HTML and related input names.
+ *
+ * @param array $ia Question information array (SGQA and metadata used by renderers; e.g. qid and fieldname at indices used by this function).
+ * @return array [string $answerHtml, array $inputNames] Rendered HTML for the answer control as the first element and a list of input field names as the second element.
  */
 function do_yesno($ia)
 {
@@ -2551,10 +2555,10 @@ function do_yesno($ia)
 }
 
 /**
- * Renders Gender Question Types.
+ * Render the gender (Female/Male) question input and return its HTML and input names.
  *
- * @param array $ia
- * @return array
+ * @param array $ia Question information array (SGQA and related metadata used to build the input).
+ * @return array Array where element 0 is the rendered answer HTML and element 1 is an array of related input field names.
  */
 function do_gender($ia)
 {
@@ -2594,10 +2598,16 @@ function do_gender($ia)
 
 // ---------------------------------------------------------------
 /**
-* Construct answer part array_5point
-* @param array $ia
-* @return array
-*/
+ * Render a 5-point Likert-style array question and return its answer HTML and form field names.
+ *
+ * Builds the HTML for a 5-point array question (optionally adding a "No answer" column and suffix
+ * column when configured), applies per-subquestion relevance/mandatory state and selected values,
+ * and collects the input field names used for submission.
+ *
+ * @param array $ia Question information array (survey-internal question descriptor, index-based).
+ * @return array [string $answerHtml, array $inputNames] $answerHtml is the rendered HTML for the question;
+ *               $inputNames is a list of SGQA field names for each subquestion (one entry per row).
+ */
 function do_array_5point($ia)
 {
     global $thissurvey;
@@ -2816,7 +2826,12 @@ function do_array_5point($ia)
 * @param array $ia
 * @return array
 */
-// TMSW TODO - Can remove DB query by passing in answer list from EM
+/**
+ * Render a 10-point array question and return its rendered HTML and related input names.
+ *
+ * @param array $ia Question information array containing question id, base name (SGQA), mandatory flag and other metadata required for rendering.
+ * @return array The first element is the rendered HTML string for the 10-point array question; the second element is an array of input field names (SGQA identifiers) produced for the question.
+ */
 function do_array_10point($ia)
 {
     global $thissurvey;
@@ -2988,6 +3003,16 @@ function do_array_10point($ia)
 }
 
 
+/ **
+ * Render a "Yes / No / Uncertain" array question and return its rendered HTML and input field names.
+ *
+ * Renders the question's header, columns and rows according to question attributes and session state.
+ * Determines checked states from the survey session, respects mandatory and SHOW_NO_ANSWER settings,
+ * and collects the SGQA input names for all subquestions.
+ *
+ * @param array $ia Question information array (standard LimeSurvey $ia structure: contains QID, field name, question attributes, mandatory flag, etc.).
+ * @return array First element is the rendered HTML string for the question; second element is an array of input field names (SGQA) used by the question.
+ */
 function do_array_yesnouncertain($ia)
 {
     $aLastMoveResult         = LimeExpressionManager::GetLastMoveResult();
@@ -3094,6 +3119,16 @@ function do_array_yesnouncertain($ia)
 }
 
 
+/**
+ * Renders an "Increase / Same / Decrease" array question and returns its HTML and related input names.
+ *
+ * Renders the question as a table of subquestions with three choice columns (Increase, Same, Decrease)
+ * and an optional "No answer" column when the question is not mandatory and SHOW_NO_ANSWER is enabled.
+ * Selected states are read from the current survey session and mandatory subquestion violations are marked.
+ *
+ * @param array $ia Question information array (survey/question context and identifiers).
+ * @return array First element is the rendered HTML string for the question; second element is an array of input field names for all subquestions.
+ */
 function do_array_increasesamedecrease($ia)
 {
     $aLastMoveResult         = LimeExpressionManager::GetLastMoveResult();
@@ -4286,9 +4321,14 @@ function do_array_multiflexi($ia)
 // ---------------------------------------------------------------
 // TMSW TODO - Can remove DB query by passing in answer list from EM
 /**
- * Renders array by column question type.
- * @param array $ia
- * @return array
+ * Render an "array by column" question and return its HTML and input names.
+ *
+ * Builds the data required to display a matrix where answers are laid out as columns,
+ * computes checked states (including consolidated "No answer" handling), marks
+ * subquestion mandatory violations, and renders the question template.
+ *
+ * @param array $ia Question information array (internal LimeSurvey $ia structure).
+ * @return array [string $answerHtml, array|string $inputNames] Rendered HTML for the answer area and a list of related input field names (or an empty string on error).
  * @throws CException
  */
 function do_arraycolumns($ia)
@@ -4883,16 +4923,15 @@ function getLabelInputWidth($labelAttributeWidth, $inputAttributeWidth)
 }
 
 /**
-* Take a date string and fill out missing parts, like day, hour, minutes
-* (not seconds).
-* If string is NOT in standard date format (Y-m-d H:i), this methods makes no
-* sense.
-* Used when fetching answer for do_date, where answer can come from a default
-* answer expression like date('Y').
-* Will also truncate date('c') to format Y-m-d H:i.
-* @param string $dateString
-* @return string
-*/
+ * Normalize a partial ISO-like date string to the 'Y-m-d H:i' format by filling missing components.
+ *
+ * Accepts year-only, year-month, year-month-day, and other common ISO-like datetime strings (including
+ * date('c')). Seconds and smaller fractions are discarded. If the input cannot be interpreted as a date,
+ * an empty string is returned.
+ *
+ * @param string $dateString Partial or complete date/time string (e.g. "2024", "2024-03", "2024-03-05 14", "2024-03-05 14:30", or an ISO 8601 timestamp).
+ * @return string The normalized date/time formatted as "Y-m-d H:i", or an empty string on failure.
+ */
 function fillDate($dateString)
 {
     switch (strlen($dateString)) {
@@ -4928,15 +4967,10 @@ function fillDate($dateString)
 }
 
 /**
- * Check whether the "No Answer" option is selected for a given survey question.
- *
- * This function looks up the current survey session data
- * and checks whether the given SGQA identifier code
- * has a empty string value, indicating that the "No Answer" option has been checked.
+ * Determines whether the "No Answer" option is selected for the given SGQA identifier.
  *
  * @param string $sSGQA The SGQA identifier of the question to check.
- *
- * @return bool True if the "No Answer" option is checked (empty string value found), false otherwise.
+ * @return bool `true` if the survey session contains the SGQA key and its value is an empty string, `false` otherwise.
  */
 function getIsNoAnswerChecked($sSGQA)
 {

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -3083,7 +3083,7 @@ function do_array_yesnouncertain($ia)
             $Ychecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'Y') ? 'CHECKED' : '';
             $Uchecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'U') ? 'CHECKED' : '';
             $Nchecked  = (isset($_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname]) && $_SESSION['survey_' . Yii::app()->getConfig('surveyID')][$myfname] == 'N') ? 'CHECKED' : '';
-            $NAchecked = getIsNoAnswerChecked($myfname) ? 'CHECKED' : '';;
+            $NAchecked = getIsNoAnswerChecked($myfname) ? 'CHECKED' : '';
 
             $sRows .= doRender('/survey/questions/answer/arrays/yesnouncertain/rows/answer_row', array(
                 'basename'               => $ia[1],

--- a/application/models/QuestionBaseRenderer.php
+++ b/application/models/QuestionBaseRenderer.php
@@ -447,24 +447,19 @@ abstract class QuestionBaseRenderer extends StaticModel
     }
 
     /**
-     * Determine whether the "No Answer" option is checked for a given survey question.
+     * Checks if the "No Answer" option is checked for a given survey question.
      *
-     * This function checks the survey session array to see if a response exists
-     * for the provided SGQA identifier code. If no
-     * identifier is passed, it defaults to using the object's `$sSGQA` property.
+     * Determines whether an empty string response exists in the survey session
+     * for the given SGQA identifier, indicating that "No Answer" was selected.
      *
-     * @param string|null $sSGQA Optional SGQA identifier. Defaults to the instance's `$sSGQA` if not provided.
-     *
-     * @return bool True if a non-null value is found in the survey session array for the SGQA, false otherwise.
+     * @param string|null $sSGQA Optional SGQA identifier. If null, uses the instance's $sSGQA property.
+     * @return bool True if "No Answer" is selected (empty string in session), false otherwise.
      */
-    public function getIsNoAnswerChecked($sSGQA = null)
+    protected function isNoAnswerChecked($sSGQA = null)
     {
         $sSGQA = $sSGQA ?: $this->sSGQA;
-        $checked = false;
-        if (array_key_exists($sSGQA, $this->aSurveySessionArray)) {
-            $checked = $this->aSurveySessionArray[$sSGQA] !== null;
-        }
-        return $checked;
+
+        return getIsNoAnswerChecked($sSGQA);
     }
 
     abstract public function getMainView();

--- a/application/models/QuestionBaseRenderer.php
+++ b/application/models/QuestionBaseRenderer.php
@@ -446,6 +446,27 @@ abstract class QuestionBaseRenderer extends StaticModel
         return $script;
     }
 
+    /**
+     * Determine whether the "No Answer" option is checked for a given survey question.
+     *
+     * This function checks the survey session array to see if a response exists
+     * for the provided SGQA identifier code. If no
+     * identifier is passed, it defaults to using the object's `$sSGQA` property.
+     *
+     * @param string|null $sSGQA Optional SGQA identifier. Defaults to the instance's `$sSGQA` if not provided.
+     *
+     * @return bool True if a non-null value is found in the survey session array for the SGQA, false otherwise.
+     */
+    public function getIsNoAnswerChecked($sSGQA = null)
+    {
+        $sSGQA = $sSGQA ?: $this->sSGQA;
+        $checked = false;
+        if (array_key_exists($sSGQA, $this->aSurveySessionArray)) {
+            $checked = $this->aSurveySessionArray[$sSGQA] !== null;
+        }
+        return $checked;
+    }
+
     abstract public function getMainView();
     abstract public function getRows();
     abstract public function render();

--- a/application/models/QuestionBaseRenderer.php
+++ b/application/models/QuestionBaseRenderer.php
@@ -432,10 +432,12 @@ abstract class QuestionBaseRenderer extends StaticModel
     }
 
     /**
-     * Returns the question script to render depending on the language.
-     * If "Use for all languages" is set, the base language's script is used.
-     * @return string|null
-     */
+         * Selects and returns the question script for the appropriate language.
+         *
+         * When the question is configured to "use for all languages", the survey's base language script is chosen; otherwise the renderer language is used.
+         *
+         * @return string|null The localized question script, or null if no script is set for the resolved language.
+         */
     protected function getQuestionScript()
     {
         $language = $this->oQuestion->same_script ? $this->oQuestion->survey->language : $this->sLanguage;
@@ -462,7 +464,25 @@ abstract class QuestionBaseRenderer extends StaticModel
         return getIsNoAnswerChecked($sSGQA);
     }
 
-    abstract public function getMainView();
-    abstract public function getRows();
-    abstract public function render();
+    /**
+ * Provides the view identifier used to render the question's main template.
+ *
+ * @return string The view file name or path used to render the question's primary block.
+ */
+abstract public function getMainView();
+    /**
+ * Provide the rows used to render the question for the current view.
+ *
+ * Implementations must return an ordered array of row data structures representing
+ * the subquestions, answer rows, or structural blocks required by the renderer.
+ *
+ * @return array Ordered list of row definitions for rendering the question.
+ */
+abstract public function getRows();
+    /**
+ * Render the question and produce its HTML representation.
+ *
+ * @return string The rendered HTML for this question.
+ */
+abstract public function render();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified and corrected "No answer" selection so radio/checkbox options show consistent checked states across question types.

* **Refactor**
  * Consolidated "No answer" checked-state handling into shared logic used by multiple renderers to reduce inconsistencies.

* **Documentation**
  * Clarified docblocks describing row construction and script/language selection in renderer routines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->