### PR TITLE
New feature: New audit log plugin setting to disallow non-superadmins to disable AuditLog on individual surveys

### DIFF
--- a/application/core/plugins/AuditLog/AuditLog.php
+++ b/application/core/plugins/AuditLog/AuditLog.php
@@ -627,19 +627,30 @@ class AuditLog extends \LimeSurvey\PluginManager\PluginBase
         $pluginsettings = $this->getPluginSettings(true);
 
         $event = $this->getEvent();
+
+        // Build the auditing setting meta data
+        $auditingSetting = array(
+            'type' => 'select',
+            'options' => array(0 => 'No',
+                1 => 'Yes'),
+            'default' => 1,
+            'tab' => 'notification', // @todo: Setting no used yet
+            'category' => 'Auditing for person-related data', // @todo: Setting no used yet
+            'label' => 'Audit log for this survey:',
+            'current' => $this->get('auditing', 'Survey', $event->get('survey'))
+        );
+
+        // Disable the control for non-superadmin users to prevent them from disabling audit
+        $oCurrentUser = $this->api->getCurrentUser();
+        if ($oCurrentUser !== null && !Permission::model()->hasGlobalPermission('superadmin', 'read', $oCurrentUser->uid)) {
+            $auditingSetting['htmlOptions'] = array('disabled' => 'disabled');
+            $auditingSetting['help'] = gT('Only superadmins can disable the audit log for a survey.');
+        }
+
         $event->set("surveysettings.{$this->id}", array(
             'name' => get_class($this),
             'settings' => array(
-                'auditing' => array(
-                    'type' => 'select',
-                    'options' => array(0 => 'No',
-                        1 => 'Yes'),
-                    'default' => 1,
-                    'tab' => 'notification', // @todo: Setting no used yet
-                    'category' => 'Auditing for person-related data', // @todo: Setting no used yet
-                    'label' => 'Audit log for this survey:',
-                    'current' => $this->get('auditing', 'Survey', $event->get('survey'))
-                )
+                'auditing' => $auditingSetting
             )
         ));
     }
@@ -667,6 +678,20 @@ class AuditLog extends \LimeSurvey\PluginManager\PluginBase
             $oldSurvey = Survey::model()->find('sid = :sid', array(':sid' => $iSurveyID));
 
             $oldAttributes = $oldSurvey->getAttributes();
+
+            // Prevent non-superadmins from disabling auditing for a survey
+            $oCurrentUser = $this->api->getCurrentUser();
+            if (isset($newAttributes['auditing']) && isset($oldAttributes['auditing'])
+                && $newAttributes['auditing'] != $oldAttributes['auditing']
+                && (int)$newAttributes['auditing'] === 0
+                && !Permission::model()->hasGlobalPermission('superadmin', 'read', $oCurrentUser->uid)
+            ) {
+                // Revert the change and show an error message
+                $oModifiedSurvey->auditing = $oldAttributes['auditing'];
+                $newAttributes['auditing'] = $oldAttributes['auditing'];
+                App()->setFlashMessage(gT('You are not allowed to disable the audit log for this survey.'), 'error');
+            }
+
             $diff = array_diff_assoc($newAttributes, $oldAttributes);
             if (count($diff) > 0) {
                 $oAutoLog = $this->api->newModel($this, 'log');


### PR DESCRIPTION
<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Dev: The base version of the AuditLog plugin allows any survey designer to disable the audit log for their survey, which may be undesirable. This new feature adds a plugin configuration parameter that allows platform administrators to decide whether to disable this ability for non superadmin users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control whether non-superadmin survey admins may disable per-survey auditing.
  * Survey settings UI now reflects that policy—auditing control is disabled when overrides are not allowed and shows permission hints.

* **Bug Fixes / Enforcement**
  * Prevents unauthorized attempts to disable auditing at display and save time, ensuring policy is consistently enforced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->