### PR TITLE
Fixed issue #20404: Exclusive option not placed correct when using ra…

### DIFF
--- a/application/models/services/QuestionOrderingService/RandomizerHelper.php
+++ b/application/models/services/QuestionOrderingService/RandomizerHelper.php
@@ -89,13 +89,13 @@ class RandomizerHelper
         foreach ($groupedSubquestions as $scaleId => &$scaleArray) {
             $scaleArray = \ls\mersenne\shuffle($scaleArray);
         }
-
         // Reinsert excluded subquestion if needed
         if ($excludedSubquestion !== null) {
             $scaleId = $excludedSubquestion->scale_id;
+
             array_splice(
                 $groupedSubquestions[$scaleId],
-                ($excludedSubquestion->question_order - 1),
+                ($excludedSubquestion->question_order),
                 0,
                 [$excludedSubquestion]
             );

--- a/application/models/services/QuestionOrderingService/RandomizerHelper.php
+++ b/application/models/services/QuestionOrderingService/RandomizerHelper.php
@@ -69,7 +69,7 @@ class RandomizerHelper
         // Check for excluded subquestion before randomization
         /* @param string|null $excludeAllOthers */
         $excludeAllOthers = $question->getQuestionAttribute('exclude_all_others');
-        $excludedSubquestion = null;
+        $excludedSubquestions = [];
 
         if (
             $excludeAllOthers !== '' && $excludeAllOthers !== null &&

--- a/application/models/services/QuestionOrderingService/RandomizerHelper.php
+++ b/application/models/services/QuestionOrderingService/RandomizerHelper.php
@@ -89,7 +89,7 @@ class RandomizerHelper
         foreach ($groupedSubquestions as $scaleId => &$scaleArray) {
             $scaleArray = \ls\mersenne\shuffle($scaleArray);
         }
-        foreach($excludedSubquestions as $excludedSubquestion) {
+        foreach ($excludedSubquestions as $excludedSubquestion) {
             $scaleId = $excludedSubquestion->scale_id;
             array_splice(
                 $groupedSubquestions[$scaleId],
@@ -118,10 +118,10 @@ class RandomizerHelper
             return [$excludedSubquestions, $groupedSubquestions];
         }
         /* @var array of code tfor exclude */
-        $excludeAllOthersTitle = explode(";",$excludeAllOthers);
+        $excludeAllOthersTitle = explode(";", $excludeAllOthers);
         foreach ($groupedSubquestions as $scaleId => $scaleArray) {
             foreach ($scaleArray as $key => $subquestion) {
-                if (in_array($subquestion->title,$excludeAllOthersTitle)) {
+                if (in_array($subquestion->title, $excludeAllOthersTitle)) {
                     $subquestion->question_order = $key;
                     $excludedSubquestions[] = $subquestion;
                     $groupedSubquestions[$scaleId][$key] = null;

--- a/application/models/services/QuestionOrderingService/RandomizerHelper.php
+++ b/application/models/services/QuestionOrderingService/RandomizerHelper.php
@@ -89,10 +89,10 @@ class RandomizerHelper
         foreach ($groupedSubquestions as $scaleId => &$scaleArray) {
             $scaleArray = \ls\mersenne\shuffle($scaleArray);
         }
+
         // Reinsert excluded subquestion if needed
         if ($excludedSubquestion !== null) {
             $scaleId = $excludedSubquestion->scale_id;
-
             array_splice(
                 $groupedSubquestions[$scaleId],
                 ($excludedSubquestion->question_order),

--- a/application/models/services/QuestionOrderingService/RandomizerHelper.php
+++ b/application/models/services/QuestionOrderingService/RandomizerHelper.php
@@ -77,9 +77,9 @@ class RandomizerHelper
                 $question->getQuestionAttribute('subquestion_order') == 'random')
         ) {
             [
-                $excludedSubquestion,
+                $excludedSubquestions,
                 $groupedSubquestions
-            ] = $this->extractExcludedSubquestion(
+            ] = $this->extractExcludedSubquestions(
                 $groupedSubquestions,
                 $excludeAllOthers
             );
@@ -89,9 +89,7 @@ class RandomizerHelper
         foreach ($groupedSubquestions as $scaleId => &$scaleArray) {
             $scaleArray = \ls\mersenne\shuffle($scaleArray);
         }
-
-        // Reinsert excluded subquestion if needed
-        if ($excludedSubquestion !== null) {
+        foreach($excludedSubquestions as $excludedSubquestion) {
             $scaleId = $excludedSubquestion->scale_id;
             array_splice(
                 $groupedSubquestions[$scaleId],
@@ -100,13 +98,44 @@ class RandomizerHelper
                 [$excludedSubquestion]
             );
         }
-
         return $groupedSubquestions;
     }
 
     /**
-     * Extract excluded subquestion from the grouped subquestions
+     * Extract excluded subquestions from the grouped subquestions if there are only one
      *
+     * @param array $groupedSubquestions Subquestions grouped by scale_id
+     * @param string $excludeAllOthers The code of the excluded subquestion
+     * @return array [excludedSubquestions, updatedGroupedSubquestions] : excludedSubquestions is subquestion array with order set to index
+     */
+    public function extractExcludedSubquestions(
+        array $groupedSubquestions,
+        string $excludeAllOthers
+    ): array {
+        $excludedSubquestions = [];
+
+        if (empty($excludeAllOthers)) {
+            return [$excludedSubquestions, $groupedSubquestions];
+        }
+        /* @var array of code tfor exclude */
+        $excludeAllOthersTitle = explode(";",$excludeAllOthers);
+        foreach ($groupedSubquestions as $scaleId => $scaleArray) {
+            foreach ($scaleArray as $key => $subquestion) {
+                if (in_array($subquestion->title,$excludeAllOthersTitle)) {
+                    $subquestion->question_order = $key;
+                    $excludedSubquestions[] = $subquestion;
+                    $groupedSubquestions[$scaleId][$key] = null;
+                }
+            }
+            $groupedSubquestions[$scaleId] = array_values(array_filter($groupedSubquestions[$scaleId]));
+        }
+        return [$excludedSubquestions, $groupedSubquestions];
+    }
+
+    /**
+     * Extract single excluded subquestion from the grouped subquestions
+     *
+     * @deprecated 6.16.5 : use extractExcludedSubquestions to have multiple excluded subquestions
      * @param array $groupedSubquestions Subquestions grouped by scale_id
      * @param string $excludeAllOthers The code of the excluded subquestion
      * @return array [excludedSubquestion, updatedGroupedSubquestions]


### PR DESCRIPTION
…ndomized order

Dev: set as original position

<!-- Thank you for contributing to LimeSurvey! To make our work easier, please make sure to follow the instructions below. Thank you. -->

<!-- A pull request to LimeSurvey can either be a bug fix, a new feature or an internal development fix (refactoring etc). For bug fixes and new features, you must include the number to the Mantis issue from bugs.limesurvey.org. If no issue exists yet, please create it. Make sure to write down exactly how to reproduce a bug. For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation and merge. -->

<!-- Fixed issues should always go to the master branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch. -->

<!-- New features should always go to the develop branch. For more information about release schedule and code requirements, please see the following manual pages: https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule and https://manual.limesurvey.org/How_to_contribute_new_features -->

<!-- Keep one of the below lines. -->

Fixed issue #<Mantis issue number>:
New feature #<Mantis issue number>:
Dev:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of excluded subquestions during randomization: multiple excluded items (e.g., semicolon-separated titles) are now recognized and each restored to its correct position within the group.
  * Rewrote extraction and reinsertion logic to support multiple exclusions while retaining compatibility with single-item exclusions, improving ordering accuracy after randomization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->