### PR TITLE
Fixed issue #20447: [security] User can set any existing theme when saving survey

### DIFF
--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -599,15 +599,13 @@ class Survey extends LSActiveRecord implements PermissionInterface
      */
     public function filterTemplateSave($sTemplateName)
     {
+        // Make sure the user has permission to use the template.
         // 'inherit' is always permitted — the dropdown shows it without any permission check
         if ($sTemplateName !== 'inherit' && !Permission::model()->hasTemplatePermission($sTemplateName)) {
-            // Reset to default only if different from actual value
+            // For new records we can just set it to inherit, for existing ones we keep the old value.
             if (!$this->isNewRecord) {
                 $oSurvey = self::model()->findByPkNoCache($this->sid);
-                if ($oSurvey->template != $sTemplateName) {
-                    // No need to test !is_null($oSurvey)
-                    $sTemplateName = getGlobalSetting('defaulttheme');
-                }
+                $sTemplateName = $oSurvey->template ?? 'inherit';
             } else {
                 $sTemplateName = 'inherit';
             }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -603,8 +603,7 @@ class Survey extends LSActiveRecord implements PermissionInterface
         if ($sTemplateName !== 'inherit' && !Permission::model()->hasTemplatePermission($sTemplateName)) {
             // Reset to default only if different from actual value
             if (!$this->isNewRecord) {
-                $this->resetCache();
-                $oSurvey = self::model()->findByPk($this->sid);
+                $oSurvey = self::model()->findByPkNoCache($this->sid);
                 if ($oSurvey->template != $sTemplateName) {
                     // No need to test !is_null($oSurvey)
                     $sTemplateName = getGlobalSetting('defaulttheme');
@@ -1023,6 +1022,18 @@ class Survey extends LSActiveRecord implements PermissionInterface
         }
         $model = parent::findByPk($pk, $condition, $params);
         return $model;
+    }
+
+    /**
+     * Finds a single active record with the specified primary key, skipping the cache used by findByPk.
+     * @param mixed $pk primary key value(s). Use array for multiple primary keys. For composite key, each key value must be an array (column name=>column value).
+     * @param mixed $condition query condition or criteria.
+     * @param array $params parameters to be bound to an SQL statement.
+     * @return static|null the record found. Null if none is found.
+     */
+    public function findByPkNoCache($pk, $condition = '', $params = array())
+    {
+        return parent::findByPk($pk, $condition, $params);
     }
 
     /**

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -599,9 +599,11 @@ class Survey extends LSActiveRecord implements PermissionInterface
      */
     public function filterTemplateSave($sTemplateName)
     {
-        if (!Permission::model()->hasTemplatePermission($sTemplateName)) {
+        // 'inherit' is always permitted — the dropdown shows it without any permission check
+        if ($sTemplateName !== 'inherit' && !Permission::model()->hasTemplatePermission($sTemplateName)) {
             // Reset to default only if different from actual value
             if (!$this->isNewRecord) {
+                $this->resetCache();
                 $oSurvey = self::model()->findByPk($this->sid);
                 if ($oSurvey->template != $sTemplateName) {
                     // No need to test !is_null($oSurvey)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template selection now respects permission rules: "inherit" remains always allowed.
  * Existing surveys without permission preserve their stored template (or fallback to "inherit") instead of forcing the global default.
  * New surveys without permission default to "inherit".
  * Template names are validated and returned consistently after these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->