### PR TITLE
Fixed issue #20474: In Copy Survey modal window the button text overflows

### DIFF
--- a/application/views/surveyAdministration/partial/_modalCopySurvey.php
+++ b/application/views/surveyAdministration/partial/_modalCopySurvey.php
@@ -75,7 +75,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-cancel" data-bs-dismiss="modal"><?php eT("Cancel"); ?></button>
-                <input type='submit' id="copy-submit" class="btn btn-info col-3" value='<?php eT("Copy survey"); ?>' />
+                <input type='submit' id="copy-submit" class="btn btn-info" value='<?php eT("Copy survey"); ?>' />
 
                 <!-- Submit -->
             </div>


### PR DESCRIPTION
Fixed issue #20474: https://bugs.limesurvey.org/view.php?id=20474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout of the copy-survey button in the modal dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->