### PR TITLE
Bug/tb 82 anonymize responses dates

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5122,8 +5122,8 @@ class LimeExpressionManager
                 if($this->surveyOptions['anonymized'] == true) {
                     // we set a default timestamp here, in the responses view it
                     // should be clear that this response is anonymized
-                    $sdata['datestamp'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
-                    $sdata['startdate'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                    $sdata['datestamp'] = $this->defaultDateTime();
+                    $sdata['startdate'] = $this->defaultDateTime();
                 } else {
                     $sdata['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
                     $sdata['startdate'] = $_SESSION[$this->sessid]['datestamp'];
@@ -5205,7 +5205,7 @@ class LimeExpressionManager
             if ($this->surveyOptions['datestamp'] && isset($_SESSION[$this->sessid]['datestamp'])) {
                 $_SESSION[$this->sessid]['datestamp'] = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
                 if($this->surveyOptions['anonymized'] == true) {
-                    $aResponseAttributes['datestamp'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                    $aResponseAttributes['datestamp'] = $this->defaultDateTime();
                 } else {
                     $aResponseAttributes['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
                 }
@@ -5336,12 +5336,12 @@ class LimeExpressionManager
                         /* Less update : just do what you need to to */
                         if ($this->surveyOptions['datestamp']) {
                             if($this->surveyOptions['anonymized'] == true) {
-                                $submitdate = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                                $submitdate = $this->defaultDateTime();
                             } else {
                                 $submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
                             }
                         } else {
-                            $submitdate = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                            $submitdate = $this->defaultDateTime();
                         }
                         if (!Response::model($this->sid)->updateByPk($oResponse->id, ['submitdate' => $submitdate]) && $submitdate != $oResponse->submitdate) {
                             LimeExpressionManager::addFrontendFlashMessage('error', $this->gT('An error happened when trying to submit your response.'), $this->sid);
@@ -5357,6 +5357,17 @@ class LimeExpressionManager
             'readWrite' => 'N',
         ];
         return $message;
+    }
+
+    /**
+     * Returns the default dateTime we use to initialize or make the date anonymized
+     * It is set to "01-01-1980 00:00:00"
+     *
+     * @return string
+     */
+    private function defaultDateTime()
+    {
+        return date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
     }
 
     /**

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -5119,8 +5119,15 @@ class LimeExpressionManager
                 $sdata['token'] = $this->surveyOptions['token'];
             }
             if ($this->surveyOptions['datestamp'] == true) {
-                $sdata['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
-                $sdata['startdate'] = $_SESSION[$this->sessid]['datestamp'];
+                if($this->surveyOptions['anonymized'] == true) {
+                    // we set a default timestamp here, in the responses view it
+                    // should be clear that this response is anonymized
+                    $sdata['datestamp'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                    $sdata['startdate'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                } else {
+                    $sdata['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
+                    $sdata['startdate'] = $_SESSION[$this->sessid]['datestamp'];
+                }
             }
             if ($this->surveyOptions['ipaddr'] == true) {
                 $sdata['ipaddr'] = getIPAddress();
@@ -5197,7 +5204,11 @@ class LimeExpressionManager
 
             if ($this->surveyOptions['datestamp'] && isset($_SESSION[$this->sessid]['datestamp'])) {
                 $_SESSION[$this->sessid]['datestamp'] = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
-                $aResponseAttributes['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
+                if($this->surveyOptions['anonymized'] == true) {
+                    $aResponseAttributes['datestamp'] = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                } else {
+                    $aResponseAttributes['datestamp'] = $_SESSION[$this->sessid]['datestamp'];
+                }
             }
             if ($this->surveyOptions['ipaddr']) {
                 $aResponseAttributes['ipaddr'] = getIPAddress();
@@ -5324,7 +5335,11 @@ class LimeExpressionManager
                     if ($finished && ($oResponse->submitdate == null || Survey::model()->findByPk($this->sid)->isAllowEditAfterCompletion)) {
                         /* Less update : just do what you need to to */
                         if ($this->surveyOptions['datestamp']) {
-                            $submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                            if($this->surveyOptions['anonymized'] == true) {
+                                $submitdate = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
+                            } else {
+                                $submitdate = dateShift(date("Y-m-d H:i:s"), "Y-m-d H:i:s", $this->surveyOptions['timeadjust']);
+                            }
                         } else {
                             $submitdate = date("Y-m-d H:i:s", mktime(0, 0, 0, 1, 1, 1980));
                         }


### PR DESCRIPTION
Fixed issue #T82: anonymize responses should have higher priority then datestamp. Submit date and date last action and start date should be anonymized if the setting is set to on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When surveys are configured as anonymized, timestamp fields now display a constant default value instead of actual submission times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->