### PR TITLE
Fixed issue #20480: Proper font support for non-latin chars in PDF export

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -372,31 +372,13 @@ $config['pdfdefaultfont'] = 'auto'; //Default font for the pdf Export
 *  Some language are not tested : need translation for Yes,No and Gender : ckb, swh
 */
 $config['alternatepdffontfile'] = array(
-    'ar' => 'dejavusans', // 'dejavusans' work but maybe more characters in aealarabiya or almohanad: but then need a dynamic font size too
-    'be' => 'dejavusans',
-    'bg' => 'dejavusans',
     'zh-Hans' => 'cid0cs',
     'zh-Hant-HK' => 'cid0ct',
     'zh-Hant-TW' => 'cid0ct',
-    'cs' => 'dejavusans',
-    'cs-informal' => 'dejavusans', // This one not really tested: no translation for Yes/No or Gender
-    'el' => 'dejavusans',
     'he' => 'freesans',
-    'hi' => 'dejavusans',
-    'hr' => 'dejavusans',
-    'hu' => 'dejavusans',
     'ja' => 'cid0jp',
     'ko' => 'cid0kr',
-    'lv' => 'dejavusans',
-    'lt' => 'dejavusans',
-    'mk' => 'dejavusans',
-    'mt' => 'dejavusans',
-    'fa' => 'dejavusans',
-    'pl' => 'dejavusans',
     'pa' => 'freesans',
-    'ro' => 'dejavusans',
-    'ru' => 'dejavusans',
-    'sr' => 'dejavusans'
 );
 /**
 *  $notsupportlanguages - array of language where no font was found for PDF

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -397,6 +397,7 @@ $config['alternatepdffontfile'] = array(
     'ro' => 'dejavusans',
     'ru' => 'dejavusans',
     'sr' => 'dejavusans',
+    'en' => 'dejavusans',
 );
 /**
 *  $notsupportlanguages - array of language where no font was found for PDF

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -396,8 +396,7 @@ $config['alternatepdffontfile'] = array(
     'pa' => 'freesans',
     'ro' => 'dejavusans',
     'ru' => 'dejavusans',
-    'sr' => 'dejavusans',
-    'en' => 'dejavusans',
+    'sr' => 'dejavusans'
 );
 /**
 *  $notsupportlanguages - array of language where no font was found for PDF

--- a/application/config/tcpdf.php
+++ b/application/config/tcpdf.php
@@ -197,9 +197,9 @@
     * HTML <small> font size ratio
     ***********************************************************/
 
-    $tcpdf['page_font'] = 'freesans';
+    $tcpdf['page_font'] = 'dejavusans';
     $tcpdf['page_font_size'] = 9;
-    $tcpdf['data_font'] = 'freesans';
+    $tcpdf['data_font'] = 'dejavusans';
     $tcpdf['data_font_size'] = 8;
     $tcpdf['mono_font'] = 'freemono';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched default PDF fonts to DejaVu Sans for page and data text, improving font consistency across generated documents (including headers/footers).
  * Removed several alternate PDF font mappings for specific languages, simplifying fallback behavior for those locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->