### PR TITLE
New feature #20482: Add one click unsubscribe functionality

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -161,6 +161,7 @@ $internalConfig = array(
                 'rest',
                 'admin/remotecontrol',
                 'plugins/unsecure',
+                'optout/tokens',
             ),
             'csrfCookie' => array(
                 'secure' => ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)),

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -1,4 +1,6 @@
-<?php  if (!defined('BASEPATH')) {
+<?php
+
+if (!defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
 /*
@@ -20,7 +22,7 @@ $route['<_sid:\d+>/lang-<_lang:\w+[-\w]+>/tk-<_token:\w+>/*'] = "survey/index/si
 $route['<_sid:\d+>/lang-<_lang:\w+[-\w]+>/*'] = "survey/index/sid/<_sid>/lang/<_lang>";
 $route['<_sid:\d+>/tk-<_token:\w+>/*'] = "survey/index/sid/<_sid>/token/<_token>";
 $route['<_sid:\d+>/*'] = "survey/index/sid/<_sid>";
-$route['<sid:\d+>'] = array('survey/index', 'matchValue'=>true);
+$route['<sid:\d+>'] = array('survey/index', 'matchValue' => true);
 
 //Admin Routes
 $route['admin/index'] = "admin"; // this can not be changed to "dashboard/view" as long as the AdminController exists, will break "path" urlFormat
@@ -57,11 +59,11 @@ $route['rest/<_api_version:\w+>/<_entity>/<_id>/<_basetable>'] = array(
 
 //optout - optin
 $route['optout/<_sid:\d+>/(:any)/(:any)'] = "optout/index/<_sid>/$2/$3";
-$route['optout/tokens/<surveyid:\d+>'] = array('optout/tokens', 'matchValue'=>true);
-$route['optout/participants/<surveyid:\d+>'] = array('optout/participants', 'matchValue'=>true);
-$route['optin/tokens/<surveyid:\d+>'] = array('optin/tokens', 'matchValue'=>true);
-$route['optin/participants/<surveyid:\d+>'] = array('optin/participants', 'matchValue'=>true);
-$route['statistics_user/<surveyid:\d+>'] = array('StatisticsUser/action', 'matchValue'=>true);
+$route['optout/tokens/<surveyid:\d+>'] = array('optout/tokens', 'matchValue' => true);
+$route['optout/participants/<surveyid:\d+>'] = array('optout/participants', 'matchValue' => true);
+$route['optin/tokens/<surveyid:\d+>'] = array('optin/tokens', 'matchValue' => true);
+$route['optin/participants/<surveyid:\d+>'] = array('optin/participants', 'matchValue' => true);
+$route['statistics_user/<surveyid:\d+>'] = array('StatisticsUser/action', 'matchValue' => true);
 $route['statistics_user/action'] = 'StatisticsUser/action';
 
 //$route['<_controller:\w+>/<_action:\w+>'] = '<_controller>/<_action>';

--- a/application/controllers/OptinController.php
+++ b/application/controllers/OptinController.php
@@ -66,7 +66,7 @@ class OptinController extends LSYii_Controller
         if (!isset($token)) {
             $message = gT('You are not a participant of this survey.');
         } else {
-            if ($token->emailstatus != 'OptOut') {
+            if (!$token->optOutStatus) {
                 $message = gT('You are already a participant of this survey.');
             } else {
                 $message = gT('Please confirm that you want to be added back to this survey by clicking the button below.') . '<br>' . gT("After confirmation you may start receiving invitations and reminders for this survey.");
@@ -91,7 +91,7 @@ class OptinController extends LSYii_Controller
         $accessToken = Token::sanitizeToken(Yii::app()->request->getQuery('token'));
 
         //IF there is no survey ID, redirect back to the default public page
-        if (!$surveyId) {
+        if (!$surveyId || !$accessToken) {
             $this->redirect(['/']);
         }
 
@@ -119,8 +119,6 @@ class OptinController extends LSYii_Controller
         if (!isset($token)) {
             $message = gT('You are not a participant of this survey.');
         } else {
-            $optedOutFromSurvey = substr((string) $token->emailstatus, 0, strlen('OptOut')) == 'OptOut';
-
             $blacklistHandler = new LimeSurvey\Models\Services\ParticipantBlacklistHandler();
             $participant = $blacklistHandler->getCentralParticipantFromToken($token);
             $isBlacklisted = !empty($participant) && $participant->blacklisted == 'Y';
@@ -130,7 +128,7 @@ class OptinController extends LSYii_Controller
             } elseif ($isBlacklisted) {
                 $message = gT('Please confirm that you want to be added back to the central participant list for this site.');
                 $link = Yii::app()->createUrl('optin/addtokens', ['surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken, 'global' => true]);
-            } elseif ($optedOutFromSurvey) {
+            } elseif ($token->optOutStatus) {
                 $message = gT('Please confirm that you want to be added back to this survey by clicking the button below.') . '<br>' . gT("After confirmation you may start receiving invitations and reminders for this survey.");
                 $link = Yii::app()->createUrl('optin/addtokens', ['surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken]);
             } elseif (empty($participant)) {
@@ -162,7 +160,7 @@ class OptinController extends LSYii_Controller
         Yii::app()->loadHelper('database');
         Yii::app()->loadHelper('sanitize');
 
-        if (!$surveyId) {
+        if (!$surveyId || !$accessToken) {
             $this->redirect(['/']);
         }
 
@@ -189,9 +187,11 @@ class OptinController extends LSYii_Controller
         if (!isset($token)) {
             $message = gT('You are not a participant of this survey.');
         } else {
-            if ($token->emailstatus == 'OptOut') {
-                $token->emailstatus = 'OK';
-                $token->save();
+            if ($token->optOutStatus) {
+                $token->optIn();
+                if (!$token->save(true, ['emailstatus'])) {
+                    throw new CHttpException(500, gT('An internal error occurred while the Web server was processing your request.'));
+                }
                 $message = gT('You have been successfully added back to this survey.');
             } elseif ($token->emailstatus == 'OK') {
                 $message = gT('You are already a participant of this survey.');

--- a/application/controllers/OptoutController.php
+++ b/application/controllers/OptoutController.php
@@ -13,6 +13,42 @@
  *
  */
 
+/*
+    there are a few different flows through this controller
+
+    GET optout/actiontokens -> GET optout/removetokens
+
+    user vists optouturl and for older themes there is a button
+    that actually opts out via a GET request when clicked. the
+    problem with this is that some mail filters crawl the optout url
+    and perform that GET request, causing participants to be opted out
+
+    GET optout/actiontokens -> POST optout/removetoken
+
+    user vists optouturl and for newer themes there is a form
+    which POSTs to an endpoint intead. the automated filters will
+    not perform the POST request. this prevents the above problem.
+
+    POST optout/actiontokens
+
+    this is one click unsubscribe, a special post request is sent
+    to the list unsubscribe url (the same url a user would visit
+    to manually opt out, first flow above) when mail clients have
+    this available, if a user reports a message as spam, the client
+    can then offer to unsubscribe the user instead.
+
+    GET optout/participants -> GET optout/removetokens
+
+    similar to the first flow above, but opts out the participant
+    from the central participant database as well as the survey
+    and all other surveys if they request it
+
+    GET optout/participants -> POST optout/removetokens
+
+    similar to the second flow above, solves the get vs post request
+    issue. similar functionality to the previous flow.
+*/
+
 /**
  * optout
  *
@@ -34,6 +70,19 @@ class OptoutController extends LSYii_Controller
      */
     public function actiontokens()
     {
+        // handle a one click unsubscribe post request
+        // this is distinct from the "secure POST link"
+        // mentioned above which is a different endpoint
+        // per rfc8058
+        // "The target of
+        // the POST action is the same as the one in the GET action for a manual
+        // unsubscription, so this is intended to allow the same server code to
+        // handle both."
+        if(Yii::app()->request->isPostRequest) {
+            $this->oneClickUnsubscribe();
+            return;
+        }
+
         $iSurveyID     = Yii::app()->request->getQuery('surveyid');
         $sLanguageCode = Yii::app()->request->getQuery('langcode');
         $sToken        = Token::sanitizeToken(Yii::app()->request->getQuery('token'));
@@ -65,7 +114,7 @@ class OptoutController extends LSYii_Controller
         if (!isset($oToken)) {
             $sMessage = gT('You are not a participant of this survey.');
         } else {
-            if (substr((string) $oToken->emailstatus, 0, strlen('OptOut')) == 'OptOut') {
+            if ($oToken->optOutStatus) {
                 $sMessage = gT('You have already been removed from this survey.');
             } else {
                 $sMessage = gT('Please confirm that you want to opt out of this survey by clicking the button below.') . '<br>' . gT("After confirmation you won't receive any invitations or reminders for this survey anymore.");
@@ -75,6 +124,32 @@ class OptoutController extends LSYii_Controller
             $tokenAttributes = $oToken->getAttributes();
         }
         $this->renderHtml($sMessage, $oSurvey, $link, $tokenAttributes, [], $postLink ?? '');
+    }
+
+    /**
+     * Handle post request for one click unsubcribe
+     * See: https://datatracker.ietf.org/doc/html/rfc8058
+     *
+     * Note the following explicit requirement:
+     * The mail sender MUST NOT return an HTTPS redirect, since redirected
+     * POST actions have historically not worked reliably, and many browsers
+     * have turned redirected HTTP POSTs into GETs.
+     */
+    public function oneClickUnsubscribe()
+    {
+        // per rfc8058
+        // "A mail receiver can do a one-click unsubscription by performing an
+        // HTTPS POST to the HTTPS URI in the List-Unsubscribe header.  It sends
+        // the key/value pair in the List-Unsubscribe-Post header as the request
+        // body."
+        // and
+        // "The List-Unsubscribe-Post header MUST contain the single
+        // key/value pair "List-Unsubscribe=One-Click"."
+        if (Yii::app()->request->getPost('List-Unsubscribe') !== "One-Click") {
+            throw new CHttpException(400, gT('Invalid request.'));
+        }
+
+        $this->handleOptout();
     }
 
     /**
@@ -119,8 +194,6 @@ class OptoutController extends LSYii_Controller
         if (!isset($token)) {
             $message = gT('You are not a participant of this survey.');
         } else {
-            $optedOutFromSurvey = substr((string) $token->emailstatus, 0, strlen('OptOut')) == 'OptOut';
-
             $blacklistHandler = new LimeSurvey\Models\Services\ParticipantBlacklistHandler();
             $participant = $blacklistHandler->getCentralParticipantFromToken($token);
 
@@ -128,7 +201,7 @@ class OptoutController extends LSYii_Controller
                 $message = gT('Please confirm that you want to be removed from the central participant list for this site.');
                 $link = Yii::app()->createUrl('optout/removetokens', array('surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken, 'global' => true));
                 $postLink = Yii::app()->createUrl('optout/removetoken', array('surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken, 'global' => true));
-            } elseif (!$optedOutFromSurvey) {
+            } elseif (!$token->optOutStatus) {
                 $message = gT('Please confirm that you want to opt out of this survey by clicking the button below.') . '<br>' . gT("After confirmation you won't receive any invitations or reminders for this survey anymore.");
                 $link = Yii::app()->createUrl('optout/removetokens', array('surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken));
                 $postLink = Yii::app()->createUrl('optout/removetoken', array('surveyid' => $surveyId, 'langcode' => $baseLanguage, 'token' => $accessToken));
@@ -214,9 +287,11 @@ class OptoutController extends LSYii_Controller
         if (!isset($token)) {
             $message = gT('You are not a participant in this survey.');
         } else {
-            if (substr((string) $token->emailstatus, 0, strlen('OptOut')) !== 'OptOut') {
-                $token->emailstatus = 'OptOut';
-                $token->save();
+            if (!$token->optOutStatus) {
+                $token->optOut();
+                if (!$token->save(true, ['emailstatus'])) {
+                    throw new CHttpException(500, gT('An internal error occurred while the Web server was processing your request.'));
+                }
                 $message = gT('You have been successfully removed from this survey.');
             } else {
                 $message = gT('You have already been removed from this survey.');

--- a/application/controllers/RegisterController.php
+++ b/application/controllers/RegisterController.php
@@ -358,7 +358,7 @@ class RegisterController extends LSYii_Controller
             $oToken->decrypt();
             if ($oToken->usesleft < 1 && $aSurveyInfo['alloweditaftercompletion'] != 'Y') {
                 $this->aRegisterErrors[] = gT("The email address you have entered is already registered and the survey has been completed.");
-            } elseif (strtolower(substr(trim((string) $oToken->emailstatus), 0, 6)) === "optout") {
+            } elseif ($oToken->optOutStatus) {
                 // And global blocklisting ?
                 {
                 $this->aRegisterErrors[] = gT("This email address cannot be used because it was opted out of this survey.");

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -3082,7 +3082,7 @@ class Tokens extends SurveyCommonAction
         if ($request->getPost('bypassbademails') == '1') {
             return "emailstatus = 'OK'";
         } else {
-            return "emailstatus <> 'OptOut' OR emailstatus IS NULL";
+            return "emailstatus NOT LIKE 'OptOut%' OR emailstatus IS NULL";
         }
     }
 

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -343,6 +343,23 @@ class LimeMailer extends PHPMailer
             $this->addAddress($sEmailaddress, $oToken->firstname . " " . $oToken->lastname);
         }
         $this->addCustomHeader("X-tokenid", $oToken->token);
+
+        // add list unsubscribe header
+        // see: https://datatracker.ietf.org/doc/html/rfc2369
+        // the url is the same as OPTOUTURL replacement field
+        $oneClickURL = App()->getController()->createAbsoluteUrl(
+            "/optout/tokens",
+            [
+                "surveyid" => $this->surveyId,
+                "token" => $oToken->token,
+                "langcode" => $this->mailLanguage,
+            ],
+        );
+        $this->addCustomHeader("List-Unsubscribe", "<$oneClickURL>");
+
+        // add one click unsubscribe header
+        // see: https://datatracker.ietf.org/doc/html/rfc8058
+        $this->addCustomHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click");
     }
 
     /**

--- a/application/models/Token.php
+++ b/application/models/Token.php
@@ -423,7 +423,7 @@ abstract class Token extends Dynamic
             array('lastname', 'filter', 'filter' => array(self::class, 'sanitizeAttribute')),
             array('language', 'LSYii_Validators', 'isLanguage' => true),
             array('language','in','range' => array_merge(array($this->survey->language), explode(' ', $this->survey->additional_languages)),'allowEmpty' => true,'message' => gT('Language code is invalid in this survey')),
-            array(implode(',', $this->tableSchema->columnNames), 'safe'),
+            array(implode(',', $this->tableSchema->columnNames ?? []), 'safe'),
             /* pseudo date : force date or specific string ? */
             array('remindersent', 'length', 'min' => 0, 'max' => 17),
             array('remindersent', 'filter', 'filter' => array(self::class, 'sanitizeAttribute')),
@@ -527,9 +527,37 @@ abstract class Token extends Dynamic
         if (Yii::app()->getConfig('blacklistnewsurveys') == "Y" && $this->getIsNewRecord()) {
             $blacklistHandler = new LimeSurvey\Models\Services\ParticipantBlacklistHandler();
             if ($blacklistHandler->isTokenBlacklisted($this)) {
-                $this->emailstatus = "OptOut";
+                $this->optOut();
             }
         }
         return parent::onBeforeSave($event);
+    }
+
+    /**
+     * Get opt out status of token from email status
+     * @return bool true if token is opted out, false if not
+     */
+    public function getOptOutStatus()
+    {
+        // This must be something for backwards compatibility
+        // the query above also has OptOut% in the summary function
+        // implying something comes after
+        return substr((string) $this->emailstatus, 0, strlen('OptOut')) === 'OptOut';
+    }
+
+    /**
+     * Opt out the token by updating the email status
+     */
+    public function optOut()
+    {
+        $this->emailstatus = 'OptOut';
+    }
+
+    /**
+     * Opt in the token by updating the email status
+     */
+    public function optIn()
+    {
+        $this->emailstatus = 'OK';
     }
 }

--- a/application/models/services/ParticipantBlacklistHandler.php
+++ b/application/models/services/ParticipantBlacklistHandler.php
@@ -119,11 +119,12 @@ class ParticipantBlacklistHandler
         $optedoutSurveyIds = [];
         foreach ($surveys as $survey) {
             if ($survey->hasTokensTable) {
-                $token = \Token::model($survey->sid)->findByAttributes(['participant_id' => $participant->participant_id], "emailstatus <> 'OptOut'");
+                $token = \Token::model($survey->sid)->findByAttributes(['participant_id' => $participant->participant_id], "emailstatus NOT LIKE 'OptOut%' OR emailstatus IS NULL");
                 if (!empty($token)) {
-                    $token->emailstatus = 'OptOut';
-                    $token->save();
-                    $optedoutSurveyIds[] = $survey->sid;
+                    $token->optOut();
+                    if($token->save(true, ['emailstatus'])) {
+                        $optedoutSurveyIds[] = $survey->sid;
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://bugs.limesurvey.org/view.php?id=20482

New feature #20482: Add one click unsubscribe functionality



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RFC 8058 one‑click unsubscribe support and included List‑Unsubscribe headers in outgoing emails.

* **Improvements**
  * Unified and more reliable opt‑out/opt‑in state handling across flows.
  * Stricter request validation, added redirect guards, and explicit error handling when persistence fails.

* **Chores**
  * Normalized routing and CSRF configuration to enable the one‑click flow from email clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->