### PR TITLE
AT-1984: Fixed language based attribute are only being updated in the base language

### DIFF
--- a/editor/src/components/QuestionSettings/QuestionSettings.js
+++ b/editor/src/components/QuestionSettings/QuestionSettings.js
@@ -38,6 +38,7 @@ export const QuestionSettings = ({ surveyId }) => {
     isExpressionScriptPanelOpen: false,
   })
   const [scenarioToPatch, setScenarioToPatch] = useState(null)
+  const [activeLanguage] = useAppState(STATES.ACTIVE_LANGUAGE)
 
   // holds the scenario ID currently has a new conditions (waiting for temp condition IDs to be replaced)
   const [pendingScenarioName, setPendingScenarioName] = useState(null)
@@ -213,7 +214,7 @@ export const QuestionSettings = ({ surveyId }) => {
                 handleUpdate={updateAttribute}
                 title={setting.title}
                 attributes={setting.attributes}
-                language={language}
+                language={activeLanguage}
               />
             )
           })}

--- a/editor/src/components/QuestionSettings/Setting.js
+++ b/editor/src/components/QuestionSettings/Setting.js
@@ -37,19 +37,32 @@ export const Setting = ({
     return undefined
   }
 
+  const getFullAttributeValueFromPath = (attributePath) => {
+    const path = attributePath.split('.')
+    return path.reduce((acc, key) => acc[key], question) || ''
+  }
+
   const getUpdateValueFromPath = (value, attribute) => {
     const attributePath = attribute?.attributePath ?? ''
     const attributeName = attributePath.toString().includes('attributes.')
       ? attributePath.replace('attributes.', '')
       : ''
 
+    // Todo: why is it called advanced attribute?
     const isAdvancedAttribute = attributePath.includes('attributes.')
 
     const updateValue = {}
 
     if (isAdvancedAttribute) {
-      updateValue[attributeName] = {
-        [attribute.languageBased ? language : '']: value,
+      if (attribute.languageBased) {
+        updateValue[attributeName] = {
+          ...getFullAttributeValueFromPath(attributePath),
+          [language]: value,
+        }
+      } else {
+        updateValue[attributeName] = {
+          ['']: value,
+        }
       }
     } else {
       attribute.returnValues.map((returnValue) => {

--- a/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
@@ -393,6 +393,7 @@ export const getDisplayAttributes = () => ({
   SUBQUESTION_TITLE: {
     component: Input,
     attributePath: 'attributes.other_position_code',
+    languageBased: true,
     props: {
       dataTestId: 'sub-question-title',
       labelText: t("Subquestion title for 'After specific subquestion'"),

--- a/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
@@ -600,6 +600,7 @@ export const getDisplayAttributes = () => ({
   PLACEHOLDER_ANSWER: {
     component: Input,
     attributePath: 'attributes.placeholder',
+    languageBased: true,
     props: {
       dataTestId: 'placeholder-answer',
       labelText: t('Placeholder answer'),
@@ -619,6 +620,7 @@ export const getDisplayAttributes = () => ({
   DROPDOWN_PREFIX_SUFFIX: {
     component: Input,
     attributePath: 'attributes.dropdown_prepostfix',
+    languageBased: true,
     props: {
       dataTestId: 'dropdown-prefix-suffix',
       labelText: t('Dropdown prefix/suffix'),

--- a/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getDisplayAttributes.js
@@ -193,6 +193,7 @@ export const getDisplayAttributes = () => ({
   ANSWER_PREFIX: {
     component: Input,
     attributePath: 'attributes.prefix',
+    languageBased: true,
     props: {
       dataTestId: 'answer-prefix',
       labelText: t('Answer prefix'),
@@ -201,6 +202,7 @@ export const getDisplayAttributes = () => ({
   ANSWER_SUFFIX: {
     component: Input,
     attributePath: 'attributes.suffix',
+    languageBased: true,
     props: {
       dataTestId: 'answer-suffix',
       labelText: t('Answer suffix'),

--- a/editor/src/components/QuestionSettings/attributes/getLogicAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getLogicAttributes.js
@@ -152,8 +152,9 @@ export const getLogicAttributes = () => ({
   SUBQUESTION_VALIDATION_TIP: {
     component: Input,
     attributePath: 'attributes.em_validation_sq_tip',
+    languageBased: true,
     props: {
-      labelText: t('Question validation tip'),
+      labelText: t('Subquestion validation tip'),
     },
   },
   QUESTION_VALIDATION_TIP: {


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use the app’s active language in question settings so UI follows the selected language.
  * Ensure prefix, suffix, placeholder, dropdown prefix/suffix and subquestion title can hold separate values per language.
  * Merge updated translations with existing localized values instead of overwriting them.
  * Clarified subquestion validation tip label text to "Subquestion validation tip".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->