### PR TITLE
Fixed issue #20491: Missing feedback when registering with the same email

### DIFF
--- a/themes/survey/fruity_twentythree/views/subviews/registration/register_message.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/registration/register_message.twig
@@ -19,7 +19,7 @@
     <div {{ aSurveyInfo.attr.registermessagea }} class="large-heading">
         {{ gT("Thank you for registering.") }}
         <div class="form-heading mt-3">
-            {{ gT("You will receive an email shortly.") }}
+            {{ gT("You will receive an email shortly. But if you already registered, you will not receive another email.") }}
         </div>
     </div>
 {% else %}

--- a/themes/survey/vanilla/views/subviews/registration/register_message.twig
+++ b/themes/survey/vanilla/views/subviews/registration/register_message.twig
@@ -16,7 +16,7 @@
 #}
 
 {% if registerSuccess %}
-    <h4 {{ aSurveyInfo.attr.registermessageb }} >{{ gT("Thank you for registering. You will receive an email shortly.") }}</h4>
+    <h4 {{ aSurveyInfo.attr.registermessageb }} >{{ gT("Thank you for registering. You will receive an email shortly. But if you already registered, you will not receive another email.") }}</h4>
 {% else %}
     {% if sStartDate %}
     <h4 {{ aSurveyInfo.attr.registermessagea }} > {{ gT("You may register for this survey but you have to wait for the {{sStartDate}} before starting the survey.") }}</h4>


### PR DESCRIPTION
- added feedback when registering for a survey with the same email address

Fixed issue #20491: Missing feedback when registering with the same email


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration success message across themes to clarify that users will not receive duplicate confirmation emails if already registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->