### PR TITLE
Fixed issue #TB-92: filecount qcode not being mapped correctly

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3615,6 +3615,10 @@ class LimeExpressionManager
                 case Question::QT_X_TEXT_DISPLAY: //BOILERPLATE QUESTION
                 case Question::QT_Y_YES_NO_RADIO: //YES/NO radio-buttons
                 case Question::QT_VERTICAL_FILE_UPLOAD: //File Upload
+                    $varName = !empty($aid)
+                        ? $fielddata['title'] . '_' . $aid
+                        : $fielddata['title'];
+                    break;
                 case Question::QT_ASTERISK_EQUATION: //Equation
                     $csuffix = '';
                     $sqsuffix = '';

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3614,16 +3614,16 @@ class LimeExpressionManager
                 case Question::QT_U_HUGE_FREE_TEXT: //Huge free text
                 case Question::QT_X_TEXT_DISPLAY: //BOILERPLATE QUESTION
                 case Question::QT_Y_YES_NO_RADIO: //YES/NO radio-buttons
-                case Question::QT_VERTICAL_FILE_UPLOAD: //File Upload
-                    $varName = !empty($aid)
-                        ? $fielddata['title'] . '_' . $aid
-                        : $fielddata['title'];
-                    break;
                 case Question::QT_ASTERISK_EQUATION: //Equation
                     $csuffix = '';
                     $sqsuffix = '';
                     $varName = $fielddata['title'];
                     $question = $fielddata['question'];
+                    break;
+                case Question::QT_VERTICAL_FILE_UPLOAD: //File Upload
+                    $varName = !empty($aid)
+                        ? $fielddata['title'] . '_' . $aid
+                        : $fielddata['title'];
                     break;
                 case Question::QT_1_ARRAY_DUAL: // Array dual scale
                     $csuffix = $fielddata['aid'] . '#' . $fielddata['scale_id'];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected variable naming for vertical file-upload questions in the expression manager so identifiers include the answer index when present. This prevents naming collisions with other question types and ensures calculated expressions and field references resolve to the intended upload field reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->