### PR TITLE
Fixed issue #TB-98:  expression rowdivid had wrong result for array numbers and array text types

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3327,12 +3327,12 @@ class LimeExpressionManager
      */
     public function setVariableAndTokenMappingsForExpressionManager($surveyid, $forceRefresh = false, $anonymized = false)
     {
-        if (isset($_SESSION['LEMforceRefresh'])) {
-            unset($_SESSION['LEMforceRefresh']);
-            $forceRefresh = true;
-        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database') || ($this->sPreviewMode === 'logic'))) {
-            return false;   // means that those variables have been cached and no changes needed
-        }
+//        if (isset($_SESSION['LEMforceRefresh'])) {
+//            unset($_SESSION['LEMforceRefresh']);
+//            $forceRefresh = true;
+//        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database') || ($this->sPreviewMode === 'logic'))) {
+//            return false;   // means that those variables have been cached and no changes needed
+//        }
         $now = microtime(true);
         $this->em->SetSurveyMode($this->surveyMode);
         $survey = Survey::model()->findByPk($surveyid);
@@ -3692,8 +3692,10 @@ class LimeExpressionManager
                     $sqsuffix = '_' . substr((string) $fielddata['aid'], 0, (int)strpos((string) $fielddata['aid'], '_'));
                     $varName = $fielddata['title'] . '_' . $fielddata['aid'];
                     $question = $fielddata['subquestion1'] . '[' . $fielddata['subquestion2'] . ']';
-                    //                    $question = $fielddata['question'] . ': ' . $fielddata['subquestion1'] . '[' . $fielddata['subquestion2'] . ']';
-                    $rowdivid = substr((string) $sgqa, 0, (int)strpos((string) $sgqa, '_'));
+                    // 2D arrays: $sgqa = Q{qid}_S{rowSubqID}_S{colSubqID}, keep Q{qid}_S{rowSubqID}
+                    $firstUnderscore = strpos((string) $sgqa, '_');
+                    $secondUnderscore = strpos((string) $sgqa, '_', $firstUnderscore + 1);
+                    $rowdivid = substr((string) $sgqa, 0, $secondUnderscore);
                     break;
                 default:
                     // TODO: Internal error if this happens

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -3327,12 +3327,12 @@ class LimeExpressionManager
      */
     public function setVariableAndTokenMappingsForExpressionManager($surveyid, $forceRefresh = false, $anonymized = false)
     {
-//        if (isset($_SESSION['LEMforceRefresh'])) {
-//            unset($_SESSION['LEMforceRefresh']);
-//            $forceRefresh = true;
-//        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database') || ($this->sPreviewMode === 'logic'))) {
-//            return false;   // means that those variables have been cached and no changes needed
-//        }
+        if (isset($_SESSION['LEMforceRefresh'])) {
+            unset($_SESSION['LEMforceRefresh']);
+            $forceRefresh = true;
+        } elseif ($forceRefresh === false && !empty($this->knownVars) && ((!$this->sPreviewMode) || ($this->sPreviewMode === 'database') || ($this->sPreviewMode === 'logic'))) {
+            return false;   // means that those variables have been cached and no changes needed
+        }
         $now = microtime(true);
         $this->em->SetSurveyMode($this->surveyMode);
         $survey = Survey::model()->findByPk($surveyid);


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable/token mapping for two-dimensional (matrix) questions so row identifiers now retain full subquestion references, ensuring correct row-specific expression evaluation and more reliable dynamic calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->