### PR TITLE
Fixed issue #TB-96 and TB-103: function convertLegacyInsertans() doesn't convert everything to the correct format

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5639,7 +5639,9 @@ function convertLegacyInsertans($text, array $questions = [], $newOldSurveyQuest
                 $qcode = $parentTitle . '_comment.shown';
             } else {
                 // Any other suffix is a subquestion code (e.g. SQ001, F1, 1, ls1)
-                $qcode = $parentTitle . '_' . $resolvedSuffix . '.shown';
+                // If the suffix already starts with '_' (e.g. "_filecount"), don't add another one
+                $separator = str_starts_with($resolvedSuffix, '_') ? '' : '_';
+                $qcode = $parentTitle . $separator . $resolvedSuffix . '.shown';
             }
 
             return $hasBraces ? '{' . $qcode . '}' : $qcode;

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5557,57 +5557,91 @@ function csvEscape($string)
 }
 
 /**
- * Convert legacy INSERTANS tags to modern question code references
+ * Convert legacy INSERTANS tags to modern question code references.
  *
- * Converts {INSERTANS:SIDXGIDXQID} format to questionTitle.shown format
+ * The result is wrapped in curly braces only when the source tag also used curly braces.
+ *
+ * When the QID+suffix boundary is ambiguous (e.g. purely numeric suffixes in array
+ * questions like {INSERTANS:136212X36X10921}), the function progressively tries
+ * shorter QID values until a known QID is found, treating the remainder as suffix.
+ *
  * Examples:
- * - {INSERTANS:554233X11X1} ? G01Q02.shown (if QID 1 exists)
- * - {INSERTANS:554233X11X11} ? {INSERTANS:554233X11X11} (if QID 11 doesn't exist)
- * - {INSERTANS:554233X11X1someText} ? someText.shown (if QID 1 exists)
- * - {INSERTANS:554233X11X11someText} ? {INSERTANS:554233X11X11someText} (if QID 11 doesn't exist)
+ * - {INSERTANS:554233X11X1}        → {G01Q02.shown}          (with braces, QID exists)
+ * - INSERTANS:554233X11X1          → G01Q02.shown             (without braces, QID exists)
+ * - {INSERTANS:554233X11X99}       → {INSERTANS:554233X11X99} (unchanged, QID not found)
+ * - {INSERTANS:554233X11X1other}   → {G01Q02_other.shown}    (other field)
+ * - {INSERTANS:554233X11X1comment} → {G01Q02_comment.shown}  (comment field)
+ * - {INSERTANS:554233X11X1SQ001}   → {G01Q02_SQ001.shown}    (subquestion suffix)
+ * - {INSERTANS:136212X36X10921}    → {qArray5Point_1.shown}   (numeric suffix, QID=1092)
  *
  * @param string $text The text containing INSERTANS tags
- * @param array $questions The list of all questions
- * @param array $newOldSurveyQuestionMap The mapping between the old question IDs and the new question IDs in the new survey
- * @return string The text with INSERTANS tags converted
+ * @param array $questions The list of all question objects (parent and subquestions)
+ * @param array $newOldSurveyQuestionMap Mapping from new question IDs to old question IDs
+ * @return string The text with INSERTANS tags converted to qcode.shown format
  */
 function convertLegacyInsertans($text, array $questions = [], $newOldSurveyQuestionMap = [])
 {
-    $txtInsertans = "{INSERTANS:";
-
-    if (empty($text) || !str_contains($text, $txtInsertans) || empty($questions) || empty($newOldSurveyQuestionMap)) {
+    if (empty($text) || !str_contains($text, 'INSERTANS:') || empty($questions)) {
         return $text;
     }
 
-    $questionCodes = [];
+    // Map old QID → question title, built via the new→old mapping
+    $questionCodesByOldQid = [];
     foreach ($questions as $question) {
-        $questionCodes[$newOldSurveyQuestionMap[$question->qid]] = $question->title;
-    }
-
-    $insertansPos = strpos($text, $txtInsertans);
-    if ($insertansPos !== false) {
-        $insertansParts = explode($txtInsertans, $text);
-        for ($index = 1; $index < count($insertansParts); $index++) {
-            $curlyPosition = strpos($insertansParts[$index], "}");
-            $rawField = substr($insertansParts[$index], 0, $curlyPosition);
-            $content = (strlen($insertansParts[$index]) === $curlyPosition) ? "" : substr($insertansParts[$index], $curlyPosition + 1);
-            $subField = substr($rawField, strpos($rawField, "X") + 1);
-            $title = substr($subField, strpos($subField, "X") + 1);
-            if (preg_match('/^(\d+)([a-zA-Z].*)$/', $title, $match)) {
-                $oldQid = (int) $match[1];
-                $title = $match[2];
-                if(!isset($questionCodes[$oldQid]))
-                    $title = "";
-            } else {
-                $title = $questionCodes[$title] ?? "";
-            }
-            $insertansParts[$index] = !empty($title) ?  $title . ".shown" . $content : $txtInsertans . $rawField . '}' . $content;
+        if (!empty($newOldSurveyQuestionMap[$question->qid])) {
+            $questionCodesByOldQid[$newOldSurveyQuestionMap[$question->qid]] = $question->title;
         }
-
-        return implode($insertansParts);
     }
 
-    return $text;
+    return preg_replace_callback(
+        '/(\{?)INSERTANS:([^}\s]+)\}?/',
+        static function ($matches) use ($questionCodesByOldQid) {
+            $hasBraces = $matches[1] === '{';
+            $rawField  = $matches[2];
+
+            // Only old SGQA format is supported: SIDXGIDXQID[suffix]
+            if (!preg_match('/^(\d+)X(\d+)X(\d+)(.*)$/', $rawField, $m)) {
+                return $matches[0]; // Not a recognised format – leave unchanged
+            }
+
+            $qidPart = $m[3];
+            $suffix  = $m[4];
+
+            // Resolve QID: the regex greedily captures all digits into $qidPart,
+            // but for array-type questions the suffix can be purely numeric
+            // (e.g. "10921" = QID 1092 + suffix "1"). Try the full number first,
+            // then progressively shorten $qidPart, moving trailing digits to $suffix.
+            $parentTitle = null;
+            $resolvedSuffix = $suffix;
+            for ($i = strlen($qidPart); $i >= 1; $i--) {
+                $tryQid    = (int) substr($qidPart, 0, $i);
+                $trySuffix = substr($qidPart, $i) . $suffix;
+                if (isset($questionCodesByOldQid[$tryQid])) {
+                    $parentTitle    = $questionCodesByOldQid[$tryQid];
+                    $resolvedSuffix = $trySuffix;
+                    break;
+                }
+            }
+
+            if ($parentTitle === null) {
+                return $matches[0]; // QID not found – leave unchanged
+            }
+
+            if ($resolvedSuffix === '') {
+                $qcode = $parentTitle . '.shown';
+            } elseif (strtolower($resolvedSuffix) === 'other') {
+                $qcode = $parentTitle . '_other.shown';
+            } elseif (strtolower($resolvedSuffix) === 'comment') {
+                $qcode = $parentTitle . '_comment.shown';
+            } else {
+                // Any other suffix is a subquestion code (e.g. SQ001, F1, 1, ls1)
+                $qcode = $parentTitle . '_' . $resolvedSuffix . '.shown';
+            }
+
+            return $hasBraces ? '{' . $qcode . '}' : $qcode;
+        },
+        $text
+    );
 }
 
 /**

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5586,10 +5586,12 @@ function convertLegacyInsertans($text, array $questions = [], $newOldSurveyQuest
         return $text;
     }
 
-    // Map old QID → question title, built via the new→old mapping
+    // Map old QID → question title, built via the new→old mapping.
+    // Only parent questions (parent_qid = 0) are included, because INSERTANS
+    // references parent QIDs with the subquestion code as suffix.
     $questionCodesByOldQid = [];
     foreach ($questions as $question) {
-        if (!empty($newOldSurveyQuestionMap[$question->qid])) {
+        if (!empty($newOldSurveyQuestionMap[$question->qid]) && empty($question->parent_qid)) {
             $questionCodesByOldQid[$newOldSurveyQuestionMap[$question->qid]] = $question->title;
         }
     }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5573,6 +5573,7 @@ function csvEscape($string)
  * - {INSERTANS:554233X11X1comment} → {G01Q02_comment.shown}  (comment field)
  * - {INSERTANS:554233X11X1SQ001}   → {G01Q02_SQ001.shown}    (subquestion suffix)
  * - {INSERTANS:136212X36X10921}    → {qArray5Point_1.shown}   (numeric suffix, QID=1092)
+ * - {INSERTANS:136212X36X1098money#0} → {qArrayDualScale_money_0.shown} (dual scale, # → _)
  *
  * @param string $text The text containing INSERTANS tags
  * @param array $questions The list of all question objects (parent and subquestions)
@@ -5626,6 +5627,9 @@ function convertLegacyInsertans($text, array $questions = [], $newOldSurveyQuest
             if ($parentTitle === null) {
                 return $matches[0]; // QID not found – leave unchanged
             }
+
+            // Dual-scale arrays use '#' as separator (e.g. "money#0"), convert to '_'
+            $resolvedSuffix = str_replace('#', '_', $resolvedSuffix);
 
             if ($resolvedSuffix === '') {
                 $qcode = $parentTitle . '.shown';

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5635,12 +5635,8 @@ function convertLegacyInsertans($text, array $questions = [], $newOldSurveyQuest
 
             if ($resolvedSuffix === '') {
                 $qcode = $parentTitle . '.shown';
-            } elseif (strtolower($resolvedSuffix) === 'other') {
-                $qcode = $parentTitle . '_other.shown';
-            } elseif (strtolower($resolvedSuffix) === 'comment') {
-                $qcode = $parentTitle . '_comment.shown';
             } else {
-                // Any other suffix is a subquestion code (e.g. SQ001, F1, 1, ls1)
+                // Suffix is a subquestion code (e.g. SQ001, other, comment, F1, 1, ls1)
                 // If the suffix already starts with '_' (e.g. "_filecount"), don't add another one
                 $separator = str_starts_with($resolvedSuffix, '_') ? '' : '_';
                 $qcode = $parentTitle . $separator . $resolvedSuffix . '.shown';

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1170,7 +1170,6 @@ class Update_700 extends DatabaseUpdateBase
         foreach ($defaultValues as $defaultValue) {
             $dvids[] = $defaultValue->dvid;
         }
-        $default10ns = DefaultValueL10n::model()->findAll("dvid in (" . implode(",", $dvids) . ")");
 
         $entityFields = [
             [
@@ -1178,7 +1177,7 @@ class Update_700 extends DatabaseUpdateBase
                 'fields' => ['cfieldname', 'value']
             ],
             [
-                'entities' => QuestionL10n::model()->findAll("qid in (" . implode(",", $qids) . ")"),
+                'entities' => (new QuestionL10n())->resetScope()->findAll("qid in (" . implode(",", $qids) . ")"),
                 'fields' => ["question", "script", "help"]
             ],
             [
@@ -1186,7 +1185,7 @@ class Update_700 extends DatabaseUpdateBase
                 'fields' => ['title', 'relevance']
             ],
             [
-                'entities' => SurveyLanguageSetting::model()->findAll("surveyls_survey_id=" . $sid),
+                'entities' => (new SurveyLanguageSetting())->resetScope()->findAll("surveyls_survey_id=" . $sid),
                 'fields' => ['surveyls_urldescription', 'surveyls_url']
             ],
             [
@@ -1202,11 +1201,11 @@ class Update_700 extends DatabaseUpdateBase
                 'fields' => ['name', 'message']
             ],
             [
-                'entities' => $default10ns,
+                'entities' => (new DefaultValueL10n())->resetScope()->findAll("dvid in (" . implode(",", $dvids) . ")"),
                 'fields' => ['defaultvalue']
             ],
             [
-                'entities' => AnswerL10n::model()->findAll("aid in (" . implode(",", $aids) . ")"),
+                'entities' => (new AnswerL10n())->resetScope()->findAll("aid in (" . implode(",", $aids) . ")"),
                 'fields' => ['answer']
             ]
         ];

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1083,12 +1083,8 @@ class Update_700 extends DatabaseUpdateBase
 
                 if ($resolvedSuffix === '') {
                     $qcode = $parentTitle . '.shown';
-                } elseif (strtolower($resolvedSuffix) === 'other') {
-                    $qcode = $parentTitle . '_other.shown';
-                } elseif (strtolower($resolvedSuffix) === 'comment') {
-                    $qcode = $parentTitle . '_comment.shown';
                 } else {
-                    // Any other suffix is a subquestion code (e.g. SQ001, F1, 1, ls1)
+                    // Suffix is a subquestion code (e.g. SQ001, other, comment, F1, 1, ls1)
                     // If the suffix already starts with '_' (e.g. "_filecount"), don't add another one
                     $separator = (strpos($resolvedSuffix, '_') === 0) ? '' : '_';
                     $qcode = $parentTitle . $separator . $resolvedSuffix . '.shown';

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -29,6 +29,9 @@ class Update_700 extends DatabaseUpdateBase
 
     protected $questionCodes = [];
 
+    /** @var array Survey IDs that have already been processed for INSERTANS conversion */
+    protected $insertansProcessedSids = [];
+
     /**
      * This function generates an array containing the fieldcode, and matching data in the same order as the activate script
      *
@@ -1133,7 +1136,99 @@ class Update_700 extends DatabaseUpdateBase
         return $changed;
     }
 
-    /** @SuppressWarnings(PHPMD.ExcessiveMethodLength) */
+    /**
+     * Convert INSERTANS tags and fix SGQA references in all text fields of a survey.
+     *
+     * Loads all relevant entities (QuestionL10n, QuestionGroupL10n, SurveyLanguageSetting,
+     * Conditions, Assessments, QuotaLanguageSettings, DefaultValueL10n, AnswerL10n) and
+     * applies handleInsertans() plus optional fixText() replacements, then saves changed records.
+     *
+     * @param int|string $sid The survey ID
+     * @param Question[] $questions The survey's questions (with answers eager-loaded)
+     * @param array $fieldNames SGQA→new field name map for fixText (may be empty)
+     * @param array $additionalNames SGQA→Q{qid} map for fixText (may be empty)
+     * @param bool $guardRelevance When true, skip saving Question entities with relevance field
+     *                              if the question's survey relation is missing (active survey guard)
+     */
+    protected function convertSurveyInsertans($sid, array $questions, array $fieldNames = [], array $additionalNames = [], $guardRelevance = false)
+    {
+        $qids = [0];
+        $gids = [0];
+        $aids = [0];
+        foreach ($questions as $question) {
+            $qids[] = $question->qid;
+            if (!in_array($question->gid, $gids)) {
+                $gids[] = (int)$question->gid;
+            }
+            foreach ($question->answers as $answer) {
+                $aids[] = $answer->aid;
+            }
+        }
+
+        $defaultValues = DefaultValue::model()->findAll("qid in (" . implode(",", $qids) . ")");
+        $dvids = [0];
+        foreach ($defaultValues as $defaultValue) {
+            $dvids[] = $defaultValue->dvid;
+        }
+        $default10ns = DefaultValueL10n::model()->findAll("dvid in (" . implode(",", $dvids) . ")");
+
+        $entityFields = [
+            [
+                'entities' => Condition::model()->findAll("qid in (" . implode(",", $qids) . ")"),
+                'fields' => ['cfieldname', 'value']
+            ],
+            [
+                'entities' => QuestionL10n::model()->findAll("qid in (" . implode(",", $qids) . ")"),
+                'fields' => ["question", "script", "help"]
+            ],
+            [
+                'entities' => $questions,
+                'fields' => ['title', 'relevance']
+            ],
+            [
+                'entities' => SurveyLanguageSetting::model()->findAll("surveyls_survey_id=" . $sid),
+                'fields' => ['surveyls_urldescription', 'surveyls_url']
+            ],
+            [
+                'entities' => QuotaLanguageSetting::model()->with(['quota' => ['condition' => 'sid=' . $sid]])->together()->findAll(),
+                'fields' => ['quotals_url', 'quotals_urldescrip']
+            ],
+            [
+                'entities' => (new QuestionGroupL10n())->resetScope()->findAll("gid in (" . implode(",", $gids) . ")"),
+                'fields' => ['description', 'group_name']
+            ],
+            [
+                'entities' => Assessment::model()->findAll("sid = " . $sid),
+                'fields' => ['name', 'message']
+            ],
+            [
+                'entities' => $default10ns,
+                'fields' => ['defaultvalue']
+            ],
+            [
+                'entities' => AnswerL10n::model()->findAll("aid in (" . implode(",", $aids) . ")"),
+                'fields' => ['answer']
+            ]
+        ];
+
+        foreach ($entityFields as $ef) {
+            foreach ($ef['entities'] as $entity) {
+                $changed = $this->handleInsertans($entity, $ef['fields'], $sid);
+                if (!empty($fieldNames)) {
+                    $changed = $this->fixText($entity, $ef['fields'], $fieldNames) || $changed;
+                }
+                if (!empty($additionalNames)) {
+                    $changed = $this->fixText($entity, $ef['fields'], $additionalNames) || $changed;
+                }
+                if ($changed) {
+                    if ($guardRelevance && in_array('relevance', $ef['fields']) && $entity->qid && (!$entity->survey)) {
+                        continue;
+                    }
+                    $entity->save();
+                }
+            }
+        }
+    }
     public function up()
     {
         $this->db->createCommand($this->insertRankingSubquestions())->execute();
@@ -1271,6 +1366,7 @@ class Update_700 extends DatabaseUpdateBase
                 $parts = explode("_", $TABLE_NAME);
                 $index = count($parts) - ((strpos($TABLE_NAME, "old") === false) ? 1 : 2);
                 $sid = $parts[$index];
+                $this->insertansProcessedSids[$sid] = true;
                 foreach ($keys as $oldName) {
                     $names[$oldName] = $fieldMap[$TABLE_NAME][$oldName];
                 }
@@ -1278,18 +1374,8 @@ class Update_700 extends DatabaseUpdateBase
                 $questions = Question::model()->with('answers')->findAll("sid = :sid", [
                     ":sid" => $sid
                 ]);
-                $qids = [0];
-                $gids = [0];
-                $aids = [0];
                 foreach ($questions as $question) {
                     $rawAdditionalNames["{$question->sid}X{$question->gid}X{$question->qid}"] = "Q{$question->qid}";
-                    $qids[] = $question->qid;
-                    if (!in_array($question->gid, $gids)) {
-                        $gids[] = (int)$question->gid;
-                    }
-                    foreach ($question->answers as $answer) {
-                        $aids[] = $answer->aid;
-                    }
                 }
                 $additionalNameKeys = array_keys($rawAdditionalNames);
                 arsort($additionalNameKeys);
@@ -1297,86 +1383,20 @@ class Update_700 extends DatabaseUpdateBase
                 foreach ($additionalNameKeys as $additionalNameKey) {
                     $additionalNames[$additionalNameKey] = $rawAdditionalNames[$additionalNameKey];
                 }
-                $defaultValues = DefaultValue::model()->findAll("qid in (" . implode(",", $qids) . ")");
-                $dvids = [0];
-                foreach ($defaultValues as $defaultValue) {
-                    $dvids[] = $defaultValue->dvid;
-                }
-                $default10ns = DefaultValueL10n::model()->findAll("dvid in (" . implode(",", $dvids) . ")");
-                $entityFields = [
-                    [
-                        'entities' => Condition::model()->findAll("qid in (" . implode(",", $qids) . ")"),
-                        'fields' => ['cfieldname', 'value']
-                    ],
-                    [
-                        'entities' => QuestionL10n::model()->findAll("qid in (" . implode(",", $qids) . ")"),
-                        'fields' => ["question", "script", "help"]
-                    ],
-                    [
-                        'entities' => $questions,
-                        'fields' => ['title', 'relevance']
-                    ],
-                    [
-                        'entities' => SurveyLanguageSetting::model()->findAll("surveyls_survey_id=" . $sid),
-                        'fields' => ['surveyls_urldescription', 'surveyls_url']
-                    ],
-                    [
-                        'entities' => QuotaLanguageSetting::model()->with(['quota' => ['condition' => 'sid=' . $sid]])->together()->findAll(),
-                        'fields' => ['quotals_url', 'quotals_urldescrip']
-                    ],
-                    [
-                        'entities' => (new QuestionGroupL10n())->resetScope()->findAll("gid in (" . implode(",", $gids) . ")"),
-                        'fields' => ['description', 'group_name']
-                    ],
-                    [
-                        'entities' => Assessment::model()->findAll("sid = " . $sid),
-                        'fields' => ['name', 'message']
-                    ],
-                    [
-                        'entities' => $default10ns,
-                        'fields' => ['defaultvalue']
-                    ],
-                    [
-                        'entities' => AnswerL10n::model()->findAll("aid in (" . implode(",", $aids) . ")"),
-                        'fields' => ['answer']
-                    ]
-                ];
-                foreach ($entityFields as $ef) {
-                    foreach ($ef['entities'] as $entity) {
-                        $save = [
-                            $this->handleInsertans($entity, $ef['fields'], $sid),
-                            $this->fixText($entity, $ef['fields'], $names),
-                            $this->fixText($entity, $ef['fields'], $additionalNames)
-                        ];
-                        if ($save[0] || $save[1] || $save[2]) {
-                            if (!(in_array('relevance', $ef['fields']) && $entity->qid && (!$entity->survey))) {
-                                $entity->save();
-                            }
-                        }
-                    }
-                }
+                $this->convertSurveyInsertans($sid, $questions, $names, $additionalNames, true);
             }
         }
 
         $passiveSurveys = Survey::model()->findAll("active <> 'Y'");
         foreach ($passiveSurveys as $passiveSurvey) {
             $sid = $passiveSurvey->sid;
-            $qids = [0];
-            $gids = [0];
-            $aids = [0];
+            $this->insertansProcessedSids[$sid] = true;
             $questions = Question::model()->with('answers')->findAll("sid = :sid", [
                 ":sid" => $passiveSurvey->sid
             ]);
             $rawAdditionalNames = [];
             foreach ($questions as $question) {
                 $rawAdditionalNames["{$question->sid}X{$question->gid}X{$question->qid}"] = "Q{$question->qid}";
-                $qids[] = $question->qid;
-                if (!in_array($question->gid, $gids)) {
-                    $gids[] = (int)$question->gid;
-                }
-                foreach ($question->answers as $answer) {
-                    $aids[] = $answer->aid;
-                }
             }
             $additionalNameKeys = array_keys($rawAdditionalNames);
             arsort($additionalNameKeys);
@@ -1412,62 +1432,20 @@ class Update_700 extends DatabaseUpdateBase
                     }
                 }
             }
-            $defaultValues = DefaultValue::model()->findAll("qid in (" . implode(",", $qids) . ")");
-            $dvids = [0];
-            foreach ($defaultValues as $defaultValue) {
-                $dvids[] = $defaultValue->dvid;
+            $this->convertSurveyInsertans($sid, $questions, $newFields, $additionalNames);
+        }
+
+        // Catch-all: convert INSERTANS tags for any surveys not already processed above.
+        // The active-survey loop only processes surveys that have response tables with SGQA columns,
+        // so active surveys without such columns would be missed.
+        $allSurveys = Survey::model()->findAll();
+        foreach ($allSurveys as $survey) {
+            $sid = $survey->sid;
+            if (isset($this->insertansProcessedSids[$sid])) {
+                continue;
             }
-            $default10ns = DefaultValueL10n::model()->findAll("dvid in (" . implode(",", $dvids) . ")");
-            $entityFields = [
-                [
-                    'entities' => Condition::model()->findAll("qid in (" . implode(",", $qids) . ")"),
-                    'fields' => ['cfieldname', 'value']
-                ],
-                [
-                    'entities' => QuestionL10n::model()->findAll("qid in (" . implode(",", $qids) . ")"),
-                    'fields' => ["question", "script", "help"]
-                ],
-                [
-                    'entities' => $questions,
-                    'fields' => ['title', 'relevance']
-                ],
-                [
-                    'entities' => SurveyLanguageSetting::model()->findAll("surveyls_survey_id=" . $sid),
-                    'fields' => ['surveyls_urldescription', 'surveyls_url']
-                ],
-                [
-                    'entities' => QuotaLanguageSetting::model()->with(['quota' => ['condition' => 'sid=' . $sid]])->together()->findAll(),
-                    'fields' => ['quotals_url', 'quotals_urldescrip']
-                ],
-                [
-                    'entities' => (new QuestionGroupL10n())->resetScope()->findAll("gid in (" . implode(",", $gids) . ")"),
-                    'fields' => ['description', 'group_name']
-                ],
-                [
-                    'entities' => Assessment::model()->findAll("sid = " . $sid),
-                    'fields' => ['name', 'message']
-                ],
-                [
-                    'entities' => $default10ns,
-                    'fields' => ['defaultvalue']
-                ],
-                [
-                    'entities' => AnswerL10n::model()->findAll("aid in (" . implode(",", $aids) . ")"),
-                    'fields' => ['answer']
-                ]
-            ];
-            foreach ($entityFields as $ef) {
-                foreach ($ef['entities'] as $entity) {
-                    $save = [
-                        $this->handleInsertans($entity, $ef['fields'], $sid),
-                        $this->fixText($entity, $ef['fields'], $newFields),
-                        $this->fixText($entity, $ef['fields'], $additionalNames)
-                    ];
-                    if ($save[0] || $save[1] || $save[2]) {
-                        $entity->save();
-                    }
-                }
-            }
+            $questions = Question::model()->with('answers')->findAll("sid = :sid", [":sid" => $sid]);
+            $this->convertSurveyInsertans($sid, $questions);
         }
 
         foreach ($scripts as $TABLE_NAME => $content) {

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1110,11 +1110,14 @@ class Update_700 extends DatabaseUpdateBase
     protected function handleInsertans(LSActiveRecord &$record, $fields, $sid)
     {
         $changed = false;
+        $sid = (int) $sid;
 
-        // Lazy-load question codes for this survey (QID → title)
-        if (empty($this->questionCodes[$sid])) {
+        // Lazy-load question codes for this survey (QID → title).
+        // Only parent questions (parent_qid = 0) are included, because INSERTANS
+        // references parent QIDs with the subquestion code as suffix.
+        if (!isset($this->questionCodes[$sid])) {
             $this->questionCodes[$sid] = [];
-            $questions = Question::model()->findAll("sid = :sid", [":sid" => $sid]);
+            $questions = Question::model()->findAll("sid = :sid AND parent_qid = 0", [":sid" => $sid]);
             foreach ($questions as $question) {
                 $this->questionCodes[$sid][$question->qid] = $question->title;
             }
@@ -1152,6 +1155,7 @@ class Update_700 extends DatabaseUpdateBase
      */
     protected function convertSurveyInsertans($sid, array $questions, array $fieldNames = [], array $additionalNames = [], $guardRelevance = false)
     {
+        $sid = (int) $sid;
         $qids = [0];
         $gids = [0];
         $aids = [0];

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1036,6 +1036,7 @@ class Update_700 extends DatabaseUpdateBase
      * @param string $text The text containing INSERTANS tags
      * @param array $questionCodesByQid Mapping of QID => question title
      * @return string The text with INSERTANS tags converted to qcode.shown format
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function convertLegacyInsertans($text, array $questionCodesByQid)
     {
@@ -1152,6 +1153,7 @@ class Update_700 extends DatabaseUpdateBase
      * @param array $additionalNames SGQA→Q{qid} map for fixText (may be empty)
      * @param bool $guardRelevance When true, skip saving Question entities with relevance field
      *                              if the question's survey relation is missing (active survey guard)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function convertSurveyInsertans($sid, array $questions, array $fieldNames = [], array $additionalNames = [], $guardRelevance = false)
     {
@@ -1232,6 +1234,7 @@ class Update_700 extends DatabaseUpdateBase
             }
         }
     }
+    /** @SuppressWarnings(PHPMD.ExcessiveMethodLength) */
     public function up()
     {
         $this->db->createCommand($this->insertRankingSubquestions())->execute();

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1022,44 +1022,114 @@ class Update_700 extends DatabaseUpdateBase
     }
 
     /**
-     * Checks for insertans tags and replaces them with titles
-     * @param LSActiveRecord $record the record whose insertans is to be handled
-     * @param mixed $fields the fields where it may occur
-     * @param mixed $sid the id of the survey
-     * @return bool whether we changed the record
+     * Convert legacy INSERTANS tags to modern question code references.
+     *
+     * The result is wrapped in curly braces only when the source tag also used curly braces.
+     *
+     * When the QID+suffix boundary is ambiguous (e.g. purely numeric suffixes in array
+     * questions like {INSERTANS:136212X36X10921}), the function progressively tries
+     * shorter QID values until a known QID is found, treating the remainder as suffix.
+     *
+     * @param string $text The text containing INSERTANS tags
+     * @param array $questionCodesByQid Mapping of QID => question title
+     * @return string The text with INSERTANS tags converted to qcode.shown format
+     */
+    protected function convertLegacyInsertans($text, array $questionCodesByQid)
+    {
+        if (empty($text) || strpos($text, 'INSERTANS:') === false || empty($questionCodesByQid)) {
+            return $text;
+        }
+
+        return preg_replace_callback(
+            '/(\{?)INSERTANS:([^}\s]+)\}?/',
+            static function ($matches) use ($questionCodesByQid) {
+                $hasBraces = $matches[1] === '{';
+                $rawField  = $matches[2];
+
+                // Only old SGQA format is supported: SIDXGIDXQID[suffix]
+                if (!preg_match('/^(\d+)X(\d+)X(\d+)(.*)$/', $rawField, $m)) {
+                    return $matches[0]; // Not a recognised format – leave unchanged
+                }
+
+                $qidPart = $m[3];
+                $suffix  = $m[4];
+
+                // Resolve QID: the regex greedily captures all digits into $qidPart,
+                // but for array-type questions the suffix can be purely numeric
+                // (e.g. "10921" = QID 1092 + suffix "1"). Try the full number first,
+                // then progressively shorten $qidPart, moving trailing digits to $suffix.
+                $parentTitle = null;
+                $resolvedSuffix = $suffix;
+                for ($i = strlen($qidPart); $i >= 1; $i--) {
+                    $tryQid    = (int) substr($qidPart, 0, $i);
+                    $trySuffix = substr($qidPart, $i) . $suffix;
+                    if (isset($questionCodesByQid[$tryQid])) {
+                        $parentTitle    = $questionCodesByQid[$tryQid];
+                        $resolvedSuffix = $trySuffix;
+                        break;
+                    }
+                }
+
+                if ($parentTitle === null) {
+                    return $matches[0]; // QID not found – leave unchanged
+                }
+
+                // Dual-scale arrays use '#' as separator (e.g. "money#0"), convert to '_'
+                $resolvedSuffix = str_replace('#', '_', $resolvedSuffix);
+
+                if ($resolvedSuffix === '') {
+                    $qcode = $parentTitle . '.shown';
+                } elseif (strtolower($resolvedSuffix) === 'other') {
+                    $qcode = $parentTitle . '_other.shown';
+                } elseif (strtolower($resolvedSuffix) === 'comment') {
+                    $qcode = $parentTitle . '_comment.shown';
+                } else {
+                    // Any other suffix is a subquestion code (e.g. SQ001, F1, 1, ls1)
+                    // If the suffix already starts with '_' (e.g. "_filecount"), don't add another one
+                    $separator = (strpos($resolvedSuffix, '_') === 0) ? '' : '_';
+                    $qcode = $parentTitle . $separator . $resolvedSuffix . '.shown';
+                }
+
+                return $hasBraces ? '{' . $qcode . '}' : $qcode;
+            },
+            $text
+        );
+    }
+
+    /**
+     * Applies convertLegacyInsertans() to the specified fields of a record.
+     *
+     * @param LSActiveRecord $record the record whose fields are to be converted
+     * @param array $fields the field names where INSERTANS tags may occur
+     * @param int|string $sid the survey ID (used to lazy-load question codes)
+     * @return bool whether the record was changed
      */
     protected function handleInsertans(LSActiveRecord &$record, $fields, $sid)
     {
         $changed = false;
-        $txtInsertans = "{INSERTANS:";
-        foreach ($fields as $field) {
-            $insertansPos = strpos($record->{$field} ?? "", $txtInsertans);
-            if ($insertansPos !== false) {
-                $changed = true;
-                if (empty($this->questionCodes[$sid])) {
-                    $this->questionCodes[$sid] = [];
-                    $questions = Question::model()->findAll("sid = :sid", [":sid" => $sid]);
-                    foreach ($questions as $question) {
-                        $this->questionCodes[$sid][$question->qid] = $question->title;
-                    }
-                }
-                $insertansParts = explode($txtInsertans, $record->{$field});
-                for ($index = 1; $index < count($insertansParts); $index++) {
-                    $curlyPosition = strpos($insertansParts[$index], "}");
-                    $rawField = substr($insertansParts[$index], 0, $curlyPosition);
-                    $content = (strlen($insertansParts[$index]) === $curlyPosition) ? "" : substr($insertansParts[$index], $curlyPosition + 1);
-                    $subField = substr($rawField, strpos($rawField, "X") + 1);
-                    $title = substr($subField, strpos($subField, "X") + 1);
-                    if (preg_match('/[a-zA-Z]/i', $title, $match)) {
-                        $title = substr($title, strpos($title, $match[0]));
-                    } else {
-                        $title = $this->questionCodes[$sid][$title] ?? "";
-                    }
-                    $insertansParts[$index] = $title . ".shown" . $content;
-                }
-                $record->{$field} = implode($insertansParts);
+
+        // Lazy-load question codes for this survey (QID → title)
+        if (empty($this->questionCodes[$sid])) {
+            $this->questionCodes[$sid] = [];
+            $questions = Question::model()->findAll("sid = :sid", [":sid" => $sid]);
+            foreach ($questions as $question) {
+                $this->questionCodes[$sid][$question->qid] = $question->title;
             }
         }
+
+        foreach ($fields as $field) {
+            $text = $record->{$field} ?? '';
+            if ($text === '' || strpos($text, 'INSERTANS:') === false) {
+                continue;
+            }
+
+            $converted = $this->convertLegacyInsertans($text, $this->questionCodes[$sid]);
+            if ($converted !== $text) {
+                $record->{$field} = $converted;
+                $changed = true;
+            }
+        }
+
         return $changed;
     }
 


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable conversion of legacy INSERTANS tokens using pattern-based matching; preserves original brace usage and only rewrites when text changes.
  * Ambiguous numeric IDs now resolve progressively; improved suffix mapping (empty, other, comment, dual-scale, subquestion) to target correct shown fields.

* **Chores**
  * Migration runs per-survey with tracking of processed surveys to ensure comprehensive, non-duplicated conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->