### PR TITLE
Fix issue #20494: Conditional Remote Code Execution via Question Theme Path Traversal and Custom Twig Extension Injection

### DIFF
--- a/application/controllers/admin/PluginManagerController.php
+++ b/application/controllers/admin/PluginManagerController.php
@@ -568,6 +568,12 @@ class PluginManagerController extends SurveyCommonAction
                 $this->errorAndRedirect(gT('The plugin is not compatible with your version of LimeSurvey.'));
             }
 
+            $pluginManager = App()->getPluginManager();
+            if (!$pluginManager->validatePluginName($config->getName())) {
+                $installer->abort();
+                $this->errorAndRedirect(gT('Invalid plugin name in config.xml.'));
+            }
+
             // Show confirmation page.
             $abortUrl = $this->getPluginManagerUrl('abortUploadedPlugin');
             $plugin = Plugin::model()->find('name = :name', [':name' => $config->getName()]);

--- a/application/controllers/admin/Themes.php
+++ b/application/controllers/admin/Themes.php
@@ -315,8 +315,7 @@ class Themes extends SurveyCommonAction
                     throw new Exception(gT('The question theme is not compatible with your version of LimeSurvey.'));
                 }
                 $questionThemeName = $config->getName();
-                \Yii::import('application.helpers.sanitize_helper', true);
-                if (!validate_path_component($questionThemeName)) {
+                if (!$installer->validateQuestionThemeName($questionThemeName)) {
                     $installer->abort();
                     throw new Exception(gT('Invalid question theme name in config.xml'));
                 }

--- a/application/controllers/admin/Themes.php
+++ b/application/controllers/admin/Themes.php
@@ -305,9 +305,6 @@ class Themes extends SurveyCommonAction
             }
 
             try {
-                $src = $_FILES['the_file']['tmp_name'];
-                $extConfig = ExtensionConfig::loadFromZip($src);
-                $destdir = $extConfig->getName();
                 // TODO: Replace with extension installer factory.
                 $installer = $this->getQuestionThemeInstaller();
                 $installer->fetchFiles();
@@ -317,7 +314,13 @@ class Themes extends SurveyCommonAction
                     $installer->abort();
                     throw new Exception(gT('The question theme is not compatible with your version of LimeSurvey.'));
                 }
-                $questionTheme = QuestionTheme::model()->findByAttributes(['name' => $config->getName()]);
+                $questionThemeName = $config->getName();
+                \Yii::import('application.helpers.sanitize_helper', true);
+                if (!validate_path_component($questionThemeName)) {
+                    $installer->abort();
+                    throw new Exception(gT('Invalid question theme name in config.xml'));
+                }
+                $questionTheme = QuestionTheme::model()->findByAttributes(['name' => $questionThemeName]);
                 try {
                     if (empty($questionTheme)) {
                         $installer->install();
@@ -353,6 +356,7 @@ class Themes extends SurveyCommonAction
             }
         }
 
+        // Question theme uploads should already have returned from the branch above.
         $sNewDirectoryName = $this->getNewDirectoryName($themeType, $_FILES['the_file']['tmp_name']);
 
         if ($themeType == 'survey') {

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -586,7 +586,9 @@ function sanitize_alphanumeric($value)
  */
 function validate_path_component($string)
 {
-    $string = (string) $string;
+    if (!is_string($string)) {
+        return false;
+    }
 
     return !(
         $string === ''

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -586,9 +586,11 @@ function sanitize_alphanumeric($value)
  */
 function validate_path_component($string)
 {
+    $string = (string) $string;
+
     return !(
         $string === ''
-        || strpos((string) $string, '.') === 0
+        || strpos($string, '.') === 0
         || preg_match('/[\\\\\/]/', $string) === 1
         || preg_match('/[\x00-\x1F\x7F]/', $string) === 1
     );

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -577,9 +577,9 @@ function sanitize_alphanumeric($value)
 /**
  * Validate that a value is safe to use as a single filesystem path component.
  *
- * This rejects empty values, path separators, "." / ".." and ASCII control
- * characters so callers can safely append the value to a trusted base path
- * without worrying about directory traversal.
+ * This rejects empty values, leading-dot names, path separators and ASCII
+ * control characters so callers can safely append the value to a trusted
+ * base path without worrying about directory traversal or hidden directories.
  *
  * @param string $string
  * @return bool
@@ -588,8 +588,7 @@ function validate_path_component($string)
 {
     return !(
         $string === ''
-        || $string === '.'
-        || $string === '..'
+        || strpos((string) $string, '.') === 0
         || preg_match('/[\\\\\/]/', $string) === 1
         || preg_match('/[\x00-\x1F\x7F]/', $string) === 1
     );

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -573,3 +573,24 @@ function sanitize_alphanumeric($value)
 {
     return preg_replace("/[^a-zA-Z0-9\-\_]/", "", $value);
 }
+
+/**
+ * Validate that a value is safe to use as a single filesystem path component.
+ *
+ * This rejects empty values, path separators, "." / ".." and ASCII control
+ * characters so callers can safely append the value to a trusted base path
+ * without worrying about directory traversal.
+ *
+ * @param string $string
+ * @return bool
+ */
+function validate_path_component($string)
+{
+    return !(
+        $string === ''
+        || $string === '.'
+        || $string === '..'
+        || preg_match('/[\\\\\/]/', $string) === 1
+        || preg_match('/[\x00-\x1F\x7F]/', $string) === 1
+    );
+}

--- a/application/libraries/ExtensionInstaller/QuestionThemeInstaller.php
+++ b/application/libraries/ExtensionInstaller/QuestionThemeInstaller.php
@@ -31,7 +31,12 @@ class QuestionThemeInstaller extends ExtensionInstaller
     public function install()
     {
         $extConfig = $this->getConfig();
-        $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $extConfig->getName();
+        $questionThemeName = $extConfig->getName();
+        \Yii::import('application.helpers.sanitize_helper', true);
+        if (!validate_path_component($questionThemeName)) {
+            throw new Exception(gT('Invalid question theme name in config.xml'));
+        }
+        $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $questionThemeName;
 
         if ($this->fileFetcher->move($destdir)) {
             $questionTheme = new QuestionTheme();
@@ -90,12 +95,17 @@ class QuestionThemeInstaller extends ExtensionInstaller
     public function update()
     {
         $extConfig = $this->getConfig();
-        $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $extConfig->getName();
+        $questionThemeName = $extConfig->getName();
+        \Yii::import('application.helpers.sanitize_helper', true);
+        if (!validate_path_component($questionThemeName)) {
+            throw new Exception(gT('Invalid question theme name in config.xml'));
+        }
+        $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $questionThemeName;
 
         if ($this->fileFetcher->move($destdir)) {
-            $questionTheme =  QuestionTheme::model()->findByAttributes(['name' => $extConfig->getName()]);
+            $questionTheme =  QuestionTheme::model()->findByAttributes(['name' => $questionThemeName]);
             if (empty($questionTheme)) {
-                throw new Exception('Tried to update question theme but found no theme with name ' . $extConfig->getName());
+                throw new Exception('Tried to update question theme but found no theme with name ' . $questionThemeName);
             }
             $xmlFolder = $this->getXmlFolder($destdir);
             if (empty($xmlFolder)) {

--- a/application/libraries/ExtensionInstaller/QuestionThemeInstaller.php
+++ b/application/libraries/ExtensionInstaller/QuestionThemeInstaller.php
@@ -32,8 +32,7 @@ class QuestionThemeInstaller extends ExtensionInstaller
     {
         $extConfig = $this->getConfig();
         $questionThemeName = $extConfig->getName();
-        \Yii::import('application.helpers.sanitize_helper', true);
-        if (!validate_path_component($questionThemeName)) {
+        if (!$this->validateQuestionThemeName($questionThemeName)) {
             throw new Exception(gT('Invalid question theme name in config.xml'));
         }
         $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $questionThemeName;
@@ -96,8 +95,7 @@ class QuestionThemeInstaller extends ExtensionInstaller
     {
         $extConfig = $this->getConfig();
         $questionThemeName = $extConfig->getName();
-        \Yii::import('application.helpers.sanitize_helper', true);
-        if (!validate_path_component($questionThemeName)) {
+        if (!$this->validateQuestionThemeName($questionThemeName)) {
             throw new Exception(gT('Invalid question theme name in config.xml'));
         }
         $destdir = App()->getConfig('userquestionthemerootdir') . DIRECTORY_SEPARATOR . $questionThemeName;
@@ -143,5 +141,29 @@ class QuestionThemeInstaller extends ExtensionInstaller
             }
         }
         return null;
+    }
+
+    /**
+     * Validate that a question theme name is safe to use for installation.
+     *
+     * @param string $questionThemeName
+     * @return bool
+     */
+    public function validateQuestionThemeName($questionThemeName)
+    {
+        // TODO: Should this be stricter, e.g. only allow alphanumeric characters plus hyphens and underscores?
+
+        // Reject path traversal and other unsafe path component values.
+        \Yii::import('application.helpers.sanitize_helper', true);
+        if (!validate_path_component($questionThemeName)) {
+            return false;
+        }
+
+        // Match the QuestionTheme model validation limit for the name field.
+        if (mb_strlen((string) $questionThemeName, 'UTF-8') > 150) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/application/libraries/PluginManager/PluginManager.php
+++ b/application/libraries/PluginManager/PluginManager.php
@@ -137,6 +137,9 @@ class PluginManager extends \CApplicationComponent
         }
 
         $newName = (string) $extensionConfig->xml->metadata->name;
+        if (!$this->validatePluginName($newName)) {
+            return [false, gT('Invalid plugin name in config.xml.')];
+        }
         if (!$this->isWhitelisted($newName)) {
             return [false, gT('The plugin is not in the plugin allowlist.')];
         }
@@ -424,8 +427,24 @@ class PluginManager extends \CApplicationComponent
         if (empty($alias)) {
             return null;
         }
-        $folder = Yii::getPathOfAlias($alias) . '/' . $config->getName();
+        $pluginName = $config->getName();
+        if (!$this->validatePluginName($pluginName)) {
+            throw new \InvalidArgumentException(gT('Invalid plugin name in config.xml.'));
+        }
+        $folder = Yii::getPathOfAlias($alias) . '/' . $pluginName;
         return $folder;
+    }
+
+    /**
+     * Validate that a plugin name can safely serve as folder, file and class name.
+     * Plugin names are used as a flat class identifier throughout the plugin manager.
+     *
+     * @param string $pluginName
+     * @return bool
+     */
+    public function validatePluginName($pluginName)
+    {
+        return preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', (string) $pluginName) === 1;
     }
 
     /**

--- a/tests/unit/helpers/SanitizeHelperTest.php
+++ b/tests/unit/helpers/SanitizeHelperTest.php
@@ -19,6 +19,7 @@ class SanitizeHelperTest extends TestBaseClass
             '',
             '.',
             '..',
+            '.git',
             '../twig/extensions',
             '..\\twig\\extensions',
             "bad\0name",

--- a/tests/unit/helpers/SanitizeHelperTest.php
+++ b/tests/unit/helpers/SanitizeHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ls\tests;
+
+class SanitizeHelperTest extends TestBaseClass
+{
+    public function testValidatePathComponentAllowsSinglePathComponent()
+    {
+        \Yii::import('application.helpers.sanitize_helper', true);
+
+        $this->assertTrue(validate_path_component('Range-Slider'));
+    }
+
+    public function testValidatePathComponentRejectsUnsafeNames()
+    {
+        \Yii::import('application.helpers.sanitize_helper', true);
+
+        $cases = [
+            '',
+            '.',
+            '..',
+            '../twig/extensions',
+            '..\\twig\\extensions',
+            "bad\0name",
+        ];
+
+        foreach ($cases as $case) {
+            $this->assertFalse(
+                validate_path_component($case),
+                'Expected invalid path component to be rejected: ' . json_encode($case)
+            );
+        }
+    }
+}

--- a/tests/unit/helpers/SanitizeHelperTest.php
+++ b/tests/unit/helpers/SanitizeHelperTest.php
@@ -20,9 +20,12 @@ class SanitizeHelperTest extends TestBaseClass
             '.',
             '..',
             '.git',
+            'foo/bar',
+            'foo\\bar',
             '../twig/extensions',
             '..\\twig\\extensions',
             "bad\0name",
+            "\x7F",
         ];
 
         foreach ($cases as $case) {

--- a/tests/unit/plugins/PluginManagerTest.php
+++ b/tests/unit/plugins/PluginManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ls\tests;
+
+use LimeSurvey\PluginManager\PluginManager;
+
+class PluginManagerTest extends TestBaseClass
+{
+    public function testValidatePluginNameAllowsFlatClassNames()
+    {
+        $pluginManager = new PluginManager();
+
+        $this->assertTrue($pluginManager->validatePluginName('Authdb'));
+        $this->assertTrue($pluginManager->validatePluginName('Foo_Bar'));
+        $this->assertTrue($pluginManager->validatePluginName('Plugin123'));
+    }
+
+    public function testValidatePluginNameRejectsUnsafeOrUnsupportedNames()
+    {
+        $pluginManager = new PluginManager();
+
+        $cases = [
+            '',
+            '1Plugin',
+            'Foo-Bar',
+            'Foo.Bar',
+            'Vendor\\Plugin',
+            'foo/bar',
+            '../twig/extensions/PoC',
+        ];
+
+        foreach ($cases as $case) {
+            $this->assertFalse(
+                $pluginManager->validatePluginName($case),
+                'Expected invalid plugin name to be rejected: ' . json_encode($case)
+            );
+        }
+    }
+}

--- a/tests/unit/questionthemes/QuestionThemeInstallerTest.php
+++ b/tests/unit/questionthemes/QuestionThemeInstallerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ls\tests;
+
+use LimeSurvey\ExtensionInstaller\QuestionThemeInstaller;
+
+class QuestionThemeInstallerTest extends TestBaseClass
+{
+    public function testValidateQuestionThemeNameAllowsSafeQuestionThemeNames()
+    {
+        $installer = new QuestionThemeInstaller();
+
+        $this->assertTrue($installer->validateQuestionThemeName('Range-Slider'));
+        $this->assertTrue($installer->validateQuestionThemeName('QuestionTheme_123'));
+        $this->assertTrue($installer->validateQuestionThemeName(str_repeat('a', 150)));
+    }
+
+    public function testValidateQuestionThemeNameRejectsUnsafeOrTooLongNames()
+    {
+        $installer = new QuestionThemeInstaller();
+
+        $cases = [
+            '',
+            '.',
+            '..',
+            '../twig/extensions',
+            '..\\twig\\extensions',
+            str_repeat('a', 151),
+        ];
+
+        foreach ($cases as $case) {
+            $this->assertFalse(
+                $installer->validateQuestionThemeName($case),
+                'Expected invalid question theme name to be rejected: ' . json_encode($case)
+            );
+        }
+    }
+}

--- a/tests/unit/questionthemes/QuestionThemeInstallerTest.php
+++ b/tests/unit/questionthemes/QuestionThemeInstallerTest.php
@@ -23,6 +23,7 @@ class QuestionThemeInstallerTest extends TestBaseClass
             '',
             '.',
             '..',
+            '.hidden',
             '../twig/extensions',
             '..\\twig\\extensions',
             str_repeat('a', 151),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin and question-theme uploads now validate names from config files and abort installation with an error when names are invalid, preventing unsafe or unintended directories.
* **New Features**
  * Added a reusable path-component validation utility enforcing character rules and a 150-character limit for installer names.
* **Tests**
  * Added unit tests covering plugin name, theme name, and path-component validation (allowed and disallowed cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->