### PR TITLE
Fixed issue #TB-106:  question attribute "array_filter_exclude" was not working with new fieldname structure

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -1259,11 +1259,7 @@ class LimeExpressionManager
                                 }
                                 foreach ($cascadedAFE as $_cafe) {
                                     $sgq = ((isset($this->qcode2sgq[$_cafe])) ? $this->qcode2sgq[$_cafe] : $_cafe);
-                                    $fkey = explode("_", $sq['varName'])[0] . "_" . trim($_cafe);
-                                    if (!isset($this->qcode2sgqa[$fkey])) {
-                                        continue;
-                                    }
-                                    $fqid = substr(explode("_", $this->qcode2sgqa[$fkey])[0], 1);
+                                    $fqid = substr(explode("_", $sgq)[0], 1);
                                     if (!isset($this->q2subqInfo[$fqid])) {
                                         continue;
                                     }


### PR DESCRIPTION
$fqid value for array_filter_exclude loop was not adapted to new fieldnames (it was for array_filter loop)

# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal expression processing logic for subquestion handling to use a more streamlined approach, enhancing system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->