### PR TITLE
Fixed issue #TB-108: enabled option toggle for active surveys

### DIFF
--- a/editor/src/components/QuestionSettings/Setting.js
+++ b/editor/src/components/QuestionSettings/Setting.js
@@ -154,6 +154,7 @@ export const Setting = ({
             'questionThemeName',
             'encrypted',
             'attributes.save_as_default',
+            'other',
           ].includes(attribute.attributePath) && isSurveyActive
 
         return (


### PR DESCRIPTION
Fixed issue #TB-108: enabled option toggle for active surveys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved question settings to properly disable certain attributes when a survey is active, preventing unintended modifications to protected settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->