### PR TITLE
Fixed issue [security] #20495: Unrestricted getConfig() access in Twig sandbox

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -884,5 +884,14 @@ $config['allow_unserialize_attributedescriptions'] = false;
 // @see https://www.php.net/unserialize
 $config['allow_unserialize_attachments'] = false;
 
+// Allow to use a allow list for getConfig function in twig
+// used only if it's an array, else use a fixed denylist and the extra denylist in config
+// @see https://bugs.limesurvey.org/view.php?id=20495
+$config['twig_getConfig_allowlist'] = null;
+
+// Allow to add more global settings to a deny for getConfig function in twig
+// @see https://bugs.limesurvey.org/view.php?id=20495
+$config['twig_getConfig_extradenylist'] = [];
+
 return $config;
 //settings deleted

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -886,10 +886,14 @@ $config['allow_unserialize_attachments'] = false;
 
 // Allow to use a allow list for getConfig function in twig
 // used only if it's an array, else use a fixed denylist and the extra denylist in config
+// If you want to allow 'securesetting', set this to ['securesetting'].
+// All settings except 'securesetting' will be denied. 'securesetting' will be allowed.
 // @see https://bugs.limesurvey.org/view.php?id=20495
 $config['twig_getConfig_allowlist'] = null;
 
 // Allow to add more global settings to a deny for getConfig function in twig
+// LimeSurvye already disallow most unsecure settings.
+// If you want to disallow 'unsecuresetting', set this to ['unsecuresetting']
 // @see https://bugs.limesurvey.org/view.php?id=20495
 $config['twig_getConfig_extradenylist'] = [];
 

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -660,7 +660,7 @@ class LS_Twig_Extension extends AbstractExtension
      */
     public static function getConfig($name)
     {
-        /* if allowlist is an array, use it */
+        /* if allowlist is an array, use it but only for deny; not for allowing */
         $allowlist = App()->getConfig('twig_getConfig_allowlist');
         if (is_array($allowlist) && !in_array($name, $allowlist, true)) {
             return false;
@@ -701,13 +701,13 @@ class LS_Twig_Extension extends AbstractExtension
             'ssl_disable_alert',
             'ssl_emergency_override',
             'registrationEmailDelay',
-             /* autentication related */
+             /* authentication related */
             'auth_webserver',
             'auth_webserver_user_map',
             'auth_webserver_autocreate_user',
             'auth_webserver_autocreate_profile',
             'auth_webserver_autocreate_permissions',
-            /* connexion related */
+            /* connection related */
             'proxy_host_name',
             'proxy_host_port',
             'reverseProxyIpHeader',

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -668,7 +668,7 @@ class LS_Twig_Extension extends AbstractExtension
         }
         /* @var string[] $forcedDeny list of config forced to deny */
         $forcedDeny = [
-            /* encryption security inlcude deprecated */
+            /* encryption security include deprecated */
             'encryptionkeypair',
             'encryptionpublickey',
             'encryptionsecretkey',
@@ -683,6 +683,12 @@ class LS_Twig_Extension extends AbstractExtension
             'ssl_disable_alert',
             'ssl_emergency_override',
             'registrationEmailDelay',
+             /* autentication related */
+            'auth_webserver',
+            'auth_webserver_user_map',
+            'auth_webserver_autocreate_user',
+            'auth_webserver_autocreate_profile',
+            'auth_webserver_autocreate_permissions',
             /* connexion related */
             'proxy_host_name',
             'proxy_host_port',
@@ -696,6 +702,21 @@ class LS_Twig_Extension extends AbstractExtension
             'GeoNamesUsername',
             'emailsmtppassword',
             'bounceaccountpass',
+            /* email related */
+            'emailmethod',
+            'emailsmtphost',
+            'emailsmtpuser',
+            'emailsmtpssl',
+            'emailplugin',
+            'bounceaccounthost',
+            'bounceaccountuser',
+            'bounceaccounttype',
+            'bounceencryption',
+            'bounceencryption',
+            /* password related */
+            'display_user_password_in_html',
+            'display_user_password_in_email',
+            'passwordvalidationrules',
             /* directory related */
             'magic_file',
             'magic_database',

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -676,6 +676,8 @@ class LS_Twig_Extension extends AbstractExtension
             'encryptionsecretboxkey',
             /* security related */
             'forcedsuperadmin',
+            'defaultuser',
+            'defaultpass',
             'loginIpWhitelist',
             'tokenIpWhitelist',
             'ssl_disable_alert',

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -658,11 +658,11 @@ class LS_Twig_Extension extends AbstractExtension
      * @param string $name
      * @return mixed
      */
-    public static function getConfig($item)
+    public static function getConfig($name)
     {
         /* if allowlist is an array, use it */
         if (is_array(App()->getConfig('twig_getConfig_allowlist'))) {
-            if (!in_array($item, App()->getConfig('twig_getConfig_allowlist'))) {
+            if (!in_array($name, App()->getConfig('twig_getConfig_allowlist'))) {
                 return false;
             }
         }
@@ -719,14 +719,14 @@ class LS_Twig_Extension extends AbstractExtension
             'lsadminmodulesrootdir',
         ];
         /* if in core deny list is an array, return false */
-        if (!in_array($item, $forcedDeny)) {
+        if (in_array($name, $forcedDeny)) {
             return false;
         }
         /* if in config deny list is an array, return false */
-        if (!in_array($item, App()->getConfig('twig_getConfig_extradenylist'))) {
+        if (in_array($name, App()->getConfig('twig_getConfig_extradenylist'))) {
             return false;
         }
-        return Yii::app()->getConfig($item);
+        return App()->getConfig($name);
     }
 
 

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -652,8 +652,80 @@ class LS_Twig_Extension extends AbstractExtension
         return 'rgba(' . join(', ', $return) . ',' . $alpha . ')';
     }
 
+    /**
+     * Shortcut to get configuration value
+     * @see ConsoleApplication->getConfig and LSYii_Application->getConfig
+     * @param string $name
+     * @return mixed
+     */
     public static function getConfig($item)
     {
+        /* if allowlist is an array, use it */
+        if (is_array(App()->getConfig('twig_getConfig_allowlist'))) {
+            if (!in_array($item, App()->getConfig('twig_getConfig_allowlist'))) {
+                return false;
+            }
+        }
+        /* @var string[] $forcedDeny list of config forced to deny */
+        $forcedDeny = [
+            /* encryption security inlcude deprecated */
+            'encryptionkeypair',
+            'encryptionpublickey',
+            'encryptionsecretkey',
+            'encryptionnonce',
+            'encryptionsecretboxkey',
+            /* security related */
+            'forcedsuperadmin',
+            'loginIpWhitelist',
+            'tokenIpWhitelist',
+            'ssl_disable_alert',
+            'ssl_emergency_override',
+            'registrationEmailDelay',
+            /* connexion related */
+            'proxy_host_name',
+            'proxy_host_port',
+            'reverseProxyIpHeader',
+            'reverseProxyIpAddresses',
+            /* Setting keys and password */
+            'googleMapsAPIKey',
+            'ipInfoDbAPIKey',
+            'googleanalyticsapikey',
+            'googletranslateapikey',
+            'GeoNamesUsername',
+            'emailsmtppassword',
+            'bounceaccountpass',
+            /* directory related */
+            'magic_file',
+            'magic_database',
+            'rootdir',
+            'publicdir',
+            'homedir',
+            'configdir',
+            'tempdir',
+            'imagedir',
+            'uploaddir',
+            'standardthemerootdir',
+            'publicstylepath',
+            'corequestiontypedir',
+            'corequestionthemedir',
+            'corequestionthemerootdir',
+            'styledir',
+            'questiontypedir',
+            'userthemerootdir',
+            'usertwigextensionrootdir',
+            'customquestionthemedir',
+            'userquestionthemerootdir',
+            'userfontsrootdir',
+            'lsadminmodulesrootdir',
+        ];
+        /* if in core deny list is an array, return false */
+        if (!in_array($item, $forcedDeny)) {
+            return false;
+        }
+        /* if in config deny list is an array, return false */
+        if (!in_array($item, App()->getConfig('twig_getConfig_extradenylist'))) {
+            return false;
+        }
         return Yii::app()->getConfig($item);
     }
 

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -725,7 +725,7 @@ class LS_Twig_Extension extends AbstractExtension
             return false;
         }
         /* if in config deny list is an array, return false */
-        if (in_array($name, App()->getConfig('twig_getConfig_extradenylist'))) {
+        if (is_array(App()->getConfig('twig_getConfig_extradenylist')) && in_array($name, App()->getConfig('twig_getConfig_extradenylist'))) {
             return false;
         }
         return App()->getConfig($name);

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -661,13 +661,31 @@ class LS_Twig_Extension extends AbstractExtension
     public static function getConfig($name)
     {
         /* if allowlist is an array, use it */
-        if (is_array(App()->getConfig('twig_getConfig_allowlist'))) {
-            if (!in_array($name, App()->getConfig('twig_getConfig_allowlist'))) {
-                return false;
-            }
+        $allowlist = App()->getConfig('twig_getConfig_allowlist');
+        if (is_array($allowlist) && !in_array($name, $allowlist, true)) {
+            return false;
         }
         /* @var string[] $forcedDeny list of config forced to deny */
-        $forcedDeny = [
+        $forcedDeny = self::getForcedDenyConfig();
+        /* if in core deny list, return false */
+        if (in_array($name, $forcedDeny, true)) {
+            return false;
+        }
+        /* if in config deny list, return false */
+        $extraDeny = App()->getConfig('twig_getConfig_extradenylist');
+        if (is_array($extraDeny) && in_array($name, $extraDeny, true)) {
+            return false;
+        }
+        return App()->getConfig($name);
+    }
+
+    /**
+     * List of fixed deny getConfig
+     * @return string[]
+     */
+    private static function getForcedDenyConfig()
+    {
+        return [
             /* encryption security include deprecated */
             'encryptionkeypair',
             'encryptionpublickey',
@@ -740,17 +758,7 @@ class LS_Twig_Extension extends AbstractExtension
             'userfontsrootdir',
             'lsadminmodulesrootdir',
         ];
-        /* if in core deny list is an array, return false */
-        if (in_array($name, $forcedDeny)) {
-            return false;
-        }
-        /* if in config deny list is an array, return false */
-        if (is_array(App()->getConfig('twig_getConfig_extradenylist')) && in_array($name, App()->getConfig('twig_getConfig_extradenylist'))) {
-            return false;
-        }
-        return App()->getConfig($name);
     }
-
 
     /**
      * Retrieve all the previous answers from a given token

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -712,7 +712,6 @@ class LS_Twig_Extension extends AbstractExtension
             'bounceaccountuser',
             'bounceaccounttype',
             'bounceencryption',
-            'bounceencryption',
             /* password related */
             'display_user_password_in_html',
             'display_user_password_in_email',


### PR DESCRIPTION
Dev: need template edit access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two admin configuration options to control which template configuration keys can be accessed: an optional allowlist and an extra denylist.
  * Runtime enforcement now blocks retrieval of restricted or sensitive settings by combining a built-in denylist with the configurable denylist and optional allowlist for finer-grained exposure control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->