### PR TITLE
Fixed issue [security] #20495: Unrestricted getConfig() access in Twig sandbox

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -884,11 +884,11 @@ $config['allow_unserialize_attributedescriptions'] = false;
 // @see https://www.php.net/unserialize
 $config['allow_unserialize_attachments'] = false;
 
-// Allow unserializing (with PHP unserialize function) attachments attributes when importing survey
-// In limesurvey 6.16.17: attachments attribute move from serialize to json_encode. If you need to keep attachment when upload, you have to allow it
-// Warning: Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this.
-// @see https://www.php.net/unserialize
-$config['twig_getConfig_allowlist'] = false;
+// Allow to allow specific element for getConfig function in twig
+// LimeSurvey already allow most needed and used setting, but you can need more.
+// If you want to allow 'securesetting', set this to ['securesetting']
+// @see https://bugs.limesurvey.org/view.php?id=20495
+$config['twig_getConfig_extraallowlist'] = null;
 
 return $config;
 //settings deleted

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -884,5 +884,11 @@ $config['allow_unserialize_attributedescriptions'] = false;
 // @see https://www.php.net/unserialize
 $config['allow_unserialize_attachments'] = false;
 
+// Allow unserializing (with PHP unserialize function) attachments attributes when importing survey
+// In limesurvey 6.16.17: attachments attribute move from serialize to json_encode. If you need to keep attachment when upload, you have to allow it
+// Warning: Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this.
+// @see https://www.php.net/unserialize
+$config['twig_getConfig_allowlist'] = false;
+
 return $config;
 //settings deleted

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -665,7 +665,7 @@ class LS_Twig_Extension extends AbstractExtension
         if (in_array($name, $coreAllowedList, true)) {
             return App()->getConfig($name);
         }
-        /* if allowlist is an array, use it but only for deny; not for allowing */
+        /* if allowlist is an array, use it */
         $extraAllowedList = App()->getConfig('twig_getConfig_extraallowlist');
         if (is_array($extraAllowedList) && in_array($name, $extraAllowedList, true)) {
             return App()->getConfig($name);

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -652,11 +652,74 @@ class LS_Twig_Extension extends AbstractExtension
         return 'rgba(' . join(', ', $return) . ',' . $alpha . ')';
     }
 
-    public static function getConfig($item)
+    /**
+     * Shortcut to get configuration value
+     * @see ConsoleApplication->getConfig and LSYii_Application->getConfig
+     * @param string $name
+     * @return mixed
+     */
+    public static function getConfig($name)
     {
-        return Yii::app()->getConfig($item);
+        /* Core allowedlist */
+        $coreAllowedList = self::getAllowedConfig();
+        if (in_array($name, $coreAllowedList, true)) {
+            return App()->getConfig($name);
+        }
+        /* if allowlist is an array, use it but only for deny; not for allowing */
+        $extraAllowedList = App()->getConfig('twig_getConfig_extraallowlist');
+        if (is_array($extraAllowedList) && in_array($name, $extraAllowedList, true)) {
+            return App()->getConfig($name);
+        }
+        return false;
     }
 
+    /**
+     * List of fixed allowed setting in getConfig
+     * @return string[]
+     */
+    private static function getAllowedConfig()
+    {
+        return [
+            /* Used for global and error page */
+            'sitename',
+            'siteadminname',
+            'siteadminemail',
+            /* Needed by question view */
+            'surveyID',
+            /* Clearly public */
+            'defaultlang',
+            'defaulttheme',
+            'defaultfixedtheme',
+            'maintenancemode',
+            'repeatheadings',
+            'minrepeatheadings',
+            'printanswershonorsconditions',
+            /* Potential usage in theme */
+            'generalscripts', // Used in core Questions
+            'shownoanswer',
+            'showpopups',
+            'demoMode',
+            /* url */
+            'publicurl',
+            'tempurl',
+            'assets',
+            'imageurl',
+            'uploadurl',
+            'standardthemerooturl',
+            'adminscripts',
+            'generalscripts',
+            'styleurl',
+            'publicstyle',
+            'publicstyleurl',
+            'sCKEditorURL',
+            'userthemerooturl',
+            'adminimageurl',
+            'applicationurl',
+            'extensionsurl',
+            'adminstyleurl',
+            'userfontsurl',
+        ];
+    }
 
     /**
      * Retrieve all the previous answers from a given token

--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -633,6 +633,14 @@ class LS_Twig_Extension extends AbstractExtension
     }
 
 
+    /**
+     * Lightens a CSS hex color by a given amount and returns a CSS color string.
+     *
+     * @param string $cssColor Hex color string in the form `#RRGGBB`.
+     * @param int $grade Amount to increase each RGB channel (positive to lighten, negative to darken).
+     * @param float|int $alpha Alpha channel value between 0 and 1. When equal to `1`, a hex color is returned.
+     * @return string A color string: a hex color (`#RRGGBB`) when `$alpha === 1`, otherwise an `rgba(r, g, b, a)` string.
+     */
     public static function lightencss($cssColor, $grade = 10, $alpha = 1)
     {
         $aColors = str_split(substr((string) $cssColor, 1), 2);
@@ -653,10 +661,14 @@ class LS_Twig_Extension extends AbstractExtension
     }
 
     /**
-     * Shortcut to get configuration value
-     * @see ConsoleApplication->getConfig and LSYii_Application->getConfig
-     * @param string $name
-     * @return mixed
+     * Retrieve a configuration value restricted to an internal allowlist.
+     *
+     * Returns the configuration value for $name when $name is present in the built-in allowlist
+     * or in the `twig_getConfig_extraallowlist` configuration (when that extra list is an array).
+     * Returns `false` for any key that is not allowed.
+     *
+     * @param string $name The configuration key to read.
+     * @return mixed The configuration value when allowed, `false` otherwise.
      */
     public static function getConfig($name)
     {
@@ -674,8 +686,12 @@ class LS_Twig_Extension extends AbstractExtension
     }
 
     /**
-     * List of fixed allowed setting in getConfig
-     * @return string[]
+     * Fixed allowlist of configuration keys considered safe for exposure to templates.
+     *
+     * The array contains the configuration key names that are permitted to be read
+     * by template-level configuration accessors.
+     *
+     * @return string[] Array of allowed configuration key names.
      */
     private static function getAllowedConfig()
     {


### PR DESCRIPTION
Dev: all deny, use allowedList only
Dev: add a core allowed list + an extra config allowed list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template configuration access is restricted by default; only explicitly allowed keys are readable.
  * Administrators can extend the template config allowlist via a new configuration setting.
  * Templates attempting to read non-allowed keys will receive no value (access denied).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->