### PR TITLE
Fixed issue [security] #20505: Stored XSS in Limesurvey via Global Settings (reported by masquerad3r )

### DIFF
--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -438,9 +438,19 @@ class GlobalSettings extends SurveyCommonAction
         SettingGlobal::setSetting('bPdfQuestionBold', sanitize_int(Yii::app()->getRequest()->getPost('bPdfQuestionBold')));
         SettingGlobal::setSetting('bPdfQuestionBorder', sanitize_int(Yii::app()->getRequest()->getPost('bPdfQuestionBorder')));
         SettingGlobal::setSetting('bPdfResponseBorder', sanitize_int(Yii::app()->getRequest()->getPost('bPdfResponseBorder')));
-        SettingGlobal::setSetting('googleMapsAPIKey', Yii::app()->getRequest()->getPost('googleMapsAPIKey'));
-        SettingGlobal::setSetting('googleanalyticsapikey', Yii::app()->getRequest()->getPost('googleanalyticsapikey'));
-        SettingGlobal::setSetting('googletranslateapikey', Yii::app()->getRequest()->getPost('googletranslateapikey'));
+        /* @see https://docs.cloud.google.com/docs/authentication/api-keys#components */
+        $googleapikeys = ['googleMapsAPIKey', 'googleanalyticsapikey', 'googletranslateapikey'];
+        foreach ($googleapikeys as $googleapikey) {
+            $value = trim(App()->getRequest()->getPost($googleapikey));
+            $fixedValue = preg_replace('/[^A-Za-z0-9_-]/', '', $fixedValue);
+            if ($value !== $fixedValue) {
+                /* Add an alert to the user */
+                Yii::app()->setFlashMessage(sprintf(gT("Invalue value set for %s, reset to %s"), $value, $fixedValue), 'warning');
+                /* Add a warning for log for server admin */
+                Yii::log("Invalid value %s set for %s in global settings", 'warning', 'application.controller.admin.globalsettings');
+            }
+            SettingGlobal::setSetting($googleapikey, $fixedValue);
+        }
         SettingGlobal::setSetting('surveyPreview_require_Auth', Yii::app()->getRequest()->getPost('surveyPreview_require_Auth'));
         SettingGlobal::setSetting('RPCInterface', Yii::app()->getRequest()->getPost('RPCInterface'));
         SettingGlobal::setSetting('rpc_publish_api', Yii::app()->getRequest()->getPost('rpc_publish_api'));

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -447,7 +447,7 @@ class GlobalSettings extends SurveyCommonAction
                 /* Add an alert to the user */
                 Yii::app()->setFlashMessage(sprintf(gT("Invalue value set for %s, reset to %s"), $value, $fixedValue), 'warning');
                 /* Add a warning for log for server admin */
-                Yii::log("Invalid value %s set for %s in global settings", 'warning', 'application.controller.admin.globalsettings');
+                Yii::log("Invalid value set for {$googleapikey} in global settings.", 'warning', 'application.controller.admin.globalsettings');
             }
             SettingGlobal::setSetting($googleapikey, $fixedValue);
         }

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -445,7 +445,7 @@ class GlobalSettings extends SurveyCommonAction
             $fixedValue = sanitize_googleapikey($value);
             if ($value !== $fixedValue) {
                 /* Add an alert to the user */
-                Yii::app()->setFlashMessage(sprintf(gT("Invalue value set for %s, reset to %s"), $value, $fixedValue), 'warning');
+                Yii::app()->setFlashMessage(sprintf(gT("Invalid value set for %s, reset to %s"), $value, $fixedValue), 'warning');
                 /* Add a warning for log for server admin */
                 Yii::log("Invalid value set for {$googleapikey} in global settings.", 'warning', 'application.controller.admin.globalsettings');
             }

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -442,7 +442,7 @@ class GlobalSettings extends SurveyCommonAction
         $googleapikeys = ['googleMapsAPIKey', 'googleanalyticsapikey', 'googletranslateapikey'];
         foreach ($googleapikeys as $googleapikey) {
             $value = trim(App()->getRequest()->getPost($googleapikey));
-            $fixedValue = preg_replace('/[^A-Za-z0-9_-]/', '', $fixedValue);
+            $fixedValue = sanitize_googleapikey($value);
             if ($value !== $fixedValue) {
                 /* Add an alert to the user */
                 Yii::app()->setFlashMessage(sprintf(gT("Invalue value set for %s, reset to %s"), $value, $fixedValue), 'warning');

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -445,7 +445,7 @@ class GlobalSettings extends SurveyCommonAction
             $fixedValue = sanitize_googleapikey($value);
             if ($value !== $fixedValue) {
                 /* Add an alert to the user */
-                Yii::app()->setFlashMessage(sprintf(gT("Invalid value set for %s, reset to %s"), $value, $fixedValue), 'warning');
+                Yii::app()->setFlashMessage(sprintf(gT("Invalid value set for %s, reset to %s"), $googleapikey, $fixedValue), 'warning');
                 /* Add a warning for log for server admin */
                 Yii::log("Invalid value set for {$googleapikey} in global settings.", 'warning', 'application.controller.admin.globalsettings');
             }

--- a/application/controllers/admin/globalsettings.php
+++ b/application/controllers/admin/globalsettings.php
@@ -441,7 +441,7 @@ class GlobalSettings extends SurveyCommonAction
         /* @see https://docs.cloud.google.com/docs/authentication/api-keys#components */
         $googleapikeys = ['googleMapsAPIKey', 'googleanalyticsapikey', 'googletranslateapikey'];
         foreach ($googleapikeys as $googleapikey) {
-            $value = trim(App()->getRequest()->getPost($googleapikey));
+            $value = trim(strval(App()->getRequest()->getPost($googleapikey)));
             $fixedValue = sanitize_googleapikey($value);
             if ($value !== $fixedValue) {
                 /* Add an alert to the user */

--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -3517,7 +3517,7 @@ class statistics_helper
 
         $sOutputHTML .= '</div>';
 
-        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
+        $sGoogleMapsAPIKey = sanitize_googleapikey(App()->getConfig("googleMapsAPIKey"));
         if (!empty($sGoogleMapsAPIKey)) {
             $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
         }
@@ -3736,7 +3736,7 @@ class statistics_helper
             }
         }    //end if -> show summary results
 
-        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
+        $sGoogleMapsAPIKey = sanitize_googleapikey(App()->getConfig("googleMapsAPIKey"));
         if (!empty($sGoogleMapsAPIKey)) {
             $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
         }
@@ -4070,7 +4070,7 @@ class statistics_helper
 
                 break;
             case 'html':
-                $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
+                $sGoogleMapsAPIKey = sanitize_googleapikey(App()->getConfig("googleMapsAPIKey"));
                 if (!empty($sGoogleMapsAPIKey)) {
                     $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
                 }

--- a/application/helpers/admin/statistics_helper.php
+++ b/application/helpers/admin/statistics_helper.php
@@ -3517,7 +3517,7 @@ class statistics_helper
 
         $sOutputHTML .= '</div>';
 
-        $sGoogleMapsAPIKey = trim((string) Yii::app()->getConfig("googleMapsAPIKey"));
+        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
         if (!empty($sGoogleMapsAPIKey)) {
             $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
         }
@@ -3736,7 +3736,7 @@ class statistics_helper
             }
         }    //end if -> show summary results
 
-        $sGoogleMapsAPIKey = trim((string) Yii::app()->getConfig("googleMapsAPIKey"));
+        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
         if (!empty($sGoogleMapsAPIKey)) {
             $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
         }
@@ -4070,7 +4070,7 @@ class statistics_helper
 
                 break;
             case 'html':
-                $sGoogleMapsAPIKey = trim((string) Yii::app()->getConfig("googleMapsAPIKey"));
+                $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
                 if (!empty($sGoogleMapsAPIKey)) {
                     $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
                 }

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2208,7 +2208,7 @@ function do_shortfreetext($ia)
         $currentLocation = $currentLatLong[0] . " " . $currentLatLong[1];
 
         Yii::app()->getClientScript()->registerScriptFile(Yii::app()->getConfig('generalscripts') . "map.js", LSYii_ClientScript::POS_END);
-        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
+        $sGoogleMapsAPIKey = sanitize_googleapikey(App()->getConfig("googleMapsAPIKey"));
         if ($aQuestionAttributes['location_mapservice'] == 1 && !empty($sGoogleMapsAPIKey)) {
             Yii::app()->getClientScript()->registerScriptFile("//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}", LSYii_ClientScript::POS_BEGIN);
         } elseif ($aQuestionAttributes['location_mapservice'] == 2) {

--- a/application/helpers/qanda_helper.php
+++ b/application/helpers/qanda_helper.php
@@ -2208,7 +2208,7 @@ function do_shortfreetext($ia)
         $currentLocation = $currentLatLong[0] . " " . $currentLatLong[1];
 
         Yii::app()->getClientScript()->registerScriptFile(Yii::app()->getConfig('generalscripts') . "map.js", LSYii_ClientScript::POS_END);
-        $sGoogleMapsAPIKey = trim((string) Yii::app()->getConfig("googleMapsAPIKey"));
+        $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
         if ($aQuestionAttributes['location_mapservice'] == 1 && !empty($sGoogleMapsAPIKey)) {
             Yii::app()->getClientScript()->registerScriptFile("//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}", LSYii_ClientScript::POS_BEGIN);
         } elseif ($aQuestionAttributes['location_mapservice'] == 2) {

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -499,6 +499,16 @@ function sanitize_languagecodeS($codestringtosanitize)
     return implode(" ", $codearray);
 }
 
+/**
+/* Sanitize a google api key
+ * @see https://docs.cloud.google.com/docs/authentication/api-keys#components
+ * @param string|null
+ * @return string
+ **/
+function sanitize_googleapikey($string)
+{
+    return preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval($string)));
+}
 
 function sanitize_signedint($integer, $min = '', $max = '')
 {

--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -2797,7 +2797,7 @@ class userstatistics_helper
 
                 break;
             case 'html':
-                $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
+                $sGoogleMapsAPIKey = sanitize_googleapikey(App()->getConfig("googleMapsAPIKey"));
                 if (!empty($sGoogleMapsAPIKey)) {
                     $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
                 }

--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -2797,7 +2797,7 @@ class userstatistics_helper
 
                 break;
             case 'html':
-                $sGoogleMapsAPIKey = trim((string) Yii::app()->getConfig("googleMapsAPIKey"));
+                $sGoogleMapsAPIKey = preg_replace('/[^A-Za-z0-9_-]/', '', trim(strval(App()->getConfig("googleMapsAPIKey"))));
                 if (!empty($sGoogleMapsAPIKey)) {
                     $sOutputHTML .= "<script type=\"text/javascript\" src=\"//maps.googleapis.com/maps/api/js?sensor=false&key={$sGoogleMapsAPIKey}\"></script>\n";
                 }


### PR DESCRIPTION
Dev: hard filter all load of googleMapsAPIKey
Dev: hard filter on save and show alert and log
Dev: see https://docs.cloud.google.com/docs/authentication/api-keys#components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation/sanitization of Google API keys to remove invalid characters, reducing configuration errors and preventing broken map integrations.
  * Admin save now shows a visible warning when a submitted API key is altered by sanitization and records a server-side warning log.

* **Chores**
  * Unified API key handling across the app and added centralized sanitization for consistent, safer use of Google Maps-related keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->