### PR TITLE
Fixed issue: interface language consistency between main & new editor…

### DIFF
--- a/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurveyOwner.php
+++ b/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurveyOwner.php
@@ -32,4 +32,22 @@ class TransformerOutputSurveyOwner extends TransformerOutputActiveRecord
             'user_status' => 'userStatus',
         ]);
     }
+
+    /**
+     * Transform data and resolve 'auto' lang to the browser language.
+     *
+     * @param mixed $data
+     * @param mixed $options
+     * @return mixed
+     */
+    public function transform($data, $options = [])
+    {
+        $result = parent::transform($data, $options);
+        $lang = $result['lang'];
+        if ($lang === 'auto') {
+            \Yii::app()->loadHelper('common');
+            $result['lang'] = getBrowserLanguage();
+        }
+        return $result;
+    }
 }

--- a/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurveyOwner.php
+++ b/application/libraries/Api/Command/V1/Transformer/Output/TransformerOutputSurveyOwner.php
@@ -43,10 +43,12 @@ class TransformerOutputSurveyOwner extends TransformerOutputActiveRecord
     public function transform($data, $options = [])
     {
         $result = parent::transform($data, $options);
-        $lang = $result['lang'];
-        if ($lang === 'auto') {
-            \Yii::app()->loadHelper('common');
-            $result['lang'] = getBrowserLanguage();
+        if (is_array($result) && array_key_exists('lang', $result)) {
+            $lang = $result['lang'];
+            if ($lang === 'auto') {
+                \Yii::app()->loadHelper('common');
+                $result['lang'] = getBrowserLanguage();
+            }
         }
         return $result;
     }


### PR DESCRIPTION
… when locale is auto

# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic browser language detection: when a survey owner language is set to "auto", the system now detects and applies the user's browser language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->