### PR TITLE
Fixed issue : interface language reset to default "en" if we return back to classic editor from new editor when user language is auto

### DIFF
--- a/application/libraries/Api/Authentication/SessionUtil.php
+++ b/application/libraries/Api/Authentication/SessionUtil.php
@@ -29,7 +29,7 @@ class SessionUtil
         $app = Yii::app();
 
         $userLang = $aUserData['lang'];
-        if($userLang === 'auto' || $userLang === '' || $userLang === null) {
+        if ($userLang === 'auto' || $userLang === '' || $userLang === null) {
             $app->loadHelper('common');
             $userLang = getBrowserLanguage();
         }

--- a/application/libraries/Api/Authentication/SessionUtil.php
+++ b/application/libraries/Api/Authentication/SessionUtil.php
@@ -28,6 +28,12 @@ class SessionUtil
         /** @var \LSYii_Application */
         $app = Yii::app();
 
+        $userLang = $aUserData['lang'];
+        if($userLang === 'auto' || $userLang === '' || $userLang === null) {
+            $app->loadHelper('common');
+            $userLang = getBrowserLanguage();
+        }
+
         $session = array(
             'loginID' => intval($aUserData['uid']),
             'user' => $aUserData['users_name'],
@@ -40,7 +46,7 @@ class SessionUtil
             // This format is defined as '6' in
             // insurveytranslator_helper.php / getDateFormatData()
             'dateformat' => 6,
-            'adminlang' => $aUserData['lang']
+            'adminlang' => $userLang
         );
         foreach ($session as $k => $v) {
             $app->session[$k] = $v;


### PR DESCRIPTION
…t detect the browser language

# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin language handling to detect and use the browser language when a user's language is set to "auto" or left unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->