### PR TITLE
LB-138: Fixed autonumber save on copy when IDs are not to be reset

### DIFF
--- a/application/models/services/CopySurvey.php
+++ b/application/models/services/CopySurvey.php
@@ -145,7 +145,7 @@ class CopySurvey
         if ($this->options->isResetResponseStartId()) {
             $destinationSurvey->autonumber_start = 0;
             $destinationSurvey->save();
-        } else if ($this->sourceSurvey->isActive) {
+        } elseif ($this->sourceSurvey->isActive) {
             $lastResponse = Yii::app()->db->createCommand()
                 ->select("MAX(id) as maxrecordid")
                 ->from("{{responses_" . $this->sourceSurvey->sid . "}}")

--- a/application/models/services/CopySurvey.php
+++ b/application/models/services/CopySurvey.php
@@ -151,7 +151,8 @@ class CopySurvey
                 ->from("{{responses_" . $this->sourceSurvey->sid . "}}")
                 ->queryAll()
             ;
-            if (count($lastResponse)) {
+            $result = $lastResponse[0]['maxrecordid'] ?? null;
+            if ($result) {
                 $destinationSurvey->autonumber_start = $lastResponse[0]['maxrecordid'] + 1;
                 $destinationSurvey->save();
             }

--- a/application/models/services/CopySurvey.php
+++ b/application/models/services/CopySurvey.php
@@ -145,6 +145,16 @@ class CopySurvey
         if ($this->options->isResetResponseStartId()) {
             $destinationSurvey->autonumber_start = 0;
             $destinationSurvey->save();
+        } else if ($this->sourceSurvey->isActive) {
+            $lastResponse = Yii::app()->db->createCommand()
+                ->select("MAX(id) as maxrecordid")
+                ->from("{{responses_" . $this->sourceSurvey->sid . "}}")
+                ->queryAll()
+            ;
+            if (count($lastResponse)) {
+                $destinationSurvey->autonumber_start = $lastResponse[0]['maxrecordid'] + 1;
+                $destinationSurvey->save();
+            }
         }
 
         if ($this->options->isPermissions()) {


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copying a survey now continues response numbering from the source survey’s latest response when the source is active and a numbering reset was not requested, preventing ID conflicts and preserving sequence; the option to reset numbering to start at zero still works as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->