### PR TITLE
Fixed issue #19852: Privacy policy not shownfor "All in one" surveys

### DIFF
--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -296,17 +296,17 @@ function activateActionLink(){
             var submitbtn=false;
             if(!confirmedby){
                 $.each(submit, function(name, value) {
-                    if ($("[name='"+name+"']").length == 0) {
+                    if ($("form#limesurvey [name='"+name+"']").length == 0) {
                         $("<input/>",{
                             'type':"hidden",
                             'name':name,
                             'value':value,
                         }).appendTo('form#limesurvey');
                     } else {
-                        $("[name='"+name+"']").last().attr('value',value);
+                        $("form#limesurvey [name='"+name+"']").last().attr('value',value);
                         /* If it was a submit button : choose it for jquery action done on load */
-                        if ($("[name='"+name+"']").last().attr('type') == "submit") {
-                            submitbtn = $("[name='"+name+"']");
+                        if ($("form#limesurvey [name='"+name+"']").last().attr('type') == "submit") {
+                            submitbtn = $("form#limesurvey [name='"+name+"']").last();
                         }
                     }
                 });
@@ -317,8 +317,8 @@ function activateActionLink(){
                             'type':"submit",
                             'id':"js-limesurvey-submit",
                             'name':"js-limesurvey-submit",
-                            'class':"",
-                            'style':"display:block",
+                            'class':"d-none ls-hidden",
+                            'style':"display:none",
                             'value':"js-limesurvey-submit",
                         }).appendTo('form#limesurvey');
                     }

--- a/assets/packages/limesurvey/survey.js
+++ b/assets/packages/limesurvey/survey.js
@@ -286,21 +286,45 @@ function activateActionLink(){
     if(!$('form#limesurvey').length){
         $('[data-limesurvey-submit]').remove();
     }
-    /* Submit limesurvey form on click */
+    /* Try to submit limesurvey form on click */
     else{
         $('[data-limesurvey-submit]').on('click',function(event) {
             event.preventDefault();
             var submit=$(this).data('limesurvey-submit');
             var confirmedby=$(this).data('confirmedby');
+            /* Trigger click on a button, needed for policy for example */
+            var submitbtn=false;
             if(!confirmedby){
                 $.each(submit, function(name, value) {
-                    $("<input/>",{
-                        'type':"hidden",
-                        'name':name,
-                        'value':value,
-                    }).appendTo('form#limesurvey');
+                    if ($("[name='"+name+"']").length == 0) {
+                        $("<input/>",{
+                            'type':"hidden",
+                            'name':name,
+                            'value':value,
+                        }).appendTo('form#limesurvey');
+                    } else {
+                        $("[name='"+name+"']").last().attr('value',value);
+                        /* If it was a submit button : choose it for jquery action done on load */
+                        if ($("[name='"+name+"']").last().attr('type') == "submit") {
+                            submitbtn = $("[name='"+name+"']");
+                        }
+                    }
                 });
-                $('form#limesurvey').submit();
+                /* If no submit button : create one */
+                if (!submitbtn) {
+                    if ($("#js-limesurvey-submit").length == 0) {
+                        $("<input/>",{
+                            'type':"submit",
+                            'id':"js-limesurvey-submit",
+                            'name':"js-limesurvey-submit",
+                            'class':"",
+                            'style':"display:block",
+                            'value':"js-limesurvey-submit",
+                        }).appendTo('form#limesurvey');
+                    }
+                    submitbtn=$("#js-limesurvey-submit");
+                }
+                $(submitbtn).trigger('click');
             }else{
                 var submits=$.extend(submit,confirmedby);
                 confirmSurveyDialog($(this).data('confirmlabel'),$(this).text(),submits)

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy.twig
@@ -40,12 +40,10 @@
             {% endblock %}
         {% endif %}
         {% block datasecurity %}
-            {% if aSurveyInfo.format != 'A' %}
-                {% if (aSurveyInfo.showsurveypolicynotice == 1) %}
-                    {{include('./subviews/privacy/privacy_text.twig')}}
-                {% elseif (aSurveyInfo.showsurveypolicynotice == 2) %}
-                    {{include( './subviews/privacy/privacy_modal.twig')}}
-                {% endif %}
+            {% if (aSurveyInfo.showsurveypolicynotice == 1) %}
+                {{include('./subviews/privacy/privacy_text.twig')}}
+            {% elseif (aSurveyInfo.showsurveypolicynotice == 2) %}
+                {{include( './subviews/privacy/privacy_modal.twig')}}
             {% endif %}
         {% endblock %}
     </div>

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
@@ -14,6 +14,10 @@ See COPYRIGHT.php for copyright notices and details.
 Show the privacy message and the data security message will be available in a modal
 #}
 {% set describedbyprivacy = "datasecurity_notice" %}
+    {% set privacychecked = "" %}
+    {% if getPost('datasecurity_accepted') %}
+        {% set privacychecked = "checked" %}
+    {%endif %}
 {% if aSurveyInfo.datasecurity_error %}
     <div class="ls-privacy-block">
         <div class="{{ aSurveyInfo.class.activealert }} alert alert-danger alert-dismissible alert-dismissible {% if not aSurveyInfo.datasecuritynotaccepted %}ls-js-hidden {% endif %}" {{ aSurveyInfo.attr.activealert }}
@@ -29,7 +33,7 @@ Show the privacy message and the data security message will be available in a mo
 <div class="ls-privacy-block">
     <div class="row row-cols-lg-auto align-items-center datasecurity-checkbox-container">
         <div class="col-12 checkbox-item">
-            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
+            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" {{ privacychecked }} type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
             <label for="datasecurity_accepted"
                    class="control-label checkbox-label form-check-label datasecurity-checkbox-label {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">
                 {{ aSurveyInfo.datasecurity_notice_label }}

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_text.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_text.twig
@@ -15,6 +15,10 @@ Show the privacy message and the data security message will be available in a mo
 #}
 
 {% set describeprivacy = "" %}
+{% set privacychecked = "" %}
+{% if getPost('datasecurity_accepted') %}
+    {% set privacychecked = "checked" %}
+{%endif %}
 {% if aSurveyInfo.datasecurity_notice %}
     <div class="ls-privacy-block">
         <div id="datasecurity_notice_label" class="fw-bold text-uppercase">
@@ -41,7 +45,7 @@ Show the privacy message and the data security message will be available in a mo
 <div class="ls-privacy-block">
     <div class="row row-cols-lg-auto align-items-center datasecurity-checkbox-container">
         <div class="col-12 checkbox-item">
-            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} text-primary form-check-input" type="checkbox" name="datasecurity_accepted"
+            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} text-primary form-check-input" type="checkbox" {{ privacychecked }} name="datasecurity_accepted"
                    id="datasecurity_accepted"{% if describeprivacy %} aria-describedby="{{ describeprivacy }}" {% endif %}/>
             <label for="datasecurity_accepted"
                    class="text-primary control-label checkbox-label form-check-label datasecurity-checkbox-label {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">

--- a/themes/survey/vanilla/views/subviews/privacy/privacy.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy.twig
@@ -42,12 +42,10 @@
             {% endblock %}
         {% endif %}
         {% block datasecurity %}
-            {% if aSurveyInfo.format != 'A' %}
-                {% if (aSurveyInfo.showsurveypolicynotice == 1) %}
-                    {{include('./subviews/privacy/privacy_text.twig')}}
-                {% elseif (aSurveyInfo.showsurveypolicynotice == 2) %}
-                    {{include( './subviews/privacy/privacy_modal.twig')}}
-                {% endif %}
+            {% if (aSurveyInfo.showsurveypolicynotice == 1) %}
+                {{include('./subviews/privacy/privacy_text.twig')}}
+            {% elseif (aSurveyInfo.showsurveypolicynotice == 2) %}
+                {{include( './subviews/privacy/privacy_modal.twig')}}
             {% endif %}
         {% endblock %}
     </div>

--- a/themes/survey/vanilla/views/subviews/privacy/privacy_modal.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy_modal.twig
@@ -15,6 +15,10 @@
 
 #}
 {% set describedbyprivacy = "datasecurity_notice" %}
+{% set privacychecked = "" %}
+{% if getPost('datasecurity_accepted') %}
+    {% set privacychecked = "checked" %}
+{%endif %}
 {% if aSurveyInfo.datasecurity_error %}
 <div class="{{ aSurveyInfo.class.activealert }} alert alert-danger alert-dismissible alert-dismissible {% if not aSurveyInfo.datasecuritynotaccepted %}ls-js-hidden {% endif %}" {{ aSurveyInfo.attr.activealert }} id="datasecurity_error">
 	<a {{ aSurveyInfo.attr.activealertbutton }} class="{{ aSurveyInfo.class.activealertbutton }} btn-close" aria-hidden="true"></a>
@@ -25,7 +29,7 @@
 	{% endif %}
 {% endif %}
 <div class="form-check">
-    <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
+    <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" {{ privacychecked }} type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
     <label for="datasecurity_accepted" class="form-check-label fw-bold {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">{{ aSurveyInfo.datasecurity_notice_label }}</label>
 </div>
 <div class="collapse fade mb-3" id="data-security-modal-{{aSurveyInfo.sid}}">

--- a/themes/survey/vanilla/views/subviews/privacy/privacy_text.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy_text.twig
@@ -16,6 +16,10 @@
 #}
 <div class="privacy-block">
     {% set describeprivacy = "" %}
+    {% set privacychecked = "" %}
+    {% if getPost('datasecurity_accepted') %}
+        {% set privacychecked = "checked" %}
+    {%endif %}
     {% if aSurveyInfo.datasecurity_notice %}
         <div class="limit-text-window {{ aSurveyInfo.class.privacydatasectextbody }}" id="datasecurity_notice">
             {{ aSurveyInfo.datasecurity_notice }}
@@ -33,7 +37,7 @@
     {% endif %}
     <div class="row row-cols-lg-auto g-1 align-items-center">
         <div class="col-12">
-            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted"{% if describeprivacy %} aria-describedby="{{describeprivacy}}" {% endif %}/>
+            <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" type="checkbox" name="datasecurity_accepted" {{ privacychecked }} id="datasecurity_accepted"{% if describeprivacy %} aria-describedby="{{describeprivacy}}" {% endif %}/>
             <label for="datasecurity_accepted" class="form-check-label fw-bold {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">
                 {{ aSurveyInfo.datasecurity_notice_label }}
             </label>


### PR DESCRIPTION
Dev: moving to twig part alow usage on all in one
Dev: need to control all submit action
Dev: better attach to existing button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Privacy consent checkbox now persists its checked state after submission.
  * Form navigation no longer creates duplicate form fields and reliably triggers the intended submit control.

* **Improvements**
  * Privacy notice selection logic unified so the appropriate notice displays consistently across survey themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->