### PR TITLE
Fixed issue #20499: Updating question code didn't update condition

### DIFF
--- a/application/models/services/QuestionAggregateService/QuestionService.php
+++ b/application/models/services/QuestionAggregateService/QuestionService.php
@@ -284,6 +284,7 @@ class QuestionService
         }
 
         $originalRelevance = $question->relevance;
+        $originalTitle = $question->title;
 
         if ($question->type !== ($data['type'] ?? $question->type)) {
             $answers = Answer::model()->findAll('qid = :qid', [':qid' => $question->qid]);
@@ -308,6 +309,19 @@ class QuestionService
             throw new PersistErrorException(
                 gT('Update failed, could not save.')
             );
+        }
+
+         if ($question->title !== $originalTitle) {
+            $dependentConditions = Condition::model()->findAllByAttributes([
+                'cqid' => $question->qid
+            ]);
+            $dependentQuestionIds = [];
+            foreach ($dependentConditions as $condition) {
+                $dependentQuestionIds[(int) $condition->qid] = true;
+            }
+            foreach (array_keys($dependentQuestionIds) as $dependentQuestionId) {
+                LimeExpressionManager::UpgradeConditionsToRelevance(null, $dependentQuestionId);
+            }
         }
 
         // If relevance equation was manually edited,

--- a/application/models/services/QuestionAggregateService/QuestionService.php
+++ b/application/models/services/QuestionAggregateService/QuestionService.php
@@ -270,37 +270,12 @@ class QuestionService
      */
     private function updateQuestionData(Question $question, $data)
     {
-        // @todo something wrong in frontend ... (?what is wrong?)
-        if (isset($data['same_default'])) {
-            if ($data['same_default'] == 1) {
-                $data['same_default'] = 0;
-            } else {
-                $data['same_default'] = 1;
-            }
-        }
-
-        if (!isset($data['same_script'])) {
-            $data['same_script'] = 0;
-        }
+        $data = $this->normalizeQuestionFlags($data);
 
         $originalRelevance = $question->relevance;
         $originalTitle = $question->title;
-
         if ($question->type !== ($data['type'] ?? $question->type)) {
-            $answers = Answer::model()->findAll('qid = :qid', [':qid' => $question->qid]);
-            $qids = [];
-            foreach ($answers as $answer) {
-                $conditions = Condition::model()->findAll('cqid = :qid and value = :title', [':qid' => $question->qid, ':title' => $answer->code]);
-                foreach ($conditions as $condition) {
-                    $qids[$condition->qid] = true;
-                    $condition->delete();
-                }
-                AnswerL10n::model()->deleteAll('aid = :aid', [':aid' => $answer->aid]);
-                $answer->delete();
-            }
-            foreach ($qids as $qid => $value) {
-                LimeExpressionManager::UpgradeConditionsToRelevance(null, $qid);
-            }
+            $this->removeAnswersAndDependentConditions($question->qid);
         }
 
         $question->setAttributes($data, false);
@@ -311,19 +286,9 @@ class QuestionService
             );
         }
 
-         if ($question->title !== $originalTitle) {
-            $dependentConditions = Condition::model()->findAllByAttributes([
-                'cqid' => $question->qid
-            ]);
-            $dependentQuestionIds = [];
-            foreach ($dependentConditions as $condition) {
-                $dependentQuestionIds[(int) $condition->qid] = true;
-            }
-            foreach (array_keys($dependentQuestionIds) as $dependentQuestionId) {
-                LimeExpressionManager::UpgradeConditionsToRelevance(null, $dependentQuestionId);
-            }
+        if ($question->title !== $originalTitle) {
+            $this->upgradeDependentQuestionRelevance($question->qid);
         }
-
         // If relevance equation was manually edited,
         // existing conditions must be cleared
         if (
@@ -338,6 +303,67 @@ class QuestionService
         return $question;
     }
 
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function normalizeQuestionFlags($data)
+    {
+        // @todo something wrong in frontend ... (?what is wrong?)
+        if (isset($data['same_default'])) {
+            $data['same_default'] = $data['same_default'] == 1 ? 0 : 1;
+        }
+
+        if (!isset($data['same_script'])) {
+            $data['same_script'] = 0;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $questionId
+     * @return void
+     */
+    private function removeAnswersAndDependentConditions($questionId)
+    {
+        $answers = Answer::model()->findAll('qid = :qid', [':qid' => $questionId]);
+        $qids = [];
+        foreach ($answers as $answer) {
+            $conditions = Condition::model()->findAll(
+                'cqid = :qid and value = :title',
+                [':qid' => $questionId, ':title' => $answer->code]
+            );
+            foreach ($conditions as $condition) {
+                $qids[$condition->qid] = true;
+                $condition->delete();
+            }
+            AnswerL10n::model()->deleteAll('aid = :aid', [':aid' => $answer->aid]);
+            $answer->delete();
+        }
+
+        foreach (array_keys($qids) as $qid) {
+            LimeExpressionManager::UpgradeConditionsToRelevance(null, $qid);
+        }
+    }
+
+    /**
+     * @param int $questionId
+     * @return void
+     */
+    private function upgradeDependentQuestionRelevance($questionId)
+    {
+        $dependentConditions = Condition::model()->findAllByAttributes([
+            'cqid' => $questionId
+        ]);
+        $dependentQuestionIds = [];
+        foreach ($dependentConditions as $condition) {
+            $dependentQuestionIds[(int) $condition->qid] = true;
+        }
+        foreach (array_keys($dependentQuestionIds) as $dependentQuestionId) {
+            LimeExpressionManager::UpgradeConditionsToRelevance(null, $dependentQuestionId);
+        }
+    }
     /**
      * Save defaults
      */


### PR DESCRIPTION
Fixed issue #20499: Updating question code didn't update condition

**Summary**

- Fixed question save logic to detect when the question code (title) changes and then refresh relevance for all dependent questions that use conditions based on that question (conditions.cqid = current qid). This ensures condition rendering reflects the updated question code instead of the stale one. 
- Kept the change scoped to QuestionService::updateQuestionData() so it runs automatically on normal question edits and does not alter unrelated condition flows. 

**Testing**

- ✅ php -l application/models/services/QuestionAggregateService/QuestionService.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced question editing with better handling of question properties and dependent relationships.
  * Improved data integrity when modifying question types or titles.
  * Refined cleanup of question answers and associated conditions during edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->