### PR TITLE
Fixed issue #20382: Logo is not shown on smaller screens + spacing issues

### DIFF
--- a/assets/survey_themes/fruity_twentythree/core/old_core_theme.js
+++ b/assets/survey_themes/fruity_twentythree/core/old_core_theme.js
@@ -23,9 +23,8 @@ export var ThemeScripts = function () {
      * in endpage and in $(window).resize
      */
     var fixBodyPadding = function fixBodyPadding() {
-        var navHeight = Math.round($('#survey-nav').outerHeight() || 0);
-        var progressHeight = Math.round($('.top-container').outerHeight(true) || 0);
-        $('body').css('padding-top', (navHeight + progressHeight) + 'px');
+        var navHeight = Math.round($('#survey-nav.fixed-top').outerHeight() || 0);
+        $('body').css('padding-top', navHeight + 'px');
     };
 
     /**

--- a/assets/survey_themes/fruity_twentythree/core/old_core_theme.js
+++ b/assets/survey_themes/fruity_twentythree/core/old_core_theme.js
@@ -23,7 +23,9 @@ export var ThemeScripts = function () {
      * in endpage and in $(window).resize
      */
     var fixBodyPadding = function fixBodyPadding() {
-        $('body').css('padding-top', Math.round($('#survey-nav').outerHeight()) + 'px');
+        var navHeight = Math.round($('#survey-nav').outerHeight() || 0);
+        var progressHeight = Math.round($('.top-container').outerHeight(true) || 0);
+        $('body').css('padding-top', (navHeight + progressHeight) + 'px');
     };
 
     /**

--- a/assets/survey_themes/fruity_twentythree/navbar/navbar.scss
+++ b/assets/survey_themes/fruity_twentythree/navbar/navbar.scss
@@ -24,20 +24,18 @@ Responsive navbar-brand image CSS
 ***********************************/
 
 .logo-container {
-    padding: 0px;
+    padding: 0;
     float: left;
-
+    flex-shrink: 0;
     font-size: 18px;
     line-height: 20px;
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-  @media(max-width: 768px) {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */

--- a/assets/survey_themes/fruity_twentythree/progressbar/progressbar.scss
+++ b/assets/survey_themes/fruity_twentythree/progressbar/progressbar.scss
@@ -1,5 +1,5 @@
 .top-container {
-    margin-bottom: 2rem;
+    margin-bottom: 0.5rem;
     .ls-progress-container {
         padding: 4px 0;
     }

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
@@ -12044,14 +12044,10 @@ Responsive navbar-brand image CSS
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14878,7 +14874,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple.css
@@ -12060,21 +12060,18 @@ Responsive navbar-brand image CSS
 - add 100% height and width auto ... similar to how bootstrap img-responsive class works
 ***********************************/
 .logo-container {
-  padding: 0px;
+  padding: 0;
   float: left;
+  flex-shrink: 0;
   font-size: 18px;
   line-height: 20px;
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14901,7 +14898,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
@@ -12044,14 +12044,10 @@ Responsive navbar-brand image CSS
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14878,7 +14874,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
@@ -12060,21 +12060,18 @@ Responsive navbar-brand image CSS
 - add 100% height and width auto ... similar to how bootstrap img-responsive class works
 ***********************************/
 .logo-container {
-  padding: 0px;
+  padding: 0;
   float: left;
+  flex-shrink: 0;
   font-size: 18px;
   line-height: 20px;
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14901,7 +14898,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
@@ -12044,14 +12044,10 @@ Responsive navbar-brand image CSS
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14878,7 +14874,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape.css
@@ -12060,21 +12060,18 @@ Responsive navbar-brand image CSS
 - add 100% height and width auto ... similar to how bootstrap img-responsive class works
 ***********************************/
 .logo-container {
-  padding: 0px;
+  padding: 0;
   float: left;
+  flex-shrink: 0;
   font-size: 18px;
   line-height: 20px;
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14901,7 +14898,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
@@ -12044,14 +12044,10 @@ Responsive navbar-brand image CSS
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14878,7 +14874,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango.css
@@ -12060,21 +12060,18 @@ Responsive navbar-brand image CSS
 - add 100% height and width auto ... similar to how bootstrap img-responsive class works
 ***********************************/
 .logo-container {
-  padding: 0px;
+  padding: 0;
   float: left;
+  flex-shrink: 0;
   font-size: 18px;
   line-height: 20px;
 }
 
 .logo-container > img {
-  max-height: 90px;
-  padding: 15px;
+  display: block;
+  max-height: 84px;
+  padding: 8px 0;
   width: auto;
-}
-@media (max-width: 768px) {
-  .logo-container > img {
-    max-height: 60px;
-  }
 }
 
 /* text overflows, ellipsis and hyphens */
@@ -14901,7 +14898,7 @@ a [class^=ri-], a [class*=" ri-"] {
 }
 
 .top-container {
-  margin-bottom: 2rem;
+  margin-bottom: 0.5rem;
 }
 .top-container .ls-progress-container {
   padding: 4px 0;

--- a/themes/survey/fruity_twentythree/scripts/theme.js
+++ b/themes/survey/fruity_twentythree/scripts/theme.js
@@ -125,7 +125,9 @@ var ThemeScripts = exports.ThemeScripts = function ThemeScripts() {
    * in endpage and in $(window).resize
    */
   var fixBodyPadding = function fixBodyPadding() {
-    $('body').css('padding-top', Math.round($('#survey-nav').outerHeight()) + 'px');
+    var navHeight = Math.round($('#survey-nav').outerHeight() || 0);
+    var progressHeight = Math.round($('.top-container').outerHeight(true) || 0);
+    $('body').css('padding-top', navHeight + progressHeight + 'px');
   };
 
   /**

--- a/themes/survey/fruity_twentythree/scripts/theme.js
+++ b/themes/survey/fruity_twentythree/scripts/theme.js
@@ -125,9 +125,8 @@ var ThemeScripts = exports.ThemeScripts = function ThemeScripts() {
    * in endpage and in $(window).resize
    */
   var fixBodyPadding = function fixBodyPadding() {
-    var navHeight = Math.round($('#survey-nav').outerHeight() || 0);
-    var progressHeight = Math.round($('.top-container').outerHeight(true) || 0);
-    $('body').css('padding-top', navHeight + progressHeight + 'px');
+    var navHeight = Math.round($('#survey-nav.fixed-top').outerHeight() || 0);
+    $('body').css('padding-top', navHeight + 'px');
   };
 
   /**


### PR DESCRIPTION
Fixed issue #20382: Logo is not shown on smaller screens + spacing issues

**Summary**

- Fixed Fruity23 logo rendering on small screens by updating navbar logo styles to prevent shrinking away and to use tighter vertical padding (instead of the previous heavy padding), so the logo remains visible within a ~100px header. 
- Reduced excessive spacing between header and progress bar by shrinking the top container bottom margin from 2rem to 0.5rem. 
- Fixed header/progress positioning behavior on scroll by updating body top-padding calculation to include both fixed navbar height and progress container height. This was applied in source JS and compiled runtime JS. 
- Synced compiled Fruity23 variation CSS files so runtime themes reflect the same logo and spacing fixes. 

**Testing**

- ✅ git status --short | rg "fruity_twentythree|old_core_theme|theme.js"
- ✅ git commit -m "Fix Fruity23 mobile logo visibility and header/progress spacing"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted navbar logo sizing and spacing for improved visual balance across all theme variants.
  * Refined logo container layout and removed some responsive overrides for more consistent rendering.
  * Reduced spacing between progress area and form content.

* **Refactor**
  * Fixed top-page padding so page content aligns correctly when the navigation bar is fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->