### PR TITLE
Fixed issue #20502: POST-based self-XSS in Statistics View

### DIFF
--- a/application/controllers/admin/Statistics.php
+++ b/application/controllers/admin/Statistics.php
@@ -249,6 +249,10 @@ class Statistics extends SurveyCommonAction
         //second row below options -> filter settings headline
 
         $filterchoice_state = returnGlobal('filterchoice_state');
+        // filterchoice_state is expected to be '1' or '' (it's used effectively as a boolean).
+        // @todo: Check if this is actually used, as the listeners in statistics.js seem stale. For now,
+        //        just coherce it to a valid value, to make it safe in case it is used later.
+        $filterchoice_state = !empty($filterchoice_state) ? '1' : '';
         $aData['filterchoice_state'] = $filterchoice_state;
 
 

--- a/application/views/admin/export/statistics_subviews/_response_filters.php
+++ b/application/views/admin/export/statistics_subviews/_response_filters.php
@@ -1,6 +1,6 @@
 <!-- AUTOSCROLLING DIV CONTAINING QUESTION FILTERS -->
 <div id="statisticsresponsefilters" class="statisticsfilters scrollheight_400">
-    <input type='hidden' id='filterchoice_state' name='filterchoice_state' value='<?php echo CHtml::encode($filterchoice_state); ?>' />
+    <input type='hidden' id='filterchoice_state' name='filterchoice_state' value='<?php echo $filterchoice_state; ?>' />
 
     <?php
         $dshresults = $dshresults ?? '';

--- a/application/views/admin/export/statistics_subviews/_response_filters.php
+++ b/application/views/admin/export/statistics_subviews/_response_filters.php
@@ -1,6 +1,6 @@
 <!-- AUTOSCROLLING DIV CONTAINING QUESTION FILTERS -->
 <div id="statisticsresponsefilters" class="statisticsfilters scrollheight_400">
-    <input type='hidden' id='filterchoice_state' name='filterchoice_state' value='<?php echo $filterchoice_state; ?>' />
+    <input type='hidden' id='filterchoice_state' name='filterchoice_state' value='<?php echo CHtml::encode($filterchoice_state); ?>' />
 
     <?php
         $dshresults = $dshresults ?? '';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of statistics filter selections by standardizing filter state processing to ensure predictable behavior across different input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->