### PR TITLE
Fixed issue #20507: Unclosed twig comments in vanilla/fruity_twentythree themes

### DIFF
--- a/themes/survey/fruity_twentythree/views/subviews/content/main.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/content/main.twig
@@ -18,7 +18,7 @@
 
     NOTE: This content is included inside mainrow.twig
     NOTE: see layout_global.twig for more infos
-}
+#}
 
 {# Include the form opening tag #}
 {{ include('./subviews/header/start_form.twig') }} <!-- main form -->

--- a/themes/survey/vanilla/views/subviews/content/main.twig
+++ b/themes/survey/vanilla/views/subviews/content/main.twig
@@ -18,7 +18,7 @@
 
     NOTE: This content is included inside mainrow.twig
     NOTE: see layout_global.twig for more infos
-}
+#}
 
 {# Include the form opening tag #}
 {{ include('./subviews/header/start_form.twig') }} <!-- main form -->


### PR DESCRIPTION
Fixed issue #20507: unclosed twig comments in vanilla/fruity_twentythree themes

Attribution comment at the beginning of views/subviews/content/main.twig is incorrectly closed in survey themes vanilla and fruity_twentythree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template syntax errors in survey themes that were preventing proper page rendering. Survey pages now display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->