### PR TITLE
AT-1798: Add key prop to input element in SubquestionCodeInput component

### DIFF
--- a/editor/src/components/QuestionTypes/subquestionCodeComponents.js
+++ b/editor/src/components/QuestionTypes/subquestionCodeComponents.js
@@ -24,6 +24,7 @@ export const SubquestionCodeInput = ({
       </div>
     ) : (
       <input
+        key={code}
         style={{ marginLeft: isColumnTitle ? '0px' : '20px' }}
         className="question-code-tag"
         type="text"


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input field behavior in the subquestion code component to properly handle code value changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->