### PR TITLE
Fixed issue #19510: Labels - Assessment value - Evaluation values are not reported when creating a question

### DIFF
--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -888,15 +888,12 @@ $(document).on('ready pjax:scriptcomplete', function () {
                 $('#add-answer-option-input-javascript-datas').data('assessmentvisible') == 1;
               labelSet.labels.forEach((label) => {
                 // Label title is not concatenated directly because it may have non-encoded HTML
-                const titleCols = assessmentVisible ? 'col-lg-7' : 'col-lg-9';
-                const $labelTitleDiv = $(`<div class="${titleCols}"></div>`);
-                $labelTitleDiv.text(label.title);
+                const $labelTitleDiv = $('<div class="col-lg-9"></div>');
+                const assessmentValue = parseInt(label.assessment_value, 10) || 0;
+                $labelTitleDiv.text(assessmentVisible ? `[${assessmentValue}] ${label.title}` : label.title);
                 const $listItem = $listItemTemplate.clone();
                 $listItem.append(`<div class="col-lg-3 text-end" style="border-right: 4px solid #cdcdcd">${label.code}</div>`);
                 $listItem.append($labelTitleDiv);
-                if (assessmentVisible) {
-                  $listItem.append(`<div class="col-lg-2 text-end">${parseInt(label.assessment_value, 10) || 0}</div>`);
-                }
                 $listItem.attr('data-label', JSON.stringify(label));
                 $itemList.append($listItem);
 

--- a/assets/scripts/admin/questionEditor.js
+++ b/assets/scripts/admin/questionEditor.js
@@ -884,13 +884,19 @@ $(document).on('ready pjax:scriptcomplete', function () {
 
             if (labelSet.labels) {
               isEmpty = false;
+              const assessmentVisible = source === 'answeroptions' &&
+                $('#add-answer-option-input-javascript-datas').data('assessmentvisible') == 1;
               labelSet.labels.forEach((label) => {
                 // Label title is not concatenated directly because it may have non-encoded HTML
-                const $labelTitleDiv = $('<div class="col-lg-9"></div>');
+                const titleCols = assessmentVisible ? 'col-lg-7' : 'col-lg-9';
+                const $labelTitleDiv = $(`<div class="${titleCols}"></div>`);
                 $labelTitleDiv.text(label.title);
                 const $listItem = $listItemTemplate.clone();
                 $listItem.append(`<div class="col-lg-3 text-end" style="border-right: 4px solid #cdcdcd">${label.code}</div>`);
                 $listItem.append($labelTitleDiv);
+                if (assessmentVisible) {
+                  $listItem.append(`<div class="col-lg-2 text-end">${parseInt(label.assessment_value, 10) || 0}</div>`);
+                }
                 $listItem.attr('data-label', JSON.stringify(label));
                 $itemList.append($listItem);
 
@@ -1146,6 +1152,9 @@ $(document).on('ready pjax:scriptcomplete', function () {
             }
 
             $tr.find('td.subquestion-text, td.answeroption-text').find('input[type=text]').val(label.title);
+            if (source === 'answeroptions') {
+              $tr.find('td.assessment-value').find('input').val(label.assessment_value ?? 0);
+            }
             $table.find('tbody').append($tr);
 
             if (source === 'subquestions') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment values now correctly display in label previews when the "assessment visible" option is enabled.
  * Assessment values are properly transferred when copying labels to the answer options table, defaulting to 0 when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->