### PR TITLE
Dev: fixed issue #20509: debug=2 : Implicitly marking parameter $managingUser as nullable is deprecated

### DIFF
--- a/application/models/services/UserManager.php
+++ b/application/models/services/UserManager.php
@@ -24,8 +24,8 @@ class UserManager
      * @param User|null $targetUser
      */
     public function __construct(
-        LSWebUser $managingUser = null,
-        User $targetUser = null
+        ?LSWebUser $managingUser = null,
+        ?User $targetUser = null
     ) {
         $this->managingUser = $managingUser;
         $this->targetUser = $targetUser;


### PR DESCRIPTION
Dev: use ? for php7.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality with enhanced type hint specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->