### PR TITLE
Fixed issue #20506: add default 'type' key to participant attribute a…

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '6.17.1';
-$config['dbversionnumber'] = 649;
+$config['dbversionnumber'] = 650;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -2849,7 +2849,12 @@ class Tokens extends SurveyCommonAction
         }
         foreach ($aTokenFieldNames as $sTokenFieldName) {
             if (strpos($sTokenFieldName, 'attribute_') === 0 && (!isset($aData['attrfieldnames']) || !isset($aData['attrfieldnames'][$sTokenFieldName]))) {
-                $aData['attrfieldnames'][$sTokenFieldName] = array('description' => $sTokenFieldName, 'mandatory' => 'N', 'type' => 'TB');
+                $aData['attrfieldnames'][$sTokenFieldName] = array(
+                    'description' => $sTokenFieldName,
+                    'mandatory' => 'N',
+                    'type' => 'TB', // TB = text input (default)
+                    'type_options' => '[]'
+                );
             }
         }
 

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -2843,9 +2843,6 @@ class Tokens extends SurveyCommonAction
                 if (array_key_exists('description', $aAttrData) && $aAttrData['description'] == '') {
                     $aAttrData['description'] = $sField;
                 }
-                if (!array_key_exists('type', $aAttrData)) {
-                    $aAttrData['type'] = 'TB';
-                }
                 $aAttrData = decodeAttributeSelectOptions($aAttrData);
                 $aData['attrfieldnames'][(string) $sField] = $aAttrData;
             }

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -2843,13 +2843,16 @@ class Tokens extends SurveyCommonAction
                 if (array_key_exists('description', $aAttrData) && $aAttrData['description'] == '') {
                     $aAttrData['description'] = $sField;
                 }
+                if (!array_key_exists('type', $aAttrData)) {
+                    $aAttrData['type'] = 'TB';
+                }
                 $aAttrData = decodeAttributeSelectOptions($aAttrData);
                 $aData['attrfieldnames'][(string) $sField] = $aAttrData;
             }
         }
         foreach ($aTokenFieldNames as $sTokenFieldName) {
             if (strpos($sTokenFieldName, 'attribute_') === 0 && (!isset($aData['attrfieldnames']) || !isset($aData['attrfieldnames'][$sTokenFieldName]))) {
-                $aData['attrfieldnames'][$sTokenFieldName] = array('description' => $sTokenFieldName, 'mandatory' => 'N');
+                $aData['attrfieldnames'][$sTokenFieldName] = array('description' => $sTokenFieldName, 'mandatory' => 'N', 'type' => 'TB');
             }
         }
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3147,7 +3147,8 @@ function getTokenFieldsAndNames($surveyid, $bOnlyAttributes = false)
             'mandatory' => 'N',
             'showregister' => 'N',
             'cpdbmap' => '',
-            'type' => 'TB',
+            'type' => 'TB', // TB = text input (default)
+            'type_options' => '[]',
             );
         } elseif (empty($aSavedExtraTokenFields[$sField]['description'])) {
             $aSavedExtraTokenFields[$sField]['description'] = $sField;

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -5048,6 +5048,21 @@ function decodeTokenAttributes(string $tokenAttributeData)
     unset($aReturnData['firstname']);
     unset($aReturnData['lastname']);
     unset($aReturnData['email']);
+
+    // Ensure all additional attributes have 'type' (text input) and 'type_options' defaults.
+    // Needed for surveys created before participant attribute types (AT-1771) were introduced.
+    foreach ($aReturnData as $sKey => &$aAttrData) {
+        if (preg_match('/^attribute_\d+$/', $sKey) && is_array($aAttrData) && count($aAttrData) > 1) {
+            if (!array_key_exists('type', $aAttrData)) {
+                $aAttrData['type'] = 'TB'; // TB = text input (default)
+            }
+            if (!array_key_exists('type_options', $aAttrData)) {
+                $aAttrData['type_options'] = '[]';
+            }
+        }
+    }
+    unset($aAttrData);
+
     return $aReturnData;
 }
 

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3146,7 +3146,8 @@ function getTokenFieldsAndNames($surveyid, $bOnlyAttributes = false)
             'description' => $sField,
             'mandatory' => 'N',
             'showregister' => 'N',
-            'cpdbmap' => ''
+            'cpdbmap' => '',
+            'type' => 'TB',
             );
         } elseif (empty($aSavedExtraTokenFields[$sField]['description'])) {
             $aSavedExtraTokenFields[$sField]['description'] = $sField;

--- a/application/helpers/update/updates/Update_650.php
+++ b/application/helpers/update/updates/Update_650.php
@@ -36,6 +36,9 @@ class Update_650 extends DatabaseUpdateBase
                 if (!preg_match('/^attribute_\d+$/', $key)) {
                     continue;
                 }
+                if (!is_array($attributes)) {
+                    continue;
+                }
 
                 // Skip entries that only contain "encrypted" – those are default token fields, not custom attributes.
                 if (count($attributes) <= 1 && array_key_exists('encrypted', $attributes)) {

--- a/application/helpers/update/updates/Update_650.php
+++ b/application/helpers/update/updates/Update_650.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+use CException;
+
+class Update_650 extends DatabaseUpdateBase
+{
+    /**
+     * Adds default 'type' and 'type_options' keys to participant attribute descriptions
+     * for surveys that were created before AT-1771 (participant attribute types).
+     *
+     * @throws CException If a database update operation fails.
+     */
+    public function up()
+    {
+        // Only fetch sid and attributedescriptions to minimize DB load.
+        $rows = $this->db->createCommand()
+            ->select('sid, attributedescriptions')
+            ->from('{{surveys}}')
+            ->where("attributedescriptions IS NOT NULL AND attributedescriptions != :empty", [':empty' => ''])
+            ->queryAll();
+
+        foreach ($rows as $row) {
+            $raw = $row['attributedescriptions'];
+
+            // Skip non-JSON values (legacy serialized data should not exist at this DB version, but be safe).
+            $decoded = json_decode($raw, true);
+            if (!is_array($decoded)) {
+                continue;
+            }
+
+            $modified = false;
+            foreach ($decoded as $key => &$attributes) {
+                // Only process additional attributes (attribute_1, attribute_2, …).
+                if (!preg_match('/^attribute_\d+$/', $key)) {
+                    continue;
+                }
+
+                // Skip entries that only contain "encrypted" – those are default token fields, not custom attributes.
+                if (count($attributes) <= 1 && array_key_exists('encrypted', $attributes)) {
+                    continue;
+                }
+
+                // Add 'type' with default 'TB' (text box) if missing.
+                if (!array_key_exists('type', $attributes)) {
+                    $attributes['type'] = 'TB';
+                    $modified = true;
+                }
+
+                // Add 'type_options' with default empty JSON array if missing.
+                if (!array_key_exists('type_options', $attributes)) {
+                    $attributes['type_options'] = '[]';
+                    $modified = true;
+                }
+            }
+            unset($attributes);
+
+            if ($modified) {
+                $this->db->createCommand()->update(
+                    '{{surveys}}',
+                    ['attributedescriptions' => json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)],
+                    'sid = :sid',
+                    [':sid' => $row['sid']]
+                );
+            }
+        }
+    }
+}

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -739,7 +739,7 @@ class Survey extends LSActiveRecord implements PermissionInterface
                     'encrypted' => 'N',
                     'show_register' => 'N',
                     'cpdbmap' => '',
-                    'type' => 'TB',
+                    'type' => 'TB', // TB = text input (default)
                     'type_options' => [],
                 ), $aValues);
             }

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -738,7 +738,9 @@ class Survey extends LSActiveRecord implements PermissionInterface
                     'mandatory' => 'N',
                     'encrypted' => 'N',
                     'show_register' => 'N',
-                    'cpdbmap' => ''
+                    'cpdbmap' => '',
+                    'type' => 'TB',
+                    'type_options' => [],
                 ), $aValues);
             }
         }


### PR DESCRIPTION
…rrays preventing undefined index errors

# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure extra/custom token attributes consistently include a default input type ("TB") and default type-options so attribute metadata is normalized across surveys and forms.

* **Chores**
  * Add a data migration to backfill existing survey attribute metadata where needed and bump the application version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->