### PR TITLE
LE-738: content editable plugin slot

### DIFF
--- a/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
+++ b/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
@@ -60,7 +60,7 @@ export const ContentEditable = ({
       inputRef.current?.focus()
     }
   }, [inputRef.current])
-  
+
   return (
     <>
       <ReactContentEditable
@@ -76,7 +76,11 @@ export const ContentEditable = ({
         onKeyDown={onKeyDown}
         data-testid={testId}
       />
-      <PluginSlot slotName={PLUGIN_SLOTS.CONTENT_EDITOR} value={value} onChange={onChange} />
+      <PluginSlot
+        slotName={PLUGIN_SLOTS.CONTENT_EDITOR}
+        value={value}
+        onChange={onChange}
+      />
     </>
   )
 }

--- a/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
+++ b/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
@@ -80,6 +80,7 @@ export const ContentEditable = ({
         slotName={PLUGIN_SLOTS.CONTENT_EDITOR}
         value={value}
         onChange={onChange}
+        focused={isFocused}
       />
     </>
   )

--- a/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
+++ b/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
@@ -7,6 +7,8 @@ import {
   ReplaceQuestionCodesWithAnswers,
   STATES,
 } from 'helpers'
+import { PluginSlot } from 'plugins/PluginSlot'
+import { PLUGIN_SLOTS } from 'plugins/slots'
 
 export const ContentEditable = ({
   onFocus,
@@ -58,20 +60,23 @@ export const ContentEditable = ({
       inputRef.current?.focus()
     }
   }, [inputRef.current])
-
+  
   return (
-    <ReactContentEditable
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      innerRef={inputRef}
-      className={`content-editable`}
-      disabled={disabled}
-      html={questionTitle?.toString()}
-      onChange={({ target: { value } }) => onChange(value)}
-      data-placeholder={placeholder}
-      autoFocus={focus}
-      onKeyDown={onKeyDown}
-      data-testid={testId}
-    />
+    <>
+      <ReactContentEditable
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        innerRef={inputRef}
+        className={`content-editable`}
+        disabled={disabled}
+        html={questionTitle?.toString()}
+        onChange={({ target: { value } }) => onChange(value)}
+        data-placeholder={placeholder}
+        autoFocus={focus}
+        onKeyDown={onKeyDown}
+        data-testid={testId}
+      />
+      <PluginSlot slotName={PLUGIN_SLOTS.CONTENT_EDITOR} value={value} onChange={onChange} />
+    </>
   )
 }

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -6,6 +6,8 @@ import beautify from 'js-beautify'
 import { CodeEditor } from '../CodeMirror/CodeMirror'
 import { mceToolbar } from './mceToolbar'
 import { toolbarActions } from './toolbarActions'
+import { PluginSlot } from 'plugins/PluginSlot'
+import { PLUGIN_SLOTS } from 'plugins/slots'
 
 const FORCED_ROOT_BLOCK = 'p'
 
@@ -81,6 +83,12 @@ export const TinyMCE = ({
     editorValueRef.current = newValue
   }
 
+  const updateTitle = (newValue) => {
+    setEditorValue(newValue)
+    handleOnChange(newValue)
+    editorValueRef.current = newValue
+  }
+
   const normalizeContent = () => {
     if (isFocused) {
       return
@@ -139,51 +147,54 @@ export const TinyMCE = ({
   }, [editorRef.current])
 
   return (
-    <Editor
-      onInit={(evt, editor) => {
-        editorRef.current = editor
-        setFirstLoad(false)
-        const contentArea = editor.getBody()
-        contentArea.setAttribute('data-testid', testId)
-      }}
-      tinymceScriptSrc={`${process.env.PUBLIC_URL}/tinymce/js/tinymce/tinymce.min.js`}
-      onEditorChange={onEditorChange}
-      id={id}
-      disabled={isDisabled}
-      initialValue={editorValue}
-      onFocus={handleOnFocus}
-      onBlur={handleOnBlur}
-      onMouseEnter={normalizeContent}
-      onMouseLeave={transformTokensToBadges}
-      init={{
-        setup: (editor) => {
-          mceToolbar(editor)
-          toolbarActions(
-            editor,
-            openHtmlEditorRef,
-            codeToQuestionRef,
-            attributeDescriptionsRef,
-            questionNumber,
-            language,
-            surveyHeader
-          )
-        },
-        placeholder,
-        menubar: false,
-        branding: false,
-        inline: true,
-        license_key: 'gpl',
-        valid_elements: '*[*]',
-        valid_styles: '*[*]',
-        plugins: ['link'],
-        verify_html: false,
-        disabled,
-        toolbar: showToolbar
-          ? 'alignmentMenu customBold customItalic link toolbarActions'
-          : false,
-        selector: id,
-        forced_root_block: FORCED_ROOT_BLOCK,
-      }}
-    />
+    <>
+      <Editor
+        onInit={(evt, editor) => {
+          editorRef.current = editor
+          setFirstLoad(false)
+          const contentArea = editor.getBody()
+          contentArea.setAttribute('data-testid', testId)
+        }}
+        tinymceScriptSrc={`${process.env.PUBLIC_URL}/tinymce/js/tinymce/tinymce.min.js`}
+        onEditorChange={onEditorChange}
+        id={id}
+        disabled={isDisabled}
+        initialValue={editorValue}
+        onFocus={handleOnFocus}
+        onBlur={handleOnBlur}
+        onMouseEnter={normalizeContent}
+        onMouseLeave={transformTokensToBadges}
+        init={{
+          setup: (editor) => {
+            mceToolbar(editor)
+            toolbarActions(
+              editor,
+              openHtmlEditorRef,
+              codeToQuestionRef,
+              attributeDescriptionsRef,
+              questionNumber,
+              language,
+              surveyHeader
+            )
+          },
+          placeholder,
+          menubar: false,
+          branding: false,
+          inline: true,
+          license_key: 'gpl',
+          valid_elements: '*[*]',
+          valid_styles: '*[*]',
+          plugins: ['link'],
+          verify_html: false,
+          disabled,
+          toolbar: showToolbar
+            ? 'alignmentMenu customBold customItalic link toolbarActions'
+            : false,
+          selector: id,
+          forced_root_block: FORCED_ROOT_BLOCK,
+        }}
+      />
+      <PluginSlot slotName={PLUGIN_SLOTS.CONTENT_EDITOR} value={editorValueRef.current} onChange={updateTitle} />
+    </>
   )
 }

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -84,6 +84,7 @@ export const TinyMCE = ({
   }
 
   const updateTitle = (newValue) => {
+    if (firstLoad || disabled) return
     setEditorValue(newValue)
     handleOnChange(newValue)
     editorValueRef.current = newValue

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -194,7 +194,11 @@ export const TinyMCE = ({
           forced_root_block: FORCED_ROOT_BLOCK,
         }}
       />
-      <PluginSlot slotName={PLUGIN_SLOTS.CONTENT_EDITOR} value={editorValueRef.current} onChange={updateTitle} />
+      <PluginSlot
+        slotName={PLUGIN_SLOTS.CONTENT_EDITOR}
+        value={editorValueRef.current}
+        onChange={updateTitle}
+      />
     </>
   )
 }

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -84,7 +84,9 @@ export const TinyMCE = ({
   }
 
   const updateTitle = (newValue) => {
-    if (firstLoad || disabled) return
+    if (firstLoad || disabled) {
+      return
+    }
     setEditorValue(newValue)
     handleOnChange(newValue)
     editorValueRef.current = newValue

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -201,6 +201,7 @@ export const TinyMCE = ({
         slotName={PLUGIN_SLOTS.CONTENT_EDITOR}
         value={editorValueRef.current}
         onChange={updateTitle}
+        focused={isFocused}
       />
     </>
   )

--- a/editor/src/plugins/slots.js
+++ b/editor/src/plugins/slots.js
@@ -7,4 +7,5 @@ export const PLUGIN_SLOTS = {
   SHARING_OVERVIEW_BOTTOM_RIGHT: 'sharingoverview:bottom:right',
   TRANSLATIONS_PANEL: 'translations:panel:content',
   FEEDBACK_FORM_OPEN: 'feedback:form:open',
+  CONTENT_EDITOR: 'content:editor:extra', // extra logic for editable content ( contentEditable & tinymce)
 }


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin slot for content editors so extensions can inject UI and interact with both plain-text and rich-text editors.
  * Editor components now surface and synchronize plugin-driven updates with the editor content and focus state.
  * Backward compatible — no public API changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LimeSurvey/LimeSurvey/pull/4964)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->