### PR TITLE
Dev: Implemented checks for dashboard loading

### DIFF
--- a/tests/data/surveys/limesurvey_survey_CorruptedSurvey.lss
+++ b/tests/data/surveys/limesurvey_survey_CorruptedSurvey.lss
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+ <LimeSurveyDocType>Survey</LimeSurveyDocType>
+ <DBVersion>650</DBVersion>
+ <languages>
+  <language>de</language>
+ </languages>
+ <groups>
+  <fields>
+   <fieldname>gid</fieldname>
+   <fieldname>sid</fieldname>
+   <fieldname>group_order</fieldname>
+   <fieldname>randomization_group</fieldname>
+   <fieldname>grelevance</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <gid><![CDATA[683]]></gid>
+    <sid><![CDATA[928171]]></sid>
+    <group_order><![CDATA[0]]></group_order>
+    <randomization_group/>
+    <grelevance/>
+   </row>
+  </rows>
+ </groups>
+ <group_l10ns>
+  <fields>
+   <fieldname>id</fieldname>
+   <fieldname>gid</fieldname>
+   <fieldname>group_name</fieldname>
+   <fieldname>description</fieldname>
+   <fieldname>language</fieldname>
+   <fieldname>sid</fieldname>
+   <fieldname>group_order</fieldname>
+   <fieldname>randomization_group</fieldname>
+   <fieldname>grelevance</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <id><![CDATA[1422]]></id>
+    <gid><![CDATA[683]]></gid>
+    <group_name><![CDATA[test]]></group_name>
+    <description><![CDATA[test]]></description>
+    <language><![CDATA[de]]></language>
+    <sid><![CDATA[928171]]></sid>
+    <group_order><![CDATA[0]]></group_order>
+    <randomization_group/>
+    <grelevance/>
+   </row>
+  </rows>
+ </group_l10ns>
+ <questions>
+  <fields>
+   <fieldname>qid</fieldname>
+   <fieldname>parent_qid</fieldname>
+   <fieldname>sid</fieldname>
+   <fieldname>gid</fieldname>
+   <fieldname>type</fieldname>
+   <fieldname>title</fieldname>
+   <fieldname>preg</fieldname>
+   <fieldname>other</fieldname>
+   <fieldname>mandatory</fieldname>
+   <fieldname>encrypted</fieldname>
+   <fieldname>question_order</fieldname>
+   <fieldname>scale_id</fieldname>
+   <fieldname>same_default</fieldname>
+   <fieldname>relevance</fieldname>
+   <fieldname>question_theme_name</fieldname>
+   <fieldname>modulename</fieldname>
+   <fieldname>same_script</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <qid><![CDATA[7232]]></qid>
+    <parent_qid><![CDATA[0]]></parent_qid>
+    <sid><![CDATA[928171]]></sid>
+    <gid><![CDATA[683]]></gid>
+    <type><![CDATA[T]]></type>
+    <title><![CDATA[test]]></title>
+    <preg/>
+    <other><![CDATA[N]]></other>
+    <mandatory><![CDATA[N]]></mandatory>
+    <encrypted><![CDATA[N]]></encrypted>
+    <question_order><![CDATA[1]]></question_order>
+    <scale_id><![CDATA[0]]></scale_id>
+    <same_default><![CDATA[0]]></same_default>
+    <relevance><![CDATA[1]]></relevance>
+    <question_theme_name><![CDATA[longfreetext]]></question_theme_name>
+    <same_script><![CDATA[0]]></same_script>
+   </row>
+  </rows>
+ </questions>
+ <question_l10ns>
+  <fields>
+   <fieldname>id</fieldname>
+   <fieldname>qid</fieldname>
+   <fieldname>question</fieldname>
+   <fieldname>help</fieldname>
+   <fieldname>script</fieldname>
+   <fieldname>language</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <id><![CDATA[17733]]></id>
+    <qid><![CDATA[7232]]></qid>
+    <question><![CDATA[test]]></question>
+    <help/>
+    <language><![CDATA[de]]></language>
+   </row>
+  </rows>
+ </question_l10ns>
+ <surveys>
+  <fields>
+   <fieldname>sid</fieldname>
+   <fieldname>gsid</fieldname>
+   <fieldname>admin</fieldname>
+   <fieldname>expires</fieldname>
+   <fieldname>startdate</fieldname>
+   <fieldname>adminemail</fieldname>
+   <fieldname>anonymized</fieldname>
+   <fieldname>format</fieldname>
+   <fieldname>savetimings</fieldname>
+   <fieldname>template</fieldname>
+   <fieldname>language</fieldname>
+   <fieldname>additional_languages</fieldname>
+   <fieldname>datestamp</fieldname>
+   <fieldname>usecookie</fieldname>
+   <fieldname>allowregister</fieldname>
+   <fieldname>allowsave</fieldname>
+   <fieldname>autonumber_start</fieldname>
+   <fieldname>autoredirect</fieldname>
+   <fieldname>allowprev</fieldname>
+   <fieldname>printanswers</fieldname>
+   <fieldname>ipaddr</fieldname>
+   <fieldname>ipanonymize</fieldname>
+   <fieldname>refurl</fieldname>
+   <fieldname>showsurveypolicynotice</fieldname>
+   <fieldname>publicstatistics</fieldname>
+   <fieldname>publicgraphs</fieldname>
+   <fieldname>listpublic</fieldname>
+   <fieldname>htmlemail</fieldname>
+   <fieldname>sendconfirmation</fieldname>
+   <fieldname>tokenanswerspersistence</fieldname>
+   <fieldname>assessments</fieldname>
+   <fieldname>usecaptcha</fieldname>
+   <fieldname>usetokens</fieldname>
+   <fieldname>bounce_email</fieldname>
+   <fieldname>attributedescriptions</fieldname>
+   <fieldname>emailresponseto</fieldname>
+   <fieldname>emailnotificationto</fieldname>
+   <fieldname>tokenlength</fieldname>
+   <fieldname>showxquestions</fieldname>
+   <fieldname>showgroupinfo</fieldname>
+   <fieldname>shownoanswer</fieldname>
+   <fieldname>showqnumcode</fieldname>
+   <fieldname>bouncetime</fieldname>
+   <fieldname>bounceprocessing</fieldname>
+   <fieldname>bounceaccounttype</fieldname>
+   <fieldname>bounceaccounthost</fieldname>
+   <fieldname>bounceaccountpass</fieldname>
+   <fieldname>bounceaccountencryption</fieldname>
+   <fieldname>bounceaccountuser</fieldname>
+   <fieldname>showwelcome</fieldname>
+   <fieldname>showprogress</fieldname>
+   <fieldname>questionindex</fieldname>
+   <fieldname>navigationdelay</fieldname>
+   <fieldname>nokeyboard</fieldname>
+   <fieldname>alloweditaftercompletion</fieldname>
+   <fieldname>googleanalyticsstyle</fieldname>
+   <fieldname>googleanalyticsapikey</fieldname>
+   <fieldname>tokenencryptionoptions</fieldname>
+   <fieldname>lastmodified</fieldname>
+   <fieldname>access_mode</fieldname>
+   <fieldname>showregisterpolicy</fieldname>
+   <fieldname>showtokenpolicy</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <sid><![CDATA[928171]]></sid>
+    <gsid><![CDATA[1]]></gsid>
+    <admin/>
+    <adminemail/>
+    <anonymized><![CDATA[N]]></anonymized>
+    <format><![CDATA[G]]></format>
+    <savetimings><![CDATA[N]]></savetimings>
+    <template><![CDATA[fruity]]></template>
+    <language><![CDATA[de]]></language>
+    <additional_languages/>
+    <datestamp><![CDATA[N]]></datestamp>
+    <usecookie><![CDATA[N]]></usecookie>
+    <allowregister><![CDATA[N]]></allowregister>
+    <allowsave><![CDATA[Y]]></allowsave>
+    <autonumber_start><![CDATA[1]]></autonumber_start>
+    <autoredirect><![CDATA[Y]]></autoredirect>
+    <allowprev><![CDATA[N]]></allowprev>
+    <printanswers><![CDATA[N]]></printanswers>
+    <ipaddr><![CDATA[N]]></ipaddr>
+    <ipanonymize><![CDATA[N]]></ipanonymize>
+    <refurl><![CDATA[N]]></refurl>
+    <showsurveypolicynotice><![CDATA[0]]></showsurveypolicynotice>
+    <publicstatistics><![CDATA[N]]></publicstatistics>
+    <publicgraphs><![CDATA[N]]></publicgraphs>
+    <listpublic><![CDATA[N]]></listpublic>
+    <htmlemail><![CDATA[Y]]></htmlemail>
+    <sendconfirmation><![CDATA[Y]]></sendconfirmation>
+    <tokenanswerspersistence><![CDATA[N]]></tokenanswerspersistence>
+    <assessments><![CDATA[N]]></assessments>
+    <usecaptcha><![CDATA[N]]></usecaptcha>
+    <usetokens><![CDATA[N]]></usetokens>
+    <bounce_email/>
+    <emailresponseto/>
+    <emailnotificationto/>
+    <tokenlength><![CDATA[15]]></tokenlength>
+    <showxquestions><![CDATA[Y]]></showxquestions>
+    <showgroupinfo><![CDATA[B]]></showgroupinfo>
+    <shownoanswer><![CDATA[Y]]></shownoanswer>
+    <showqnumcode><![CDATA[X]]></showqnumcode>
+    <bounceprocessing><![CDATA[N]]></bounceprocessing>
+    <showwelcome><![CDATA[Y]]></showwelcome>
+    <showprogress><![CDATA[Y]]></showprogress>
+    <questionindex><![CDATA[0]]></questionindex>
+    <navigationdelay><![CDATA[0]]></navigationdelay>
+    <nokeyboard><![CDATA[N]]></nokeyboard>
+    <alloweditaftercompletion><![CDATA[N]]></alloweditaftercompletion>
+    <googleanalyticsstyle/>
+    <googleanalyticsapikey/>
+    <tokenencryptionoptions/>
+    <lastmodified><![CDATA[2026-05-13 10:27:48]]></lastmodified>
+    <access_mode><![CDATA[O]]></access_mode>
+    <showregisterpolicy><![CDATA[I]]></showregisterpolicy>
+    <showtokenpolicy><![CDATA[I]]></showtokenpolicy>
+   </row>
+  </rows>
+ </surveys>
+ <surveys_languagesettings>
+  <fields>
+   <fieldname>surveyls_survey_id</fieldname>
+   <fieldname>surveyls_policy_error</fieldname>
+   <fieldname>surveyls_email_invite_subj</fieldname>
+   <fieldname>surveyls_email_invite</fieldname>
+   <fieldname>surveyls_email_remind_subj</fieldname>
+   <fieldname>surveyls_email_remind</fieldname>
+   <fieldname>surveyls_email_register_subj</fieldname>
+   <fieldname>surveyls_email_register</fieldname>
+   <fieldname>surveyls_email_confirm_subj</fieldname>
+   <fieldname>surveyls_email_confirm</fieldname>
+   <fieldname>surveyls_dateformat</fieldname>
+   <fieldname>surveyls_attributecaptions</fieldname>
+   <fieldname>surveyls_alias</fieldname>
+   <fieldname>email_admin_notification_subj</fieldname>
+   <fieldname>email_admin_notification</fieldname>
+   <fieldname>email_admin_responses_subj</fieldname>
+   <fieldname>email_admin_responses</fieldname>
+   <fieldname>surveyls_numberformat</fieldname>
+   <fieldname>attachments</fieldname>
+   <fieldname>surveyls_language</fieldname>
+   <fieldname>surveyls_title</fieldname>
+   <fieldname>surveyls_description</fieldname>
+   <fieldname>surveyls_welcometext</fieldname>
+   <fieldname>surveyls_endtext</fieldname>
+   <fieldname>surveyls_policy_notice</fieldname>
+   <fieldname>surveyls_policy_notice_label</fieldname>
+   <fieldname>surveyls_url</fieldname>
+   <fieldname>surveyls_urldescription</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <surveyls_survey_id><![CDATA[928171]]></surveyls_survey_id>
+    <surveyls_policy_error/>
+    <surveyls_email_invite_subj><![CDATA[Einladung zu einer Umfrage]]></surveyls_email_invite_subj>
+    <surveyls_email_invite><![CDATA[Hallo {FIRSTNAME},<br />
+<br />
+Hiermit möchten wir Sie zu einer Umfrage einladen.<br />
+<br />
+Der Titel der Umfrage ist <br />
+'{SURVEYNAME}'<br />
+<br />
+'{SURVEYDESCRIPTION}'<br />
+<br />
+Um an dieser Umfrage teilzunehmen, klicken Sie bitte auf den unten stehenden Link.<br />
+<br />
+Mit freundlichen Grüßen,<br />
+<br />
+{ADMINNAME} ({ADMINEMAIL})<br />
+<br />
+----------------------------------------------<br />
+Klicken Sie hier um die Umfrage zu starten:<br />
+{SURVEYURL}<br />
+<br />
+Wenn Sie an diese Umfrage nicht teilnehmen und keine weiteren Erinnerungen erhalten möchten, klicken Sie bitte auf den folgenden Link:<br />
+{OPTOUTURL}<br />
+<br />
+Wenn Sie geblockt sind, jedoch wieder teilnehmen und weitere Einladungen erhalten möchten, klicken Sie bitte auf den folgenden Link:<br />
+{OPTINURL}]]></surveyls_email_invite>
+    <surveyls_email_remind_subj><![CDATA[Erinnerung an die Teilnahme an einer Umfrage]]></surveyls_email_remind_subj>
+    <surveyls_email_remind><![CDATA[Hallo {FIRSTNAME},<br />
+<br />
+Vor kurzem haben wir Sie zu einer Umfrage eingeladen.<br />
+<br />
+Zu unserem Bedauern haben wir bemerkt, dass Sie die Umfrage noch nicht ausgefüllt haben. Wir möchten Ihnen mitteilen, dass die Umfrage noch aktiv ist und würden uns freuen, wenn Sie teilnehmen könnten.<br />
+<br />
+Der Titel der Umfrage ist <br />
+'{SURVEYNAME}'<br />
+<br />
+'{SURVEYDESCRIPTION}'<br />
+<br />
+Um an dieser Umfrage teilzunehmen, klicken Sie bitte auf den unten stehenden Link.<br />
+<br />
+ Mit freundlichen Grüßen,<br />
+<br />
+{ADMINNAME} ({ADMINEMAIL})<br />
+<br />
+----------------------------------------------<br />
+Klicken Sie hier um die Umfrage zu starten:<br />
+{SURVEYURL}<br />
+<br />
+Wenn Sie an diese Umfrage nicht teilnehmen und keine weiteren Erinnerungen erhalten möchten, klicken Sie bitte auf den folgenden Link:<br />
+{OPTOUTURL}]]></surveyls_email_remind>
+    <surveyls_email_register_subj><![CDATA[Registrierungsbestätigung für Teilnahmeumfrage]]></surveyls_email_register_subj>
+    <surveyls_email_register><![CDATA[Hallo {FIRSTNAME},<br />
+<br />
+Sie (oder jemand, der Ihre E-Mail benutzt hat) haben sich für eine Umfrage mit dem Titel {SURVEYNAME} angemeldet.<br />
+<br />
+Um an dieser Umfrage teilzunehmen, klicken Sie bitte auf den folgenden Link.<br />
+<br />
+{SURVEYURL}<br />
+<br />
+Wenn Sie irgendwelche Fragen zu dieser Umfrage haben oder wenn Sie sich _nicht_ für diese Umfrage angemeldet haben und sie glauben, dass Ihnen diese E-Mail irrtümlicherweise zugeschickt worden ist, kontaktieren Sie bitte {ADMINNAME} unter {ADMINEMAIL}.]]></surveyls_email_register>
+    <surveyls_email_confirm_subj><![CDATA[Bestätigung für die Teilnahme an unserer Umfrage]]></surveyls_email_confirm_subj>
+    <surveyls_email_confirm><![CDATA[Hallo {FIRSTNAME},<br />
+<br />
+Vielen Dank für die Teilnahme an der Umfrage mit dem Titel {SURVEYNAME}. Ihre Antworten wurden bei uns gespeichert.<br />
+<br />
+Wenn Sie irgendwelche Fragen zu dieser E-Mail haben, kontaktieren Sie bitte {ADMINNAME} unter {ADMINEMAIL}.<br />
+<br />
+Mit freundlichen Grüßen,<br />
+<br />
+{ADMINNAME}]]></surveyls_email_confirm>
+    <surveyls_dateformat><![CDATA[1]]></surveyls_dateformat>
+    <surveyls_alias/>
+    <email_admin_notification_subj><![CDATA[Antwortabsendung für Umfrage {SURVEYNAME}]]></email_admin_notification_subj>
+    <email_admin_notification><![CDATA[Hallo,<br />
+<br />
+Eine neue Antwort wurde für die Umfrage '{SURVEYNAME}' abgegeben.<br />
+<br />
+Klicken Sie auf den folgenden Link um den Antwortdatensatz anzusehen:<br />
+{VIEWRESPONSEURL}<br />
+<br />
+Klicken Sie auf den folgenden Link um den Antwortdatensatz zu bearbeiten:<br />
+{EDITRESPONSEURL}<br />
+<br />
+Um die Statistik zu sehen, klicken Sie hier:<br />
+{STATISTICSURL}]]></email_admin_notification>
+    <email_admin_responses_subj><![CDATA[Antwortabsendung für Umfrage {SURVEYNAME} mit Ergebnissen]]></email_admin_responses_subj>
+    <email_admin_responses><![CDATA[Hallo,<br />
+<br />
+Eine neue Antwort wurde für die Umfrage '{SURVEYNAME}' abgegeben.<br />
+<br />
+Klicken Sie auf den folgenden Link um den Antwortdatensatz anzusehen:<br />
+{VIEWRESPONSEURL}<br />
+<br />
+Klicken Sie auf den folgenden Link um den Antwortdatensatz zu bearbeiten:<br />
+{EDITRESPONSEURL}<br />
+<br />
+Um die Statistik zu sehen, klicken Sie hier:<br />
+{STATISTICSURL}<br />
+<br />
+<br />
+Die folgenden Antworten wurden vom Teilnehmer gegeben:<br />
+{ANSWERTABLE}]]></email_admin_responses>
+    <surveyls_numberformat><![CDATA[0]]></surveyls_numberformat>
+    <surveyls_language><![CDATA[de]]></surveyls_language>
+    <surveyls_title><![CDATA[Corrupted survey - missing language]]></surveyls_title>
+    <surveyls_description/>
+    <surveyls_welcometext><![CDATA[test]]></surveyls_welcometext>
+    <surveyls_endtext/>
+    <surveyls_policy_notice/>
+    <surveyls_policy_notice_label/>
+    <surveyls_url><![CDATA[http://google.com]]></surveyls_url>
+    <surveyls_urldescription><![CDATA[google]]></surveyls_urldescription>
+   </row>
+  </rows>
+ </surveys_languagesettings>
+ <surveys_groups>
+  <fields>
+   <fieldname>gsid</fieldname>
+   <fieldname>name</fieldname>
+   <fieldname>title</fieldname>
+   <fieldname>template</fieldname>
+   <fieldname>description</fieldname>
+   <fieldname>parent_id</fieldname>
+   <fieldname>alwaysavailable</fieldname>
+  </fields>
+  <rows>
+   <row>
+    <gsid><![CDATA[1]]></gsid>
+    <name><![CDATA[default]]></name>
+    <title><![CDATA[Default]]></title>
+    <description><![CDATA[Default survey group]]></description>
+   </row>
+  </rows>
+ </surveys_groups>
+ <themes>
+  <theme>
+   <sid>928171</sid>
+   <template_name>fruity</template_name>
+   <config>
+    <options>inherit</options>
+   </config>
+  </theme>
+ </themes>
+ <themes_inherited>
+  <theme>
+   <sid>928171</sid>
+   <template_name>fruity</template_name>
+   <config>
+    <options>
+     <ajaxmode>off</ajaxmode>
+     <fixnumauto>enable</fixnumauto>
+     <brandlogo>on</brandlogo>
+     <brandlogofile>image::theme::files/logo.png</brandlogofile>
+     <container>on</container>
+     <backgroundimage>off</backgroundimage>
+     <animatebody>off</animatebody>
+     <bodyanimationduration>false</bodyanimationduration>
+     <animatequestion>off</animatequestion>
+     <questionanimationduration>false</questionanimationduration>
+     <animatealert>off</animatealert>
+     <alertanimationduration>false</alertanimationduration>
+     <font>noto</font>
+     <bodybackgroundcolor>#ffffff</bodybackgroundcolor>
+     <fontcolor>#444444</fontcolor>
+     <questionbackgroundcolor>#ffffff</questionbackgroundcolor>
+     <questionborder>on</questionborder>
+     <questioncontainershadow>on</questioncontainershadow>
+     <checkicon>f00c</checkicon>
+     <animatecheckbox>on</animatecheckbox>
+     <checkboxanimation>rubberBand</checkboxanimation>
+     <checkboxanimationduration>500</checkboxanimationduration>
+     <animateradio>on</animateradio>
+     <radioanimation>zoomIn</radioanimation>
+     <radioanimationduration>500</radioanimationduration>
+     <zebrastriping>off</zebrastriping>
+     <stickymatrixheaders>off</stickymatrixheaders>
+     <greyoutselected>off</greyoutselected>
+     <hideprivacyinfo>off</hideprivacyinfo>
+     <crosshover>off</crosshover>
+     <showpopups>1</showpopups>
+     <showclearall>off</showclearall>
+     <questionhelptextposition>top</questionhelptextposition>
+     <notables>1</notables>
+    </options>
+   </config>
+  </theme>
+ </themes_inherited>
+</document>

--- a/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
+++ b/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
@@ -11,9 +11,6 @@ use Facebook\WebDriver\Exception\NoSuchElementException;
 class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
 {
 
-    /** keep surveyurl */
-    protected static $surveyUrl;
-
     /**
      * Import survey before test
      */
@@ -35,7 +32,7 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         \Yii::app()->session['loginID'] = 1;
 
         // Browser login.
-        self::adminLogin($username, $password, $wait = false);
+        self::adminLogin($username, $password, false);
 
         // Import survey
         $surveyFile =  self::$surveysFolder . '/limesurvey_survey_CorruptedSurvey.lss';
@@ -67,8 +64,7 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
             $screenshot = $web->takeScreenshot();
             $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';
             file_put_contents($filename, $screenshot);
-            $this->assertFalse(
-                true,
+            $this->fail(
                 'Url: ' . $url . PHP_EOL .
                 'Screenshot in ' . $filename . PHP_EOL . $ex->getMessage()
             );
@@ -95,8 +91,7 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
             $screenshot = $web->takeScreenshot();
             $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';
             file_put_contents($filename, $screenshot);
-            $this->assertFalse(
-                true,
+            $this->fail(
                 'Url: ' . $url . PHP_EOL .
                 'Screenshot in ' . $filename . PHP_EOL . $ex->getMessage()
             );

--- a/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
+++ b/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
@@ -39,9 +39,14 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         self::importSurvey($surveyFile);
 
         // Corrupt the survey by setting the language to empty string
-        \Yii::app()->db->createCommand(
+        $affectedRows = \Yii::app()->db->createCommand(
             "UPDATE {{surveys_languagesettings}} SET surveyls_language = '' WHERE surveyls_survey_id = :sid AND surveyls_language = 'de'"
         )->execute([':sid' => self::$surveyId]);
+        self::assertGreaterThan(
+            0,
+            $affectedRows,
+            'Corruption setup failed: no language row was updated for the imported survey.'
+       );
     }
 
     /**
@@ -52,14 +57,15 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         $urlMan = \Yii::app()->urlManager;
         $urlMan->setBaseUrl('http://' . self::$domain . '/index.php');
         $web = self::$webDriver;
-
+        $url = $urlMan->createUrl('dashboard/view?Survey%5Bsearched_value%5D=&active=&gsid=&viewtype=box-widget');
+            
         try {
-            $url = $urlMan->createUrl('dashboard/view?Survey%5Bsearched_value%5D=&active=&gsid=&viewtype=box-widget');
             $web->get($url);
 
             // Verify no PHP error is shown
             $pageSource = $web->getPageSource();
             $this->assertStringNotContainsString('500: Internal Server Error', $pageSource);
+            $this->assertStringContainsString('/dashboard', $web->getCurrentUrl());
         } catch (\Exception $ex) {
             $screenshot = $web->takeScreenshot();
             $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';
@@ -79,14 +85,15 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         $urlMan = \Yii::app()->urlManager;
         $urlMan->setBaseUrl('http://' . self::$domain . '/index.php');
         $web = self::$webDriver;
+        $url = $urlMan->createUrl('dashboard/view?active=&viewtype=list-widget');
 
         try {
-            $url = $urlMan->createUrl('dashboard/view?active=&viewtype=list-widget');
             $web->get($url);
 
             // Verify no PHP error is shown
             $pageSource = $web->getPageSource();
             $this->assertStringNotContainsString('500: Internal Server Error', $pageSource);
+            $this->assertStringContainsString('/dashboard', $web->getCurrentUrl());
         } catch (\Exception $ex) {
             $screenshot = $web->takeScreenshot();
             $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';

--- a/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
+++ b/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
@@ -47,6 +47,9 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         )->execute([':sid' => self::$surveyId]);
     }
 
+    /**
+     * Test if dashboard card view can be loaded with a corrupted survey (missing language)
+     */
     public function testDashboardCardViewLoadedWithCorruptedSurvey()
     {
         $urlMan = \Yii::app()->urlManager;
@@ -72,6 +75,9 @@ class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
         }
     }
 
+    /**
+     * Test if dashboard list view can be loaded with a corrupted survey (missing language)
+     */
     public function testDashboardListViewLoadedWithCorruptedSurvey()
     {
         $urlMan = \Yii::app()->urlManager;

--- a/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
+++ b/tests/functional/frontend/DashboardLoadedWithCorruptedSurveyTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ls\tests;
+
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\Exception\NoSuchElementException;
+
+/**
+* Test if dashboard (card and list views) can be loaded with a corrupted survey (missing language)
+**/
+class DashboardLoadedWithCorruptedSurveyTest extends TestBaseClassWeb
+{
+
+    /** keep surveyurl */
+    protected static $surveyUrl;
+
+    /**
+     * Import survey before test
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $username = getenv('ADMINUSERNAME');
+        if (!$username) {
+            $username = 'admin';
+        }
+
+        $password = getenv('PASSWORD');
+        if (!$password) {
+            $password = 'password';
+        }
+
+        // Permission to everything.
+        \Yii::app()->session['loginID'] = 1;
+
+        // Browser login.
+        self::adminLogin($username, $password, $wait = false);
+
+        // Import survey
+        $surveyFile =  self::$surveysFolder . '/limesurvey_survey_CorruptedSurvey.lss';
+        self::importSurvey($surveyFile);
+
+        // Corrupt the survey by setting the language to empty string
+        \Yii::app()->db->createCommand(
+            "UPDATE {{surveys_languagesettings}} SET surveyls_language = '' WHERE surveyls_survey_id = :sid AND surveyls_language = 'de'"
+        )->execute([':sid' => self::$surveyId]);
+    }
+
+    public function testDashboardCardViewLoadedWithCorruptedSurvey()
+    {
+        $urlMan = \Yii::app()->urlManager;
+        $urlMan->setBaseUrl('http://' . self::$domain . '/index.php');
+        $web = self::$webDriver;
+
+        try {
+            $url = $urlMan->createUrl('dashboard/view?Survey%5Bsearched_value%5D=&active=&gsid=&viewtype=box-widget');
+            $web->get($url);
+
+            // Verify no PHP error is shown
+            $pageSource = $web->getPageSource();
+            $this->assertStringNotContainsString('500: Internal Server Error', $pageSource);
+        } catch (\Exception $ex) {
+            $screenshot = $web->takeScreenshot();
+            $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';
+            file_put_contents($filename, $screenshot);
+            $this->assertFalse(
+                true,
+                'Url: ' . $url . PHP_EOL .
+                'Screenshot in ' . $filename . PHP_EOL . $ex->getMessage()
+            );
+        }
+    }
+
+    public function testDashboardListViewLoadedWithCorruptedSurvey()
+    {
+        $urlMan = \Yii::app()->urlManager;
+        $urlMan->setBaseUrl('http://' . self::$domain . '/index.php');
+        $web = self::$webDriver;
+
+        try {
+            $url = $urlMan->createUrl('dashboard/view?active=&viewtype=list-widget');
+            $web->get($url);
+
+            // Verify no PHP error is shown
+            $pageSource = $web->getPageSource();
+            $this->assertStringNotContainsString('500: Internal Server Error', $pageSource);
+        } catch (\Exception $ex) {
+            $screenshot = $web->takeScreenshot();
+            $filename = self::$screenshotsFolder . '/' . __CLASS__ . '_' . __FUNCTION__ . '.png';
+            file_put_contents($filename, $screenshot);
+            $this->assertFalse(
+                true,
+                'Url: ' . $url . PHP_EOL .
+                'Screenshot in ' . $filename . PHP_EOL . $ex->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+    }
+}
+


### PR DESCRIPTION
Implemented tests that check that the dashboard card and list views load, even if there is a corrupted survey with missing language in table surveys_languagesettings.

## PR type

Dev: Implemented checks for dashboard loading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional tests to verify the dashboard (card and list views) still loads when a survey’s language setting is corrupted.
* **Tests (Data)**
  * Added a corrupted LimeSurvey export fixture to exercise language, localization, theme, and configuration edge cases during import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LimeSurvey/LimeSurvey/pull/4975)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->