### PR TITLE
Fixed issue #20138:  ComfortUpdate does not sufficiently check if existing files can be modified

### DIFF
--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -197,7 +197,7 @@ class UpdateForm extends CFormModel
             if (file_exists($lsRootPath . $check)) {
                 if (!is_writable($lsRootPath . $check)) {
                     $readOnly[] = $lsRootPath . $check;
-                } elseif (!$this->isFileOwnedByCurrentProcess($lsRootPath . $check)) {
+                } elseif (!$this->isFileModifiable($lsRootPath . $check)) {
                     // File is writable but not owned by current process
                     // This prevents updates from failing mid-process due to ownership issues
                     // Fixes: Bug #20138
@@ -792,12 +792,12 @@ class UpdateForm extends CFormModel
                 }
             }
 
-            // Check not only if directory is writable, but also if it's owned by current process
-            // This ensures the user running the update owns the files
+            // Check not only if directory is writable, but also if it can be modified
+            // This ensures the current process can modify files (by ownership, root, or permissions)
             // Fixes: Bug #20138 - ComfortUpdate fails when files owned by different user
             if ($is_writable && file_exists($searchpath)) {
-                $is_owned = $this->isFileOwnedByCurrentProcess($searchpath);
-                if (!$is_owned) {
+                $is_modifiable = $this->isFileModifiable($searchpath);
+                if (!$is_modifiable) {
                     $is_writable = false;
                 }
             }
@@ -816,11 +816,11 @@ class UpdateForm extends CFormModel
             file_exists($this->rootdir . $file['file'])
             && is_writable($this->rootdir . $file['file'])
         ) {
-            // Check if file is owned by current process
+            // Check if file can be modified (ownership, root, or permissions)
             // This is necessary even if file is writable, as file ownership may prevent updates
             // Fixes: Bug #20138 - ComfortUpdate fails when files owned by different user
-            $is_owned = $this->isFileOwnedByCurrentProcess($this->rootdir . $file['file']);
-            if (!$is_owned) {
+            $is_modifiable = $this->isFileModifiable($this->rootdir . $file['file']);
+            if (!$is_modifiable) {
                 $checkedfile->type = 'readonlyfile';
                 $checkedfile->file = $this->rootdir . $file['file'];
             }
@@ -843,7 +843,7 @@ class UpdateForm extends CFormModel
      * @param string $path Path to file or directory to test
      * @return bool True if current process can modify the file, false otherwise
      */
-    private function isFileOwnedByCurrentProcess($path)
+    private function isFileModifiable($path)
     {
         if (!file_exists($path)) {
             return false;

--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -191,11 +191,16 @@ class UpdateForm extends CFormModel
         $toCheck = $content->list;
         $readOnly = array();
 
-        // We check the write permission of files
+        // We check the write permission of files and ability to modify timestamps
         $lsRootPath = dirname((string) Yii::app()->request->scriptFile) . '/';
         foreach ($toCheck as $check) {
             if (file_exists($lsRootPath . $check)) {
                 if (!is_writable($lsRootPath . $check)) {
+                    $readOnly[] = $lsRootPath . $check;
+                } elseif (!$this->isFileOwnedByCurrentProcess($lsRootPath . $check)) {
+                    // File is writable but not owned by current process
+                    // This prevents updates from failing mid-process due to ownership issues
+                    // Fixes: Bug #20138
                     $readOnly[] = $lsRootPath . $check;
                 }
             }
@@ -787,6 +792,16 @@ class UpdateForm extends CFormModel
                 }
             }
 
+            // Check not only if directory is writable, but also if it's owned by current process
+            // This ensures the user running the update owns the files
+            // Fixes: Bug #20138 - ComfortUpdate fails when files owned by different user
+            if ($is_writable && file_exists(dirname($searchpath))) {
+                $is_owned = $this->isFileOwnedByCurrentProcess(dirname($searchpath));
+                if (!$is_owned) {
+                    $is_writable = false;
+                }
+            }
+
             if (!$is_writable) {
                 $checkedfile->type = 'readonlyfile';
                 $checkedfile->file = $searchpath;
@@ -797,9 +812,55 @@ class UpdateForm extends CFormModel
         ) {
             $checkedfile->type = 'readonlyfile';
             $checkedfile->file = $this->rootdir . $file['file'];
+        } elseif (
+            file_exists($this->rootdir . $file['file'])
+            && is_writable($this->rootdir . $file['file'])
+        ) {
+            // Check if file is owned by current process
+            // This is necessary even if file is writable, as file ownership may prevent updates
+            // Fixes: Bug #20138 - ComfortUpdate fails when files owned by different user
+            $is_owned = $this->isFileOwnedByCurrentProcess($this->rootdir . $file['file']);
+            if (!$is_owned) {
+                $checkedfile->type = 'readonlyfile';
+                $checkedfile->file = $this->rootdir . $file['file'];
+            }
         }
 
         return $checkedfile;
+    }
+
+    /**
+     * Check if a file or directory is owned by the current process user
+     * This is essential before updating files, as file operations require proper file ownership
+     * 
+     * On Linux/Unix systems, uses POSIX functions to verify the current process UID matches file owner UID.
+     * This prevents failures when files are writable but owned by a different user (Bug #20138).
+     *
+     * @param string $path Path to file or directory to test
+     * @return bool True if file is owned by current process user, false otherwise
+     */
+    private function isFileOwnedByCurrentProcess($path)
+    {
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        // Check if POSIX functions are available (available on Linux/Unix, not on Windows)
+        if (function_exists('posix_geteuid') && function_exists('fileowner')) {
+            $currentUid = @posix_geteuid();
+            $fileUid = @fileowner($path);
+            
+            // If we successfully got both UIDs, check if they match
+            if ($currentUid !== false && $fileUid !== false) {
+                return ($currentUid === $fileUid);
+            }
+        }
+
+        // POSIX not available or unable to determine ownership
+        // On Windows or systems without POSIX, we can't directly check ownership
+        // but is_writable() in the caller should already handle basic permission checks
+        // Return true to allow the update to proceed (permission already verified)
+        return true;
     }
 
 

--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -279,7 +279,7 @@ class UpdateForm extends CFormModel
             $archive = new LimeSurvey\Zip();
             $archive->open($this->tempdir . DIRECTORY_SEPARATOR . $file_to_unzip);
 
-            if ($archive->extractTo($this->rootdir . DIRECTORY_SEPARATOR) == 0) {
+            if (@$archive->extractTo($this->rootdir . DIRECTORY_SEPARATOR) == 0) {
                 $return = array('result' => false, 'error' => 'unzip_error', 'message' => $archive->getStatusString());
                 $archive->close();
                 return (object) $return;
@@ -859,15 +859,13 @@ class UpdateForm extends CFormModel
             // 2. We're root (UID 0) - root can modify any file, OR
             // 3. File is writable (permissions allow modification)
             if ($currentUid !== false && $fileUid !== false) {
-                return ($currentUid === $fileUid) || ($currentUid === 0) || is_writable($path);
+                return ($currentUid === $fileUid) || ($currentUid === 0);
             }
         }
 
         // POSIX not available or unable to determine ownership
-        // On Windows or systems without POSIX, we can't directly check ownership
         // but is_writable() should handle basic permission checks
-        // Return true to allow the update to proceed (permission already verified by caller)
-        return true;
+        return is_writable($path);
     }
 
 

--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -832,12 +832,12 @@ class UpdateForm extends CFormModel
     /**
      * Check if the current process can modify a file or directory
      * This is essential before updating files, as file operations require proper permissions
-     * 
+     *
      * On Linux/Unix systems, uses POSIX functions to check:
      * 1. If current process is root (UID 0) - can always modify, OR
      * 2. If current process owns the file (UID match) - can modify, OR
      * 3. If the file/directory has write permissions set - can modify via permissions
-     * 
+     *
      * This prevents failures when permission bits alone don't allow expected modifications (Bug #20138).
      *
      * @param string $path Path to file or directory to test
@@ -853,7 +853,7 @@ class UpdateForm extends CFormModel
         if (function_exists('posix_geteuid') && function_exists('fileowner')) {
             $currentUid = @posix_geteuid();
             $fileUid = @fileowner($path);
-            
+
             // If we successfully got both UIDs, check if we can modify:
             // 1. We own the file (UID match), OR
             // 2. We're root (UID 0) - root can modify any file, OR

--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -830,14 +830,18 @@ class UpdateForm extends CFormModel
     }
 
     /**
-     * Check if a file or directory is owned by the current process user
-     * This is essential before updating files, as file operations require proper file ownership
+     * Check if the current process can modify a file or directory
+     * This is essential before updating files, as file operations require proper permissions
      * 
-     * On Linux/Unix systems, uses POSIX functions to verify the current process UID matches file owner UID.
-     * This prevents failures when files are writable but owned by a different user (Bug #20138).
+     * On Linux/Unix systems, uses POSIX functions to check:
+     * 1. If current process is root (UID 0) - can always modify, OR
+     * 2. If current process owns the file (UID match) - can modify, OR
+     * 3. If the file/directory has write permissions set - can modify via permissions
+     * 
+     * This prevents failures when permission bits alone don't allow expected modifications (Bug #20138).
      *
      * @param string $path Path to file or directory to test
-     * @return bool True if file is owned by current process user, false otherwise
+     * @return bool True if current process can modify the file, false otherwise
      */
     private function isFileOwnedByCurrentProcess($path)
     {
@@ -850,16 +854,19 @@ class UpdateForm extends CFormModel
             $currentUid = @posix_geteuid();
             $fileUid = @fileowner($path);
             
-            // If we successfully got both UIDs, check if they match
+            // If we successfully got both UIDs, check if we can modify:
+            // 1. We own the file (UID match), OR
+            // 2. We're root (UID 0) - root can modify any file, OR
+            // 3. File is writable (permissions allow modification)
             if ($currentUid !== false && $fileUid !== false) {
-                return ($currentUid === $fileUid);
+                return ($currentUid === $fileUid) || ($currentUid === 0) || is_writable($path);
             }
         }
 
         // POSIX not available or unable to determine ownership
         // On Windows or systems without POSIX, we can't directly check ownership
-        // but is_writable() in the caller should already handle basic permission checks
-        // Return true to allow the update to proceed (permission already verified)
+        // but is_writable() should handle basic permission checks
+        // Return true to allow the update to proceed (permission already verified by caller)
         return true;
     }
 

--- a/application/models/UpdateForm.php
+++ b/application/models/UpdateForm.php
@@ -795,8 +795,8 @@ class UpdateForm extends CFormModel
             // Check not only if directory is writable, but also if it's owned by current process
             // This ensures the user running the update owns the files
             // Fixes: Bug #20138 - ComfortUpdate fails when files owned by different user
-            if ($is_writable && file_exists(dirname($searchpath))) {
-                $is_owned = $this->isFileOwnedByCurrentProcess(dirname($searchpath));
+            if ($is_writable && file_exists($searchpath)) {
+                $is_owned = $this->isFileOwnedByCurrentProcess($searchpath);
                 if (!$is_owned) {
                     $is_writable = false;
                 }


### PR DESCRIPTION
Bug report: https://bugs.limesurvey.org/view.php?id=20138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update validation to ensure the updater can actually perform required modifications, not just that targets are writable.
  * Targets that are writable but not modifiable by the process are now treated as read-only to avoid failed updates.
  * Enhanced ownership/modifiability checks when system info is available; falls back to permissive checks on unsupported platforms.
  * Suppressed noisy errors during update archive extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LimeSurvey/LimeSurvey/pull/5005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->