### PR TITLE
Fixed issue #20540: Adjusted templates to comply to LS7

### DIFF
--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -19,6 +19,8 @@ use QuestionGroupL10n;
 use Assessment;
 use DefaultValue;
 use AnswerL10n;
+use SurveysGroupsettings;
+use Template;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -1001,6 +1003,26 @@ class Update_700 extends DatabaseUpdateBase
     }
 
     /**
+     * Updates group templates if they are not fruity_twentythree or an extended version of it or inherit
+     * @return void
+     */
+    public function updateGroupTemplates()
+    {
+        $fruities = [];
+        $fruityTemplates = Template::model()->findAll(":fruity in (extends, name)", [':fruity' => 'fruity_twentythree']);
+        foreach ($fruityTemplates as $fruityTemplate) {
+            $fruities []= $fruityTemplate->name;
+        }
+        $groupTemplates = SurveysGroupsettings::model()->findAll();
+        foreach ($groupTemplates as $groupTemplate) {
+            if (!in_array($groupTemplate->template, array_merge(['inherit', $fruities]))) {
+                $groupTemplate->template = 'fruity_twentythree';
+                $groupTemplate->save();
+            }
+        }
+    }
+
+    /**
      * Fixes textual data, replacing old fieldname representation with new fieldname representation. We don't save the record even if changed here, because
      * outside of the method we may want to do additional things
      * @param LSActiveRecord $record the record whose fields are to be fixed
@@ -1234,6 +1256,7 @@ class Update_700 extends DatabaseUpdateBase
     /** @SuppressWarnings(PHPMD.ExcessiveMethodLength) */
     public function up()
     {
+        $this->updateGroupTemplates();
         $this->db->createCommand($this->insertRankingSubquestions())->execute();
         $this->db->createCommand($this->insertRankingSubquestionsL10ns())->execute();
         $this->doPreparations();

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1015,7 +1015,7 @@ class Update_700 extends DatabaseUpdateBase
         }
         $groupTemplates = SurveysGroupsettings::model()->findAll();
         foreach ($groupTemplates as $groupTemplate) {
-            if (!in_array($groupTemplate->template, array_merge(['inherit', $fruities]))) {
+            if (!in_array($groupTemplate->template, array_merge(['inherit'], $fruities))) {
                 $groupTemplate->template = 'fruity_twentythree';
                 $groupTemplate->save();
             }


### PR DESCRIPTION
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Update process now normalizes non-inherited, non-fruity group templates to the standard fruity_twentythree during migrations.
* **Bug Fixes**
  * Prevents unexpected or incompatible group template assignments after upgrades while preserving inherited and existing fruity templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LimeSurvey/LimeSurvey/pull/5015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->