### PR TITLE
Fixed issue : Add allowed_classes to unserialize() to prevent PHP Object Injection

### DIFF
--- a/application/core/LSMessageSource.php
+++ b/application/core/LSMessageSource.php
@@ -69,7 +69,7 @@ class LSMessageSource extends CMessageSource
         ) {
             $key = self::CACHE_KEY_PREFIX . $messageFile . $category . '.' . $language;
             if (($data = $cache->get($key)) !== false) {
-                return unserialize($data);
+                return unserialize($data, ['allowed_classes' => false]);
             }
         }
 

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -717,7 +717,13 @@ class LimeExpressionManager
             unset($_SESSION['LEMdirtyFlag']);
         } elseif (!isset(self::$instance)) {
             if (isset($_SESSION['LEMsingleton'])) {
-                self::$instance = unserialize($_SESSION['LEMsingleton'], ['allowed_classes' => [LimeExpressionManager::class, ExpressionManager::class]]);
+                $restored = @unserialize($_SESSION['LEMsingleton'], ['allowed_classes' => [LimeExpressionManager::class, ExpressionManager::class]]);
+                /* $_SESSION['LEMsingleton'] can be not empty but unserialize return false */
+                /* You need to check if it's OK */
+                if (!($restored instanceof self) || !($restored->em instanceof ExpressionManager)) {
+                    throw new CHttpException(400, gT("Your session seems broken", 'unescaped'));
+                }
+                self::$instance = $restored;
                 /* Since we get it via session, need to launch core event again */
                 self::$instance->em->ExpressionManagerStartEvent();
             } else {

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -717,7 +717,7 @@ class LimeExpressionManager
             unset($_SESSION['LEMdirtyFlag']);
         } elseif (!isset(self::$instance)) {
             if (isset($_SESSION['LEMsingleton'])) {
-                self::$instance = unserialize($_SESSION['LEMsingleton'], ['allowed_classes' => [LimeExpressionManager::class]]);
+                self::$instance = unserialize($_SESSION['LEMsingleton'], ['allowed_classes' => [LimeExpressionManager::class, ExpressionManager::class]]);
                 /* Since we get it via session, need to launch core event again */
                 self::$instance->em->ExpressionManagerStartEvent();
             } else {

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -721,7 +721,7 @@ class LimeExpressionManager
                 /* $_SESSION['LEMsingleton'] can be not empty but unserialize return false */
                 /* You need to check if it's OK */
                 if (!($restored instanceof self) || !($restored->em instanceof ExpressionManager)) {
-                    throw new CHttpException(400, gT("Your session seems broken", 'unescaped'));
+                    throw new CHttpException(400, gT("We are sorry but your session has expired.", 'unescaped'));
                 }
                 self::$instance = $restored;
                 /* Since we get it via session, need to launch core event again */

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -717,7 +717,7 @@ class LimeExpressionManager
             unset($_SESSION['LEMdirtyFlag']);
         } elseif (!isset(self::$instance)) {
             if (isset($_SESSION['LEMsingleton'])) {
-                self::$instance = unserialize($_SESSION['LEMsingleton']);
+                self::$instance = unserialize($_SESSION['LEMsingleton'], ['allowed_classes' => [LimeExpressionManager::class]]);
                 /* Since we get it via session, need to launch core event again */
                 self::$instance->em->ExpressionManagerStartEvent();
             } else {

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -721,6 +721,10 @@ class LimeExpressionManager
                 /* $_SESSION['LEMsingleton'] can be not empty but unserialize return false */
                 /* You need to check if it's OK */
                 if (!($restored instanceof self) || !($restored->em instanceof ExpressionManager)) {
+                    if (!empty($_SESSION['LEMsid'])) {
+                        killSurveySession($_SESSION['LEMsid']);
+                    }
+                    unset($_SESSION['LEMsingleton']);
                     throw new CHttpException(400, gT("We are sorry but your session has expired.", 'unescaped'));
                 }
                 self::$instance = $restored;


### PR DESCRIPTION
## Summary

Two `unserialize()` call sites are missing `allowed_classes` restriction, which leaves them vulnerable to **PHP Object Injection** attacks.

## Affected Files

### 1. `application/core/LSMessageSource.php` (line 72)

`LSMessageSource::loadMessages()` deserializes translation string data from the cache backend (Yii cache component). The cached data contains only plain arrays of translated strings — no objects. Setting `allowed_classes => false` is safe and prevents any PHP class from being instantiated during deserialization.

### 2. `application/helpers/expressions/em_manager_helper.php` (line 720)

`LimeExpressionManager::singleton()` deserializes the `LimeExpressionManager` singleton from `$_SESSION['LEMsingleton']`. Session-based `unserialize()` without `allowed_classes` is exploitable if an attacker can write to the session store (e.g., via session fixation, filesystem session injection, or a compromised session backend).

Setting `allowed_classes => [LimeExpressionManager::class]` ensures that only the expected class is reconstructed — any injected gadget class will be returned as `__PHP_Incomplete_Class` instead.

## Impact

Without these restrictions, an attacker who can influence cache or session data can inject a serialized PHP gadget chain, potentially leading to arbitrary code execution (RCE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made cached translation reads safer by preventing unsafe re-creation of objects from tampered cache entries.
  * Hardened session restore so only expected objects are accepted, with validation that clears invalid session state and fails fast when restoration is unsafe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->