### PR TITLE
Fixed issue #20548

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -870,9 +870,9 @@ $config['reverseProxyIpAddresses'] = [];
 // Works together with "reverseProxyIpAddresses" setting.
 $config['reverseProxyIpHeader'] = 'HTTP_X_FORWARDED_FOR';
 
-// List of allowed hostnames for this LimeSurvey instance.
-// If set, any request with a Host header not matching one of these entries will be rejected.
-// This protects against Host header injection attacks (e.g. in password reset emails).
+// If set, secure absolute URLs will only use the current request host when it matches one of these entries.
+// Otherwise LimeSurvey falls back to an absolute publicurl or refuses to generate the absolute URL.
+// This protects link-generation paths (e.g. password reset emails) against Host header injection.
 // Example: ['survey.example.com', 'internal.example.com']
 $config['allowedHosts'] = [];
 

--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -870,6 +870,12 @@ $config['reverseProxyIpAddresses'] = [];
 // Works together with "reverseProxyIpAddresses" setting.
 $config['reverseProxyIpHeader'] = 'HTTP_X_FORWARDED_FOR';
 
+// List of allowed hostnames for this LimeSurvey instance.
+// If set, any request with a Host header not matching one of these entries will be rejected.
+// This protects against Host header injection attacks (e.g. in password reset emails).
+// Example: ['survey.example.com', 'internal.example.com']
+$config['allowedHosts'] = [];
+
 // Allow unserializing (with PHP unserialize function) token attributes when importing or reading a survey object
 // Since LimeSurvey 3, token attributes data is saved as JSON. If you use an older survey file and need to get token attributes, you must enable this setting.
 // Warning: Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this.

--- a/application/models/services/PasswordManagement.php
+++ b/application/models/services/PasswordManagement.php
@@ -31,37 +31,58 @@ class PasswordManagement
     }
 
     /**
-     * Creates an absolute URL for use in emails without relying on the HTTP Host header.
+     * Creates an absolute URL for use in emails without relying on an unvalidated HTTP Host header.
      * This prevents Host Header Injection attacks where an attacker could manipulate
      * the Host header to generate password reset links pointing to a malicious domain.
      *
-     * Uses the configured 'publicurl' if it contains a scheme and host,
-     * otherwise falls back to SERVER_NAME.
+     * Priority:
+     * 1. If 'allowedHosts' is configured and the request host is whitelisted → use it
+     *    (supports domain aliasing where multiple domains serve the same instance)
+     * 2. If 'publicurl' is an absolute URL → use it as trusted base
+     * 3. Otherwise → return null (insecure configuration, refuse to generate URL)
      *
      * @param string $route the URL route
      * @param array $params additional GET parameters
-     * @return string the constructed absolute URL
+     * @return string|null the constructed absolute URL, or null if no trusted base URL can be determined
      */
-    private static function createSecureAbsoluteUrl(string $route, array $params = []): string
+    private static function createSecureAbsoluteUrl(string $route, array $params = []): ?string
     {
-        $publicUrl = \Yii::app()->getConfig('publicurl');
-        $parsedPublicUrl = parse_url((string) $publicUrl);
+        $baseUrl = null;
 
-        if (isset($parsedPublicUrl['scheme']) && isset($parsedPublicUrl['host'])) {
-            // publicurl is absolute - use it as trusted base
-            $baseUrl = rtrim($publicUrl, '/');
-        } else {
-            // Construct base URL from SERVER_NAME (controlled by server config, not client)
+        // Option 1: Validate request host against allowedHosts whitelist
+        // This preserves domain aliasing (multiple domains pointing to same instance)
+        $allowedHosts = \Yii::app()->getConfig('allowedHosts');
+        if (!empty($allowedHosts) && is_array($allowedHosts)) {
             $isSecure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
             $scheme = $isSecure ? 'https' : 'http';
-            $serverName = $_SERVER['SERVER_NAME'] ?? 'localhost';
-            $port = $_SERVER['SERVER_PORT'] ?? '';
-            $baseUrl = $scheme . '://' . $serverName;
-            if ($port && !(($scheme === 'http' && $port == '80') || ($scheme === 'https' && $port == '443'))) {
-                $baseUrl .= ':' . $port;
+            $httpHost = $_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? '');
+            $hostOnly = parse_url($scheme . '://' . $httpHost, PHP_URL_HOST);
+
+            if ($hostOnly && in_array($hostOnly, $allowedHosts)) {
+                $baseUrl = $scheme . '://' . $httpHost;
+                $appBaseUrl = \Yii::app()->getBaseUrl();
+                $baseUrl = $baseUrl . $appBaseUrl;
             }
-            $appBaseUrl = \Yii::app()->getBaseUrl();
-            $baseUrl = $baseUrl . $appBaseUrl;
+        }
+
+        // Option 2: Fall back to absolute publicurl
+        if ($baseUrl === null) {
+            $publicUrl = \Yii::app()->getConfig('publicurl');
+            $parsedPublicUrl = parse_url((string) $publicUrl);
+
+            if (isset($parsedPublicUrl['scheme']) && isset($parsedPublicUrl['host'])) {
+                $baseUrl = rtrim($publicUrl, '/');
+            }
+        }
+
+        // Option 3: No safe base URL available
+        if ($baseUrl === null) {
+            \Yii::log(
+                'Password reset email not sent: configure "allowedHosts" (recommended for domain aliasing) or "publicurl" (as absolute URL) to prevent Host Header Injection.',
+                \CLogger::LEVEL_ERROR,
+                'application.security'
+            );
+            return null;
         }
 
         $relativeUrl = \Yii::app()->createUrl($route, $params);
@@ -82,6 +103,9 @@ class PasswordManagement
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );
+        if ($loginUrl === null) {
+            return null;
+        }
         $siteAdminEmail = \Yii::app()->getConfig("siteadminemail");
         $emailSubject = \Yii::app()->getConfig("admincreationemailsubject");
         $emailTemplate = \Yii::app()->getConfig("admincreationemailtemplate");
@@ -205,6 +229,10 @@ class PasswordManagement
                 'admin/authentication/sa/newPassword/',
                 ['param' => $this->user->validation_key]
             );
+            if ($linkToResetPage === null) {
+                $sMessage = gT('Email failed');
+                return $sMessage;
+            }
             $body = array();
             $body[] = gT('You have requested to reset the password for your account.');
             $body[] = sprintf(gT('To complete this process, please click on the following link: %s') . "\n", $linkToResetPage);
@@ -256,6 +284,11 @@ class PasswordManagement
         switch ($type) {
             case self::EMAIL_TYPE_RESET_PW:
                 $renderArray = $this->getRenderArray();
+                if ($renderArray === null) {
+                    $mailer = new \LimeMailer();
+                    $mailer->ErrorInfo = gT('Email failed: server URL configuration is insecure.');
+                    return $mailer;
+                }
                 $subject = "[" . \Yii::app()->getConfig("sitename") . "] " . gT(
                     "Your login credentials have been reset"
                 );
@@ -269,6 +302,11 @@ class PasswordManagement
             default:
                 //Get email template from globalSettings
                 $aAdminEmail = $this->generateAdminCreationEmail();
+                if ($aAdminEmail === null) {
+                    $mailer = new \LimeMailer();
+                    $mailer->ErrorInfo = gT('Email failed: server URL configuration is insecure.');
+                    return $mailer;
+                }
                 $subject = $aAdminEmail["subject"];
                 $body = $aAdminEmail["body"];
                 break;
@@ -288,7 +326,7 @@ class PasswordManagement
     }
 
     /**
-     * @return array
+     * @return array|null null if secure URL could not be generated
      */
     public function getRenderArray()
     {
@@ -297,6 +335,9 @@ class PasswordManagement
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );
+        if ($absoluteUrl === null || $passwordResetUrl === null) {
+            return null;
+        }
         return [
             'surveyapplicationname' => \Yii::app()->getConfig("sitename"),
             'emailMessage' => sprintf(gT("Hello %s,"), $this->user->full_name) . "<br />"

--- a/application/models/services/PasswordManagement.php
+++ b/application/models/services/PasswordManagement.php
@@ -31,6 +31,44 @@ class PasswordManagement
     }
 
     /**
+     * Creates an absolute URL for use in emails without relying on the HTTP Host header.
+     * This prevents Host Header Injection attacks where an attacker could manipulate
+     * the Host header to generate password reset links pointing to a malicious domain.
+     *
+     * Uses the configured 'publicurl' if it contains a scheme and host,
+     * otherwise falls back to SERVER_NAME.
+     *
+     * @param string $route the URL route
+     * @param array $params additional GET parameters
+     * @return string the constructed absolute URL
+     */
+    private static function createSecureAbsoluteUrl(string $route, array $params = []): string
+    {
+        $publicUrl = \Yii::app()->getConfig('publicurl');
+        $parsedPublicUrl = parse_url((string) $publicUrl);
+
+        if (isset($parsedPublicUrl['scheme']) && isset($parsedPublicUrl['host'])) {
+            // publicurl is absolute - use it as trusted base
+            $baseUrl = rtrim($publicUrl, '/');
+        } else {
+            // Construct base URL from SERVER_NAME (controlled by server config, not client)
+            $isSecure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+            $scheme = $isSecure ? 'https' : 'http';
+            $serverName = $_SERVER['SERVER_NAME'] ?? 'localhost';
+            $port = $_SERVER['SERVER_PORT'] ?? '';
+            $baseUrl = $scheme . '://' . $serverName;
+            if ($port && !(($scheme === 'http' && $port == '80') || ($scheme === 'https' && $port == '443'))) {
+                $baseUrl .= ':' . $port;
+            }
+            $appBaseUrl = \Yii::app()->getBaseUrl();
+            $baseUrl = $baseUrl . $appBaseUrl;
+        }
+
+        $relativeUrl = \Yii::app()->createUrl($route, $params);
+        return $baseUrl . $relativeUrl;
+    }
+
+    /**
      * This function prepare the email template to send to the new created user
      *
      *
@@ -40,8 +78,7 @@ class PasswordManagement
     {
         $adminEmail = [];
         $siteName = \Yii::app()->getConfig("sitename");
-        /* Usage of Yii::app()->createAbsoluteUrl, disable publicurl, See mantis #19619 */
-        $loginUrl = \Yii::app()->createAbsoluteUrl(
+        $loginUrl = self::createSecureAbsoluteUrl(
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );
@@ -164,8 +201,7 @@ class PasswordManagement
             $now = new DateTime();
             $this->user->last_forgot_email_password = $now->format('Y-m-d H:i:s');
             $this->user->save();
-            /* Usage of Yii::app()->createAbsoluteUrl, disable publicurl, See mantis #19619 */
-            $linkToResetPage = \Yii::app()->createAbsoluteUrl(
+            $linkToResetPage = self::createSecureAbsoluteUrl(
                 'admin/authentication/sa/newPassword/',
                 ['param' => $this->user->validation_key]
             );
@@ -256,9 +292,8 @@ class PasswordManagement
      */
     public function getRenderArray()
     {
-        /* Usage of Yii::app()->createAbsoluteUrl, disable publicurl, See mantis #19619 */
-        $absoluteUrl = \Yii::app()->createAbsoluteUrl("/admin");
-        $passwordResetUrl = \Yii::app()->createAbsoluteUrl(
+        $absoluteUrl = self::createSecureAbsoluteUrl('/admin');
+        $passwordResetUrl = self::createSecureAbsoluteUrl(
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );

--- a/application/models/services/PasswordManagement.php
+++ b/application/models/services/PasswordManagement.php
@@ -36,18 +36,19 @@ class PasswordManagement
      * the Host header to generate password reset links pointing to a malicious domain.
      *
      * Priority:
-     * 1. If 'allowedHosts' is configured and the request host is whitelisted → use it
+     * 1. If 'allowedHosts' is configured and the request host is whitelisted - use it
      *    (supports domain aliasing where multiple domains serve the same instance)
-     * 2. If 'publicurl' is an absolute URL → use it as trusted base
-     * 3. Otherwise → return null (insecure configuration, refuse to generate URL)
+     * 2. If 'publicurl' is an absolute URL - use it as trusted base
+     * 3. Otherwise - return null (insecure configuration, refuse to generate URL)
      *
      * @param string $route the URL route
      * @param array $params additional GET parameters
      * @return string|null the constructed absolute URL, or null if no trusted base URL can be determined
      */
-    private static function createSecureAbsoluteUrl(string $route, array $params = []): ?string
+    private static function createValidatedAbsoluteUrl(string $route, array $params = []): ?string
     {
         $baseUrl = null;
+        $externalBasePath = null;
 
         // Option 1: Validate request host against allowedHosts whitelist
         // This preserves domain aliasing (multiple domains pointing to same instance)
@@ -59,9 +60,9 @@ class PasswordManagement
             $hostOnly = parse_url($scheme . '://' . $httpHost, PHP_URL_HOST);
 
             if ($hostOnly && in_array($hostOnly, $allowedHosts)) {
-                // Only scheme + host (+ port). Do NOT append getBaseUrl() here
-                // because createUrl() already includes the base path.
-                $baseUrl = $scheme . '://' . $httpHost;
+                // Use only the validated hostname, not the raw HTTP_HOST
+                // (which could contain an attacker-controlled port).
+                $baseUrl = $scheme . '://' . $hostOnly;
             }
         }
 
@@ -71,13 +72,15 @@ class PasswordManagement
             $parsedPublicUrl = parse_url((string) $publicUrl);
 
             if (isset($parsedPublicUrl['scheme']) && isset($parsedPublicUrl['host'])) {
-                // Extract only scheme + host + port from publicurl, discard path
-                // because createUrl() already includes the base path.
                 $hostPart = $parsedPublicUrl['scheme'] . '://' . $parsedPublicUrl['host'];
                 if (isset($parsedPublicUrl['port'])) {
                     $hostPart .= ':' . $parsedPublicUrl['port'];
                 }
                 $baseUrl = $hostPart;
+                // Preserve the path from publicurl for proxied/subdirectory installs
+                if (isset($parsedPublicUrl['path']) && $parsedPublicUrl['path'] !== '/') {
+                    $externalBasePath = rtrim($parsedPublicUrl['path'], '/');
+                }
             }
         }
 
@@ -92,6 +95,18 @@ class PasswordManagement
         }
 
         $relativeUrl = \Yii::app()->createUrl($route, $params);
+
+        // If publicurl has an external path prefix different from the internal base,
+        // replace the internal base path with the external one.
+        if ($externalBasePath !== null) {
+            $internalBase = \Yii::app()->getBaseUrl();
+            if ($internalBase !== '' && strpos($relativeUrl, $internalBase) === 0) {
+                $relativeUrl = $externalBasePath . substr($relativeUrl, strlen($internalBase));
+            } elseif ($internalBase === '' || $internalBase === '/') {
+                $relativeUrl = $externalBasePath . $relativeUrl;
+            }
+        }
+
         return $baseUrl . $relativeUrl;
     }
 
@@ -105,7 +120,7 @@ class PasswordManagement
     {
         $adminEmail = [];
         $siteName = \Yii::app()->getConfig("sitename");
-        $loginUrl = self::createSecureAbsoluteUrl(
+        $loginUrl = self::createValidatedAbsoluteUrl(
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );
@@ -231,7 +246,7 @@ class PasswordManagement
             $now = new DateTime();
             $this->user->last_forgot_email_password = $now->format('Y-m-d H:i:s');
             $this->user->save();
-            $linkToResetPage = self::createSecureAbsoluteUrl(
+            $linkToResetPage = self::createValidatedAbsoluteUrl(
                 'admin/authentication/sa/newPassword/',
                 ['param' => $this->user->validation_key]
             );
@@ -336,8 +351,8 @@ class PasswordManagement
      */
     public function getRenderArray()
     {
-        $absoluteUrl = self::createSecureAbsoluteUrl('/admin');
-        $passwordResetUrl = self::createSecureAbsoluteUrl(
+        $absoluteUrl = self::createValidatedAbsoluteUrl('/admin');
+        $passwordResetUrl = self::createValidatedAbsoluteUrl(
             'admin/authentication/sa/newPassword',
             ['param' => $this->user->validation_key]
         );

--- a/application/models/services/PasswordManagement.php
+++ b/application/models/services/PasswordManagement.php
@@ -59,9 +59,9 @@ class PasswordManagement
             $hostOnly = parse_url($scheme . '://' . $httpHost, PHP_URL_HOST);
 
             if ($hostOnly && in_array($hostOnly, $allowedHosts)) {
+                // Only scheme + host (+ port). Do NOT append getBaseUrl() here
+                // because createUrl() already includes the base path.
                 $baseUrl = $scheme . '://' . $httpHost;
-                $appBaseUrl = \Yii::app()->getBaseUrl();
-                $baseUrl = $baseUrl . $appBaseUrl;
             }
         }
 
@@ -71,7 +71,13 @@ class PasswordManagement
             $parsedPublicUrl = parse_url((string) $publicUrl);
 
             if (isset($parsedPublicUrl['scheme']) && isset($parsedPublicUrl['host'])) {
-                $baseUrl = rtrim($publicUrl, '/');
+                // Extract only scheme + host + port from publicurl, discard path
+                // because createUrl() already includes the base path.
+                $hostPart = $parsedPublicUrl['scheme'] . '://' . $parsedPublicUrl['host'];
+                if (isset($parsedPublicUrl['port'])) {
+                    $hostPart .= ':' . $parsedPublicUrl['port'];
+                }
+                $baseUrl = $hostPart;
             }
         }
 

--- a/tests/unit/services/PasswordManagementSecureUrlTest.php
+++ b/tests/unit/services/PasswordManagementSecureUrlTest.php
@@ -248,11 +248,13 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         // Request via domain-a
         $_SERVER['HTTP_HOST'] = 'domain-a.com';
         $urlA = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '1']);
+        $this->assertNotNull($urlA);
         $this->assertStringStartsWith('https://domain-a.com', $urlA);
 
         // Request via domain-b
         $_SERVER['HTTP_HOST'] = 'domain-b.com';
         $urlB = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '2']);
+        $this->assertNotNull($urlB);
         $this->assertStringStartsWith('https://domain-b.com', $urlB);
     }
 }

--- a/tests/unit/services/PasswordManagementSecureUrlTest.php
+++ b/tests/unit/services/PasswordManagementSecureUrlTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace ls\tests;
+
+use LimeSurvey\Models\Services\PasswordManagement;
+
+/**
+ * Tests for PasswordManagement::createSecureAbsoluteUrl()
+ *
+ * Verifies the Host Header Injection fix (bug #20548):
+ * - URLs use allowedHosts-validated request host when configured
+ * - URLs fall back to absolute publicurl
+ * - Returns null when no secure base URL is available
+ * - Spoofed Host header is rejected
+ * - No double base-path prefixing
+ */
+class PasswordManagementSecureUrlTest extends TestBaseClass
+{
+    /** @var \ReflectionMethod */
+    private static $method;
+
+    /** @var array Original $_SERVER values */
+    private $originalServer;
+
+    /** @var array Original config values */
+    private $originalConfig = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$method = new \ReflectionMethod(PasswordManagement::class, 'createSecureAbsoluteUrl');
+        self::$method->setAccessible(true);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalServer = $_SERVER;
+        $this->originalConfig = [
+            'allowedHosts' => \Yii::app()->getConfig('allowedHosts'),
+            'publicurl' => \Yii::app()->getConfig('publicurl'),
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->originalServer;
+        \Yii::app()->setConfig('allowedHosts', $this->originalConfig['allowedHosts']);
+        \Yii::app()->setConfig('publicurl', $this->originalConfig['publicurl']);
+        parent::tearDown();
+    }
+
+    /**
+     * Helper to invoke the private static method.
+     */
+    private function invokeCreateSecureAbsoluteUrl(string $route, array $params = []): ?string
+    {
+        return self::$method->invoke(null, $route, $params);
+    }
+
+    /**
+     * When allowedHosts is configured and request host is whitelisted,
+     * the URL should use the request host.
+     */
+    public function testAllowedHostUsesRequestHost(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'trusted.example.com';
+        $_SERVER['HTTPS'] = 'on';
+        \Yii::app()->setConfig('allowedHosts', ['trusted.example.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('https://trusted.example.com', $url);
+        $this->assertStringContainsString('abc123', $url);
+    }
+
+    /**
+     * When allowedHosts is configured but the request Host header is NOT in the whitelist,
+     * it should fall back to publicurl (or null).
+     */
+    public function testSpoofedHostRejectedByAllowedHosts(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'evil.attacker.com';
+        $_SERVER['HTTPS'] = 'off';
+        \Yii::app()->setConfig('allowedHosts', ['legitimate.example.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
+
+        // Since the Host doesn't match allowedHosts AND publicurl is relative → null
+        $this->assertNull($url);
+    }
+
+    /**
+     * When allowedHosts rejects the host but publicurl is absolute,
+     * it should fall back to publicurl.
+     */
+    public function testSpoofedHostFallsBackToAbsolutePublicUrl(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'evil.attacker.com';
+        $_SERVER['HTTPS'] = 'off';
+        \Yii::app()->setConfig('allowedHosts', ['legitimate.example.com']);
+        \Yii::app()->setConfig('publicurl', 'https://mysite.com/limesurvey/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'token123']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('https://mysite.com', $url);
+        $this->assertStringNotContainsString('evil.attacker.com', $url);
+        $this->assertStringContainsString('token123', $url);
+    }
+
+    /**
+     * When only publicurl is set as absolute URL (no allowedHosts),
+     * the URL should use publicurl's host.
+     */
+    public function testAbsolutePublicUrlUsedWhenNoAllowedHosts(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'anything.example.com';
+        $_SERVER['HTTPS'] = 'off';
+        \Yii::app()->setConfig('allowedHosts', null);
+        \Yii::app()->setConfig('publicurl', 'https://configured-host.example.com/survey/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'xyz']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('https://configured-host.example.com', $url);
+        $this->assertStringNotContainsString('anything.example.com', $url);
+    }
+
+    /**
+     * When neither allowedHosts nor absolute publicurl is configured,
+     * the method should return null (refuse to generate an insecure URL).
+     */
+    public function testReturnsNullWhenNoSecureConfigAvailable(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'spoofed.example.com';
+        $_SERVER['HTTPS'] = 'off';
+        \Yii::app()->setConfig('allowedHosts', null);
+        \Yii::app()->setConfig('publicurl', '/limesurvey/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'test']);
+
+        $this->assertNull($url);
+    }
+
+    /**
+     * Verify no double base-path: the returned URL should not contain
+     * the application base path duplicated.
+     */
+    public function testNoDoubleBasePathPrefixing(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'myhost.com';
+        $_SERVER['HTTPS'] = 'on';
+        \Yii::app()->setConfig('allowedHosts', ['myhost.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'val']);
+        $this->assertNotNull($url);
+
+        $basePath = \Yii::app()->getBaseUrl();
+        if ($basePath !== '' && $basePath !== '/') {
+            // The base path should appear exactly once
+            $count = substr_count($url, $basePath);
+            $this->assertEquals(1, $count, "Base path '$basePath' appears $count times in URL: $url");
+        }
+    }
+
+    /**
+     * Test that port is preserved in the URL when using allowedHosts path.
+     */
+    public function testPortPreservedWithAllowedHosts(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'myhost.com:8443';
+        $_SERVER['HTTPS'] = 'on';
+        \Yii::app()->setConfig('allowedHosts', ['myhost.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'x']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('https://myhost.com:8443', $url);
+    }
+
+    /**
+     * Test that port from publicurl is preserved.
+     */
+    public function testPortPreservedWithPublicUrl(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'untrusted.com';
+        \Yii::app()->setConfig('allowedHosts', null);
+        \Yii::app()->setConfig('publicurl', 'http://mysite.local:9090/limesurvey/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'y']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('http://mysite.local:9090', $url);
+    }
+
+    /**
+     * Test HTTP scheme when HTTPS is off.
+     */
+    public function testHttpSchemeWhenNotSecure(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'plain.example.com';
+        $_SERVER['HTTPS'] = '';
+        \Yii::app()->setConfig('allowedHosts', ['plain.example.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+
+        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'z']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('http://plain.example.com', $url);
+    }
+
+    /**
+     * Domain aliasing: different whitelisted hosts should produce
+     * URLs with their respective domains.
+     */
+    public function testDomainAliasingUsesCorrectHost(): void
+    {
+        \Yii::app()->setConfig('allowedHosts', ['domain-a.com', 'domain-b.com']);
+        \Yii::app()->setConfig('publicurl', '/');
+        $_SERVER['HTTPS'] = 'on';
+
+        // Request via domain-a
+        $_SERVER['HTTP_HOST'] = 'domain-a.com';
+        $urlA = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '1']);
+        $this->assertStringStartsWith('https://domain-a.com', $urlA);
+
+        // Request via domain-b
+        $_SERVER['HTTP_HOST'] = 'domain-b.com';
+        $urlB = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '2']);
+        $this->assertStringStartsWith('https://domain-b.com', $urlB);
+    }
+}

--- a/tests/unit/services/PasswordManagementSecureUrlTest.php
+++ b/tests/unit/services/PasswordManagementSecureUrlTest.php
@@ -5,7 +5,7 @@ namespace ls\tests;
 use LimeSurvey\Models\Services\PasswordManagement;
 
 /**
- * Tests for PasswordManagement::createSecureAbsoluteUrl()
+ * Tests for PasswordManagement::createValidatedAbsoluteUrl()
  *
  * Verifies the Host Header Injection fix (bug #20548):
  * - URLs use allowedHosts-validated request host when configured
@@ -28,7 +28,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$method = new \ReflectionMethod(PasswordManagement::class, 'createSecureAbsoluteUrl');
+        self::$method = new \ReflectionMethod(PasswordManagement::class, 'createValidatedAbsoluteUrl');
         self::$method->setAccessible(true);
     }
 
@@ -53,7 +53,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
     /**
      * Helper to invoke the private static method.
      */
-    private function invokeCreateSecureAbsoluteUrl(string $route, array $params = []): ?string
+    private function invokecreateValidatedAbsoluteUrl(string $route, array $params = []): ?string
     {
         return self::$method->invoke(null, $route, $params);
     }
@@ -69,7 +69,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', ['trusted.example.com']);
         \Yii::app()->setConfig('publicurl', '/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
 
         $this->assertNotNull($url);
         $this->assertStringStartsWith('https://trusted.example.com', $url);
@@ -87,9 +87,9 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', ['legitimate.example.com']);
         \Yii::app()->setConfig('publicurl', '/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc123']);
 
-        // Since the Host doesn't match allowedHosts AND publicurl is relative → null
+        // Since the Host doesn't match allowedHosts AND publicurl is relative â†’ null
         $this->assertNull($url);
     }
 
@@ -104,7 +104,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', ['legitimate.example.com']);
         \Yii::app()->setConfig('publicurl', 'https://mysite.com/limesurvey/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'token123']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'token123']);
 
         $this->assertNotNull($url);
         $this->assertStringStartsWith('https://mysite.com', $url);
@@ -123,7 +123,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', null);
         \Yii::app()->setConfig('publicurl', 'https://configured-host.example.com/survey/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'xyz']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'xyz']);
 
         $this->assertNotNull($url);
         $this->assertStringStartsWith('https://configured-host.example.com', $url);
@@ -141,7 +141,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', null);
         \Yii::app()->setConfig('publicurl', '/limesurvey/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'test']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'test']);
 
         $this->assertNull($url);
     }
@@ -157,7 +157,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', ['myhost.com']);
         \Yii::app()->setConfig('publicurl', '/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'val']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'val']);
         $this->assertNotNull($url);
 
         $basePath = \Yii::app()->getBaseUrl();
@@ -169,19 +169,22 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
     }
 
     /**
-     * Test that port is preserved in the URL when using allowedHosts path.
+     * Test that attacker-controlled port in Host header is NOT propagated.
+     * Only the validated hostname from allowedHosts should be used.
      */
-    public function testPortPreservedWithAllowedHosts(): void
+    public function testPortFromHostHeaderNotPropagated(): void
     {
         $_SERVER['HTTP_HOST'] = 'myhost.com:8443';
         $_SERVER['HTTPS'] = 'on';
         \Yii::app()->setConfig('allowedHosts', ['myhost.com']);
         \Yii::app()->setConfig('publicurl', '/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'x']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'x']);
 
         $this->assertNotNull($url);
-        $this->assertStringStartsWith('https://myhost.com:8443', $url);
+        // Should use only the validated hostname, NOT the raw port from HTTP_HOST
+        $this->assertStringStartsWith('https://myhost.com', $url);
+        $this->assertStringNotContainsString(':8443', $url);
     }
 
     /**
@@ -193,10 +196,27 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', null);
         \Yii::app()->setConfig('publicurl', 'http://mysite.local:9090/limesurvey/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'y']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'y']);
 
         $this->assertNotNull($url);
         $this->assertStringStartsWith('http://mysite.local:9090', $url);
+    }
+
+    /**
+     * Test that publicurl path prefix is preserved for subdirectory/proxied installs.
+     */
+    public function testPublicUrlPathPreserved(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'untrusted.com';
+        \Yii::app()->setConfig('allowedHosts', null);
+        \Yii::app()->setConfig('publicurl', 'https://proxy.example.com/surveys/');
+
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'abc']);
+
+        $this->assertNotNull($url);
+        $this->assertStringStartsWith('https://proxy.example.com', $url);
+        $this->assertStringContainsString('/surveys/', $url);
+        $this->assertStringContainsString('abc', $url);
     }
 
     /**
@@ -209,7 +229,7 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
         \Yii::app()->setConfig('allowedHosts', ['plain.example.com']);
         \Yii::app()->setConfig('publicurl', '/');
 
-        $url = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'z']);
+        $url = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => 'z']);
 
         $this->assertNotNull($url);
         $this->assertStringStartsWith('http://plain.example.com', $url);
@@ -227,12 +247,12 @@ class PasswordManagementSecureUrlTest extends TestBaseClass
 
         // Request via domain-a
         $_SERVER['HTTP_HOST'] = 'domain-a.com';
-        $urlA = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '1']);
+        $urlA = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '1']);
         $this->assertStringStartsWith('https://domain-a.com', $urlA);
 
         // Request via domain-b
         $_SERVER['HTTP_HOST'] = 'domain-b.com';
-        $urlB = $this->invokeCreateSecureAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '2']);
+        $urlB = $this->invokecreateValidatedAbsoluteUrl('admin/authentication/sa/newPassword', ['param' => '2']);
         $this->assertStringStartsWith('https://domain-b.com', $urlB);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin creation and password-reset emails now only use trusted bases for absolute links and fail safely when a secure link cannot be produced, improving resilience and security.
* **Tests**
  * Added unit tests validating secure absolute URL generation, host header protections, scheme/port/path handling, fallback behavior, and failure cases.
* **Chores**
  * Added a configurable whitelist for trusted hostnames to mitigate host-header injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->