### PR TITLE
A11y 9.1 my profile fixes2

### DIFF
--- a/application/views/admin/user/personalsettings.php
+++ b/application/views/admin/user/personalsettings.php
@@ -104,14 +104,34 @@ echo $oQuestionSelector->getModal();
                     <div class="row">
                         <div class="col-12">
                             <div class="mb-3">
-                                <?php echo TbHtml::label(gT("User name:"), 'username', ['class' => " form-label"]); ?>
-                                <div class="">
-                                    <?php echo TbHtml::textField('username', $sUsername, ['class' => 'form-control', 'readonly' => 'readonly']); ?>
-                                </div>
-                                <div class="">
-                                    <span class='text-info'><?php eT("The user name cannot be changed."); ?></span>
-                                </div>
-                            </div>
+    <?php
+    echo TbHtml::label(
+        gT("User name:"),
+        'username',
+        ['class' => 'form-label']
+    );
+    ?>
+
+    <div>
+        <?php
+        echo TbHtml::textField(
+            'username',
+            $sUsername,
+            [
+                'class' => 'form-control',
+                'readonly' => true,
+                'aria-describedby' => 'username-info'
+            ]
+        );
+        ?>
+    </div>
+
+    <div>
+        <span id="username-info" class="text-info">
+            <?php eT("The user name cannot be changed."); ?>
+        </span>
+    </div>
+</div>
                         </div>
                     </div>
                     <div class="row">
@@ -170,10 +190,10 @@ echo $oQuestionSelector->getModal();
                             <div class="mb-3">
                                 <?php echo TbHtml::label(gT("New password:"), 'password', ['class' => " form-label"]); ?>
                                 <div class="">
-                                    <?php echo TbHtml::passwordField('password', '', ['disabled' => true, 'class' => 'form-control', 'autocomplete' => "off", 'placeholder' => html_entity_decode(str_repeat("&#9679;", 10), ENT_COMPAT, 'utf-8')]); ?>
+                                    <?php echo TbHtml::passwordField('password', '', ['disabled' => true, 'class' => 'form-control', 'autocomplete' => "off", 'aria-describedby' => 'password-help', 'placeholder' => html_entity_decode(str_repeat("&#9679;", 10), ENT_COMPAT, 'utf-8')]); ?>
                                 </div>
                                 <div class="">
-                                    <span class='text-info'><?php echo $passwordHelpText; ?></span>
+                                    <span class='text-info' id="password-help"><?php echo $passwordHelpText; ?></span>
                                 </div>
                             </div>
                         </div>

--- a/application/views/admin/user/personalsettings.php
+++ b/application/views/admin/user/personalsettings.php
@@ -91,10 +91,10 @@ echo $oQuestionSelector->getModal();
     <div class="row">
         <div class="col-12">
             <ul class="nav nav-tabs" role="tablist">
-                <li role="presentation" class="nav-item"><a id="tab-your-profile" class="nav-link active" href="#your-profile" role="tab" data-bs-toggle="tab" aria-controls="your-profile" aria-selected="true"><?php eT("Profile"); ?></a></li>
-                <li role="presentation" class="nav-item"><a id="tab-your-personal-settings" class="nav-link" href="#your-personal-settings" role="tab" data-bs-toggle="tab" aria-controls="your-personal-settings" aria-selected="false"><?php eT("Personal settings"); ?></a></li>
-                <li role="presentation" class="nav-item"><a id="tab-your-personal-menues" class="nav-link" href="#your-personal-menues" role="tab" data-bs-toggle="tab" aria-controls="your-personal-menues" aria-selected="false"><?php eT("Personalized menus"); ?></a></li>
-                <li role="presentation" class="nav-item"><a id="tab-your-personal-menueentries" class="nav-link" href="#your-personal-menueentries" role="tab" data-bs-toggle="tab" aria-controls="your-personal-menueentries" aria-selected="false"><?php eT("Personalized menu entries"); ?></a></li>
+                <li role="presentation" class="nav-item"><a id="tab-your-profile" class="nav-link active" href="#your-profile" role="tab" data-bs-toggle="tab" aria-controls="your-profile" aria-selected="true" tabindex="0"><?php eT("Profile"); ?></a></li>
+                <li role="presentation" class="nav-item"><a id="tab-your-personal-settings" class="nav-link" href="#your-personal-settings" role="tab" data-bs-toggle="tab" aria-controls="your-personal-settings" aria-selected="false" tabindex="-1"><?php eT("Personal settings"); ?></a></li>
+                <li role="presentation" class="nav-item"><a id="tab-your-personal-menues" class="nav-link" href="#your-personal-menues" role="tab" data-bs-toggle="tab" aria-controls="your-personal-menues" aria-selected="false" tabindex="-1"><?php eT("Personalized menus"); ?></a></li>
+                <li role="presentation" class="nav-item"><a id="tab-your-personal-menueentries" class="nav-link" href="#your-personal-menueentries" role="tab" data-bs-toggle="tab" aria-controls="your-personal-menueentries" aria-selected="false" tabindex="-1"><?php eT("Personalized menu entries"); ?></a></li>
             </ul>
             <div class="tab-content">
 
@@ -104,34 +104,33 @@ echo $oQuestionSelector->getModal();
                     <div class="row">
                         <div class="col-12">
                             <div class="mb-3">
-    <?php
-    echo TbHtml::label(
-        gT("User name:"),
-        'username',
-        ['class' => 'form-label']
-    );
-    ?>
+                                <?php
+                                echo TbHtml::label(
+                                    gT("User name:"),
+                                    'username',
+                                    ['class' => 'form-label']
+                                );
+                                ?>
+                                <div>
+                                    <?php
+                                    echo TbHtml::textField(
+                                        'username',
+                                        $sUsername,
+                                        [
+                                            'class' => 'form-control',
+                                            'readonly' => true,
+                                            'aria-describedby' => 'username-info'
+                                        ]
+                                    );
+                                    ?>
+                                </div>
 
-    <div>
-        <?php
-        echo TbHtml::textField(
-            'username',
-            $sUsername,
-            [
-                'class' => 'form-control',
-                'readonly' => true,
-                'aria-describedby' => 'username-info'
-            ]
-        );
-        ?>
-    </div>
-
-    <div>
-        <span id="username-info" class="text-info">
-            <?php eT("The user name cannot be changed."); ?>
-        </span>
-    </div>
-</div>
+                                <div>
+                                    <span id="username-info" class="text-info">
+                                        <?php eT("The user name cannot be changed."); ?>
+                                    </span>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="row">
@@ -179,7 +178,20 @@ echo $oQuestionSelector->getModal();
                                     <span class="required">*</span>
                                 </label>
                                 <div class="">
-                                    <?php echo TbHtml::passwordField('oldpassword', '', ['disabled' => true, 'class' => 'form-control', 'autocomplete' => "off", 'placeholder' => html_entity_decode(str_repeat("&#9679;", 10), ENT_COMPAT, 'utf-8')]); ?>
+                                    <?php echo TbHtml::passwordField(
+                                        'oldpassword',
+                                        '',
+                                        [
+                                            'disabled' => true,
+                                            'class' => 'form-control',
+                                            'autocomplete' => "off",
+                                            'placeholder' => html_entity_decode(
+                                                str_repeat("&#9679;", 10),
+                                                ENT_COMPAT,
+                                                'utf-8'
+                                            )
+                                        ]
+                                    ); ?>
                                 </div>
                             </div>
                         </div>
@@ -190,7 +202,21 @@ echo $oQuestionSelector->getModal();
                             <div class="mb-3">
                                 <?php echo TbHtml::label(gT("New password:"), 'password', ['class' => " form-label"]); ?>
                                 <div class="">
-                                    <?php echo TbHtml::passwordField('password', '', ['disabled' => true, 'class' => 'form-control', 'autocomplete' => "off", 'aria-describedby' => 'password-help', 'placeholder' => html_entity_decode(str_repeat("&#9679;", 10), ENT_COMPAT, 'utf-8')]); ?>
+                                    <?php echo TbHtml::passwordField(
+                                        'password',
+                                        '',
+                                        [
+                                            'disabled' => true,
+                                            'class' => 'form-control',
+                                            'autocomplete' => "off",
+                                            'aria-describedby' => 'password-help',
+                                            'placeholder' => html_entity_decode(
+                                                str_repeat("&#9679;", 10),
+                                                ENT_COMPAT,
+                                                'utf-8'
+                                            )
+                                        ]
+                                    ); ?>
                                 </div>
                                 <div class="">
                                     <span class='text-info' id="password-help"><?php echo $passwordHelpText; ?></span>
@@ -201,7 +227,20 @@ echo $oQuestionSelector->getModal();
                             <div class="mb-3">
                                 <?php echo TbHtml::label(gT("Repeat new password:"), 'repeatpassword', ['class' => " form-label"]); ?>
                                 <div class="">
-                                    <?php echo TbHtml::passwordField('repeatpassword', '', ['disabled' => true, 'class' => 'form-control', 'autocomplete' => "off", 'placeholder' => html_entity_decode(str_repeat("&#9679;", 10), ENT_COMPAT, 'utf-8')]); ?>
+                                    <?php echo TbHtml::passwordField(
+                                        'repeatpassword',
+                                        '',
+                                        [
+                                            'disabled' => true,
+                                            'class' => 'form-control',
+                                            'autocomplete' => "off",
+                                            'placeholder' => html_entity_decode(
+                                                str_repeat("&#9679;", 10),
+                                                ENT_COMPAT,
+                                                'utf-8'
+                                            )
+                                        ]
+                                    ); ?>
                                 </div>
                             </div>
                         </div>

--- a/application/views/admin/user/personalsettings.php
+++ b/application/views/admin/user/personalsettings.php
@@ -409,6 +409,7 @@ echo $oQuestionSelector->getModal();
                                     <?php
                                     $this->widget('ext.ButtonGroupWidget.ButtonGroupWidget', [
                                         'name'          => 'showScriptEdit',
+                                        'ariaLabel'     => gT("Show script field"),
                                         'checkedOption' => $aUserSettings['showScriptEdit'] ?? 0,
                                         'selectOptions' =>    [
                                             '1' => gT("Yes", 'unescaped'),
@@ -427,6 +428,7 @@ echo $oQuestionSelector->getModal();
                                     <?php
                                     $this->widget('ext.ButtonGroupWidget.ButtonGroupWidget', [
                                         'name'          => 'noViewMode',
+                                        'ariaLabel'     => gT("Directly show edit mode"),
                                         'checkedOption' => $aUserSettings['noViewMode'] ?? 0,
                                         'selectOptions' =>    [
                                             '1' => gT("Yes", 'unescaped'),
@@ -446,6 +448,7 @@ echo $oQuestionSelector->getModal();
                                     <?php
                                     $this->widget('ext.ButtonGroupWidget.ButtonGroupWidget', [
                                         'name'          => 'lock_organizer',
+                                        'ariaLabel'     => gT("Lock question organizer in sidebar by default"),
                                         'checkedOption' => $aUserSettings['lock_organizer'] ?? 0,
                                         'selectOptions' =>    [
                                             '1' => gT("Yes", 'unescaped'),
@@ -464,6 +467,7 @@ echo $oQuestionSelector->getModal();
                                     <?php
                                     $this->widget('ext.ButtonGroupWidget.ButtonGroupWidget', [
                                         'name'          => 'createsample',
+                                        'ariaLabel'     => gT("Create example question group and question"),
                                         'checkedOption' => $aUserSettings['createsample'] ?? 'default',
                                         'selectOptions' =>    [
                                             '1' => gT("Yes", 'unescaped'),


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>

1. fix Information is not associated with the edit field by screen reader LS-2026-193
2. .fix Information is not associated with the edit field by screen reader LS-2026-194
3. fix Lable is not provided for the edit fields LS-2026-192
4. fix Radio button are not grouped with the group label LS-2026-196
5. fix Lable is not provided for the edit fields LS-2026-195

New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility in the personal settings area with improved “User name” and password-change field markup, clearer help-text associations, and screen-reader friendly labeling.
  * Updated tab navigation controls to include accessibility-friendly state and indexing attributes.
  * Added localized accessibility labels to multiple button-group controls to ensure consistent, descriptive announcements for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->