### PR TITLE
TB-116: kcfinder was not initialized for labelsets "Upload resources …

### DIFF
--- a/application/controllers/admin/Labels.php
+++ b/application/controllers/admin/Labels.php
@@ -250,6 +250,8 @@ class Labels extends SurveyCommonAction
 
             Yii::app()->loadHelper("admin.htmleditor");
 
+            initKcfinder();
+
             $aViewUrls['output'] = PrepareEditorScript(false, $this->getController());
 
             $maxSortOrder = array_reduce(


### PR DESCRIPTION
Dev TB-116: kcfinder was not initialized for labelsets "Upload resources ..."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file management functionality to the label administration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->