### PR TITLE
Fixed issue: survey start and expiry date are noew displayed and saved correctly

### DIFF
--- a/application/controllers/admin/Database.php
+++ b/application/controllers/admin/Database.php
@@ -306,15 +306,6 @@ class Database extends SurveyCommonAction
                 $input[$langCode] = $langInput;
             }
         }
-
-        if ($input['expires'] ?? false) {
-            $input['expires'] = getUTCOfDate(($input['expires']));
-        }
-
-        if ($input['startdate'] ?? false) {
-            $input['startdate'] = getUTCOfDate(($input['startdate']));
-        }
-
         $metaData = [];
         try {
             $metaData = $surveyUpdater->update(

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3611,9 +3611,25 @@ function convertFromGlobalSettingFormat(?string $sDate, bool $withTime = false):
         ? $sDateformatdata['phpdate'] . ' H:i'
         : $sDateformatdata['phpdate'];
 
-    $oDate = DateTime::createFromFormat($fromFormat, $sDate);
-    if ($oDate === false) {
-        // Fallback: let PHP try to parse the string as-is
+    // The '!' prefix resets all fields not present in the format to the Unix epoch,
+    // so a date-only value yields 00:00:00 deterministically (instead of "now").
+    $oDate = DateTime::createFromFormat('!' . $fromFormat, $sDate);
+
+    if ($oDate !== false) {
+        // Whether a value is a valid date depends on $fromFormat (e.g. "13.02.2023"
+        // is valid as d.m.Y but not as m.d.Y). createFromFormat() parses against the
+        // user's configured $fromFormat but silently normalises dates that are invalid
+        // *for that format* (e.g. "30.02.2023" as d.m.Y => "2023-03-02") instead of
+        // returning false. Such cases set parser warnings; reject them rather than
+        // persisting a silently shifted date. (Do NOT fall back to new DateTime() here,
+        // as the constructor would re-normalise the invalid date in the same way.)
+        $errors = DateTime::getLastErrors();
+        if ($errors !== false && (($errors['warning_count'] ?? 0) > 0 || ($errors['error_count'] ?? 0) > 0)) {
+            return null;
+        }
+    } else {
+        // The value did not match the user's locale format at all
+        // (e.g. it is already an ISO 'Y-m-d H:i:s' string) - let PHP try to parse it.
         try {
             $oDate = new DateTime($sDate);
         } catch (Exception $e) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2884,6 +2884,42 @@ function getUTCOfDate(?string $date = null)
 }
 
 /**
+ * Parses a date string that is in the user's global setting format and returns
+ * a normalised 'Y-m-d H:i:s' string that is safe for PHP's DateTime constructor
+ * (e.g. as direct input to getUTCOfDate()).
+ *
+ * This is the counterpart of convertToGlobalSettingFormat(): where that function
+ * converts an arbitrary date INTO the user's display format, this function parses
+ * a value that already IS in the user's display format and converts it back to an
+ * unambiguous ISO-style string.
+ *
+ * @param string|null $sDate   Date string in the user's phpdate (+ time) format
+ * @param bool        $withTime Whether a H:i time component is present
+ * @return string|null Normalised 'Y-m-d H:i:s' string, or null when parsing fails
+ */
+function convertFromGlobalSettingFormat(?string $sDate, bool $withTime = false): ?string
+{
+    if (empty($sDate)) {
+        return null;
+    }
+    $sDateformatdata = getDateFormatData(Yii::app()->session['dateformat'] ?? 1);
+    $fromFormat = $withTime
+        ? $sDateformatdata['phpdate'] . ' H:i'
+        : $sDateformatdata['phpdate'];
+
+    $oDate = DateTime::createFromFormat($fromFormat, $sDate);
+    if ($oDate === false) {
+        // Fallback: let PHP try to parse the string as-is
+        try {
+            $oDate = new DateTime($sDate);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+    return $oDate->format('Y-m-d H:i:s');
+}
+
+/**
  * Gets the date of the UTC to be displayed
  * @param string|null $date
  * @return string|null

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -3606,7 +3606,7 @@ function convertFromGlobalSettingFormat(?string $sDate, bool $withTime = false):
     if (empty($sDate)) {
         return null;
     }
-    $sDateformatdata = getDateFormatData(Yii::app()->session['dateformat']);
+    $sDateformatdata = getDateFormatData(Yii::app()->session['dateformat'] ?? 1);
     $fromFormat = $withTime
         ? $sDateformatdata['phpdate'] . ' H:i'
         : $sDateformatdata['phpdate'];

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2884,42 +2884,6 @@ function getUTCOfDate(?string $date = null)
 }
 
 /**
- * Parses a date string that is in the user's global setting format and returns
- * a normalised 'Y-m-d H:i:s' string that is safe for PHP's DateTime constructor
- * (e.g. as direct input to getUTCOfDate()).
- *
- * This is the counterpart of convertToGlobalSettingFormat(): where that function
- * converts an arbitrary date INTO the user's display format, this function parses
- * a value that already IS in the user's display format and converts it back to an
- * unambiguous ISO-style string.
- *
- * @param string|null $sDate   Date string in the user's phpdate (+ time) format
- * @param bool        $withTime Whether a H:i time component is present
- * @return string|null Normalised 'Y-m-d H:i:s' string, or null when parsing fails
- */
-function convertFromGlobalSettingFormat(?string $sDate, bool $withTime = false): ?string
-{
-    if (empty($sDate)) {
-        return null;
-    }
-    $sDateformatdata = getDateFormatData(Yii::app()->session['dateformat'] ?? 1);
-    $fromFormat = $withTime
-        ? $sDateformatdata['phpdate'] . ' H:i'
-        : $sDateformatdata['phpdate'];
-
-    $oDate = DateTime::createFromFormat($fromFormat, $sDate);
-    if ($oDate === false) {
-        // Fallback: let PHP try to parse the string as-is
-        try {
-            $oDate = new DateTime($sDate);
-        } catch (Exception $e) {
-            return null;
-        }
-    }
-    return $oDate->format('Y-m-d H:i:s');
-}
-
-/**
  * Gets the date of the UTC to be displayed
  * @param string|null $date
  * @return string|null
@@ -3622,6 +3586,43 @@ function convertToGlobalSettingFormat($sDate, $withTime = false)
         return $sDate; // We return the string date
     }
 }
+
+/**
+ * Parses a date string that is in the user's global setting format and returns
+ * a normalised 'Y-m-d H:i:s' string that is safe for PHP's DateTime constructor
+ * (e.g. as direct input to getUTCOfDate()).
+ *
+ * This is the counterpart of convertToGlobalSettingFormat(): where that function
+ * converts an arbitrary date INTO the user's display format, this function parses
+ * a value that already IS in the user's display format and converts it back to an
+ * unambiguous ISO-style string.
+ *
+ * @param string|null $sDate   Date string in the user's phpdate (+ time) format
+ * @param bool        $withTime Whether a H:i time component is present
+ * @return string|null Normalised 'Y-m-d H:i:s' string, or null when parsing fails
+ */
+function convertFromGlobalSettingFormat(?string $sDate, bool $withTime = false): ?string
+{
+    if (empty($sDate)) {
+        return null;
+    }
+    $sDateformatdata = getDateFormatData(Yii::app()->session['dateformat']);
+    $fromFormat = $withTime
+        ? $sDateformatdata['phpdate'] . ' H:i'
+        : $sDateformatdata['phpdate'];
+
+    $oDate = DateTime::createFromFormat($fromFormat, $sDate);
+    if ($oDate === false) {
+        // Fallback: let PHP try to parse the string as-is
+        try {
+            $oDate = new DateTime($sDate);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+    return $oDate->format('Y-m-d H:i:s');
+}
+
 
 /**
 * This function removes the UTF-8 Byte Order Mark from a string

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -567,9 +567,9 @@ class Survey extends LSActiveRecord implements PermissionInterface
             array('additional_languages', 'LSYii_FilterValidator', 'filter' => 'trim', 'skipOnEmpty' => true),
             array('additional_languages', 'LSYii_Validators', 'isLanguageMulti' => true),
             array('running', 'safe', 'on' => 'search'),
-            array('expires', 'date','format' => ['yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
-            array('startdate', 'date','format' => ['yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
-            array('datecreated', 'date','format' => ['yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
+            array('expires', 'date','format' => ['yyyy-MM-dd HH:mm:ss','yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
+            array('startdate', 'date','format' => ['yyyy-MM-dd HH:mm:ss','yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
+            array('datecreated', 'date','format' => ['yyyy-MM-dd HH:mm:ss','yyyy-M-d H:m:s.???','yyyy-M-d H:m:s','yyyy-M-d H:m'],'allowEmpty' => true),
             array('expires', 'checkExpireAfterStart'),
             // The Google Analytics Tracking ID is inserted in a JS script. If the following rule is changed, make sure
             // that it doesn't render it vulnerable to XSS attacks.

--- a/application/models/services/SurveyAggregateService/GeneralSettings.php
+++ b/application/models/services/SurveyAggregateService/GeneralSettings.php
@@ -6,7 +6,6 @@ use Survey;
 use Permission;
 use LSYii_Application;
 use PluginEvent;
-use Date_Time_Converter;
 use CHttpSession;
 use LimeSurvey\PluginManager\PluginManager;
 use LimeSurvey\Models\Services\Exception\{
@@ -521,25 +520,20 @@ class GeneralSettings
 
     /**
      * Format date time input
-     *
+    /**
      * Converts date time string from user local format to internal database format.
      *
+     * The input (in the user's locale format, e.g. 'd.m.Y H:i') is parsed to an
+     * unambiguous 'Y-m-d H:i:s' string via convertFromGlobalSettingFormat() and then
+     * shifted from the user's display timezone to UTC via getUTCOfDate() for storage.
+     *
      * @param string $inputDateTimeString
-     * @return string
+     * @return string|null
      */
     private function formatDateTimeInput($inputDateTimeString)
     {
-        $this->yiiApp->loadHelper('surveytranslator');
-        $this->yiiApp->loadLibrary('Date_Time_Converter');
-        $dateFormat = !empty($this->session['dateformat'])
-            ? $this->session['dateformat']
-            : 1;
-        $formatData = getDateFormatData($dateFormat);
-        $dateTimeObj = new Date_Time_Converter(
-            $inputDateTimeString,
-            $formatData['phpdate'] . ' H:i'
-        );
-        return $dateTimeObj->convert('Y-m-d H:i:s');
+        $this->yiiApp->loadHelper('common');
+        return getUTCOfDate(convertFromGlobalSettingFormat($inputDateTimeString, true));
     }
 
     /**

--- a/application/models/services/SurveyAggregateService/GeneralSettings.php
+++ b/application/models/services/SurveyAggregateService/GeneralSettings.php
@@ -520,7 +520,6 @@ class GeneralSettings
 
     /**
      * Format date time input
-    /**
      * Converts date time string from user local format to internal database format.
      *
      * The input (in the user's locale format, e.g. 'd.m.Y H:i') is parsed to an
@@ -532,7 +531,6 @@ class GeneralSettings
      */
     private function formatDateTimeInput($inputDateTimeString)
     {
-        $this->yiiApp->loadHelper('common');
         return getUTCOfDate(convertFromGlobalSettingFormat($inputDateTimeString, true));
     }
 


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Survey date fields (start date, expiry date, creation date) now accept a wider range of datetime input formats.
  * Date/time entries are parsed according to the user’s global date format (with optional time) and normalized into a consistent datetime value for processing.
  * Survey locale settings updates now use the same updated datetime handling, helping keep date values consistent end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->