### PR TITLE
Fixed issue: Extended integrity check to also catch questions that should not have answer options or should not have subquestions

### DIFF
--- a/application/controllers/admin/CheckIntegrity.php
+++ b/application/controllers/admin/CheckIntegrity.php
@@ -977,6 +977,54 @@ class CheckIntegrity extends SurveyCommonAction
             $aDelete['question_l10ns'][] = array('id' => $question['id'], 'qid' => $question['qid'], 'reason' => gT('No parent question'));
         }
 
+        /**********************************************************************/
+        /*     Check subquestions and answer options against question type    */
+        /*     Some question types require subquestions, some require answer  */
+        /*     options and some require both. Flag for deletion subquestions  */
+        /*     and answer options that do not belong to the parent question's */
+        /*     type.                                                          */
+        /**********************************************************************/
+        $aTypesWithoutSubquestions = array();
+        $aTypesWithoutAnswers = array();
+        foreach (QuestionType::modelsAttributes() as $sTypeCode => $aTypeAttributes) {
+            if (empty($aTypeAttributes['subquestions'])) {
+                $aTypesWithoutSubquestions[] = $sTypeCode;
+            }
+            if (empty($aTypeAttributes['answerscales'])) {
+                $aTypesWithoutAnswers[] = $sTypeCode;
+            }
+        }
+
+        // Subquestions belonging to a question whose type does not allow subquestions
+        if (!empty($aTypesWithoutSubquestions)) {
+            $oCriteria = new CDbCriteria();
+            $oCriteria->join = 'INNER JOIN {{questions}} parentq ON t.parent_qid = parentq.qid';
+            $oCriteria->addCondition('t.parent_qid <> 0');
+            $oCriteria->addInCondition('parentq.type', $aTypesWithoutSubquestions);
+            $orphanSubquestions = Question::model()->findAll($oCriteria);
+            foreach ($orphanSubquestions as $orphanSubquestion) {
+                $aDelete['questions'][] = array(
+                    'qid' => $orphanSubquestion['qid'],
+                    'reason' => gT('The question type does not allow subquestions')
+                );
+            }
+        }
+
+        // Answer options belonging to a question whose type does not allow answer options
+        if (!empty($aTypesWithoutAnswers)) {
+            $oCriteria = new CDbCriteria();
+            $oCriteria->join = 'INNER JOIN {{questions}} q ON t.qid = q.qid';
+            $oCriteria->addInCondition('q.type', $aTypesWithoutAnswers);
+            $orphanAnswers = Answer::model()->findAll($oCriteria);
+            foreach ($orphanAnswers as $orphanAnswer) {
+                $aDelete['answers'][] = array(
+                    'qid' => $orphanAnswer['qid'],
+                    'code' => $orphanAnswer['code'],
+                    'reason' => gT('The question type does not allow answer options')
+                );
+            }
+        }
+
 
         /**********************************************************************/
         /*     Check groups                                                   */

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -929,6 +929,16 @@ class Update_700 extends DatabaseUpdateBase
     }
 
     /**
+     * Removes any existing subquestions of ranking questions before
+     * the ranking answers are converted into subquestions, to avoid duplicates.
+     * @return string
+     */
+    public function deleteRankingSubquestions()
+    {
+        return "DELETE FROM {{questions}} WHERE parent_qid IN (SELECT qid FROM (SELECT qid FROM {{questions}} WHERE type = '" . Question::QT_R_RANKING . "' AND parent_qid = 0) AS rankingquestions)";
+    }
+
+    /**
      * Creating subquestions for ranking instead of its answers
      * @return string
      */
@@ -936,7 +946,7 @@ class Update_700 extends DatabaseUpdateBase
     {
         return "
             INSERT INTO {{questions}}(parent_qid, sid, gid, type, title, question_order, relevance)
-            SELECT q.qid, q.sid, q.gid, '" . Question::QT_T_LONG_FREE_TEXT . "', a.code, a.sortorder, '1'
+            SELECT q.qid, q.sid, q.gid, '" . Question::QT_R_RANKING . "', a.code, a.sortorder, '1'
             FROM {{answers}} a
             JOIN {{questions}} q
             ON a.qid = q.qid and q.type = '" . Question::QT_R_RANKING . "'
@@ -1234,6 +1244,7 @@ class Update_700 extends DatabaseUpdateBase
     /** @SuppressWarnings(PHPMD.ExcessiveMethodLength) */
     public function up()
     {
+        $this->db->createCommand($this->deleteRankingSubquestions())->execute();
         $this->db->createCommand($this->insertRankingSubquestions())->execute();
         $this->db->createCommand($this->insertRankingSubquestionsL10ns())->execute();
         $this->doPreparations();


### PR DESCRIPTION
Fixed issue: Remove any superflous subquestions on ranking question type before DB migration
Fixed issue: Ranking subquestions are not written as ranking type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened data integrity validation to ensure questions, subquestions, and answer options are properly aligned with their configured types
  * Improved data migration handling for ranking questions during system updates
  * Added automatic detection and cleanup of inconsistent question structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->