### PR TITLE
Fixed issue #20571: Ranking question does not properly enforce maximum column setting anymore

### DIFF
--- a/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
+++ b/application/extensions/AdvancedSettingWidget/AdvancedSettingWidget.php
@@ -50,6 +50,12 @@ class AdvancedSettingWidget extends CWidget
             }
         }
 
+        // The setting must be disabled if it is always read-only, or if it is read-only
+        // while the survey is active and the survey is currently active.
+        $surveyIsActive = !empty($this->survey) && $this->survey->active === 'Y';
+        $disabled = !empty($this->setting['readonly'])
+            || ($surveyIsActive && !empty($this->setting['readonly_when_active']));
+
         $inputBaseName = "advancedSettings[" . strtolower((string) $this->setting['category']) . "][" . $this->setting['name'] . "]";
         $content = $this->render(
             $this->setting['inputtype'],
@@ -60,7 +66,8 @@ class AdvancedSettingWidget extends CWidget
             'layout',
             [
                 'content' => $content,
-                'inputBaseName' => $inputBaseName
+                'inputBaseName' => $inputBaseName,
+                'disabled' => $disabled
             ]
         );
     }

--- a/application/extensions/AdvancedSettingWidget/views/layout.php
+++ b/application/extensions/AdvancedSettingWidget/views/layout.php
@@ -31,7 +31,13 @@ $labelAttr .= CHtml::getIdByName($inputBaseName) . '"';
             <div class="help-block collapse" id="help-<?= CHtml::getIdByName($inputBaseName); ?>" aria-expanded="false"><?= $this->setting['help']; ?></div>
         <?php endif; ?>
         </div>
-        <?= $content ?>
+        <?php if (!empty($disabled)) : ?>
+            <fieldset disabled class="w-100 border-0 p-0 m-0">
+                <?= $content ?>
+            </fieldset>
+        <?php else : ?>
+            <?= $content ?>
+        <?php endif; ?>
     </div>
 </div>
 <script>

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -1959,6 +1959,12 @@ function createFieldMap($survey, $style = 'short', $force_refresh = false, $ques
         } elseif ($arow['type'] == Question::QT_R_RANKING) {
             // Ranking questions now use subquestions instead of answer options
             $abrows = getSubQuestions($surveyid, $arow['qid'], $sLanguage);
+            // If max_subquestions is set and lower than the number of ranking items,
+            // cap the number of response columns (rank slots) to that value.
+            $qidattributes = QuestionAttribute::model()->getQuestionAttributes($qs[$arow['qid']] ?? $arow['qid']);
+            if (isset($qidattributes['max_subquestions']) && intval($qidattributes['max_subquestions']) > 0 && intval($qidattributes['max_subquestions']) < count($abrows)) {
+                $abrows = array_slice($abrows, 0, intval($qidattributes['max_subquestions']));
+            }
             $i = 0;
             foreach ($abrows as $abrow) {
                 $i++;

--- a/application/helpers/questionHelper.php
+++ b/application/helpers/questionHelper.php
@@ -572,14 +572,14 @@ class questionHelper
         );
 
         /* Ranking specific : max DB answer */
-        self::$attributes["max_subquestions"] = array(
+         self::$attributes["max_subquestions"] = array(
         "types" => Question::QT_R_RANKING,
             'readonly_when_active' => true,
             'category' => gT('Logic'),
             'sortorder' => 12,
             'inputtype' => 'integer',
             'default' => '',
-            "help" => gT('Limit the number of possible answers fixed by number of columns in database'),
+            "help" => gT('Limit the number of possible answers fixed by number of columns in database - this setting can only be edited when the survey is inactive.'),
             "caption" => gT('Maximum columns for answers')
         );
 

--- a/application/models/services/QuestionAggregateService/AttributesService.php
+++ b/application/models/services/QuestionAggregateService/AttributesService.php
@@ -107,10 +107,27 @@ class AttributesService
     {
         $questionBaseAttributes = $question->attributes;
 
+        // When the survey is active, attributes flagged as read-only (always, or
+        // read-only while the survey is active) must not be modified, even if they
+        // are present in the submitted data.
+        $survey = $question->survey;
+        $surveyIsActive = !empty($survey) && $survey->active === 'Y';
+        $readOnlyAttributes = [];
+        $attributeSettings = QuestionAttribute::getQuestionAttributesSettings($question->type);
+        foreach ($attributeSettings as $attributeName => $attributeSetting) {
+            if (
+                !empty($attributeSetting['readonly'])
+                || ($surveyIsActive && !empty($attributeSetting['readonly_when_active']))
+            ) {
+                $readOnlyAttributes[$attributeName] = true;
+            }
+        }
+
         foreach ($dataSet as $attributeKey => $attributeValue) {
             if (
                 !isset($attributeValue) ||
-                in_array($attributeKey, ['qid', 'debug', 'tempId'])
+                in_array($attributeKey, ['qid', 'debug', 'tempId']) ||
+                isset($readOnlyAttributes[$attributeKey])
             ) {
                 continue;
             }

--- a/application/models/services/QuestionAggregateService/AttributesService.php
+++ b/application/models/services/QuestionAggregateService/AttributesService.php
@@ -107,19 +107,20 @@ class AttributesService
     {
         $questionBaseAttributes = $question->attributes;
 
-        // When the survey is active, attributes flagged as read-only (always, or
-        // read-only while the survey is active) must not be modified, even if they
-        // are present in the submitted data.
+        // When the survey is active, attributes flagged as read-only while the survey
+        // is active must not be modified, even if they are present in the submitted data.
         $survey = $question->survey;
         $surveyIsActive = !empty($survey) && $survey->active === 'Y';
         $readOnlyAttributes = [];
-        $attributeSettings = QuestionAttribute::getQuestionAttributesSettings($question->type);
-        foreach ($attributeSettings as $attributeName => $attributeSetting) {
-            if (
-                !empty($attributeSetting['readonly'])
-                || ($surveyIsActive && !empty($attributeSetting['readonly_when_active']))
-            ) {
-                $readOnlyAttributes[$attributeName] = true;
+        if ($surveyIsActive && !empty($dataSet)) {
+            $attributeSettings = QuestionAttribute::getQuestionAttributesSettings($question->type);
+            foreach ($attributeSettings as $attributeName => $attributeSetting) {
+                if (
+                    !empty($attributeSetting['readonly'])
+                    || !empty($attributeSetting['readonly_when_active'])
+                ) {
+                    $readOnlyAttributes[$attributeName] = true;
+                }
             }
         }
 

--- a/editor/src/components/QuestionSettings/Setting.js
+++ b/editor/src/components/QuestionSettings/Setting.js
@@ -150,12 +150,14 @@ export const Setting = ({
         )
 
         const isDisabled =
-          [
+          ([
             'questionThemeName',
             'encrypted',
             'attributes.save_as_default',
             'other',
-          ].includes(attribute.attributePath) && isSurveyActive
+          ].includes(attribute.attributePath) ||
+            attribute.disableWhenActive) &&
+          isSurveyActive
 
         return (
           <div

--- a/editor/src/components/QuestionSettings/attributes/getLogicAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getLogicAttributes.js
@@ -168,6 +168,7 @@ export const getLogicAttributes = () => ({
   MAXIMUM_COLUMNS_FOR_ANSWERS: {
     component: Input,
     attributePath: 'attributes.max_subquestions',
+    disableWhenActive: true,
     props: {
       labelText: t('Maximum columns for answers'),
       dataTestId: 'maximum-columns-for-answers',


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reintroduced maximum subquestions limit for ranking-type questions, allowing control over the number of response options displayed, columns used in the database

* **Improvements**
  * Enhanced survey settings protection: certain settings can now be automatically disabled when a survey is active, preventing unintended modifications to survey configuration.
  * Improved UI to properly reflect read-only and disabled states for survey attributes based on survey status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->