### PR TITLE
Fixed issue #20532: STARTPOLICYLINK and ENDPOLICYLINK return errors in the survey logic view

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -703,6 +703,10 @@ class ExpressionManager
                         }
                         $this->RDP_StackPush($result);
                         return true;
+                    } elseif ($this->RDP_isKnownNonEmPlaceholder($token[0])) {
+                        // Pass through non-EM placeholders like STARTPOLICYLINK
+                        $this->RDP_StackPush(array('{' . $token[0] . '}', $token[1], 'WORD'));
+                        return true;
                     } else {
                         $this->RDP_AddError(self::gT("Undefined variable"), $token);
                         return false;
@@ -1563,10 +1567,7 @@ class ExpressionManager
                         $stringParts[] = $token[0];
                         $stringParts[] = "</span>";
                     } else {
-                        if (!$this->RDP_isValidVariable($token[0])) {
-                            $class = 'em-var-error';
-                            $displayName = $token[0];
-                        } else {
+                        if ($this->RDP_isValidVariable($token[0])) {
                             $jsName = $this->GetVarAttribute($token[0], 'jsName', '');
                             $code = $this->GetVarAttribute($token[0], 'code', '');
                             $question = $this->GetVarAttribute($token[0], 'question', '');
@@ -1633,6 +1634,13 @@ class ExpressionManager
                             } else {
                                 $class = 'em-var-after em-var-inpage';
                             }
+                        } elseif ($this->RDP_isKnownNonEmPlaceholder($token[0])) {
+                            // Don't show non-EM placeholders like STARTPOLICYLINK as errors.
+                            $stringParts[] = CHtml::encode($token[0]);
+                            break;
+                        } else {
+                            $class = 'em-var-error';
+                            $displayName = $token[0];
                         }
                         // prevent EM processing of messages within span
                         $message = implode('; ', $messages);
@@ -1810,7 +1818,7 @@ class ExpressionManager
                             $this->RDP_AddError(self::gT("Undefined function"), $token);
                         }
                     } else {
-                        if (!($this->RDP_isValidVariable($token[0]))) {
+                        if (!($this->RDP_isValidVariable($token[0])) && !$this->RDP_isKnownNonEmPlaceholder($token[0])) {
                             $this->RDP_AddError(self::gT("Undefined variable"), $token);
                         }
                     }
@@ -2605,6 +2613,16 @@ class ExpressionManager
             $sEscapeMode,
             Yii::app()->session->get('adminlang', App()->getConfig("defaultlang"))
         );
+    }
+
+    /**
+     * Return true for placeholders that are intentionally resolved outside EM, like those handled by survey themes.
+     * @param string $name
+     * @return bool
+     */
+    private function RDP_isKnownNonEmPlaceholder($name)
+    {
+        return in_array($name, ['STARTPOLICYLINK', 'ENDPOLICYLINK'], true);
     }
 }
 

--- a/tests/unit/helpers/ExpressionManagerCoreTest.php
+++ b/tests/unit/helpers/ExpressionManagerCoreTest.php
@@ -67,4 +67,21 @@ class ExpressionManagerCoreTest extends TestBaseClass
         $this->assertTrue($success, "Expression should evaluate without errors: $expression (errors: " . implode('; ', $em->GetErrors()) . ")");
         $this->assertSame($expected, $em->GetResult(), "With var='$varValue', expression: $expression");
     }
+
+    public function testKnownNonEmPlaceholdersDoNotRaiseErrors(): void
+    {
+        $em = new \ExpressionManager();
+        $result = $em->sProcessStringContainingExpressions(
+            'I accept the {STARTPOLICYLINK}privacy policy{ENDPOLICYLINK}.'
+        );
+
+        $this->assertSame('I accept the {STARTPOLICYLINK}privacy policy{ENDPOLICYLINK}.', $result);
+        $this->assertFalse($em->HasErrors());
+
+        $prettyPrint = $em->GetLastPrettyPrintExpression();
+        $this->assertStringContainsString('STARTPOLICYLINK', $prettyPrint);
+        $this->assertStringContainsString('ENDPOLICYLINK', $prettyPrint);
+        $this->assertStringNotContainsString('em-error', $prettyPrint);
+        $this->assertStringNotContainsString('em-var-error', $prettyPrint);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of specific policy-related placeholders (STARTPOLICYLINK and ENDPOLICYLINK) in expression evaluation to prevent them from being incorrectly flagged as undefined variables or displayed with error highlighting.

* **Tests**
  * Added comprehensive test coverage to verify that policy-related placeholders are properly recognized and handled without raising validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->