### PR TITLE
fix Lable is not provided for the combobox LS-2026-220 -21

### DIFF
--- a/application/extensions/yiiwheels/widgets/select2/assets/js/select2-aria.js
+++ b/application/extensions/yiiwheels/widgets/select2/assets/js/select2-aria.js
@@ -1,18 +1,45 @@
 /**
  * Accessibility enhancement for Select2 widgets.
  *
- * When a Select2 dropdown opens, copies the aria-labelledby attribute from the
- * original <select> element to the generated search input so that screen readers
- * announce the correct label when the search field receives focus.
+ * Uses a MutationObserver to detect when Select2 containers are added to the DOM.
+ * When a new container appears next to a <select> with aria-labelledby, that label
+ * reference is prepended to the combobox aria-labelledby so screen readers
+ * announce the correct label in all states (before and after opening).
+ *
+ * On select2:open, the same label reference is also copied to the search field
+ * inside the dropdown.
  */
 (function ($) {
-    $(document).on('select2:open', function (e) {
-            var $select = $(e.target);
-            var ariaLabelledBy = $select.attr('aria-labelledby');
-            if (ariaLabelledBy) {
-                var $container = $select.next('.select2-container');
-                $container.find('.select2-search__field').attr('aria-labelledby', ariaLabelledBy);
-            }
+    function patchCombobox($select) {
+        var ariaLabelledBy = $select.attr('aria-labelledby');
+        if (!ariaLabelledBy) {
+            return;
         }
-    );
+        var $combobox = $select.next('.select2-container').find('[role="combobox"]');
+        var existing = $combobox.attr('aria-labelledby') || '';
+        if (existing.indexOf(ariaLabelledBy) === -1) {
+            $combobox.attr('aria-labelledby', ariaLabelledBy + ' ' + existing);
+        }
+    }
+
+    // Patch combobox aria-labelledby whenever a Select2 container is inserted into the DOM
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            mutation.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1 && $(node).hasClass('select2-container')) {
+                    patchCombobox($(node).prev('select'));
+                }
+            });
+        });
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+
+    // On open, also patch the search field inside the dropdown
+    $(document).on('select2:open', function (e) {
+        var $select = $(e.target);
+        var ariaLabelledBy = $select.attr('aria-labelledby');
+        if (ariaLabelledBy) {
+            $select.next('.select2-container').find('.select2-search__field').attr('aria-labelledby', ariaLabelledBy);
+        }
+    });
 }(jQuery));

--- a/application/extensions/yiiwheels/widgets/select2/assets/js/select2-aria.js
+++ b/application/extensions/yiiwheels/widgets/select2/assets/js/select2-aria.js
@@ -17,7 +17,8 @@
         }
         var $combobox = $select.next('.select2-container').find('[role="combobox"]');
         var existing = $combobox.attr('aria-labelledby') || '';
-        if (existing.indexOf(ariaLabelledBy) === -1) {
+        var existingTokens = existing.split(/\s+/).filter(Boolean);
+        if (existingTokens.indexOf(ariaLabelledBy) === -1) {
             $combobox.attr('aria-labelledby', ariaLabelledBy + ' ' + existing);
         }
     }

--- a/application/views/admin/survey/subview/accordion/_generaloptions_panel.php
+++ b/application/views/admin/survey/subview/accordion/_generaloptions_panel.php
@@ -130,13 +130,15 @@ Yii::app()->getClientScript()->registerScript("GeneralOption-confirm-language", 
         <?php
         if (isset($oSurvey->owner_id) && Yii::app()->session['loginID'] == $oSurvey->owner_id || Permission::model()->hasGlobalPermission('superadmin', 'read')):?>
             <div class="mb-3">
-                <label class=" form-label" for='owner_id'><?php eT("Survey owner:"); ?></label>
+                <label id="owner_id_label" class="form-label" for="owner_id"><?php eT("Survey owner:"); ?></label>
                 <div class=""><?php
                     Yii::app()->getController()->widget('yiiwheels.widgets.select2.WhSelect2',
                         array(
                             'asDropDownList' => true,
                             'htmlOptions' => array(
-                                'style' => 'width:100%;'
+                                'id' => 'owner_id',
+                                'style' => 'width:100%;',
+                                'aria-labelledby' => 'owner_id_label'
                             ),
                             'data' => isset($users) ? $users : [],
                             'value' => $oSurvey->owner_id,
@@ -324,9 +326,9 @@ Yii::app()->getClientScript()->registerScript("GeneralOption-confirm-language", 
         </div>
         <!-- Theme -->
         <div class="mb-3" >
-            <label class=" form-label" for='template'><?php eT("Theme:"); ?></label>
+            <label id="template_label" class="form-label" for='template'><?php eT("Theme:"); ?></label>
             <div class="">
-                <select id='template' style="width:100%;" class="form-select activate-search" name='template' data-updateurl='<?php echo App()->createUrl('themeOptions/getPreviewTag') ?>'
+                <select id='template' style="width:100%;" class="form-select activate-search" name='template' aria-labelledby="template_label" data-updateurl='<?php echo App()->createUrl('themeOptions/getPreviewTag') ?>'
                         data-inherit-template-name='<?= $themeConf->template_name ?>'>
                     <?php if ($bShowInherited || $bGlobalSettings) : ?>
                         <option value="inherit" <?= ($oSurvey->template == 'inherit') ? 'selected="selected"' : ''; ?>>

--- a/application/views/admin/survey/subview/accordion/_generaloptions_panel.php
+++ b/application/views/admin/survey/subview/accordion/_generaloptions_panel.php
@@ -110,12 +110,12 @@ Yii::app()->getClientScript()->registerScript("GeneralOption-confirm-language", 
                 </div>
                 <!-- Base language -->
                 <div class="mb-3">
-                    <label class=" form-label"><?php eT("Base language:"); ?></label>
+                    <label id="language_label" class=" form-label" for="language"><?php eT("Base language:"); ?></label>
                     <div class="">
                         <?php $this->widget('yiiwheels.widgets.select2.WhSelect2',
                             array(
                                 'asDropDownList' => true,
-                                'htmlOptions' => array('style' => "width: 100%"),
+                                'htmlOptions' => array('id' => 'language', 'style' => "width: 100%", 'aria-labelledby' => 'language_label'),
                                 'data' => array_intersect_key($aAllLanguages, array_flip($oSurvey->allLanguages)),
                                 'value' => $oSurvey->language,
                                 'name' => 'language',
@@ -296,12 +296,12 @@ Yii::app()->getClientScript()->registerScript("GeneralOption-confirm-language", 
         <!-- Survey Group -->
         <?php if ($bShowAllOptions === true) { ?>
             <div class="mb-3">
-                <label class=" form-label" for='gsid'><?php eT("Group:"); ?></label>
+                <label id="gsid_label" class=" form-label" for='gsid'><?php eT("Group:"); ?></label>
                 <div class="">
                     <?php $this->widget('yiiwheels.widgets.select2.WhSelect2',
                         array(
                             'asDropDownList' => true,
-                            'htmlOptions' => array('style' => "width: 100%"),
+                            'htmlOptions' => array('style' => "width: 100%", 'aria-labelledby' => 'gsid_label'),
                             'data' => isset($aSurveyGroupList) ? $aSurveyGroupList : [],
                             'value' => $oSurvey->gsid,
                             'name' => 'gsid',


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
1.fix Lable is not provided for the combobox LS-2026-220 -21
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for admin survey “General options” by adding explicit label IDs and ensuring each label is properly linked to its Select2-enhanced field (Base language, Survey owner, Group, and Theme).
  * Enhanced Select2 accessibility behavior so screen readers reliably announce the correct labeled relationship both when the dropdown opens and within the in-search state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->