### PR TITLE
Fixed issue #AT-2115 Create table when adding first participants from CPDB

### DIFF
--- a/application/controllers/admin/ParticipantsAction.php
+++ b/application/controllers/admin/ParticipantsAction.php
@@ -1584,7 +1584,7 @@ class ParticipantsAction extends SurveyCommonAction
         $data['participant_id'] = $participant_id;
         $data['count'] = substr_count((string) $participant_id, ',') + 1;
 
-        $surveys = Survey::getSurveysWithTokenTable();
+        $surveys = Survey::getSurveysForAddingParticipants();
         $data['surveys'] = $surveys;
         $data['hasGlobalPermission'] = Permission::model()->hasGlobalPermission('surveys', 'update');
 
@@ -2531,6 +2531,20 @@ class ParticipantsAction extends SurveyCommonAction
         $participantIds = explode(",", (string) $participantIdsString);
 
         $surveyId = (int)Yii::app()->request->getPost('surveyid');
+
+        $survey = Survey::model()->findByPk($surveyId);
+        if ($survey && !$survey->hasTokensTable) {
+            if (
+                !Permission::model()->hasGlobalPermission('surveys', 'update')
+                && !Permission::model()->hasSurveyPermission($surveyId, 'tokens', 'update')
+            ) {
+                echo gT('No permission');
+                return;
+            }
+            $accessModeService = \LimeSurvey\DI::getContainer()
+                ->get(\LimeSurvey\Models\Services\SurveyAccessModeService::class);
+            $accessModeService->newParticipantTable($survey, true);
+        }
 
         /**
          * mapped can take values like

--- a/application/controllers/admin/ParticipantsAction.php
+++ b/application/controllers/admin/ParticipantsAction.php
@@ -2536,7 +2536,8 @@ class ParticipantsAction extends SurveyCommonAction
         if ($survey && !$survey->hasTokensTable) {
             if (
                 !Permission::model()->hasGlobalPermission('surveys', 'update')
-                && !Permission::model()->hasSurveyPermission($surveyId, 'tokens', 'update')
+                && !Permission::model()->hasSurveyPermission($surveyId, 'surveysettings', 'update')
+                && !Permission::model()->hasSurveyPermission($surveyId, 'tokens', 'create')
             ) {
                 echo gT('No permission');
                 return;

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -2013,6 +2013,16 @@ class Survey extends LSActiveRecord implements PermissionInterface
     }
 
     /**
+     * Get all surveys regardless of whether they already have a participant (token) table
+     *
+     * @return Survey[]
+     */
+    public static function getSurveysForAddingParticipants()
+    {
+        return self::model()->with(array('languagesettings' => array('condition' => 'surveyls_language=language'), 'owner'))->findAll();
+    }
+
+    /**
      * Fix invalid question in this survey
      * Delete question that don't exist in primary language
      */

--- a/application/views/admin/globalsettings/_email.php
+++ b/application/views/admin/globalsettings/_email.php
@@ -120,8 +120,8 @@
         <div class="mb-3">
             <label class="form-label" for="sendingrate"><?php eT("Email sending rate:"); ?></label>
             <div>
-                <?php echo CHtml::numberField("sendingrate", Yii::app()->getConfig('sendingrate'), array('class' => 'form-control', 'size' => 5, 'min' => 1)); ?>
-                <span class="hint"><?php eT("Number of seconds to wait until the next email batch is sent."); ?></span>
+                <?php echo CHtml::numberField("sendingrate", Yii::app()->getConfig('sendingrate'), array('class' => 'form-control', 'size' => 5, 'min' => 1, 'id' => 'sendingrate', 'aria-describedby' => 'sendingrate-hint')); ?>
+                <span class="hint" id="sendingrate-hint"><?php eT("Number of seconds to wait until the next email batch is sent."); ?></span>
             </div>
         </div>
         <!-- Test email -->

--- a/application/views/admin/globalsettings/_general.php
+++ b/application/views/admin/globalsettings/_general.php
@@ -76,7 +76,7 @@ $defaultBreadcrumbMode           = Yii::app()->getConfig('defaultBreadcrumbMode'
                 <?php eT("Administration theme:"); ?>
             </label>
             <div class="col-12">
-                <select class="form-select" name="admintheme" id="admintheme">
+                <select class="form-select" name="admintheme" id="admintheme" aria-describedby="admintheme-hint">
                     <?php foreach ($aListOfThemeObjects as $templatename => $templateconfig) : ?>
                         <option value='<?php echo CHtml::encode($templatename); ?>' <?php echo ($thisadmintheme == $templatename) ? "selected='selected'" : "" ?> >
                             <?php echo CHtml::encode($templateconfig->metadata->name); ?>
@@ -86,7 +86,7 @@ $defaultBreadcrumbMode           = Yii::app()->getConfig('defaultBreadcrumbMode'
             </div>
             <?php if (Permission::model()->hasGlobalPermission('superadmin', 'read')) : ?>
                 <div class="col-12 form-label ">
-                    <span class="hint">
+                    <span class="hint" id="admintheme-hint">
                     <?php eT("You can add your custom themes in upload/admintheme"); ?>
                     </span>
                 </div>
@@ -100,7 +100,7 @@ $defaultBreadcrumbMode           = Yii::app()->getConfig('defaultBreadcrumbMode'
             </label>
             <div class="col-md-4">
                 <span>
-                    <select class="form-select" name="displayTimezone" id="displayTimezone">
+                    <select class="form-select" name="displayTimezone" id="displayTimezone" aria-describedby="displayTimezone-hint">
                     <?php // show a select box with all available time zones
                     $displayTimezone = App()->getConfig('displayTimezone');
                     ?>
@@ -116,7 +116,7 @@ $defaultBreadcrumbMode           = Yii::app()->getConfig('defaultBreadcrumbMode'
                 </span>
             </div>                
             <div class="col-12 form-label ">
-                <span class="hint">
+                <span class="hint" id="displayTimezone-hint">
                 <?php eT("Determines what time zone is used for displaying dates and times in surveys."); ?>  
                 </span>
             </div>

--- a/application/views/admin/globalsettings/_security.php
+++ b/application/views/admin/globalsettings/_security.php
@@ -38,11 +38,12 @@
                             '0' => gT('Off'),
                         ],
                         'htmlOptions' => [
-                            'disabled' => App()->getConfig('filterxsshtml_forcedall')
+                            'disabled' => App()->getConfig('filterxsshtml_forcedall'),
+                            'aria-describedby' => 'filterxsshtml-hint'
                         ]
                                                                 ]); ?>
                 </div>
-                <div class="help-block mt-1">
+                <div class="help-block mt-1" id="filterxsshtml-hint">
                     <?php if (!App()->getConfig('filterxsshtml_forcedall')) {
                         App()->getController()->widget('ext.AlertWidget.AlertWidget', [
                             'text' => gT("Note: XSS filtering is always disabled for the superadministrator."),
@@ -74,11 +75,12 @@
                             '0' => gT('Off'),
                         ],
                         'htmlOptions' => [
-                            'disabled' => App()->getConfig('filterxsshtml_forcedall') && App()->getConfig('filterxsshtml_enablescript') != 'gui'
+                            'disabled' => App()->getConfig('filterxsshtml_forcedall') && App()->getConfig('filterxsshtml_enablescript') != 'gui',
+                            'aria-describedby' => 'disablescriptwithxss-hint'
                         ]
                     ]); ?>
                 </div>
-                <div class="help-block mt-1">
+                <div class="help-block mt-1" id="disablescriptwithxss-hint">
                     <?php if (App()->getConfig('filterxsshtml_forcedall') && App()->getConfig('filterxsshtml_enablescript') != 'gui') {
                         $text = gT("Script editing is forcibly disabled by your configuration file. No user can add or update question script.");
                         if (App()->getConfig('filterxsshtml_enablescript') == 'superadmin') {


### PR DESCRIPTION
Fixed issue #AT-2115: Create new table when adding first participants from CPDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the list of surveys available when adding participants, so more surveys can now appear in the selection modal.
  * Participant tables can now be created automatically during the add-participants flow when appropriate.

* **Bug Fixes**
  * Added permission checks before creating participant tables for surveys that don’t already have one.

* **Documentation**
  * Improved accessibility across several admin settings by connecting form controls to their help text via ARIA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->