### PR TITLE
Fixed issue #LE-800: ranking questions user statistics

### DIFF
--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -684,35 +684,32 @@ class userstatistics_helper
         } // Ranking OPTION
         elseif ($firstletter == "R") {
             $fieldmapKey = substr($rt, 1);
-            $qqid        = (int) ltrim(explode('_', $fieldmapKey)[0], 'Q');  // numeric qid
-            $rankLabel   = substr($fieldmapKey, strpos($fieldmapKey, '_S') + 2);  // the qid part
-
-            //get question data
-            $nresult = Question::model()->with('questionl10ns')->find(array(
-                'condition' => 'language=:language AND parent_qid=0 AND t.qid=:qid',
-                'params'    => array(':language' => $language, ':qid' => $qqid)
-            ));
-
-            if ($nresult) {
-                $qtitle    = flattenText($nresult->title) . " [" . gT("Ranking") . " " . $rankLabel . "]";
-                $qtype     = $nresult->type;
-                $qquestion = flattenText($nresult->questionl10ns[$language]->question)
-                             . " [" . gT("Ranking") . " " . $rankLabel . "]";
-                $qqid      = $nresult->qid;
+            if (!isset($fieldmap[$fieldmapKey])) {
+                return [];
             }
+            $fielddata    = $fieldmap[$fieldmapKey];
+            $qqid         = $fielddata['qid'];
+            $rankPosition = (int) $fielddata['aid'];
+            $qtype        = $fielddata['type'];
 
-            //get answers – each answer is a possible choice the respondent could rank
-            $result = Answer::model()->with('answerl10ns')->findAll([
-                'condition' => 'language=:language AND qid=:qid',
-                'params'    => [':language' => $language, ':qid' => $qqid],
-                'order'     => 'sortorder'
-            ]);
-
-            foreach ($result as $row) {
-                $alist[] = array($row->code, flattenText($row->answerl10ns[$language]->answer), $fieldmapKey);
+            $rankingColumn = "Q{$qqid}";
+            $rankSubquestions = array();
+            foreach ($survey->baseQuestions as $baseQuestion) {
+                if ((int) $baseQuestion->qid === (int) $qqid) {
+                    $rankSubquestions = $baseQuestion->subquestions;
+                    break;
+                }
             }
-            // "No answer": $al[2] = $fieldmapKey so the correct column is used for counting
-            $alist[] = array("", gT("No answer"), $fieldmapKey);
+            $qtitle    = flattenText($fielddata['title']) . " [" . sprintf(gT('Rank %s'), $rankPosition) . "]";
+            $qquestion = flattenText($fielddata['question']) . " [" . gT("Ranking") . "]";
+            foreach ($rankSubquestions as $rankSubquestion) {
+                $alist[] = array(
+                    $rankSubquestion->title,
+                    flattenText($rankSubquestion->questionl10ns[$language]->question ?? ''),
+                    $rankingColumn,
+                    $rankPosition
+                );
+            }
         } else {
             if ($firstletter == "|") {
                 // File Upload
@@ -1566,14 +1563,17 @@ class userstatistics_helper
                     foreach ($oResponses as $oResponse) {
                         $sResponseColumn = $this->getFieldNameFromRawName($al[2], $digitIndex);
                         if (substr((string) $rt, 0, 1) == "R") {
+                            $rank = (int) ($al[3] ?? 0);
+                            $raw = $oResponse->$sResponseColumn;
                             if ($al[0] === "") {
                                 // Ranking No answer: column is NULL or empty
-                                if ($oResponse->$sResponseColumn === null || $oResponse->$sResponseColumn === '') {
+                                if ($raw === null || $raw === '') {
                                     $row += 1;
                                 }
                             } else {
-                                $sSubquestionCode = $al[0];
-                                if ($oResponse->$sResponseColumn == $sSubquestionCode) {
+                                $rankingArray = json_decode((string) $raw, true);
+                                if (is_array($rankingArray) && isset($rankingArray[$rank - 1])
+                                    && (string) $rankingArray[$rank - 1] === (string) $al[0]) {
                                     $row += 1;
                                 }
                             }

--- a/application/helpers/userstatistics_helper.php
+++ b/application/helpers/userstatistics_helper.php
@@ -685,7 +685,7 @@ class userstatistics_helper
         elseif ($firstletter == "R") {
             $fieldmapKey = substr($rt, 1);
             if (!isset($fieldmap[$fieldmapKey])) {
-                return [];
+                return array("alist" => $alist, "qtitle" => $qtitle, "qquestion" => $qquestion, "qtype" => $qtype, "statisticsoutput" => $statisticsoutput, "parentqid" => $qqid);
             }
             $fielddata    = $fieldmap[$fieldmapKey];
             $qqid         = $fielddata['qid'];


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranking results to count selections more accurately by matching the stored ranking response as JSON and validating the expected rank position and subquestion code.
  * Fixed ranking statistics when ranking fields are missing, returning an empty result set rather than incorrect output.
  * Enhanced ranking output formatting to use the survey’s subquestion text (with safe fallback) and consistent rank labeling, while keeping “no answer” counting behavior intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->