### PR TITLE
fix/LE-805: Quote PostgreSQL JSON column name to preserve case

### DIFF
--- a/application/helpers/update/updates/Update_709.php
+++ b/application/helpers/update/updates/Update_709.php
@@ -64,14 +64,17 @@ class Update_709 extends DatabaseUpdateBase
      */
     protected function alterPostgreSQL(int $sid, int $parent_qid, array $cols)
     {
-        $this->db->createCommand("alter table {{responses_" . $sid . "}} add column Q{$parent_qid} json")->execute();
+        $newColumn = $this->db->quoteColumnName("Q{$parent_qid}");
+        $this->db->createCommand("alter table {{responses_" . $sid . "}} add column {$newColumn} json")->execute();
+
         $alterElements = [];
         foreach ($cols as $col) {
             $alterElements[] = (!count($alterElements) ?
             "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT('\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END," :
             "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT(',\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END,");
         }
-        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = to_json(CONCAT('[', " . implode($alterElements) . " ']'))";
+
+        $updateCommand = "UPDATE {{responses_{$sid}}} SET {$newColumn} = to_json(CONCAT('[', " . implode($alterElements) . " ']'))";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how new JSON data is added and saved in PostgreSQL, reducing the chance of issues during database updates.
  * Made the database update process handle column names more reliably when creating and populating the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->