### PR TITLE
New feature: Ability to export the ready-made survey URL when exporting participants

### DIFF
--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -2347,6 +2347,7 @@ function tokensExport($iSurveyID)
     $iInvitationStatus = App()->request->getPost('invitationstatus');
     $iReminderStatus = App()->request->getPost('reminderstatus');
     $sTokenLanguage = App()->request->getPost('tokenlanguage');
+    $bIncludeSurveyLink = (bool) App()->request->getPost('includesurveylink', 0);
 
     $oSurvey = Survey::model()->findByPk($iSurveyID);
     $bIsNotAnonymous = ($oSurvey->anonymized == 'N' && $oSurvey->active == 'Y'); // db table exist (responses_$iSurveyID) ?
@@ -2439,6 +2440,9 @@ function tokensExport($iSurveyID)
                     $tokenoutput .= " <" . str_replace(",", " ", (string) $attrfielddescr[$attr_name]['description']) . ">";
         }
     }
+    if ($bIncludeSurveyLink) {
+        $tokenoutput .= ',surveylink';
+    }
     $tokenoutput .= "\n";
     echo $tokenoutput;
     $tokenoutput = "";
@@ -2504,6 +2508,11 @@ function tokensExport($iSurveyID)
             }
             foreach ($attrfieldnames as $attr_name) {
                 $tokenoutput .= '"' . str_replace('"', '""', trim((string) $brow[$attr_name])) . '",';
+            }
+            if ($bIncludeSurveyLink) {
+                $language = !empty($brow['language']) ? $brow['language'] : $oSurvey->language;
+                $surveyLink = $oSurvey->getSurveyUrl($language, ['token' => $brow['token']]);
+                $tokenoutput .= '"' . str_replace('"', '""', $surveyLink) . '",';
             }
             $tokenoutput = substr($tokenoutput, 0, -1); // remove last comma
             $tokenoutput .= "\n";

--- a/application/views/admin/token/exportdialog.php
+++ b/application/views/admin/token/exportdialog.php
@@ -120,6 +120,29 @@
                         ?>
                     </div>
                     <?php } ?>
+                    <div class="mb-3 control-group " data-name="includesurveylink">
+                        <label class="default form-label" for="includesurveylink">
+                            <?php eT('Include survey link:'); ?>
+                        </label>
+                        <div class="default controls">
+                            <?php $this->widget('ext.ButtonGroupWidget.ButtonGroupWidget', [
+                                'name' => 'includesurveylink',
+                                'checkedOption' => 0,
+                                'ariaLabel' => gT('Include survey link'),
+                                'selectOptions' => [
+                                    '1' => gT('On'),
+                                    '0' => gT('Off'),
+                                ],
+                            ]); ?>
+                        </div>
+                        <?php
+                        $this->widget('ext.AlertWidget.AlertWidget', [
+                            'text' => gT('Add a column with the participant-specific survey URL (including the token).'),
+                            'type' => 'info',
+                            'htmlOptions' => ['class' => 'mt-1'],
+                        ]);
+                        ?>
+                    </div>
                     <div class="mb-3 control-group " data-name="maskequations">
                         <label class="default form-label" for="maskequations">
                             <?php eT('Quote equations:'); ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Include survey link” setting to token exports.
  * When enabled, exported CSV files now include a survey link column with a participant-specific URL for each token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->