### PR TITLE
Fixed issue #20574: Unable to update with not compatible theme

### DIFF
--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -863,7 +863,7 @@ class TemplateConfig extends CActiveRecord
     /**
      * Uninstalls the selected surveytheme and deletes database entry and configuration
      * @param string $templatename Name of Template
-     * @return bool|int
+     * @return bool|int, if false Template are not uninstalled, integr mean the number of TemplateConfiguration uninstalled
      * @throws CDbException
      */
     public static function uninstall($templatename)
@@ -876,9 +876,12 @@ class TemplateConfig extends CActiveRecord
                         'template_name=:templateName',
                         [':templateName' => $templatename]
                     );
-                    /* Add the already deleted by findByAttributes */
-                    $count++;
-                    return $count;
+                    if ($count) {
+                        /* Number of TemplateConfiguration uninstalled */
+                        return $count;
+                    }
+                    /* No TemplateConfiguration, only Template */
+                    return true;
                 }
             }
         }

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -956,14 +956,13 @@ class TemplateConfig extends CActiveRecord
         }
         // add more tests here
 
-        // all checks succeeded, continue loading the theme
-        return $isCompatible;
+        // all checks succeeded, continue loading the theme if it compatible
+        return boolval($isCompatible);
     }
 
     /**
      * Checks if theme is compatible with the current limesurvey version
      * @param $themePath
-     * @param bool $redirect
      * @return bool|null
      */
     public static function isCompatible($themePath)

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -951,7 +951,7 @@ class TemplateConfig extends CActiveRecord
         // add more tests here
 
         // all checks succeeded, continue loading the theme
-        return true;
+        return $isCompatible;
     }
 
     /**

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -872,10 +872,13 @@ class TemplateConfig extends CActiveRecord
             $oTemplate = Template::model()->findByAttributes(['name' => $templatename]);
             if ($oTemplate) {
                 if ($oTemplate->delete()) {
-                    return TemplateConfiguration::model()->deleteAll(
+                    $count = TemplateConfiguration::model()->deleteAll(
                         'template_name=:templateName',
                         [':templateName' => $templatename]
                     );
+                    /* Add the already deleted by findByAttributes */
+                    $count++;
+                    return $count;
                 }
             }
         }

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -885,18 +885,20 @@ class TemplateConfig extends CActiveRecord
     /**
      * Uninstalls all surveythemes that are being extended from the supplied surveytheme name
      * @param $templateName
-     * @return void
+     * @return bool
      * @throws CDbException
      */
-    public static function uninstallThemesRecursive($templateName): void
+    public static function uninstallThemesRecursive($templateName): bool
     {
         $extendedTemplates = Template::model()->findAll('extends=:templateName', [':templateName' => $templateName]);
         if (!empty($extendedTemplates)) {
             foreach ($extendedTemplates as $extendedTemplate) {
-                self::uninstallThemesRecursive($extendedTemplate->name);
+                if (!self::uninstallThemesRecursive($extendedTemplate->name)) {
+                    return false;
+                }
             }
         }
-        self::uninstall($templateName);
+        return boolval(self::uninstall($templateName));
     }
 
     /**
@@ -913,19 +915,29 @@ class TemplateConfig extends CActiveRecord
         // check compatibility with current limesurvey version
         $isCompatible = TemplateConfig::isCompatible($themePath);
         if ($isCompatible === false) {
-            self::uninstallThemesRecursive($themeName);
-            if ($redirect) {
-                if (method_exists(App(), 'setFlashMessage')) {
-                    App()->setFlashMessage(
-                        sprintf(
-                            gT("Theme '%s' has been uninstalled because it's not compatible with this LimeSurvey version."),
-                            $themeName
-                        ),
-                        'error'
-                    );
-                    App()->getController()->redirect(["themeOptions/index", "#" => "surveythemes"]);
+            if (self::uninstallThemesRecursive($themeName)) {
+                if ($redirect) {
+                    if (method_exists(App(), 'setFlashMessage')) {
+                        App()->setFlashMessage(
+                            sprintf(
+                                gT("Theme '%s' has been uninstalled because it's not compatible with this LimeSurvey version."),
+                                $themeName
+                            ),
+                            'error'
+                        );
+                        App()->getController()->redirect(["themeOptions/index", "#" => "surveythemes"]);
+                    }
+                    App()->end();
                 }
-                App()->end();
+            } else {
+                App()->setFlashMessage(
+                    sprintf(
+                        gT("The “%s” theme is not compatible with this LimeSurvey version. It could not be uninstalled. Please contact %s regarding this issue."),
+                        $themeName,
+                        App()->getConfig('siteadminname'),
+                    ),
+                    'error'
+                );
             }
         } elseif ((!$isCompatible) && $redirect) {
             App()->setFlashMessage(

--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -862,8 +862,12 @@ class TemplateConfig extends CActiveRecord
 
     /**
      * Uninstalls the selected surveytheme and deletes database entry and configuration
+     * Return value can be : 
+     *    - true : Template was uninstalled, No TemplateConfiguration were uninstalled
+     *    - integer : Template was unsintalled and tells how many TemplateConfigurations were uninstalled
+     *    - false : Template was not uninstalled : lack of permission Not template of this name, issue when delete.
      * @param string $templatename Name of Template
-     * @return bool|int, if false Template are not uninstalled, integr mean the number of TemplateConfiguration uninstalled
+     * @return bool|int
      * @throws CDbException
      */
     public static function uninstall($templatename)

--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -1225,8 +1225,6 @@ class TemplateConfiguration extends TemplateConfig
                 ),
                 'error'
             );
-            App()->getController()->redirect(array("themeOptions/index", "#" => "surveythemes"));
-            App()->end();
         } else {
             App()->setFlashMessage(
                 sprintf(
@@ -1237,6 +1235,8 @@ class TemplateConfiguration extends TemplateConfig
                 'error'
             );
         }
+        App()->getController()->redirect(array("themeOptions/index", "#" => "surveythemes"));
+        App()->end();
     }
 
     /**

--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -1217,16 +1217,26 @@ class TemplateConfiguration extends TemplateConfig
      */
     protected function uninstallIncorectTheme($sTemplateName)
     {
-        TemplateConfiguration::uninstall($sTemplateName);
-        App()->setFlashMessage(
-            sprintf(
-                gT("Theme '%s' has been uninstalled because it's not compatible with this LimeSurvey version."),
-                $sTemplateName
-            ),
-            'error'
-        );
-        App()->getController()->redirect(array("themeOptions/index", "#" => "surveythemes"));
-        App()->end();
+        if (TemplateConfiguration::uninstall($sTemplateName)) {
+            App()->setFlashMessage(
+                sprintf(
+                    gT("Theme '%s' has been uninstalled because it's not compatible with this LimeSurvey version."),
+                    $sTemplateName
+                ),
+                'error'
+            );
+            App()->getController()->redirect(array("themeOptions/index", "#" => "surveythemes"));
+            App()->end();
+        } else {
+            App()->setFlashMessage(
+                sprintf(
+                    gT("The “%s” theme is not compatible with this LimeSurvey version. It could not be uninstalled. Please contact %s regarding this issue."),
+                    $sTemplateName,
+                    App()->getConfig('siteadminname'),
+                ),
+                'error'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Dev: Do not redirect in case of issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the theme uninstall flow to detect unsuccessful removals and treat them as failures instead of continuing as if they succeeded.
  * Incompatible themes now show clearer error messaging when removal fails, rather than proceeding to the success redirect flow.
  * Recursive theme cleanup now stops on the first failure and reports an overall success/failure outcome.
  * Compatibility checks now return the actual computed result to keep subsequent decisions consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->