### PR TITLE
Fixed issue #20580: "Bootstrap buttons” layout does not display the input field when the built-in “Other” option is selected

### DIFF
--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/assets/scripts/bootstrapbuttons.js
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/assets/scripts/bootstrapbuttons.js
@@ -10,32 +10,33 @@
 
 $(document).ready(function () {
     // OTHER
-    $(".bootstrap-checkbox-other-value").each(function (index, element) {
-        name = $(this).data('name');
+    $(".button-checkbox-other-value").each(function (index, element) {
+        var myfname = $(this).data('name');
+        var baseName = myfname.replace(/_Cother$/, '');
         if ($(this).val()) {
             // "other" input field
-            $("#answer" + name).val($(this).val());
-            $("#" + name + "-div").removeClass('hide');
+            $("#answer" + baseName + "other").val($(this).val());
+            $("#" + baseName + "other-div").removeClass('d-none');
         }
         // execute validation
-        checkconditions($("#answer" + name).val(), name, this.type);
+        checkconditions($("#answer" + baseName + "other").val(), myfname, this.type);
     });
 
     $(".bootstrap-checkbox-other").change(function () {
-        name = $(this).data('name');
-        // conditionaly show or hide "other" input field
+        var name = $(this).data('name');
+        // conditionally show or hide "other" input field
         if ($(this).is(':checked')) {
             $("#" + name + "-div").removeClass('d-none');
         } else {
             $("#" + name + "-div").addClass('d-none');
-            $("#answer" + name + "othertext").val('');
+            $("#answer" + name).val('');
         }
     });
 
     $(".bootstrap-other-input").on('change keyup paste', function () {
-        name = $(this).data('name');
+        var name = $(this).data('name');
         if (!$(this).val()) {
-            $("#java" + name + "other").val('');
+            $("#java" + $(this).attr('name')).val('');
         }
         checkconditions(this.value, this.name, this.type);
     });

--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
@@ -25,7 +25,7 @@
                 type="checkbox"
                 name="{{myfname}}cbox"
                 id="answer{{myfname}}cbox"
-                data-name="{{myfname}}"
+                data-name="{{ name }}other"
                 {{checkedState}}
                 aria-hidden="true"
             />


### PR DESCRIPTION


<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “Other” choices in multiple-choice bootstrap buttons survey questions.
  * Selecting or clearing an “Other” option now updates the related input and visibility more reliably.
  * Fixed the way the “Other” checkbox is identified so responses are stored in the correct field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->