### PR TITLE
AT-2157: Clean Up Invalid React Props and Console Warnings

### DIFF
--- a/editor/src/App.js
+++ b/editor/src/App.js
@@ -58,7 +58,12 @@ function App() {
           persistOptions={persistOptions}
         >
           <I18Provider i18n={i18nInstance}>
-            <RouterProvider router={router} />
+            <RouterProvider
+              router={router}
+              future={{
+                v7_startTransition: true,
+              }}
+            />
           </I18Provider>
           <div className="d-none">
             {process.env.REACT_APP_RELEASE}@{process.env.REACT_APP_COMMIT_HASH}

--- a/editor/src/components/QuestionSettings/attributes/QuestionCodeAttribute.js
+++ b/editor/src/components/QuestionSettings/attributes/QuestionCodeAttribute.js
@@ -90,7 +90,6 @@ export const QuestionCodeAttribute = ({ value, update, disabled = false }) => {
             inputClass="d-block w-100"
             className="d-flex justify-content-between align-items-center w-100"
             noPermissionDisabled={true}
-            update={update}
             disabled={disabled}
           />
         </div>

--- a/editor/src/components/QuestionSettings/attributes/QuestionCodeAttribute.js
+++ b/editor/src/components/QuestionSettings/attributes/QuestionCodeAttribute.js
@@ -83,13 +83,8 @@ export const QuestionCodeAttribute = ({ value, update, disabled = false }) => {
             key={`${focused?.qid}-question-code-attribute`}
             onChange={handleOnChange}
             value={inputValue}
-            errorMessage={errorMessage}
-            dataTestId="question-code"
-            labelText="Question code"
-            labelClass="text-nowrap d-block m-1"
-            inputClass="d-block w-100"
+            data-testid="question-code"
             className="d-flex justify-content-between align-items-center w-100"
-            noPermissionDisabled={true}
             disabled={disabled}
           />
         </div>

--- a/editor/src/components/SideBar/SideBarPanelItem.js
+++ b/editor/src/components/SideBar/SideBarPanelItem.js
@@ -5,7 +5,7 @@ import { Form } from 'react-bootstrap'
 import { TooltipContainer } from 'components'
 import { useNavigate, useParams } from 'react-router-dom'
 
-export const SideBarPanelItem = ({ key, options, page }) => {
+export const SideBarPanelItem = ({ options, page }) => {
   const { panel, menu, surveyId } = useParams()
   const navigate = useNavigate()
 
@@ -29,7 +29,6 @@ export const SideBarPanelItem = ({ key, options, page }) => {
 
   return (
     <TooltipContainer
-      key={key}
       tip={options.disabledTip}
       showTip={options.disabled}
       placement="right"

--- a/editor/src/components/SideBar/SideBarRow.js
+++ b/editor/src/components/SideBar/SideBarRow.js
@@ -132,7 +132,6 @@ export const SideBarRow = ({
                 'rotate-270': !isOpen,
                 'd-none': !isQuestionGroup,
               })}
-              data-isOpen={isOpen}
             >
               <ArrowDownIcon />
             </Button>

--- a/editor/src/i18n/scripts/identifyAndReportMissingTranslations.js
+++ b/editor/src/i18n/scripts/identifyAndReportMissingTranslations.js
@@ -62,6 +62,12 @@ export async function identifyAndReportMissingTranslations(
       throw new Error('Failed to load translation strings')
     }
 
+    const contentType = response.headers.get('content-type')
+    if (!contentType || !contentType.includes('application/json')) {
+      // 'translationStrings.json is not a valid JSON file. Skipping missing translation check.'
+      return
+    }
+
     const translationStrings = await response.json()
 
     const storageKey = `i18next_res_${userLang}-translation`


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route transition handling for smoother navigation.
  * Made missing-translation checks more resilient when translation data isn’t returned in the expected format.
  * Fixed sidebar and question settings UI attributes to keep components more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->