### PR TITLE
LE-824: Implemented fix for the group import

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -637,7 +637,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
 
     // Update question code references in custom conditions and relevance expressions
     replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
-    replaceExpressionFieldnames($iNewSID, $aQIDReplacements);
+    replaceExpressionFieldnames($newgid, $aQIDReplacements);
 
     LimeExpressionManager::RevertUpgradeConditionsToRelevance($iNewSID);
     LimeExpressionManager::UpgradeConditionsToRelevance($iNewSID);

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -637,7 +637,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
 
     // Update question code references in custom conditions and relevance expressions
     replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
-    replaceExpressionFieldnames($iNewSID, $newgid, $aQIDReplacements);
+    replaceExpressionFieldnames($newgid, $aQIDReplacements);
 
     LimeExpressionManager::RevertUpgradeConditionsToRelevance($iNewSID);
     LimeExpressionManager::UpgradeConditionsToRelevance($iNewSID);

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -637,7 +637,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
 
     // Update question code references in custom conditions and relevance expressions
     replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
-    replaceExpressionFieldnames($newgid, $aQIDReplacements);
+    replaceExpressionFieldnames($iNewSID, $newgid, $aQIDReplacements);
 
     LimeExpressionManager::RevertUpgradeConditionsToRelevance($iNewSID);
     LimeExpressionManager::UpgradeConditionsToRelevance($iNewSID);

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -637,6 +637,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
 
     // Update question code references in custom conditions and relevance expressions
     replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
+    replaceExpressionFieldnames($iNewSID, $aQIDReplacements);
 
     LimeExpressionManager::RevertUpgradeConditionsToRelevance($iNewSID);
     LimeExpressionManager::UpgradeConditionsToRelevance($iNewSID);

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4219,12 +4219,12 @@ function replaceFieldnameMatches(string|null $haystack, string|int $rawNeedle, s
 /**
 * Replaces EM variable codes in a current survey with a new one
 *
-* @param integer $iSurveyID The survey ID
+* @param integer $iGroupID The group ID
 * @param mixed $aQIDReplacements The fieldmap array (old_field=>new_field)
 */
-function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
+function replaceExpressionFieldnames($iGroupID, $aQIDReplacements)
 {
-    $arQuestions = Question::model()->findAll("sid=:sid", array(':sid' => $iSurveyID));
+    $arQuestions = Question::model()->findAll("gid=:gid", array(':gid' => $iGroupID));
     foreach ($arQuestions as $arQuestion) {
         $relevance = $arQuestion->relevance;
         foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4266,9 +4266,6 @@ function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
             foreach ($defaultValue->defaultvaluel10ns as $defaultValueL10n) {
                 $d = $defaultValueL10n->defaultvalue;
                 foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
-                    if (strlen((string) $sOldCode) <= 1 || is_numeric($sOldCode)) {
-                        continue;
-                    }
                     $d = replaceFieldnameMatches($d, $sOldFieldname, $sNewFieldname);
                 }
                 if ($defaultValueL10n->defaultvalue !== $d) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4220,12 +4220,11 @@ function replaceFieldnameMatches(string|null $haystack, string|int $rawNeedle, s
 * Replaces EM variable codes in a current survey with a new one
 *
 * @param integer $iSurveyID The group ID
-* @param integer $iGroupID The group ID
 * @param mixed $aQIDReplacements The fieldmap array (old_field=>new_field)
 */
-function replaceExpressionFieldnames($iSurveyID, $iGroupID, $aQIDReplacements)
+function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
 {
-    $arQuestions = Question::model()->findAll("gid=:gid", array(':gid' => $iGroupID));
+    $arQuestions = Question::model()->findAll("gid=:gid", array(':gid' => $iSurveyID));
     foreach ($arQuestions as $arQuestion) {
         $relevance = $arQuestion->relevance;
         foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4246,7 +4246,6 @@ function replaceExpressionFieldnames($iSurveyID, $iGroupID, $aQIDReplacements)
             }
         }
         foreach ($arQuestion->questionl10ns as $arQuestionLS) {
-            $bModified = false;
             $q = $arQuestionLS->question;
             $h = $arQuestionLS->help;
             foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4200,6 +4200,118 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
     }
 }
 
+/**
+ * Replaces fieldnames in string with their counterparts
+ * @param string|null $haystack the string where the replace is to occur
+ * @param string|int $rawNeedle the qid of the value to be replaced
+ * @param string|int $rawReplace the qid of the value to replace the needle
+ * 
+ * @return string the changed string
+ */
+function replaceFieldnameMatches(string|null $haystack, string|int $rawNeedle, string|int $rawReplace)
+{
+    if (!$haystack) {
+        return false;
+    }
+    return preg_replace("/Q{$rawNeedle}(?!\d)/i", "Q{$rawReplace}", preg_replace("/S{$rawNeedle}(?!\d)/i", "S{$rawReplace}", $haystack));
+}
+
+/**
+* Replaces EM variable codes in a current survey with a new one
+*
+* @param integer $iSurveyID The survey ID
+* @param mixed $aQIDReplacements The fieldmap array (old_field=>new_field)
+*/
+function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
+{
+    $arQuestions = Question::model()->findAll("sid=:sid", array(':sid' => $iSurveyID));
+    foreach ($arQuestions as $arQuestion) {
+        $relevance = $arQuestion->relevance;
+        foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+            $relevance = replaceFieldnameMatches($relevance, $sOldFieldname, $sNewFieldname);
+        }
+        if ($relevance !== $arQuestion->relevance) {
+            $arQuestion->relevance = $relevance;
+        }
+        foreach ($arQuestion->conditions as $condition) {
+            $cfieldname = $condition->cfieldname;
+            foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+                $cfieldname = replaceFieldnameMatches($cfieldname, $sOldFieldname, $sNewFieldname);
+            }
+            if ($condition->cfieldname !== $cfieldname) {
+                $condition->cfieldname = $cfieldname;
+                $condition->save();
+            }
+        }
+        foreach ($arQuestion->questionl10ns as $arQuestionLS) {
+            $bModified = false;
+            $q = $arQuestionLS->question;
+            $h = $arQuestionLS->help;
+            foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+                $q = replaceFieldnameMatches($q, $sOldFieldname, $sNewFieldname);
+                $h = replaceFieldnameMatches($h, $sOldFieldname, $sNewFieldname);
+            }
+            if (($arQuestionLS->question !== $q) || ($arQuestionLS->help !== $h)) {
+                $arQuestionLS->question = $q;
+                $arQuestionLS->help = $h;
+                $arQuestionLS->save();
+            }
+        }
+        // Also apply on question's default values
+        $defaultValues = DefaultValue::model()->with('defaultvaluel10ns')->findAllByAttributes(['qid' => $arQuestion->qid]);
+        foreach ($defaultValues as $defaultValue) {
+            if (empty($defaultValue->defaultvaluel10ns)) {
+                continue;
+            }
+            foreach ($defaultValue->defaultvaluel10ns as $defaultValueL10n) {
+                $d = $defaultValueL10n->defaultvalue;
+                foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+                    if (strlen((string) $sOldCode) <= 1 || is_numeric($sOldCode)) {
+                        continue;
+                    }
+                    $d = replaceFieldnameMatches($d, $sOldFieldname, $sNewFieldname);
+                }
+                if ($defaultValueL10n->defaultvalue !== $d) {
+                    $defaultValueL10n->defaultvalue = $d;
+                    $defaultValueL10n->save();
+                }
+            }
+        }
+    }
+    $arGroups = QuestionGroup::model()->findAll("sid=:sid", array(':sid' => $iSurveyID));
+    foreach ($arGroups as $arGroup) {
+        $g = $arGroup->grelevance;
+        foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+            $g = replaceFieldnameMatches($g, $sOldFieldname, $sNewFieldname);
+        }
+        if ($arGroup->grelevance !== $g) {
+            $arGroup->grelevance = $g;
+            $arGroup->save();
+        }
+        foreach ($arGroup->questiongroupl10ns as $arQuestionGroupLS) {
+            $d = $arQuestionGroupLS->description;
+            foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+                $arQuestionGroupLS->description = replaceFieldnameMatches($d, $sOldFieldname, $sNewFieldname);
+            }
+            if ($arQuestionGroupLS->description !== $d) {
+                $arQuestionGroupLS->description = $d;
+                $arQuestionGroupLS->save();
+            }
+        }
+    }
+    // Apply the replacement on survey's end message
+    $surveyLanguageSettings = SurveyLanguageSetting::model()->findAllByAttributes(array('surveyls_survey_id' => $iSurveyID));
+    foreach ($surveyLanguageSettings as $surveyLanguageSetting) {
+        $se = $surveyLanguageSetting->surveyls_endtext;
+        foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
+            $se = replaceFieldnameMatches($se, $sOldFieldname, $sNewFieldname);
+        }
+        if ($surveyLanguageSetting->surveyls_endtext !== $se) {
+            $surveyLanguageSetting->surveyls_endtext = $se;
+            $surveyLanguageSetting->save();
+        }
+    }
+}
 
 /**
 * cleanLanguagesFromSurvey() removes any languages from survey tables that are not in the passed list

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4232,6 +4232,7 @@ function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
         }
         if ($relevance !== $arQuestion->relevance) {
             $arQuestion->relevance = $relevance;
+            $arQuestion->save();
         }
         foreach ($arQuestion->conditions as $condition) {
             $cfieldname = $condition->cfieldname;

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4219,10 +4219,11 @@ function replaceFieldnameMatches(string|null $haystack, string|int $rawNeedle, s
 /**
 * Replaces EM variable codes in a current survey with a new one
 *
+* @param integer $iSurveyID The group ID
 * @param integer $iGroupID The group ID
 * @param mixed $aQIDReplacements The fieldmap array (old_field=>new_field)
 */
-function replaceExpressionFieldnames($iGroupID, $aQIDReplacements)
+function replaceExpressionFieldnames($iSurveyID, $iGroupID, $aQIDReplacements)
 {
     $arQuestions = Question::model()->findAll("gid=:gid", array(':gid' => $iGroupID));
     foreach ($arQuestions as $arQuestion) {

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4289,7 +4289,7 @@ function replaceExpressionFieldnames($iSurveyID, $aQIDReplacements)
         foreach ($arGroup->questiongroupl10ns as $arQuestionGroupLS) {
             $d = $arQuestionGroupLS->description;
             foreach ($aQIDReplacements as $sOldFieldname => $sNewFieldname) {
-                $arQuestionGroupLS->description = replaceFieldnameMatches($d, $sOldFieldname, $sNewFieldname);
+                $d = replaceFieldnameMatches($d, $sOldFieldname, $sNewFieldname);
             }
             if ($arQuestionGroupLS->description !== $d) {
                 $arQuestionGroupLS->description = $d;


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved survey import finalization so Expression Manager field references are correctly remapped when question or group identifiers change.
  * Updates expression references across question relevance, condition fields, translated question text/help, and default values to preserve expected behavior.
  * Ensures related group and survey end-page expression references (including translated group descriptions and end text) remain consistent after import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->