### PR TITLE
AT-2160: Wrong representation of selected choices in MC Image and inability to change them in edit/view response modal

### DIFF
--- a/editor/src/components/QuestionTypes/ImageChoice.js
+++ b/editor/src/components/QuestionTypes/ImageChoice.js
@@ -21,6 +21,8 @@ export const ImageChoice = ({
   update,
   value,
   isNoAnswer,
+  groupName,
+  defaultChecked = false,
   errors,
   setErrors = () => {},
 }) => {
@@ -35,6 +37,7 @@ export const ImageChoice = ({
   const onChange = (filePath) => {
     update(encodeURI(filePath))
   }
+
   const onChangePreview = (previewUrl) => {
     setPreviewUrl(previewUrl)
   }
@@ -76,9 +79,11 @@ export const ImageChoice = ({
         {!isFocused && (
           <FormCheck
             type={inputType}
-            className="pointer-events-none"
             name={'image-choice-' + idSuffix}
             data-testid={'image-choice-' + idSuffix}
+            defaultChecked={defaultChecked}
+            groupName={groupName}
+            update={(value) => update(value)}
             label={
               <ContentEditor
                 className="choice"


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image choice behavior by preserving default selections and correctly grouping choice controls.
  * Restored expected interaction with image choice controls by allowing pointer interactions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->