### PR TITLE
Fixed issue #20532: STARTPOLICYLINK and ENDPOLICYLINK return errors in the survey logic view - v2

### DIFF
--- a/application/core/LS_Twig_Extension.php
+++ b/application/core/LS_Twig_Extension.php
@@ -376,12 +376,17 @@ class LS_Twig_Extension extends AbstractExtension
      * Get the parsed output of the expression manager for a specific string
      *
      * @param String $sInString
+     * @param array $replacementFields - optional replacement values
      * @return String
      */
-    public static function getExpressionManagerOutput($sInString)
+    public static function getExpressionManagerOutput($sInString, $replacementFields = [])
     {
-        templatereplace(flattenText($sInString));
-        return LimeExpressionManager::GetLastPrettyPrintExpression();
+        templatereplace(flattenText($sInString), $replacementFields);
+        $output = LimeExpressionManager::GetLastPrettyPrintExpression();
+        if (!empty($replacementFields)) {
+            LimeExpressionManager::unsetTempVars(array_keys($replacementFields));
+        }
+        return $output;
     }
 
     /**

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -8026,6 +8026,17 @@ class LimeExpressionManager
     }
 
     /**
+     * Unset the specified temporary variable replacements
+     */
+    public static function unsetTempVars(array $keys)
+    {
+        $LEM =& LimeExpressionManager::singleton();
+        foreach ($keys as $key) {
+            unset($LEM->tempVars[$key]);
+        }
+    }
+
+    /**
      * Unit test strings containing expressions
      */
     public static function UnitTestProcessStringContainingExpressions()
@@ -9331,8 +9342,9 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
             }
             if ($aSurveyInfo['surveyls_policy_notice_label'] != '') {
                 $LEM->em->ResetErrorsAndWarnings();
-                $LEM->ProcessString($aSurveyInfo['surveyls_policy_notice_label'], 0);
+                $LEM->ProcessString($aSurveyInfo['surveyls_policy_notice_label'], 0, ['STARTPOLICYLINK' => gT("Start of the link that opens the privacy policy popup"), 'ENDPOLICYLINK' => gT("End of the link that opens the privacy policy popup")]);
                 $sPrint = viewHelper::purified(viewHelper::filterScript($LEM->GetLastPrettyPrintExpression()));
+                LimeExpressionManager::unsetTempVars(['STARTPOLICYLINK', 'ENDPOLICYLINK']);
                 $errClass = "";
                 if ($LEM->em->HasErrors()) {
                     $errClass = 'danger';

--- a/application/views/admin/survey/subview/surveydashboard/002-surveytextpanel.twig
+++ b/application/views/admin/survey/subview/surveydashboard/002-surveytextpanel.twig
@@ -84,7 +84,7 @@
                             </div>
                             <div class="col-8 ls-card-grid__description">
                                 {% if surveyTextContent.surveyls_policy_notice_label != '' %}
-                                    {{getExpressionManagerOutput(surveyTextContent.surveyls_policy_notice_label)}}
+                                    {{getExpressionManagerOutput(surveyTextContent.surveyls_policy_notice_label, {'STARTPOLICYLINK': gT("Start of the link that opens the privacy policy popup"), 'ENDPOLICYLINK': gT("End of the link that opens the privacy policy popup")})}}
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed privacy policy notices so links are correctly inserted into translated survey labels.
  * Improved handling of temporary placeholder values to prevent them from affecting subsequent content.
  * Ensured localized privacy policy link text renders correctly in survey administration views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->