### PR TITLE
Fixed issue #LE-828: [security] XSS in user activation confirmation e…

### DIFF
--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -419,7 +419,7 @@ class UserManagementController extends LSBaseController
             throw new CHttpException(403, gT("You do not have permission to access this page."));
         }
         $userId = sanitize_int(Yii::app()->request->getParam('userid'));
-        $action = Yii::app()->request->getParam('action');
+        $action = Yii::app()->request->getParam('action', 'deactivate');
         if (!in_array($action, ['activate', 'deactivate'], true)) {
             throw new CHttpException(400, gT("Invalid action"));
         }

--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -396,6 +396,8 @@ class UserManagementController extends LSBaseController
         $action = Yii::app()->request->getParam('action');
 
         $userId = sanitize_int($userId);
+        // Only allow the two known actions
+        $action = in_array($action, ['activate', 'deactivate'], true) ? $action : 'deactivate';
 
         $aData['userId'] = $userId;
         $aData['action'] = $action;

--- a/application/controllers/UserManagementController.php
+++ b/application/controllers/UserManagementController.php
@@ -420,6 +420,9 @@ class UserManagementController extends LSBaseController
         }
         $userId = sanitize_int(Yii::app()->request->getParam('userid'));
         $action = Yii::app()->request->getParam('action');
+        if (!in_array($action, ['activate', 'deactivate'], true)) {
+            throw new CHttpException(400, gT("Invalid action"));
+        }
         $oUser = User::model()->findByPk($userId);
 
         if ($oUser == null) {

--- a/application/views/userManagement/partial/confirmuseractivation.php
+++ b/application/views/userManagement/partial/confirmuseractivation.php
@@ -24,7 +24,7 @@ if ($action == 'activate') {
 <div class="modal-footer">
     <?=TbHtml::formTb(null, App()->createUrl('userManagement/userActivateDeactivate'), 'post', ["id" => "UserManagement--modalform"])?>
         <input type="hidden" name="userid" value="<?= $userId ?>" />
-        <input type="hidden" name="action" value="<?= $action ?>" />
+        <input type="hidden" name="action" value="<?= CHtml::encode($action) ?>" />
         <button type="button"  class="btn btn-cancel" data-bs-dismiss="modal">&nbsp;<?php eT("Cancel"); ?></button>
         <button class="btn btn-primary">&nbsp;<?php eT("Save"); ?></button>
     <?php echo TbHtml::endForm() ?>


### PR DESCRIPTION
…ndpoint

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for user activation/deactivation requests so only valid actions are accepted; invalid values now result in an error response.
  * Improved safety when rendering the activation/deactivation confirmation form by HTML-encoding the submitted action value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->