### PR TITLE
Fix convert_value strict mode failing exact matches on decimals

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -2960,7 +2960,7 @@ function exprmgr_convert_value($fValueToReplace, $iStrict, $sTranslateFromList, 
                     return null;
                 }
                 $fCurrentDiff = abs($aFromValues[$i] - $fValueToReplace);
-                if ($fCurrentDiff === 0) {
+                if ($fCurrentDiff == 0) {
                     return $aToValues[$i];
                 } elseif ($i === 0) {
                     $fMinimumDiff = $fCurrentDiff;

--- a/tests/unit/helpers/ExpressionCoreFunctionsTest.php
+++ b/tests/unit/helpers/ExpressionCoreFunctionsTest.php
@@ -39,4 +39,40 @@ class ExpressionCoreFunctionsTest extends TestBaseClass
             $this->assertEquals(0, exprmgr_int($value), "{$value} is not an integer with exprmgr_int");
         }
     }
+
+    /**
+     * exprmgr_convert_value maps a value using from/to lists. An exact match must
+     * return the mapped value in strict mode, including for decimal scale points:
+     * abs() then yields a float 0.0, and in PHP `0.0 === 0` is false, which used to
+     * make strict mode return null for exact decimal matches.
+     *
+     * @group em
+     */
+    public function testConvertValueFunction()
+    {
+        // Exact decimal match in strict mode must return the mapped value
+        // (regression: previously returned null because abs() produced float 0.0).
+        $this->assertEquals(
+            "20",
+            exprmgr_convert_value(2.5, 1, "1.5,2.5,3.5", "10,20,30"),
+            "convert_value should map an exact decimal match in strict mode"
+        );
+        // Exact integer match in strict mode (was already working).
+        $this->assertEquals(
+            "20",
+            exprmgr_convert_value(2, 1, "1,2,3", "10,20,30"),
+            "convert_value should map an exact integer match in strict mode"
+        );
+        // No exact match in strict mode returns null.
+        $this->assertNull(
+            exprmgr_convert_value(2.4, 1, "1.5,2.5,3.5", "10,20,30"),
+            "convert_value strict mode returns null when there is no exact match"
+        );
+        // Non-strict mode returns the nearest mapped value.
+        $this->assertEquals(
+            "20",
+            exprmgr_convert_value(2.4, 0, "1.5,2.5,3.5", "10,20,30"),
+            "convert_value non-strict mode returns the nearest mapped value"
+        );
+    }
 }

--- a/tests/unit/helpers/ExpressionCoreFunctionsTest.php
+++ b/tests/unit/helpers/ExpressionCoreFunctionsTest.php
@@ -68,11 +68,5 @@ class ExpressionCoreFunctionsTest extends TestBaseClass
             exprmgr_convert_value(2.4, 1, "1.5,2.5,3.5", "10,20,30"),
             "convert_value strict mode returns null when there is no exact match"
         );
-        // Non-strict mode returns the nearest mapped value.
-        $this->assertEquals(
-            "20",
-            exprmgr_convert_value(2.4, 0, "1.5,2.5,3.5", "10,20,30"),
-            "convert_value non-strict mode returns the nearest mapped value"
-        );
     }
 }


### PR DESCRIPTION
## Problem

The Expression Manager function `convert_value(fValue, iStrict, fromList, toList)` — `exprmgr_convert_value()` in `application/helpers/expressions/em_core_helper.php` — walks the "from" list and short-circuits on an exact match:

```php
$fCurrentDiff = abs($aFromValues[$i] - $fValueToReplace);
if ($fCurrentDiff === 0) {
    return $aToValues[$i];
```

`abs()` on a subtraction involving any decimal operand returns a **float**, and in PHP `0.0 === 0` is **false** (strict `===` requires matching types). So for non-integer scale points the exact-match branch is silently skipped. In **strict mode** (`iStrict == 1`) there is no nearest-index fallback (`if ($iStrict != 1)` is false), so an exact decimal match returns **`null`** instead of the mapped value.

Integer lists are unaffected — `abs(2 - 2)` is int `0`, and `0 === 0` is true.

## Evidence (JS twin proves intent)

The client-side twin `LEMconvert_value` in `assets/packages/expressions/em_javascript.js` uses the identical `fCurrentDiff === 0`, but in JavaScript every number is a double so `0.0 === 0` is `true` and floats match correctly. The PHP port copied `=== 0` verbatim without accounting for PHP's strict typing — so the PHP evaluation diverges from the JS evaluation of the same expression.

## Reproduction

`convert_value(2.5, 1, "1.5,2.5,3.5", "10,20,30")` (strict; exact match on `2.5`, expected `"20"`):

| | result |
|---|---|
| before (`=== 0`) | `null` ❌ (float `0.0 !== 0`) |
| after (`== 0`) | `"20"` ✅ |

Integer case `convert_value(2, 1, "1,2,3", "10,20,30")` returns `"20"` in both versions — unchanged.

## Fix

```php
if ($fCurrentDiff == 0) {
```

`$fCurrentDiff` is always numeric (abs of a numeric subtraction), so `== 0` is true only for a genuine zero difference; this matches the JS twin's behavior for both int and float scale points.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed expression value conversion so strict matching reliably returns the expected mapped result for equivalent numeric inputs, including cases affected by decimal precision.
* **Tests**
  * Added unit test coverage for strict-mode value conversion, verifying exact-match behavior and confirming strict-mode returns `null` when no exact match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->