### PR TITLE
Fixed issue #20609: Admin notification url are not updated as link

### DIFF
--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -902,7 +902,7 @@ class LimeMailer extends PHPMailer
     }
 
     /**
-     * Do the replacements : if current replacement jey is set and LimeSurvey core have it too : it reset to the needed one.
+     * Do the replacements : if current replacement key is set and LimeSurvey core have it too : it reset to the needed one.
      * @param string $string where need to replace
      * @return string
      */
@@ -928,6 +928,8 @@ class LimeMailer extends PHPMailer
             $string = preg_replace("/{TOKEN:([A-Z0-9_]+)}/", "{" . "$1" . "}", $string);
         }
         $aReplacements = array_merge($aReplacements, $aTokenReplacements);
+        $aReplacements = array_merge($aReplacements, $this->aReplacements);
+        /* Replace URL placeholders for all replacements */
         foreach ($this->aUrlsPlaceholders as $urlPlaceholder) {
             if (!empty($aReplacements["{$urlPlaceholder}URL"])) {
                 $url = $aReplacements["{$urlPlaceholder}URL"];
@@ -937,7 +939,6 @@ class LimeMailer extends PHPMailer
                 }
             }
         }
-        $aReplacements = array_merge($aReplacements, $this->aReplacements);
         return LimeExpressionManager::ProcessString($string, null, $aReplacements, 3, 1, false, false, true);
     }
 

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -476,6 +476,16 @@ class LimeMailer extends PHPMailer
     }
 
     /**
+     * Add replacement to current one
+     * @param string[]
+     * @return void
+     */
+    public function addOrReplaceReplacement($replacements)
+    {
+        $this->aReplacements = array_merge($this->aReplacements, $replacements);
+    }
+
+    /**
      * Hate to use global var
      * maybe add format : raw (array of errors), html : clean html etc …
      * @param string $format (currently only html or null (return array))

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -476,11 +476,11 @@ class LimeMailer extends PHPMailer
     }
 
     /**
-     * Add replacement to current one
+     * Add and replace current expression replacement to current one
      * @param string[]
      * @return void
      */
-    public function addOrReplaceReplacement($replacements)
+    public function addAndReplaceReplacement($replacements)
     {
         $this->aReplacements = array_merge($this->aReplacements, $replacements);
     }

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -912,9 +912,13 @@ class LimeMailer extends PHPMailer
     }
 
     /**
-     * Do the replacements : if current replacement key is set and LimeSurvey core have it too : it reset to the needed one.
-     * @param string $string where need to replace
-     * @return string
+     * Do the replacements : by order
+     * 1. Core replacement (SID, ADMINNAME ...)
+     * 2. Token replacement (TOKEN:) and if needed FIRSTNAME, LASTNAME AND ATTRIBUTE_X
+     * 3. The aReplacements set by external function
+     * The aReplacements can replace core and token replacement (by key)
+     * @param string $string original string
+     * @return string updated by LimeExpressionManager
      */
     public function doReplacements($string)
     {

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -537,7 +537,6 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
                 $failedNotificationId = null;
                 $notificationRecipient = $sRecipient;
                 $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
-                $mailer->aReplacements = $aReplacementVars;
                 $mailer->setTo($notificationRecipient);
                 $mailerSuccess = $mailer->SendMessage();
             }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -517,12 +517,10 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
         );
     }
 
-    // update replacement fields before we handle email sending
-    LimeExpressionManager::updateReplacementFields($aReplacementVars);
-
     // admin_notification (Basic admin notification)
     if (count($aEmailNotificationTo) > 0) {
         $mailer = LimeMailer::getInstance();
+        $mailer->addOrReplaceReplacement($aReplacementVars);
         $mailer->setTypeWithRaw('admin_notification', $emailLanguage);
         foreach ($aEmailNotificationTo as $sRecipient) {
             /** set mailer params for @see FailedEmailController::actionResend() */
@@ -531,16 +529,15 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
                 $responseId = $sRecipient['responseId'];
                 $notificationRecipient = $sRecipient['recipient'];
                 $emailLanguage = $sRecipient['language'];
-                $aReplacementVars['ANSWERTABLE'] = getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML);
-                LimeExpressionManager::updateReplacementFields($aReplacementVars);
+                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTypeWithRaw('admin_notification', $emailLanguage);
                 $mailer->setTo($notificationRecipient);
                 $mailerSuccess = $mailer->resend(json_decode((string) $sRecipient['resendVars'], true));
             } else {
                 $failedNotificationId = null;
                 $notificationRecipient = $sRecipient;
-                $aReplacementVars['ANSWERTABLE'] = getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML);
-                LimeExpressionManager::updateReplacementFields($aReplacementVars);
+                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
+                $mailer->aReplacements = $aReplacementVars;
                 $mailer->setTo($notificationRecipient);
                 $mailerSuccess = $mailer->SendMessage();
             }
@@ -573,6 +570,7 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
         }
         $mailer = \LimeMailer::getInstance();
         $mailer->setTypeWithRaw('admin_responses', $emailLanguage);
+        $mailer->addOrReplaceReplacement($aReplacementVars);
         foreach ($aEmailResponseTo as $sRecipient) {
             /** set mailer params for @see FailedEmailController::actionResend() */
             if (!empty($emails)) {
@@ -580,16 +578,14 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
                 $responseId = $sRecipient['responseId'];
                 $responseRecipient = $sRecipient['recipient'];
                 $emailLanguage = $sRecipient['language'];
-                $aReplacementVars['ANSWERTABLE'] = getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML);
-                LimeExpressionManager::updateReplacementFields($aReplacementVars);
+                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTypeWithRaw('admin_responses', $emailLanguage);
                 $mailer->setTo($responseRecipient);
                 $mailerSuccess = $mailer->resend(json_decode((string) $sRecipient['resendVars'], true));
             } else {
                 $failedNotificationId = null;
                 $responseRecipient = $sRecipient;
-                $aReplacementVars['ANSWERTABLE'] = getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML);
-                LimeExpressionManager::updateReplacementFields($aReplacementVars);
+                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTo($responseRecipient);
                 $mailerSuccess = $mailer->SendMessage();
             }

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -520,7 +520,7 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
     // admin_notification (Basic admin notification)
     if (count($aEmailNotificationTo) > 0) {
         $mailer = LimeMailer::getInstance();
-        $mailer->addOrReplaceReplacement($aReplacementVars);
+        $mailer->addAndReplaceReplacement($aReplacementVars);
         $mailer->setTypeWithRaw('admin_notification', $emailLanguage);
         foreach ($aEmailNotificationTo as $sRecipient) {
             /** set mailer params for @see FailedEmailController::actionResend() */
@@ -529,14 +529,14 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
                 $responseId = $sRecipient['responseId'];
                 $notificationRecipient = $sRecipient['recipient'];
                 $emailLanguage = $sRecipient['language'];
-                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
+                $mailer->addAndReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTypeWithRaw('admin_notification', $emailLanguage);
                 $mailer->setTo($notificationRecipient);
                 $mailerSuccess = $mailer->resend(json_decode((string) $sRecipient['resendVars'], true));
             } else {
                 $failedNotificationId = null;
                 $notificationRecipient = $sRecipient;
-                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
+                $mailer->addAndReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTo($notificationRecipient);
                 $mailerSuccess = $mailer->SendMessage();
             }
@@ -569,7 +569,7 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
         }
         $mailer = \LimeMailer::getInstance();
         $mailer->setTypeWithRaw('admin_responses', $emailLanguage);
-        $mailer->addOrReplaceReplacement($aReplacementVars);
+        $mailer->addAndReplaceReplacement($aReplacementVars);
         foreach ($aEmailResponseTo as $sRecipient) {
             /** set mailer params for @see FailedEmailController::actionResend() */
             if (!empty($emails)) {
@@ -577,14 +577,14 @@ function sendSubmitNotifications($surveyid, array $emails = [], bool $return = f
                 $responseId = $sRecipient['responseId'];
                 $responseRecipient = $sRecipient['recipient'];
                 $emailLanguage = $sRecipient['language'];
-                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
+                $mailer->addAndReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTypeWithRaw('admin_responses', $emailLanguage);
                 $mailer->setTo($responseRecipient);
                 $mailerSuccess = $mailer->resend(json_decode((string) $sRecipient['resendVars'], true));
             } else {
                 $failedNotificationId = null;
                 $responseRecipient = $sRecipient;
-                $mailer->addOrReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
+                $mailer->addAndReplaceReplacement(['ANSWERTABLE' => getResponseTableReplacement($surveyid, $responseId, $emailLanguage, $bIsHTML)]);
                 $mailer->setTo($responseRecipient);
                 $mailerSuccess = $mailer->SendMessage();
             }


### PR DESCRIPTION
Dev: move URL placeholders replacements at end

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of custom URL placeholders in email templates so replacement values are applied before converting resolved URLs into HTML links.
  * Refined admin notification and admin response email rendering so per-recipient placeholders (including response table content) are applied reliably during mail merge.
* **New Features**
  * Added a helper to merge replacement values into email templates for consistent placeholder resolution.
* **Refactor**
  * Streamlined the mail-merge workflow to apply shared placeholder data once, then apply per-recipient overrides only when needed.
* **Documentation**
  * Corrected a comment typo related to replacement-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->