### PR TITLE
Fixed issue #AT-2185: Bulk actions partially broken on central participants table

### DIFF
--- a/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
+++ b/application/extensions/admin/grid/MassiveActionsWidget/assets/listActions.js
@@ -25,6 +25,31 @@ function syncMassiveActionResultsTableCaption($modal, $container) {
 }
 
 /**
+ * Safely resolve a dotted global path (e.g. "LS.CPDB.onClickExport") to a callable,
+ * bound to its immediate parent object so method context is preserved.
+ * Used for the 'custom-js' and 'on-success' action callbacks so we avoid eval().
+ *
+ * @param {string} path  Dotted path to a function, resolved from window (e.g. "LS.AjaxHelper.onSuccess").
+ * @return {Function|null}  The bound function, or null if the path does not resolve to a function.
+ */
+function resolveActionCallback(path) {
+    if (typeof path !== 'string' || path === '') {
+        return null;
+    }
+    var parts = path.split('.');
+    var context = null;
+    var current = window;
+    for (var i = 0; i < parts.length; i++) {
+        if (current == null || typeof current[parts[i]] === 'undefined') {
+            return null;
+        }
+        context = current;
+        current = current[parts[i]];
+    }
+    return typeof current === 'function' ? current.bind(context) : null;
+}
+
+/**
  * Define what happen when an action is clicked:
  *
  * - redirection:
@@ -124,7 +149,7 @@ var onClickListAction =  function (e) {
      */
     if (actionType == 'custom') {
         var js = $that.data('custom-js');
-        var func = typeof window[js] === 'function' ? window[js] : null;
+        var func = resolveActionCallback(js);
         var itemIds = LS.gridSelection.getAll($grididvalue);
         if (func) { func(itemIds); }
         console.log('func itemIds');
@@ -266,7 +291,7 @@ var onClickListAction =  function (e) {
                 }
 
                 if (onSuccess) {
-                    var func = typeof window[onSuccess] === 'function' ? window[onSuccess] : null;
+                    var func = resolveActionCallback(onSuccess);
                     if (func) { func(html); }
                     return;
                 }

--- a/application/views/admin/participants/massive_actions/_selector.php
+++ b/application/views/admin/participants/massive_actions/_selector.php
@@ -17,7 +17,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
                 'iconClasses' => 'ri-delete-bin-fill text-danger',
                 'text' => gT('Delete'),
                 'grid-reload' => 'yes',
-                'on-success' => "(function(result) { LS.AjaxHelper.onSuccess(result); })",
+                'on-success' => 'LS.AjaxHelper.onSuccess',
 
                 // Modal
                 'actionType' => 'modal',
@@ -66,7 +66,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
                 'grid-reload' => 'no',
 
                 'actionType' => 'custom',
-                'custom-js' => '(function(itemIds) { LS.CPDB.onClickExport(itemIds); })'
+                'custom-js' => 'LS.CPDB.onClickExport'
             ],
             [
                 'type' => 'action',
@@ -77,7 +77,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
                 'grid-reload' => 'no',
 
                 'actionType' => 'custom',
-                'custom-js' => '(function(itemIds) { LS.CPDB.shareMassiveAction(itemIds); })'
+                'custom-js' => 'LS.CPDB.shareMassiveAction'
             ],
             [
                 'type' => 'action',
@@ -88,7 +88,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
                 'grid-reload' => 'no',
 
                 'actionType' => 'custom',
-                'custom-js' => '(function(itemIds) { LS.CPDB.addParticipantToSurvey(itemIds); })'
+                'custom-js' => 'LS.CPDB.addParticipantToSurvey'
             ]
 
         ],

--- a/application/views/admin/participants/massive_actions/_selector_attribute.php
+++ b/application/views/admin/participants/massive_actions/_selector_attribute.php
@@ -17,7 +17,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
             'iconClasses' => 'ri-delete-bin-fill text-danger',
             'text'        =>  gT('Delete'),
             'grid-reload' => 'yes',
-            'on-success'  => "(function(result) { LS.AjaxHelper.onSuccess(result); })",
+            'on-success'  => 'LS.AjaxHelper.onSuccess',
 
             // Modal
             'actionType'    => 'modal',

--- a/application/views/admin/participants/massive_actions/_selector_share.php
+++ b/application/views/admin/participants/massive_actions/_selector_share.php
@@ -17,7 +17,7 @@ $this->widget('ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget', array(
             'iconClasses' => 'ri-delete-bin-fill text-danger',
             'text'        =>  gT('Delete'),
             'grid-reload' => 'yes',
-            'on-success'  => "(function(result) { LS.AjaxHelper.onSuccess(result); })",
+            'on-success'  => 'LS.AjaxHelper.onSuccess',
 
             // Modal
             'actionType'    => 'modal',


### PR DESCRIPTION
Fixed issue #AT-2185: Bulk actions partially broken on central participants table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mass-action callback handling for nested callback references.
  * Invalid or unavailable callbacks are now safely ignored instead of causing errors.
  * Preserved callback context when executing custom actions and AJAX success handlers.

* **Refactor**
  * Updated participant management actions to use direct callback references for deletion, export, sharing, and survey actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->