### PR TITLE
Fixed issue #20392: invalid URL placeholders when using hostInfo or baseUrl and publicurl

### DIFF
--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -47,11 +47,27 @@ trait LSApplicationTrait
     public function createPublicUrl($route, $params = array(), $schema = '', $ampersand = '&')
     {
         $sPublicUrl = $this->getPublicBaseUrl(true);
-        $sActualBaseUrl = $this->getBaseUrl(true);
-        if ($sPublicUrl !== $sActualBaseUrl) {
+        $sActualAbsoluteBaseUrl = $this->getBaseUrl(true);
+        if ($sPublicUrl !== $sActualAbsoluteBaseUrl) {
+            /* @var string keep current baseUrl */
+            $sActualBaseUrl = $this->getBaseUrl(false);
+            /* @var string keep current hostInfo */
+            $sActualhostInfo = $this->getRequest()->getHostInfo();
+            /* Set hostInfo to empty and baseUrl according to showScriptName (needed) */
+            if ($this->getUrlManager()->showScriptName) {
+                $this->getUrlManager()->setBaseUrl("/index.php");
+            } else {
+                $this->getUrlManager()->setBaseUrl("");
+            }
+            $this->getRequest()->setHostInfo("");
+            /* @var string the url */
             $url = $this->createAbsoluteUrl($route, $params, $schema, $ampersand);
-            if (substr((string)$url, 0, strlen((string)$sActualBaseUrl)) == $sActualBaseUrl) {
-                $url = substr((string)$url, strlen((string)$sActualBaseUrl));
+            /* Reset baseUrl and hostInfo to previous one */
+            $this->getUrlManager()->setBaseUrl($sActualBaseUrl);
+            $this->getRequest()->setHostInfo($sActualhostInfo);
+            /* Replace Yii public uirl by publicuirl set in config */
+            if (substr((string)$url, 0, strlen((string)$sActualAbsoluteBaseUrl)) == $sActualAbsoluteBaseUrl) {
+                $url = substr((string)$url, strlen((string)$sActualAbsoluteBaseUrl));
             }
             return trim((string)$sPublicUrl, "/") . $url;
         } else {

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -49,11 +49,11 @@ trait LSApplicationTrait
         $sPublicUrl = $this->getPublicBaseUrl(true);
         $sActualAbsoluteBaseUrl = $this->getBaseUrl(true);
         if ($sPublicUrl !== $sActualAbsoluteBaseUrl) {
-            /* @var string keep current baseUrl */
-            $sActualBaseUrl = $this->getBaseUrl(false);
+            /* @var string keep current urlmanager baseUrl */
+            $sActualBaseUrl = $this->getUrlManager()->getBaseUrl(false);
             /* @var string keep current hostInfo */
             $sActualhostInfo = $this->getRequest()->getHostInfo();
-            /* Set hostInfo to empty and baseUrl according to showScriptName (needed) */
+            /* Set hostInfo to empty and baseUrl according to showScriptName (@see CUrlManager::getBaseUrl) */
             if ($this->getUrlManager()->showScriptName) {
                 $this->getUrlManager()->setBaseUrl("/index.php");
             } else {
@@ -65,7 +65,7 @@ trait LSApplicationTrait
             /* Reset baseUrl and hostInfo to previous one */
             $this->getUrlManager()->setBaseUrl($sActualBaseUrl);
             $this->getRequest()->setHostInfo($sActualhostInfo);
-            /* Replace Yii public uirl by publicuirl set in config */
+            /* Replace Yii public url by publicuirl set in config */
             if (substr((string)$url, 0, strlen((string)$sActualAbsoluteBaseUrl)) == $sActualAbsoluteBaseUrl) {
                 $url = substr((string)$url, strlen((string)$sActualAbsoluteBaseUrl));
             }

--- a/application/core/Traits/LSApplicationTrait.php
+++ b/application/core/Traits/LSApplicationTrait.php
@@ -38,6 +38,7 @@ trait LSApplicationTrait
 
     /**
      * Creates an absolute URL based on the given controller and action information.
+     * Check publicurl from config to get the final url
      * @param string $route the URL route. This should be in the format of 'ControllerID/ActionID'.
      * @param array $params additional GET parameters (name=>value). Both the name and value will be URL-encoded.
      * @param string $schema schema to use (e.g. http, https). If empty, the schema used for the current request will be used.
@@ -46,8 +47,11 @@ trait LSApplicationTrait
      */
     public function createPublicUrl($route, $params = array(), $schema = '', $ampersand = '&')
     {
+        /* @var string the base public url set by config or not */
         $sPublicUrl = $this->getPublicBaseUrl(true);
+        /* @var string the base public url without config */
         $sActualAbsoluteBaseUrl = $this->getBaseUrl(true);
+        /* If it's different : update */
         if ($sPublicUrl !== $sActualAbsoluteBaseUrl) {
             /* @var string keep current urlmanager baseUrl */
             $sActualBaseUrl = $this->getUrlManager()->getBaseUrl(false);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" stderr="true" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="tests/bootstrap.php"
+    stderr="true"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    stopOnFailure="false">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">application/models/services</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
     stderr="true"
     colors="true"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-    stopOnFailure="false">
+    >
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">application/models/services</directory>

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -23,10 +23,8 @@ class TestHelper extends TestCase
     protected static $tmpPublicUrl;
     /* @var string keep request->baseUrl */
     protected static $tmpBaseUrl;
-    /* @var boolean keep App()->urlmanager->showScriptName */
-    protected static $tmpShowScriptName;
-    /* @var string keep App()->urlmanager->urlFormat */
-    protected static $tmpUrlFormat;
+    /* @var \CUrlManager|null keep App()->urlmanager */
+    protected static $originalUrlManager;
     /* @var string keep App()->request->hostInfo */
     protected static $tmpHostInfo;
 
@@ -552,21 +550,23 @@ class TestHelper extends TestCase
     {
         self::$tmpPublicUrl = Yii::app()->getConfig('publicurl');
         self::$tmpBaseUrl = Yii::app()->getRequest()->baseUrl;
-        self::$tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
-        self::$tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
         self::$tmpHostInfo = Yii::app()->getRequest()->hostInfo;
+        self::$originalUrlManager = Yii::app()->getUrlManager();
     }
 
     /**
      * Set config and component to expected default
      */
-    public static function setToExpectedDefault()
+    public static function setUrlToExpectedDefault($urlFormat = \CUrlManager::PATH_FORMAT)
     {
         Yii::app()->setConfig('publicurl', null);
-        Yii::app()->getRequest()->baseUrl = '';
-        Yii::app()->getUrlManager()->showScriptName = true;
-        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::PATH_FORMAT;
-        // TODO what is the expected hostInfo
+        $urlManager = [
+            'urlFormat' => $urlFormat,
+            'rules' => require(APPPATH . 'config/routes.php'),
+            'showScriptName' => true,
+        ];
+        Yii::app()->setComponent('urlManager', null); // Be sure to reset component
+        Yii::app()->setComponent('urlManager', $urlManager);
     }
 
     /**
@@ -576,8 +576,8 @@ class TestHelper extends TestCase
     {
         Yii::app()->setConfig('publicurl', self::$tmpPublicUrl);
         Yii::app()->getRequest()->baseUrl = self::$tmpBaseUrl;
-        Yii::app()->getUrlManager()->showScriptName = self::$tmpShowScriptName;
-        Yii::app()->getUrlManager()->urlFormat = self::$tmpUrlFormat;
         Yii::app()->getRequest()->hostInfo = self::$tmpHostInfo;
+        Yii::app()->setComponent('urlManager', null); // Be sure to reset component
+        Yii::app()->setComponent('urlManager', self::$originalUrlManager);
     }
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -19,6 +19,17 @@ use SurveyActivator;
 
 class TestHelper extends TestCase
 {
+    /* @var string keep publicurl */
+    protected static $tmpPublicUrl;
+    /* @var string keep request->baseUrl */
+    protected static $tmpBaseUrl;
+    /* @var boolean keep App()->urlmanager->showScriptName */
+    protected static $tmpShowScriptName;
+    /* @var string keep App()->urlmanager->urlFormat */
+    protected static $tmpUrlFormat;
+    /* @var string keep App()->request->hostInfo */
+    protected static $tmpHostInfo;
+
     /**
      * Import all helpers etc.
      * @return void
@@ -532,5 +543,41 @@ class TestHelper extends TestCase
         $property = $reflection->getProperty('_hostInfo');
         $property->setAccessible(true);
         $property->setValue(Yii::app()->getRequest(), null);
+    }
+
+    /**
+     * Save url generation configuration
+     */
+    public static function saveUrlSettings()
+    {
+        self::$tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        self::$tmpBaseUrl = Yii::app()->getRequest()->baseUrl;
+        self::$tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
+        self::$tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
+        self::$tmpHostInfo = Yii::app()->getRequest()->hostInfo;
+    }
+
+    /**
+     * Set config and component to expected default
+     */
+    public static function setToExpectedDefault()
+    {
+        Yii::app()->setConfig('publicurl', null);
+        Yii::app()->getRequest()->baseUrl = '';
+        Yii::app()->getUrlManager()->showScriptName = true;
+        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::PATH_FORMAT;
+        // TODO what is the expected hostInfo
+    }
+
+    /**
+     * Reset url generation configuration
+     */
+    public static function resetUrlSettings()
+    {
+        Yii::app()->setConfig('publicurl', self::$tmpPublicUrl);
+        Yii::app()->getRequest()->baseUrl = self::$tmpBaseUrl;
+        Yii::app()->getUrlManager()->showScriptName = self::$tmpShowScriptName;
+        Yii::app()->getUrlManager()->urlFormat = self::$tmpUrlFormat;
+        Yii::app()->getRequest()->hostInfo = self::$tmpHostInfo;
     }
 }

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -9,20 +9,54 @@ use Yii;
  */
 class LSYiiApplicationTest extends TestBaseClass
 {
+    /* @var string keep publicurl */
+    protected static $tmpPublicUrl;
+    /* @var string keep request->baseUrl */
+    protected static $tmpBaseUrl;
+    /* @var boolean keep App()->urlmanager->showScriptName */
+    protected static $tmpShowScriptName;
+    /* @var string keep App()->urlmanager->urlFormat */
+    protected static $tmpUrlFormat;
+    /* @var string keep App()->request->hostInfo */
+    protected static $tmpHostInfo;
+    /**
+     * @inheritdoc
+     * Set the static var for resetting after
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        self::$tmpBaseUrl = Yii::app()->getRequest()->baseUrl;
+        self::$tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
+        self::$tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
+        self::$tmpHostInfo = Yii::app()->getRequest()->hostInfo;
+        self::setToExpectedDefault();
+    }
+
+    /**
+     * Set config and component to expected default
+     */
+    public static function setToExpectedDefault()
+    {
+        Yii::app()->setConfig('publicurl', null);
+        Yii::app()->getRequest()->baseUrl = '';
+        Yii::app()->getUrlManager()->showScriptName = true;
+        Yii::app()->getUrlManager()->urlFormat = 'path';
+        // TODO what is the expected hostInfo
+    }
+
     /**
      * Get public base url, previously set in publicurl config attribute.
      */
     public function testGetpublicBaseUrlFromConfig()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
-
         Yii::app()->setConfig('publicurl', 'http://config.example.com/');
         $url = Yii::app()->getPublicBaseUrl();
 
-        $this->assertSame($url, 'http://config.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+        $this->assertSame('http://config.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        // Reset original value.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        self::setToExpectedDefault();
     }
 
     /**
@@ -30,15 +64,10 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetAbsolutepublicBaseUrlFromConfig()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
-
         Yii::app()->setConfig('publicurl', 'http://absoluteConfig.example.com/');
         $url = Yii::app()->getPublicBaseUrl(true);
-
-        $this->assertSame($url, 'http://absoluteConfig.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
-
-        // Reset original value.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        $this->assertSame('http://absoluteConfig.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
+        self::setToExpectedDefault();
     }
 
     /**
@@ -46,15 +75,10 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromRequest()
     {
-        $tmpPublicUrl = Yii::app()->getRequest()->getBaseUrl();
-
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
-
-        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
-
-        // Reset original value.
-        Yii::app()->getRequest()->baseUrl = $tmpPublicUrl;
+        $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
+        self::setToExpectedDefault();
     }
 
     /**
@@ -62,37 +86,28 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetAbsolutepublicBaseUrlFromRequest()
     {
-        $tmpPublicUrl = Yii::app()->getRequest()->getBaseUrl();
-
         Yii::app()->getRequest()->baseUrl = '/absoluteRequest';
         $url = Yii::app()->getPublicBaseUrl(true);
 
         $this->assertSame('http://localhost/absoluteRequest', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-
-        // Reset original value.
-        Yii::app()->getRequest()->baseUrl = $tmpPublicUrl;
+        self::setToExpectedDefault();
     }
 
     /**
      * Get public base url, previously set in baseUrl request attribute.
      * A public url is also set in the baseUrl config attribute,
-     * but the one in the request attribute should be returned.
+     * getPublicBaseUrl must always return publicurl.
      */
     public function testGetpublicBaseUrlFromConfigNoSchemeInConfigPublicUrl()
     {
-        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
-        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
-
         // No scheme in url.
         Yii::app()->setConfig('publicurl', '//config.example.com/path?param=1');
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
 
-        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+        $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        // Restore original values.
-        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
-        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+        self::setToExpectedDefault();
     }
 
     /**
@@ -102,18 +117,13 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromConfigNoHostInConfigPublicUrl()
     {
-        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
-        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
-
         Yii::app()->setConfig('publicurl', 'http://');
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
 
-        $this->assertSame($url, 'http://request.example.com/', 'Unexpected url. The url does not correspond to the one previously set.');
+        $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        // Restore original values.
-        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
-        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+        self::setToExpectedDefault();
     }
 
     /**
@@ -121,10 +131,6 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithARoute()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
-        $tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
-        $tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
-
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
 
         Yii::app()->getUrlManager()->urlFormat = 'path';
@@ -145,10 +151,7 @@ class LSYiiApplicationTest extends TestBaseClass
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
 
-        // Restore original values.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
-        Yii::app()->getUrlManager()->showScriptName = $tmpShowScriptName;
-        Yii::app()->getUrlManager()->urlFormat = $tmpUrlFormat;
+        self::setToExpectedDefault();
     }
 
     /**
@@ -156,17 +159,13 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithParams()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
-
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
         $parameters = array('param_one' => 1, 'param_two' => 2);
         $url = Yii::app()->createPublicUrl('controller/action', $parameters);
 
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action', $parameters);
-        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+        $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
-        // Restore original values.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        self::setToExpectedDefault();
     }
 
     /**
@@ -174,9 +173,6 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithASchema()
     {
-        $tmpConfigPublicUrl = Yii::app()->getConfig('publicurl');
-        $tmpRequestPublicUrl = Yii::app()->getRequest()->getBaseUrl();
-
         Yii::app()->setConfig('publicurl', 'http://www.example.com');
         Yii::app()->getRequest()->baseUrl = 'www.example.com';
         Yii::app()->getRequest()->hostInfo = '';
@@ -184,12 +180,24 @@ class LSYiiApplicationTest extends TestBaseClass
         $parameters = array('param_one' => 1, 'param_two' => 2);
         $url = Yii::app()->createPublicUrl('controller/action', $parameters, 'http');
 
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action', $parameters);
-        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
+        $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
-        // Restore original values.
-        Yii::app()->setConfig('publicurl', $tmpConfigPublicUrl);
-        Yii::app()->getRequest()->baseUrl = $tmpRequestPublicUrl;
+        self::setToExpectedDefault();
+    }
+
+    /**
+     * @inheritdoc
+     * And reset request
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        Yii::app()->setConfig('publicurl', self::$tmpPublicUrl);
+        Yii::app()->getRequest()->baseUrl = self::$tmpBaseUrl;
+        Yii::app()->getUrlManager()->showScriptName = self::$tmpShowScriptName;
+        Yii::app()->getUrlManager()->urlFormat = self::$tmpUrlFormat;
+        Yii::app()->getRequest()->hostInfo = self::$tmpHostInfo;
+        /* This set hostinfo to null (unsure needed) */
         self::$testHelper->resetHostInfo();
     }
 }

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -122,15 +122,23 @@ class LSYiiApplicationTest extends TestBaseClass
     public function testCreatePublicUrlWithARoute()
     {
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        $tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
 
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
-        $url = Yii::app()->createPublicUrl('controller/action');
 
+        Yii::app()->getUrlManager()->showScriptName = true;
+        $url = Yii::app()->createPublicUrl('controller/action');
         $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route.');
+        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName.');
+
+        Yii::app()->getUrlManager()->showScriptName = false;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
+        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        Yii::app()->getUrlManager()->showScriptName = $tmpShowScriptName;
     }
 
     /**

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -116,6 +116,7 @@ class LSYiiApplicationTest extends TestBaseClass
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
         /* Deactivate urlFormat => 'get', TODO fix it, work locally, not on github */
+        /**
         Yii::app()->getUrlManager()->urlFormat = \CUrlManager::GET_FORMAT;
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
@@ -124,7 +125,7 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
-
+        **/
         self::$testHelper::setToExpectedDefault();
     }
 

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -124,6 +124,10 @@ class LSYiiApplicationTest extends TestBaseClass
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         $tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
         $tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
+        $tmpScriptUrl = Yii::app()->getRequest()->getScriptUrl();
+
+        /* Url manager always use index for public url, we use index-test.php in test */
+        Yii::app()->getRequest()->setScriptUrl("index.php");
 
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
 
@@ -152,7 +156,8 @@ class LSYiiApplicationTest extends TestBaseClass
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
         Yii::app()->getUrlManager()->showScriptName = $tmpShowScriptName;
-        Yii::app()->getUrlManager()->showScriptName = $tmpUrlFormat;
+        Yii::app()->getUrlManager()->urlFormat = $tmpUrlFormat;
+        Yii::app()->getRequest()->setScriptUrl($tmpScriptUrl);
     }
 
     /**

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -124,40 +124,31 @@ class LSYiiApplicationTest extends TestBaseClass
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         $tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
         $tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
-        $tmpScriptUrl = Yii::app()->getRequest()->getScriptUrl();
-
-        /* Url manager always use index for public url, we use index-test.php in test */
-        Yii::app()->getRequest()->setScriptUrl("index.php");
 
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
 
         Yii::app()->getUrlManager()->urlFormat = 'path';
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
+        $this->assertSame('http://www.example.com/index.php/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
 
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
+        $this->assertSame('http://www.example.com/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
 
         Yii::app()->getUrlManager()->urlFormat = 'get';
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
+        $this->assertSame('http://www.example.com/index.php?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
 
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
-        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
+        $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
         Yii::app()->getUrlManager()->showScriptName = $tmpShowScriptName;
         Yii::app()->getUrlManager()->urlFormat = $tmpUrlFormat;
-        Yii::app()->getRequest()->setScriptUrl($tmpScriptUrl);
     }
 
     /**

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -9,16 +9,6 @@ use Yii;
  */
 class LSYiiApplicationTest extends TestBaseClass
 {
-    /* @var string keep publicurl */
-    protected static $tmpPublicUrl;
-    /* @var string keep request->baseUrl */
-    protected static $tmpBaseUrl;
-    /* @var boolean keep App()->urlmanager->showScriptName */
-    protected static $tmpShowScriptName;
-    /* @var string keep App()->urlmanager->urlFormat */
-    protected static $tmpUrlFormat;
-    /* @var string keep App()->request->hostInfo */
-    protected static $tmpHostInfo;
     /**
      * @inheritdoc
      * Set the static var for resetting after
@@ -26,24 +16,8 @@ class LSYiiApplicationTest extends TestBaseClass
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$tmpPublicUrl = Yii::app()->getConfig('publicurl');
-        self::$tmpBaseUrl = Yii::app()->getRequest()->baseUrl;
-        self::$tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
-        self::$tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
-        self::$tmpHostInfo = Yii::app()->getRequest()->hostInfo;
-        self::setToExpectedDefault();
-    }
-
-    /**
-     * Set config and component to expected default
-     */
-    public static function setToExpectedDefault()
-    {
-        Yii::app()->setConfig('publicurl', null);
-        Yii::app()->getRequest()->baseUrl = '';
-        Yii::app()->getUrlManager()->showScriptName = true;
-        Yii::app()->getUrlManager()->urlFormat = 'path';
-        // TODO what is the expected hostInfo
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -56,7 +30,7 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $this->assertSame('http://config.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -67,7 +41,7 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->setConfig('publicurl', 'http://absoluteConfig.example.com/');
         $url = Yii::app()->getPublicBaseUrl(true);
         $this->assertSame('http://absoluteConfig.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -78,7 +52,7 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -90,7 +64,7 @@ class LSYiiApplicationTest extends TestBaseClass
         $url = Yii::app()->getPublicBaseUrl(true);
 
         $this->assertSame('http://localhost/absoluteRequest', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -107,7 +81,7 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -123,7 +97,7 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -133,7 +107,7 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
 
-        Yii::app()->getUrlManager()->urlFormat = 'path';
+        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::PATH_FORMAT;
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/index.php/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
@@ -141,8 +115,8 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
-
-        Yii::app()->getUrlManager()->urlFormat = 'get';
+        /* Deactivate urlFormat => 'get', TODO fix it, work locally, not on github */
+        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::GET_FORMAT;
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/index.php?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
@@ -151,7 +125,7 @@ class LSYiiApplicationTest extends TestBaseClass
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -165,7 +139,7 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -182,7 +156,7 @@ class LSYiiApplicationTest extends TestBaseClass
 
         $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
 
-        self::setToExpectedDefault();
+        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -192,11 +166,7 @@ class LSYiiApplicationTest extends TestBaseClass
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
-        Yii::app()->setConfig('publicurl', self::$tmpPublicUrl);
-        Yii::app()->getRequest()->baseUrl = self::$tmpBaseUrl;
-        Yii::app()->getUrlManager()->showScriptName = self::$tmpShowScriptName;
-        Yii::app()->getUrlManager()->urlFormat = self::$tmpUrlFormat;
-        Yii::app()->getRequest()->hostInfo = self::$tmpHostInfo;
+        self::$testHelper::resetUrlSettings();
         /* This set hostinfo to null (unsure needed) */
         self::$testHelper->resetHostInfo();
     }

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -129,12 +129,12 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName.');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName.');
 
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame($url, 'http://www.example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName.');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -17,7 +17,6 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         parent::setUpBeforeClass();
         self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -25,12 +24,11 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromConfig()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://config.example.com/');
         $url = Yii::app()->getPublicBaseUrl();
 
         $this->assertSame('http://config.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -38,10 +36,10 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetAbsolutepublicBaseUrlFromConfig()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://absoluteConfig.example.com/');
         $url = Yii::app()->getPublicBaseUrl(true);
         $this->assertSame('http://absoluteConfig.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -49,10 +47,10 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromRequest()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -60,11 +58,11 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetAbsolutepublicBaseUrlFromRequest()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->getRequest()->baseUrl = '/absoluteRequest';
         $url = Yii::app()->getPublicBaseUrl(true);
 
         $this->assertSame('http://localhost/absoluteRequest', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -74,14 +72,13 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromConfigNoSchemeInConfigPublicUrl()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         // No scheme in url.
         Yii::app()->setConfig('publicurl', '//config.example.com/path?param=1');
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
 
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -91,13 +88,12 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testGetpublicBaseUrlFromConfigNoHostInConfigPublicUrl()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://');
         Yii::app()->getRequest()->baseUrl = 'http://request.example.com/';
         $url = Yii::app()->getPublicBaseUrl();
 
         $this->assertSame('http://request.example.com/', $url, 'Unexpected url. The url does not correspond to the one previously set.');
-
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -105,9 +101,8 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithARoute()
     {
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::PATH_FORMAT);
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
-
-        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::PATH_FORMAT;
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/index.php/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
@@ -115,9 +110,9 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
-        /* Deactivate urlFormat => 'get', TODO fix it, work locally, not on github */
-        /**
-        Yii::app()->getUrlManager()->urlFormat = \CUrlManager::GET_FORMAT;
+
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::GET_FORMAT);
+        Yii::app()->setConfig('publicurl', 'http://www.example.com/');
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/index.php?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
@@ -125,8 +120,6 @@ class LSYiiApplicationTest extends TestBaseClass
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
-        **/
-        self::$testHelper::setToExpectedDefault();
     }
 
     /**
@@ -134,13 +127,12 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithParams()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
         $parameters = array('param_one' => 1, 'param_two' => 2);
         $url = Yii::app()->createPublicUrl('controller/action', $parameters);
 
-        $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
-
-        self::$testHelper::setToExpectedDefault();
+        $this->assertSame('http://www.example.com/index.php/controller/action?param_one=1&param_two=2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
     }
 
     /**
@@ -148,6 +140,7 @@ class LSYiiApplicationTest extends TestBaseClass
      */
     public function testCreatePublicUrlWithASchema()
     {
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://www.example.com');
         Yii::app()->getRequest()->baseUrl = 'www.example.com';
         Yii::app()->getRequest()->hostInfo = '';
@@ -155,9 +148,7 @@ class LSYiiApplicationTest extends TestBaseClass
         $parameters = array('param_one' => 1, 'param_two' => 2);
         $url = Yii::app()->createPublicUrl('controller/action', $parameters, 'http');
 
-        $this->assertSame('http://www.example.com/index.php/controller/action/param_one/1/param_two/2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
-
-        self::$testHelper::setToExpectedDefault();
+        $this->assertSame('http://www.example.com/index.php/controller/action?param_one=1&param_two=2', $url, 'Unexpected url. The url does not correspond with a public url, a route and two parameters.');
     }
 
     /**
@@ -168,7 +159,5 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         parent::tearDownAfterClass();
         self::$testHelper::resetUrlSettings();
-        /* This set hostinfo to null (unsure needed) */
-        self::$testHelper->resetHostInfo();
     }
 }

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -123,22 +123,36 @@ class LSYiiApplicationTest extends TestBaseClass
     {
         $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         $tmpShowScriptName = Yii::app()->getUrlManager()->showScriptName;
+        $tmpUrlFormat = Yii::app()->getUrlManager()->urlFormat;
 
         Yii::app()->setConfig('publicurl', 'http://www.example.com/');
 
+        Yii::app()->getUrlManager()->urlFormat = 'path';
         Yii::app()->getUrlManager()->showScriptName = true;
         $url = Yii::app()->createPublicUrl('controller/action');
         $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName.');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
 
         Yii::app()->getUrlManager()->showScriptName = false;
         $url = Yii::app()->createPublicUrl('controller/action');
         $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
-        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName.');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
+
+        Yii::app()->getUrlManager()->urlFormat = 'get';
+        Yii::app()->getUrlManager()->showScriptName = true;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
+
+        Yii::app()->getUrlManager()->showScriptName = false;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $expectedRelativeUrl = Yii::app()->createUrl('controller/action');
+        $this->assertSame('http://www.example.com' . $expectedRelativeUrl, $url, 'Unexpected url. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
 
         // Restore original values.
         Yii::app()->setConfig('publicurl', $tmpPublicUrl);
         Yii::app()->getUrlManager()->showScriptName = $tmpShowScriptName;
+        Yii::app()->getUrlManager()->showScriptName = $tmpUrlFormat;
     }
 
     /**

--- a/tests/unit/LSYiiApplicationTest.php
+++ b/tests/unit/LSYiiApplicationTest.php
@@ -123,6 +123,38 @@ class LSYiiApplicationTest extends TestBaseClass
     }
 
     /**
+     * Create a public url with just a route.
+     */
+    public function testCreatePublicUrlHostinfoBaserlUpdatedWithARoute()
+    {
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::PATH_FORMAT);
+        Yii::app()->getRequest()->setHostInfo('http://example.org');
+        Yii::app()->getUrlManager()->setBaseUrl('/limesurvey');
+        Yii::app()->setConfig('publicurl', 'http://www.example.com/');
+
+        Yii::app()->getUrlManager()->showScriptName = true;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $this->assertSame('http://www.example.com/index.php/controller/action', $url, 'Unexpected url if hostinfo and baseurl is set. The url does not correspond with a public url and a route with showScriptName and urlformat to path.');
+
+        Yii::app()->getUrlManager()->showScriptName = false;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $this->assertSame('http://www.example.com/controller/action', $url, 'Unexpected url if hostinfo and baseurl is set. The url does not correspond with a public url and a route without showScriptName and urlformat to path.');
+
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::GET_FORMAT);
+        Yii::app()->getRequest()->setHostInfo('http://example.org');
+        Yii::app()->getUrlManager()->setBaseUrl('/limesurvey');
+        Yii::app()->setConfig('publicurl', 'http://www.example.com/');
+
+        Yii::app()->getUrlManager()->showScriptName = true;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $this->assertSame('http://www.example.com/index.php?r=controller/action', $url, 'Unexpected url if hostinfo and baseurl is set. The url does not correspond with a public url and a route with showScriptName and urlformat to get.');
+
+        Yii::app()->getUrlManager()->showScriptName = false;
+        $url = Yii::app()->createPublicUrl('controller/action');
+        $this->assertSame('http://www.example.com/?r=controller/action', $url, 'Unexpected url if hostinfo and baseurl is set. The url does not correspond with a public url and a route without showScriptName and urlformat to get.');
+    }
+
+    /**
      * Create a public url with a route and two parameters.
      */
     public function testCreatePublicUrlWithParams()

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -382,16 +382,14 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetDefaultLanguageSurveyUrl()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $url = self::$testSurvey->getSurveyUrl();
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'en'));
+        $this->assertSame("http://example.com/index.php/survey/index/sid/" . self::$surveyId . "/lang/en", $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
-
-        // Reset original value.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -399,7 +397,8 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetSurveyUrlWithParameters()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $params = array('param_1' => 1, 'param_2' => 2);
@@ -409,8 +408,7 @@ class SurveyTest extends TestBaseClass
 
         $this->assertSame($url, $expectedUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
-        // Reset original value.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -418,21 +416,17 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetSurveyUrlSpecificLanguage()
     {
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $url = self::$testSurvey->getSurveyUrl('de');
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'de'));
-
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/de', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $url = self::$testSurvey->getSurveyUrl('sv');
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'sv'));
+        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/sv', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
-
-        // Reset original value.
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -441,31 +435,25 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlGet()
     {
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         $urlManager = Yii::app()->getUrlManager();
-
-        $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
-        $tmpUrlFormat = $urlManager->getUrlFormat();
-
         $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
+        $tmpArSurveyAlias = $arLanguageSetting->surveyls_alias;
         $arLanguageSetting->surveyls_alias = 'my-arabic-survey';
-
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         Yii::app()->setConfig('publicurl', 'http://example.com');
-
         $url = self::$testSurvey->getSurveyUrl('ar');
-        $this->assertSame($url, 'http://example.com?r=my-arabic-survey', 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com?r=my-arabic-survey', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // No alias assert.
         $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php?r=survey/index&sid=' . self::$surveyId . '&lang=ar', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
-        $urlManager->urlFormat = $tmpUrlFormat;
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -474,12 +462,12 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlPath()
     {
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         $urlManager = Yii::app()->getUrlManager();
+        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
 
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
-        $tmpUrlFormat = $urlManager->getUrlFormat();
-
-        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
 
         // Get the language setting object, modify it, and set it back
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
@@ -489,17 +477,15 @@ class SurveyTest extends TestBaseClass
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $url = self::$testSurvey->getSurveyUrl('ar');
-        $this->assertSame($url, 'http://example.com/my-arabic-survey', 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/my-arabic-survey', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // No alias assert.
         $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $expectedRelativeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
-        $this->assertSame($url, 'http://example.com' . $expectedRelativeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/ar', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
-        $urlManager->urlFormat = $tmpUrlFormat;
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -510,43 +496,40 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlGetRepeatedAlias()
     {
+        self::$testHelper::saveUrlSettings();
+        self::$testHelper::setToExpectedDefault();
         $urlManager = Yii::app()->getUrlManager();
 
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
         $tmpDeSurveyAlias = self::$testSurvey->languagesettings['de']->surveyls_alias;
-        $tmpUrlFormat = $urlManager->getUrlFormat();
 
         $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
         $arLanguageSetting->surveyls_alias = 'my-survey';
-        
+
         $deLanguageSetting = self::$testSurvey->languagesettings['de'];
         $deLanguageSetting->surveyls_alias = 'my-survey';
 
-        $tmpPublicUrl = Yii::app()->getConfig('publicurl');
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $arAliasUrl = self::$testSurvey->getSurveyUrl('ar');
-        $this->assertSame($arAliasUrl, 'http://example.com?r=my-survey&lang=ar', 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com?r=my-survey&lang=ar', $arAliasUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $deAliasUrl = self::$testSurvey->getSurveyUrl('de');
-        $this->assertSame($deAliasUrl, 'http://example.com?r=my-survey&lang=de', 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com?r=my-survey&lang=de', $deAliasUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // No alias assert.
         $arUrl = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $expectedRelativeArUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
-        $this->assertSame($arUrl, 'http://example.com' . $expectedRelativeArUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php?r=survey/index&sid=' . self::$surveyId . '&lang=ar', $arUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $deUrl = self::$testSurvey->getSurveyUrl('de', array(), false);
-        $expectedRelativeDeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'de'));
-        $this->assertSame($deUrl, 'http://example.com' . $expectedRelativeDeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php?r=survey/index&sid=' . self::$surveyId . '&lang=de', $deUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
         $deLanguageSetting->surveyls_alias = $tmpDeSurveyAlias;
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
-        $urlManager->urlFormat = $tmpUrlFormat;
+        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -567,7 +550,7 @@ class SurveyTest extends TestBaseClass
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
         $arLanguageSetting->surveyls_alias = 'my-survey';
-        
+
         $deLanguageSetting = self::$testSurvey->languagesettings['de'];
         $deLanguageSetting->surveyls_alias = 'my-survey';
 
@@ -582,12 +565,10 @@ class SurveyTest extends TestBaseClass
 
         // No alias assert.
         $arUrl = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $expectedRelativeArUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'ar'));
-        $this->assertSame($arUrl, 'http://example.com' . $expectedRelativeArUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/ar', $arUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $deUrl = self::$testSurvey->getSurveyUrl('de', array(), false);
-        $expectedRelativeDeUrl = Yii::app()->createUrl('survey/index', array('sid' => self::$surveyId, 'lang' => 'de'));
-        $this->assertSame($deUrl, 'http://example.com' . $expectedRelativeDeUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/de', $deUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;

--- a/tests/unit/models/SurveyTest.php
+++ b/tests/unit/models/SurveyTest.php
@@ -31,6 +31,7 @@ class SurveyTest extends TestBaseClass
 
         $filename = self::$surveysFolder . '/limesurvey_survey_161359_quickTranslation.lss';
         self::importSurvey($filename);
+        self::$testHelper::saveUrlSettings();
     }
 
     public function setUp(): void
@@ -382,14 +383,11 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetDefaultLanguageSurveyUrl()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $url = self::$testSurvey->getSurveyUrl();
-        $this->assertSame("http://example.com/index.php/survey/index/sid/" . self::$surveyId . "/lang/en", $url, 'Unexpected url. The url does not correspond with a public survey url.');
-
-        self::$testHelper::resetUrlSettings();
+        $this->assertSame("http://example.com/index.php/" . self::$surveyId . "?lang=en", $url, 'Unexpected url. The url does not correspond with a public survey url.');
     }
 
     /**
@@ -397,8 +395,7 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetSurveyUrlWithParameters()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $params = array('param_1' => 1, 'param_2' => 2);
@@ -407,8 +404,6 @@ class SurveyTest extends TestBaseClass
         $expectedUrl = App()->createPublicUrl('survey/index', $urlParams);
 
         $this->assertSame($url, $expectedUrl, 'Unexpected url. The url does not correspond with a public survey url.');
-
-        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -416,17 +411,14 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetSurveyUrlSpecificLanguage()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
+        self::$testHelper::setUrlToExpectedDefault();
         Yii::app()->setConfig('publicurl', 'http://example.com');
 
         $url = self::$testSurvey->getSurveyUrl('de');
-        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/de', $url, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/' . self::$surveyId . '?lang=de', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $url = self::$testSurvey->getSurveyUrl('sv');
-        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/sv', $url, 'Unexpected url. The url does not correspond with a public survey url.');
-
-        self::$testHelper::resetUrlSettings();
+        $this->assertSame('http://example.com/index.php/' . self::$surveyId . '?lang=sv', $url, 'Unexpected url. The url does not correspond with a public survey url.');
     }
 
     /**
@@ -435,10 +427,7 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlGet()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
-        $urlManager = Yii::app()->getUrlManager();
-        $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::GET_FORMAT);
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
         $tmpArSurveyAlias = $arLanguageSetting->surveyls_alias;
@@ -453,7 +442,6 @@ class SurveyTest extends TestBaseClass
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
-        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -462,10 +450,7 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlPath()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
-        $urlManager = Yii::app()->getUrlManager();
-        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::PATH_FORMAT);
 
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
 
@@ -481,11 +466,10 @@ class SurveyTest extends TestBaseClass
 
         // No alias assert.
         $url = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/ar', $url, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/' . self::$surveyId . '?lang=ar', $url, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
-        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -496,14 +480,10 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlGetRepeatedAlias()
     {
-        self::$testHelper::saveUrlSettings();
-        self::$testHelper::setToExpectedDefault();
-        $urlManager = Yii::app()->getUrlManager();
+        self::$testHelper::setUrlToExpectedDefault(\CUrlManager::GET_FORMAT);
 
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
         $tmpDeSurveyAlias = self::$testSurvey->languagesettings['de']->surveyls_alias;
-
-        $urlManager->urlFormat = \CUrlManager::GET_FORMAT;
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
         $arLanguageSetting->surveyls_alias = 'my-survey';
@@ -529,7 +509,6 @@ class SurveyTest extends TestBaseClass
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
         $deLanguageSetting->surveyls_alias = $tmpDeSurveyAlias;
-        self::$testHelper::resetUrlSettings();
     }
 
     /**
@@ -540,13 +519,10 @@ class SurveyTest extends TestBaseClass
      */
     public function testGetAliasSurveyUrlPathRepeatedAlias()
     {
-        $urlManager = Yii::app()->getUrlManager();
+        self::$testHelper::setUrlToExpectedDefault();
 
         $tmpArSurveyAlias = self::$testSurvey->languagesettings['ar']->surveyls_alias;
         $tmpDeSurveyAlias = self::$testSurvey->languagesettings['de']->surveyls_alias;
-        $tmpUrlFormat = $urlManager->getUrlFormat();
-
-        $urlManager->urlFormat = \CUrlManager::PATH_FORMAT;
 
         $arLanguageSetting = self::$testSurvey->languagesettings['ar'];
         $arLanguageSetting->surveyls_alias = 'my-survey';
@@ -565,15 +541,23 @@ class SurveyTest extends TestBaseClass
 
         // No alias assert.
         $arUrl = self::$testSurvey->getSurveyUrl('ar', array(), false);
-        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/ar', $arUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/' . self::$surveyId . '?lang=ar', $arUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         $deUrl = self::$testSurvey->getSurveyUrl('de', array(), false);
-        $this->assertSame('http://example.com/index.php/survey/index/sid/' . self::$surveyId . '/lang/de', $deUrl, 'Unexpected url. The url does not correspond with a public survey url.');
+        $this->assertSame('http://example.com/index.php/' . self::$surveyId . '?lang=de', $deUrl, 'Unexpected url. The url does not correspond with a public survey url.');
 
         // Reset original value.
         $arLanguageSetting->surveyls_alias = $tmpArSurveyAlias;
         $deLanguageSetting->surveyls_alias = $tmpDeSurveyAlias;
-        Yii::app()->setConfig('publicurl', $tmpPublicUrl);
-        $urlManager->urlFormat = $tmpUrlFormat;
+    }
+
+    /**
+     * @inheritdoc
+     * And reset request
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::$testHelper::resetUrlSettings();
     }
 }


### PR DESCRIPTION
Dev: set hostInfo and baseurl to needed way if publicurl is set
Dev: reset after get the url


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public URL generation when the configured “public URL” base differs from the current application base, with correct host and prefix handling across both script-name and non-script-name routing modes.
* **Tests**
  * Expanded coverage for public URL creation to validate behavior across multiple URL manager settings (path vs. get formats, and showScriptName true/false).
* **Chores**
  * Reformatted the phpunit configuration opening tag for consistency (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->