### PR TITLE
Feature/AT-2179 selectall floating menu

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -52,6 +52,7 @@ class SurveyAdministrationController extends LSBaseController
                     'getCurrentEditorValues',
                     'getDataSecTextSettings',
                     'getDateFormatOptions',
+                    'getAllSurveyIds',
                     'updateAccessMode',
                     ''
                 ],
@@ -313,6 +314,41 @@ class SurveyAdministrationController extends LSBaseController
                 'caption'     => gT('Selected surveys'),
             )
         );
+    }
+
+    /**
+     * Returns all survey IDs matching the current filter as a JSON array.
+     * Used by the "Select all" button in the floating actions bar to select
+     * all surveys across pagination.
+     *
+     * @return void
+     */
+    public function actionGetAllSurveyIds()
+    {
+        if (!Yii::app()->request->isAjaxRequest) {
+            throw new CHttpException(400, 'Invalid request');
+        }
+        if (!Permission::model()->hasGlobalPermission('surveys', 'read')) {
+            throw new CHttpException(403, 'Forbidden');
+        }
+
+        $model = new Survey('search');
+        $filters = Yii::app()->request->getParam('Survey', []);
+        if (is_array($filters)) {
+            $model->setAttributes($filters, false);
+        }
+
+        // Get all matching surveys without pagination limit
+        $dataProvider = $model->search(['pageSize' => 100000]);
+        $surveys = $dataProvider->getData();
+
+        $ids = array_map(static function ($survey) {
+            return (int) $survey->sid;
+        }, $surveys);
+
+        header('Content-Type: application/json');
+        echo json_encode(array_values($ids));
+        Yii::app()->end();
     }
 
     /**
@@ -3572,7 +3608,7 @@ class SurveyAdministrationController extends LSBaseController
     public function actionDeleteUrlParam()
     {
         $surveyId = sanitize_int(Yii::app()->request->getPost('surveyId'));
-        $redirectUrl = ['surveyAdministration/rendersidemenulink/', 'surveyid' => $surveyId, 'subaction' => 'panelintegration'];
+        $redirectUrl = ['surveyAdministration/rendersidemenulink', 'surveyid' => $surveyId, 'subaction' => 'panelintegration'];
         $paramId = Yii::app()->request->getPost('urlParamId');
         if (empty($paramId)) {
             throw new CHttpException(400, gT('Invalid request'));

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -333,9 +333,27 @@ class SurveyAdministrationController extends LSBaseController
         }
 
         $model = new Survey('search');
+
+        // Reset active attribute to '' so search() does not filter by the DB column default ('N').
+        // This mirrors ListSurveysWidget which explicitly sets $this->model->active = "".
+        $model->active = '';
+
+        // Apply Survey[...] grid filters (e.g. searched_value)
         $filters = Yii::app()->request->getParam('Survey', []);
         if (is_array($filters)) {
             $model->setAttributes($filters, false);
+        }
+
+        // Apply the status filter that ListSurveysWidget reads from $_GET['active']
+        $activeFilter = Yii::app()->request->getParam('active', '');
+        if (!empty($activeFilter)) {
+            $model->active = $activeFilter;
+        }
+
+        // Apply survey-group filter
+        $gsid = Yii::app()->request->getParam('gsid', '');
+        if (!empty($gsid)) {
+            $model->gsid = (int) $gsid;
         }
 
         // Get all matching surveys without pagination limit

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -353,8 +353,12 @@ class SurveyAdministrationController extends LSBaseController
             $model->gsid = (int) $gsid;
         }
 
-        // Get all matching surveys without pagination limit
-        $dataProvider = $model->search(['pageSize' => 100000]);
+        // Fetch every matching ID in a single unbounded query.
+        // getData() only returns one page, so a large fixed pageSize can still miss
+        // rows on larger installations.  Disabling pagination removes the LIMIT/OFFSET
+        // entirely so all matching survey IDs are always returned.
+        $dataProvider = $model->search();
+        $dataProvider->setPagination(false);
         $surveys = $dataProvider->getData();
 
         $ids = array_map(static function ($survey) {

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -328,9 +328,6 @@ class SurveyAdministrationController extends LSBaseController
         if (!Yii::app()->request->isAjaxRequest) {
             throw new CHttpException(400, 'Invalid request');
         }
-        if (!Permission::model()->hasGlobalPermission('surveys', 'read')) {
-            throw new CHttpException(403, 'Forbidden');
-        }
 
         $model = new Survey('search');
 

--- a/application/extensions/admin/grid/FloatingActionsWidget/FloatingActionsWidget.php
+++ b/application/extensions/admin/grid/FloatingActionsWidget/FloatingActionsWidget.php
@@ -34,6 +34,19 @@ class FloatingActionsWidget extends CWidget
     /** @var array Action definitions – see class docblock for structure */
     public $aActions = [];
 
+    /**
+     * Optional URL for the "Select all" button.
+     * When set, a "Select all" button is shown in the floating bar.
+     * Clicking it will AJAX-fetch all matching PKs from this URL and select them
+     * across pagination via LS.gridSelection.
+     *
+     * The URL should accept current filter parameters (as GET params matching the
+     * model name, e.g. ?Survey[active]=R) and return a JSON array of integer PKs.
+     *
+     * @var string|null
+     */
+    public $selectAllUrl;
+
     /** Modal view names available in MassiveActionsWidget/views/modals/ */
     private const MODAL_VIEW_NAMES = [
         'yes-no',
@@ -67,11 +80,13 @@ class FloatingActionsWidget extends CWidget
         );
 
         // 4. Initialise this bar instance after the DOM is ready
+        $selectAllUrl = $this->selectAllUrl ? addslashes($this->selectAllUrl) : '';
         Yii::app()->getClientScript()->registerScript(
             'FloatingActionsWidget-init-' . $this->gridId,
             "$(function () { LS.floatingActions.init('"
                 . $this->gridId . "', '"
-                . $this->pk . "'); });",
+                . $this->pk . "', '"
+                . $selectAllUrl . "'); });",
             LSYii_ClientScript::POS_POSTSCRIPT
         );
     }

--- a/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
+++ b/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
@@ -297,13 +297,15 @@ LS.floatingActions = (function () {
         /**
          * Initialise the floating bar for one grid.
          *
-         * @param {string} gridId  ID of the CLSGridView container element
-         * @param {string} pk      Primary key column name (without [])
+         * @param {string} gridId        ID of the CLSGridView container element
+         * @param {string} pk            Primary key column name (without [])
+         * @param {string} [selectAllUrl] Optional URL to fetch all matching PKs for "Select all"
          */
-        init: function (gridId, pk) {
+        init: function (gridId, pk, selectAllUrl) {
             var $bar  = $('#floating-actions-bar-' + gridId);
             var $grid = $('#' + gridId);
             if (!$bar.length || !$grid.length) { return; }
+
             // Hook LS.gridView.afterAjaxUpdate once (here, not at load time, so
             // that afterAjaxUpdate.js has already defined its base implementation).
             if (!_afterAjaxHooked) {
@@ -352,9 +354,9 @@ LS.floatingActions = (function () {
                 $('#' + gridId + ' thead input[type="checkbox"]').prop('checked', false);
                 _updateBar(gridId, pk);
             });
-            // Direct action buttons
+            // Direct action buttons (exclude dropdown toggles and the select-all button)
             $(document).on('click' + ns,
-                barSelector + ' .floating-actions-btn:not(.dropdown-toggle)',
+                barSelector + ' .floating-actions-btn:not(.dropdown-toggle):not(.floating-actions-select-all)',
                 function (e) { _onClick.call(this, e, gridId, pk); }
             );
             // Dropdown sub-items
@@ -362,6 +364,68 @@ LS.floatingActions = (function () {
                 barSelector + ' .floating-actions-item',
                 function (e) { _onClick.call(this, e, gridId, pk); }
             );
+            // ---- "Select all" across pagination ------------------------------
+            if (selectAllUrl) {
+                $(document).on('click' + ns, barSelector + ' .floating-actions-select-all', function (e) {
+                    e.preventDefault();
+                    var $btn = $(this);
+                    $btn.prop('disabled', true);
+
+                    // Collect current grid filter params from the URL / form
+                    var filterParams = {};
+                    // yiiGridView stores filter inputs inside the grid
+                    $('#' + gridId + ' .filters input, #' + gridId + ' .filters select').each(function () {
+                        var name = $(this).attr('name');
+                        var val  = $(this).val();
+                        if (name && val !== '') {
+                            filterParams[name] = val;
+                        }
+                    });
+
+                    $.ajax({
+                        url:      selectAllUrl,
+                        type:     'GET',
+                        data:     filterParams,
+                        dataType: 'json',
+                        success: function (ids) {
+                            if (!Array.isArray(ids)) { return; }
+
+                            // Store all IDs in gridSelection
+                            if (window.LS && LS.gridSelection) {
+                                // First clear, then add all fetched IDs
+                                LS.gridSelection.clear(gridId);
+                                ids.forEach(function (id) {
+                                    LS.gridSelection.add(gridId, String(id));
+                                });
+                            }
+
+                            // Check visible checkboxes whose PK value is in the returned IDs
+                            var idSet = {};
+                            ids.forEach(function (id) { idSet[String(id)] = true; });
+                            $('#' + gridId + ' tbody input[name="' + pkCol + '"]').each(function () {
+                                if (idSet[$(this).val()]) {
+                                    $(this).prop('checked', true);
+                                }
+                            });
+
+                            // Sync header "select all" checkbox if all visible rows are now checked
+                            var total   = $('#' + gridId + ' tbody input[name="' + pkCol + '"]').length;
+                            var checked = $('#' + gridId + ' tbody input[name="' + pkCol + '"]:checked').length;
+                            if (total > 0 && total === checked) {
+                                $('#' + gridId + ' thead input[type="checkbox"]').prop('checked', true);
+                            }
+
+                            _updateBar(gridId, pk);
+                        },
+                        error: function () {
+                            console.warn('FloatingActionsWidget: selectAllUrl request failed');
+                        },
+                        complete: function () {
+                            $btn.prop('disabled', false);
+                        }
+                    });
+                });
+            }
             // ---- Scroll: keep bar position in sync with table position ---------
             $(window).on('scroll' + ns, function () {
                 _syncBarPosition(gridId);

--- a/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
+++ b/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
@@ -381,6 +381,13 @@ LS.floatingActions = (function () {
                             filterParams[name] = val;
                         }
                     });
+                    // Also forward URL query-string params that are not inside the grid filter row
+                    // (e.g. ?active=R or ?gsid=3 set by the SearchBoxWidget / survey-group filter).
+                    (new URLSearchParams(window.location.search)).forEach(function (val, key) {
+                        if (val !== '' && !(key in filterParams)) {
+                            filterParams[key] = val;
+                        }
+                    });
 
                     $.ajax({
                         url:      selectAllUrl,

--- a/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
+++ b/application/extensions/admin/grid/FloatingActionsWidget/assets/floatingActions.js
@@ -397,13 +397,19 @@ LS.floatingActions = (function () {
                         success: function (ids) {
                             if (!Array.isArray(ids)) { return; }
 
-                            // Store all IDs in gridSelection
+                            // Store all IDs in gridSelection in one bulk operation (O(1) UI syncs).
+                            // replaceAll() replaces the entire Set and synchronises the UI once,
+                            // avoiding the O(n) DOM thrash caused by calling add() in a loop.
                             if (window.LS && LS.gridSelection) {
-                                // First clear, then add all fetched IDs
-                                LS.gridSelection.clear(gridId);
-                                ids.forEach(function (id) {
-                                    LS.gridSelection.add(gridId, String(id));
-                                });
+                                if (typeof LS.gridSelection.replaceAll === 'function') {
+                                    LS.gridSelection.replaceAll(gridId, ids);
+                                } else {
+                                    // Fallback for older gridSelection without replaceAll
+                                    LS.gridSelection.clear(gridId);
+                                    ids.forEach(function (id) {
+                                        LS.gridSelection.add(gridId, String(id));
+                                    });
+                                }
                             }
 
                             // Check visible checkboxes whose PK value is in the returned IDs

--- a/application/extensions/admin/grid/FloatingActionsWidget/views/floating_bar.php
+++ b/application/extensions/admin/grid/FloatingActionsWidget/views/floating_bar.php
@@ -6,6 +6,7 @@
  */
 $gridId = CHtml::encode($this->gridId);
 $pk     = CHtml::encode($this->pk);
+$selectAllUrl = $this->selectAllUrl ? CHtml::encode($this->selectAllUrl) : '';
 ?>
 <!-- FloatingActionsWidget: bar for grid "<?= $gridId ?>" -->
 <div
@@ -13,6 +14,7 @@ $pk     = CHtml::encode($this->pk);
     class="floating-actions-bar"
     data-grid-id="<?= $gridId ?>"
     data-pk="<?= $pk ?>"
+    <?php if ($selectAllUrl): ?>data-select-all-url="<?= $selectAllUrl ?>"<?php endif; ?>
     role="toolbar"
     aria-label="<?= gT('Actions for selected items') ?>"
 >
@@ -20,6 +22,20 @@ $pk     = CHtml::encode($this->pk);
     <span class="reg-12" aria-live="polite" aria-atomic="true">
         <span class="floating-actions-count-number">0</span>&nbsp;<?= gT('selected') ?>
     </span>
+
+    <?php if ($selectAllUrl): ?>
+        <!-- Separator before "Select all" -->
+        <div class="floating-actions-separator" role="separator" aria-hidden="true"></div>
+        <!-- Select all button -->
+        <button
+            type="button"
+            class="floating-actions-btn floating-actions-select-all"
+            title="<?= gT('Select all') ?>"
+        >
+            <i class="ri-check-line"></i>
+            <?= gT('Select all') ?>
+        </button>
+    <?php endif; ?>
 
     <?php foreach ($this->aActions as $key => $action) : ?>
         <?php if (!is_array($action) || empty($action['type'])) : ?>

--- a/application/extensions/admin/grid/assets/gridSelection.js
+++ b/application/extensions/admin/grid/assets/gridSelection.js
@@ -307,6 +307,20 @@ LS.gridSelection = (function () {
          */
         count: function (gridId) {
             return _set(gridId).size;
+        },
+
+        /**
+         * Adds a single PK value to the selection store for a grid.
+         * Does NOT touch DOM checkboxes – call restoreCheckboxes() or update
+         * visible checkboxes manually after bulk-adding entries.
+         *
+         * @param {string} gridId
+         * @param {string} pkValue
+         */
+        add: function (gridId, pkValue) {
+            _set(gridId).add(String(pkValue));
+            _syncMassiveActionButton(gridId);
+            _syncSelectionBar(gridId);
         }
     };
 }());

--- a/application/extensions/admin/grid/assets/gridSelection.js
+++ b/application/extensions/admin/grid/assets/gridSelection.js
@@ -321,6 +321,26 @@ LS.gridSelection = (function () {
             _set(gridId).add(String(pkValue));
             _syncMassiveActionButton(gridId);
             _syncSelectionBar(gridId);
+        },
+        /**
+         * Replaces the entire selection store for a grid with the supplied values
+         * and synchronises the UI exactly once.
+         *
+         * Use this instead of clear() + repeated add() calls when bulk-selecting
+         * many rows (e.g. "Select all" across pagination), to avoid triggering
+         * O(n) DOM queries for large result sets.
+         *
+         * Does NOT touch DOM checkboxes – call restoreCheckboxes() or update
+         * visible checkboxes manually after calling this method.
+         *
+         * @param {string}            gridId
+         * @param {string[]|number[]} values  Array of PK values to select.
+         */
+        replaceAll: function (gridId, values) {
+            _store.set(gridId, new Set(values.map(String)));
+            _syncHeaderCheckbox(gridId);
+            _syncMassiveActionButton(gridId);
+            _syncSelectionBar(gridId);
         }
     };
 }());

--- a/application/extensions/admin/survey/ListSurveysWidget/views/listSurveys.php
+++ b/application/extensions/admin/survey/ListSurveysWidget/views/listSurveys.php
@@ -26,9 +26,10 @@ use actions\SurveyListMassiveActions;
         // Render the floating action bar (cross-page selection, fixed at bottom)
         $floatingActions = SurveyListMassiveActions::getActions();
         $this->widget('ext.admin.grid.FloatingActionsWidget.FloatingActionsWidget', [
-            'pk'       => 'sid',
-            'gridId'   => 'survey-grid',
-            'aActions' => $floatingActions,
+            'pk'           => 'sid',
+            'gridId'       => 'survey-grid',
+            'aActions'     => $floatingActions,
+            'selectAllUrl' => Yii::app()->createUrl('surveyAdministration/getAllSurveyIds'),
         ]);
         ?>
         <?php


### PR DESCRIPTION
New feature #AT-2179: Additional button "Select all" in flaoting menu. Should check all checkboxes in gridviews over pagination


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Select all” option to the survey list’s floating actions to select all matching surveys across pagination.
  - “Select all” respects the current grid filters and updates selection state, counts, and visible row checkboxes.
  - Added a new AJAX-backed capability to retrieve all matching survey identifiers for bulk selection.
- **Bug Fixes**
  - Fixed the redirect after deleting a URL parameter in survey administration by correcting an extra trailing slash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->