### PR TITLE
Fixed issue #20596: url params (from panel integration) were not copi…

### DIFF
--- a/application/models/services/CopySurvey.php
+++ b/application/models/services/CopySurvey.php
@@ -19,6 +19,7 @@ use QuestionL10n;
 use Survey;
 use Permission;
 use SurveyLanguageSetting;
+use SurveyURLParameter;
 use Template;
 use Yii;
 
@@ -112,6 +113,11 @@ class CopySurvey
         $destinationSurvey->currentLanguageSettings->save();
         $mappingGroupIdsAndQuestionIds = $this->copyGroupsAndQuestions($copySurveyResult, $destinationSurvey);
         $this->copySurveyAssessments($copySurveyResult, $destinationSurvey, $mappingGroupIdsAndQuestionIds['questionGroupIds']);
+        $this->copyUrlParameters(
+            $destinationSurvey,
+            $mappingGroupIdsAndQuestionIds['questionIds'],
+            $mappingGroupIdsAndQuestionIds['subquestionIds']
+        );
 
         if ($this->options->isQuotas()) {
             $copySurveyQuotas = new CopySurveyQuotas($this->sourceSurvey, $destinationSurvey);
@@ -391,6 +397,7 @@ class CopySurvey
         }
         $copyResults->setCntQuestions($cntCopiedQuestions);
         $mapping['questionIds'] = $mappingQuestionIds;
+        $mapping['subquestionIds'] = $mappedSubquestionIds;
         $this->copyDefaultAnswers($mappingQuestionIds, $mappedSubquestionIds);
 
         return $mapping;
@@ -600,5 +607,49 @@ class CopySurvey
         }
 
         return $cntDefaultAnswers;
+    }
+
+    /**
+     * Copies URL parameters (panel integration) from the source survey to the destination survey,
+     * remapping targetqid and targetsqid to the new question / subquestion IDs.
+     *
+     * Must be called after copyGroupsAndQuestions() so that the ID maps are available.
+     *
+     * @param Survey $destinationSurvey
+     * @param array  $mappingQuestionIds    old qid  => new qid  (parent questions)
+     * @param array  $mappingSubquestionIds old sqid => new sqid (subquestions)
+     * @return void
+     */
+    private function copyUrlParameters($destinationSurvey, array $mappingQuestionIds, array $mappingSubquestionIds)
+    {
+        $sourceParams = SurveyURLParameter::model()->findAllByAttributes(['sid' => $this->sourceSurvey->sid]);
+
+        foreach ($sourceParams as $sourceParam) {
+            // targetqid must resolve to a copied question; skip if it can't be mapped
+            // (e.g. the question was excluded or the source data is inconsistent).
+            $newTargetQid = null;
+            if (!empty($sourceParam->targetqid)) {
+                if (!isset($mappingQuestionIds[$sourceParam->targetqid])) {
+                    continue;
+                }
+                $newTargetQid = $mappingQuestionIds[$sourceParam->targetqid];
+            }
+
+            // targetsqid is optional; map it when present, skip the whole record if mapping is missing.
+            $newTargetSqid = null;
+            if (!empty($sourceParam->targetsqid)) {
+                if (!isset($mappingSubquestionIds[$sourceParam->targetsqid])) {
+                    continue;
+                }
+                $newTargetSqid = $mappingSubquestionIds[$sourceParam->targetsqid];
+            }
+
+            $destParam = new SurveyURLParameter();
+            $destParam->sid        = $destinationSurvey->sid;
+            $destParam->parameter  = $sourceParam->parameter;
+            $destParam->targetqid  = $newTargetQid;
+            $destParam->targetsqid = $newTargetSqid;
+            $destParam->save();
+        }
     }
 }

--- a/application/models/services/CopySurvey.php
+++ b/application/models/services/CopySurvey.php
@@ -114,6 +114,7 @@ class CopySurvey
         $mappingGroupIdsAndQuestionIds = $this->copyGroupsAndQuestions($copySurveyResult, $destinationSurvey);
         $this->copySurveyAssessments($copySurveyResult, $destinationSurvey, $mappingGroupIdsAndQuestionIds['questionGroupIds']);
         $this->copyUrlParameters(
+            $copySurveyResult,
             $destinationSurvey,
             $mappingGroupIdsAndQuestionIds['questionIds'],
             $mappingGroupIdsAndQuestionIds['subquestionIds']
@@ -615,14 +616,16 @@ class CopySurvey
      *
      * Must be called after copyGroupsAndQuestions() so that the ID maps are available.
      *
+     * @param CopySurveyResult $copySurveyResult
      * @param Survey $destinationSurvey
      * @param array  $mappingQuestionIds    old qid  => new qid  (parent questions)
      * @param array  $mappingSubquestionIds old sqid => new sqid (subquestions)
      * @return void
      */
-    private function copyUrlParameters($destinationSurvey, array $mappingQuestionIds, array $mappingSubquestionIds)
+    private function copyUrlParameters($copySurveyResult, $destinationSurvey, array $mappingQuestionIds, array $mappingSubquestionIds)
     {
         $sourceParams = SurveyURLParameter::model()->findAllByAttributes(['sid' => $this->sourceSurvey->sid]);
+        $cntErrors = 0;
 
         foreach ($sourceParams as $sourceParam) {
             // targetqid must resolve to a copied question; skip if it can't be mapped
@@ -649,7 +652,12 @@ class CopySurvey
             $destParam->parameter  = $sourceParam->parameter;
             $destParam->targetqid  = $newTargetQid;
             $destParam->targetsqid = $newTargetSqid;
-            $destParam->save();
+            if (!$destParam->save()) {
+                $cntErrors ++;
+            }
+        }
+        if ($cntErrors > 0) {
+            $copySurveyResult->setWarnings(gT("One or more URL parameters could not be copied."));
         }
     }
 }


### PR DESCRIPTION
Fixed issue #20596: url params were not copied in the new copy survey process


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When copying a survey, panel integration URL parameters are now retained on the new survey.
  * URL parameters are automatically re-linked to the corresponding copied questions and subquestions (when available).
  * Parameters that can’t be mapped to valid copied questions/subquestions are skipped to prevent incorrect links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->