### PR TITLE
AT-2112: included AT-2114 and AT-2115 Create participant table when click on participants tab, and when adding first participants from CPDB - v6

### DIFF
--- a/application/controllers/admin/ParticipantsAction.php
+++ b/application/controllers/admin/ParticipantsAction.php
@@ -1584,7 +1584,7 @@ class ParticipantsAction extends SurveyCommonAction
         $data['participant_id'] = $participant_id;
         $data['count'] = substr_count((string) $participant_id, ',') + 1;
 
-        $surveys = Survey::getSurveysWithTokenTable();
+        $surveys = Survey::getSurveysForAddingParticipants();
         $data['surveys'] = $surveys;
         $data['hasGlobalPermission'] = Permission::model()->hasGlobalPermission('surveys', 'update');
 
@@ -2531,6 +2531,21 @@ class ParticipantsAction extends SurveyCommonAction
         $participantIds = explode(",", (string) $participantIdsString);
 
         $surveyId = (int)Yii::app()->request->getPost('surveyid');
+
+        $survey = Survey::model()->findByPk($surveyId);
+        if ($survey && !$survey->hasTokensTable) {
+            if (
+                !Permission::model()->hasGlobalPermission('surveys', 'update')
+                && !Permission::model()->hasSurveyPermission($surveyId, 'surveysettings', 'update')
+                && !Permission::model()->hasSurveyPermission($surveyId, 'tokens', 'create')
+            ) {
+                echo gT('No permission');
+                return;
+            }
+            $accessModeService = \LimeSurvey\DI::getContainer()
+                ->get(\LimeSurvey\Models\Services\SurveyAccessModeService::class);
+            $accessModeService->newParticipantTable($survey, true);
+        }
 
         /**
          * mapped can take values like

--- a/application/controllers/admin/Tokens.php
+++ b/application/controllers/admin/Tokens.php
@@ -138,6 +138,26 @@ class Tokens extends SurveyCommonAction
         }
         $aData['model'] = $model;
 
+        // If the participant table doesn't exist yet, show an empty grid as a preview
+        $aData['emptyGridColumns'] = null;
+        $aData['emptyGridDataProvider'] = null;
+        $aData['emptyGridFilter'] = null;
+        if (!$model) {
+            $emptyGridColumns = TokenDynamic::buildAttributesForGrid($iSurveyId, $survey);
+            $aSortableNames = array();
+            foreach ($emptyGridColumns as $aColumn) {
+                if (!empty($aColumn['name']) && $aColumn['name'] !== 'actions') {
+                    $aSortableNames[] = $aColumn['name'];
+                }
+            }
+            $aData['emptyGridColumns'] = $emptyGridColumns;
+            $aData['emptyGridFilter'] = new TokenEmptyGridFilter($aSortableNames);
+            $aData['emptyGridDataProvider'] = new CArrayDataProvider([], [
+                'pagination' => false,
+                'sort'       => ['attributes' => $aSortableNames],
+            ]);
+        }
+
         // Set number of page
         if (isset($_POST['pageSizeTokenView'])) {
             Yii::app()->user->setState('pageSizeTokenView', (int) $_POST['pageSizeTokenView']);
@@ -1196,6 +1216,30 @@ class Tokens extends SurveyCommonAction
     }
 
     /**
+     * Returns the custom attribute field names (attribute_N) for a survey.
+     *
+     * When the participant table exists the names are read from the actual table columns.
+     * When it does not exist yet, they come from the survey's attributedescriptions,
+     * so attributes can be managed before the table is created.
+     *
+     * @param Survey $oSurvey
+     * @return string[]
+     */
+    private function getSurveyAttributeFieldNames($oSurvey)
+    {
+        if ($oSurvey->hasTokensTable) {
+            return getAttributeFieldNames($oSurvey->sid);
+        }
+        $aAttributeFieldNames = array();
+        foreach (array_keys($oSurvey->decodedAttributedescriptions) as $sFieldName) {
+            if (preg_match('/^attribute_[0-9]+$/', (string) $sFieldName)) {
+                $aAttributeFieldNames[] = $sFieldName;
+            }
+        }
+        return $aAttributeFieldNames;
+    }
+
+    /**
      * Handle managetokenattributes action
      * @param int $iSurveyId
      * @return void
@@ -1210,10 +1254,6 @@ class Tokens extends SurveyCommonAction
         }
         // CHECK TO SEE IF A Survey participant list EXISTS FOR THIS SURVEY
         $bTokenExists = $oSurvey->hasTokensTable;
-        if (!$bTokenExists) {
-            //If no tokens table exists
-            $this->newParticipantTable($iSurveyId);
-        }
         Yii::app()->loadHelper("surveytranslator");
 
         $aData = array();
@@ -1224,7 +1264,7 @@ class Tokens extends SurveyCommonAction
         $aData['thissurvey'] = $oSurvey->attributes;
         $aData['surveyid'] = $iSurveyId;
         $aMandatoryAttributes = $oSurvey->getTokenEncryptionOptions();
-        $aAttributes = getAttributeFieldNames($iSurveyId);
+        $aAttributes = $this->getSurveyAttributeFieldNames($oSurvey);
         $aData['tokenFields'] = array_merge(array_keys($aMandatoryAttributes['columns']), $aAttributes);
 
         $aMandatoryList = array();
@@ -1263,7 +1303,8 @@ class Tokens extends SurveyCommonAction
         $aData['languages'] = $languages;
         $aData['tokencaptions'] = $captions;
         $aData['nrofattributes'] = 0;
-        $oToken = TokenDynamic::model($iSurveyId)->find();
+        // The example row can only be read from an existing participant table
+        $oToken = $bTokenExists ? TokenDynamic::model($iSurveyId)->find() : null;
         $aData['examplerow'] = $oToken;
         $aData['aCPDBAttributes'][''] = gT('(none)');
         foreach (ParticipantAttributeName::model()->getCPDBAttributes() as $aCPDBAttribute) {
@@ -1304,24 +1345,38 @@ class Tokens extends SurveyCommonAction
             Yii::app()->session['flashmessage'] = gT("You do not have permission to access this page.");
             $this->getController()->redirect(array("/surveyAdministration/view/surveyid/{$iSurveyId}"));
         }
-        if (!$oSurvey->hasTokensTable) {
-            // If no tokens table exists
-            $this->newParticipantTable($iSurveyId);
-        }
-
         $number2add = sanitize_int(Yii::app()->request->getPost('addnumber'), 1, 100);
-        $tokenattributefieldnames = getAttributeFieldNames($iSurveyId);
+        $tokenattributefieldnames = $this->getSurveyAttributeFieldNames($oSurvey);
+        $bTokenExists = $oSurvey->hasTokensTable;
+        $aAttributeDescriptions = $oSurvey->decodedAttributedescriptions;
         $i = 1;
 
         for ($b = 0; $b < $number2add; $b++) {
             while (in_array('attribute_' . $i, $tokenattributefieldnames) !== false) {
                 $i++;
             }
-            $tokenattributefieldnames[] = 'attribute_' . $i;
-            Yii::app()->db->createCommand(Yii::app()->db->getSchema()->addColumn("{{tokens_" . intval($iSurveyId) . "}}", 'attribute_' . $i, 'text'))->execute();
+            $sNewAttribute = 'attribute_' . $i;
+            $tokenattributefieldnames[] = $sNewAttribute;
+            if ($bTokenExists) {
+                // Add the physical column to the existing participant table
+                Yii::app()->db->createCommand(Yii::app()->db->getSchema()->addColumn("{{tokens_" . intval($iSurveyId) . "}}", $sNewAttribute, 'text'))->execute();
+            } else {
+                // No table yet, only register the attribute
+                $aAttributeDescriptions[$sNewAttribute] = array(
+                    'description'   => '',
+                    'mandatory'     => 'N',
+                    'encrypted'     => 'N',
+                    'show_register' => 'N',
+                    'cpdbmap'       => '',
+                );
+            }
         }
 
-        Yii::app()->db->schema->getTable($oSurvey->tokensTableName, true); // Refresh schema cache just in case the table existed in the past
+        if ($bTokenExists) {
+            Yii::app()->db->schema->getTable($oSurvey->tokensTableName, true); // Refresh schema cache just in case the table existed in the past
+        } else {
+            Survey::model()->updateByPk($iSurveyId, array('attributedescriptions' => json_encode($aAttributeDescriptions)));
+        }
         LimeExpressionManager::SetDirtyFlag(); // so that knows that survey participant lists have changed
 
         Yii::app()->session['flashmessage'] = sprintf(gT("%s field(s) were successfully added."), $number2add);
@@ -1337,11 +1392,6 @@ class Tokens extends SurveyCommonAction
     {
         $iSurveyId = (int) $iSurveyId;
         $oSurvey = Survey::model()->findByPk($iSurveyId);
-        // CHECK TO SEE IF A Survey participant list EXISTS FOR THIS SURVEY
-        if (!$oSurvey->hasTokensTable) {
-            Yii::app()->session['flashmessage'] = gT("No survey participant list.");
-            $this->getController()->redirect($this->getController()->createUrl("/surveyAdministration/view/surveyid/{$iSurveyId}"));
-        }
         if (!Permission::model()->hasSurveyPermission($iSurveyId, 'tokens', 'update') && !Permission::model()->hasSurveyPermission($iSurveyId, 'surveysettings', 'update')) {
             Yii::app()->session['flashmessage'] = gT("You do not have permission to access this page.");
             $this->getController()->redirect($this->getController()->createUrl("/surveyAdministration/view/surveyid/{$iSurveyId}"));
@@ -1352,7 +1402,7 @@ class Tokens extends SurveyCommonAction
         $aData['surveyid'] = $iSurveyId;
         $confirm = Yii::app()->request->getPost('confirm', '');
         $cancel = Yii::app()->request->getPost('cancel', '');
-        $tokenfields = getAttributeFieldNames($iSurveyId);
+        $tokenfields = $this->getSurveyAttributeFieldNames($oSurvey);
         $sAttributeToDelete = Yii::app()->request->getPost('deleteattribute', '');
         if (!in_array($sAttributeToDelete, $tokenfields)) {
             $sAttributeToDelete = false;
@@ -1385,9 +1435,12 @@ class Tokens extends SurveyCommonAction
             unset($aTokenAttributeDescriptions[$sAttributeToDelete]);
             Survey::model()->updateByPk($iSurveyId, array('attributedescriptions' => json_encode($aTokenAttributeDescriptions)));
 
-            $sTableName = "{{tokens_" . intval($iSurveyId) . "}}";
-            Yii::app()->db->createCommand(Yii::app()->db->getSchema()->dropColumn($sTableName, $sAttributeToDelete))->execute();
-            Yii::app()->db->schema->getTable($sTableName, true); // Refresh schema cache
+            // Drop the physical column only when the participant table already exists
+            if ($oSurvey->hasTokensTable) {
+                $sTableName = "{{tokens_" . intval($iSurveyId) . "}}";
+                Yii::app()->db->createCommand(Yii::app()->db->getSchema()->dropColumn($sTableName, $sAttributeToDelete))->execute();
+                Yii::app()->db->schema->getTable($sTableName, true); // Refresh schema cache
+            }
             LimeExpressionManager::SetDirtyFlag();
             Yii::app()->session['flashmessage'] = sprintf(gT("Attribute %s was deleted."), $sAttributeToDelete);
             Yii::app()->getController()->redirect(Yii::app()->getController()->createUrl("/admin/tokens/sa/managetokenattributes/surveyid/$iSurveyId"));
@@ -1430,8 +1483,7 @@ class Tokens extends SurveyCommonAction
             $aTokenencryptionoptions['columns'][$column] = $fieldcontents[$column]['encrypted'];
         }
 
-        // find custom attribute column names
-        $tokenattributefieldnames = getAttributeFieldNames($iSurveyId);
+        $tokenattributefieldnames = $this->getSurveyAttributeFieldNames($oSurvey);
         // custom attributes
         foreach ($tokenattributefieldnames as $fieldname) {
             if (isset(json_decode((string) $oSurvey->attributedescriptions)->$fieldname->encrypted)) {
@@ -1463,7 +1515,13 @@ class Tokens extends SurveyCommonAction
         $oDB = Yii::app()->db;
         $oTransaction = $oDB->beginTransaction();
         try {
-            $this->updateEncryption($iSurveyId, $aOptionsAfterChange);
+            if ($oSurvey->hasTokensTable) {
+                $this->updateEncryption($iSurveyId, $aOptionsAfterChange);
+            } else {
+                // No table yet: there are no rows to encrypt, but still persist the encryption
+                // preference for the mandatory columns so it is applied when the table is created.
+                Survey::model()->updateByPk($iSurveyId, ['tokenencryptionoptions' => json_encode($aTokenencryptionoptions)]);
+            }
 
             // save token encryption options if everything was ok
             Survey::model()->updateByPk($iSurveyId, ['attributedescriptions' => json_encode($fieldcontents)]);
@@ -2863,8 +2921,13 @@ class Tokens extends SurveyCommonAction
 
         $thissurvey = $oSurvey->attributes;
         $aAdditionalAttributeFields = $oSurvey->decodedAttributedescriptions;
-        $aTokenFieldNames = Yii::app()->db->getSchema()->getTable("{{tokens_$iSurveyId}}", true);
-        $aTokenFieldNames = array_keys($oSurvey->hasTokensTable ? $aTokenFieldNames->columns : $defaultFields);
+        if ($oSurvey->hasTokensTable) {
+            $aTokenFieldNames = Yii::app()->db->getSchema()->getTable("{{tokens_$iSurveyId}}", true);
+            $aTokenFieldNames = array_keys($aTokenFieldNames->columns);
+        } else {
+            // No table yet, include the core fields plus any attributes managed beforehand
+            $aTokenFieldNames = array_merge(array_keys($defaultFields), array_keys($aAdditionalAttributeFields));
+        }
         $aData['attrfieldnames'] = array();
         foreach ($aAdditionalAttributeFields as $sField => $aAttrData) {
             if (in_array($sField, $aTokenFieldNames)) {

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -2050,6 +2050,16 @@ class Survey extends LSActiveRecord implements PermissionInterface
     }
 
     /**
+     * Get all surveys regardless of whether they already have a participant (token) table
+     *
+     * @return Survey[]
+     */
+    public static function getSurveysForAddingParticipants()
+    {
+        return self::model()->with(array('languagesettings' => array('condition' => 'surveyls_language=language'), 'owner'))->findAll();
+    }
+
+    /**
      * Fix invalid question in this survey
      * Delete question that don't exist in primary language
      */

--- a/application/models/TokenDynamic.php
+++ b/application/models/TokenDynamic.php
@@ -681,6 +681,21 @@ class TokenDynamic extends LSActiveRecord
      */
     public function getStandardColsForGrid()
     {
+        return self::buildStandardColsForGrid(self::$sid, $this);
+    }
+
+    /**
+     * Builds the standard (core) grid columns for a survey participant table.
+     *
+     * Static so it works for both the populated grid and the empty grid that is
+     * shown before the participant table exists.
+     *
+     * @param int $iSurveyId
+     * @param LSActiveRecord $labeler
+     * @return array
+     */
+    public static function buildStandardColsForGrid($iSurveyId, $labeler)
+    {
         return [
             [
                 'id'                => 'tid',
@@ -698,21 +713,21 @@ class TokenDynamic extends LSActiveRecord
                 'htmlOptions'       => ['class' => ' text-end'],
             ],
             [
-                'header'            => gT('First name') . $this->setEncryptedAttributeLabel(self::$sid, 'Token', 'firstname'),
+                'header'            => gT('First name') . $labeler->setEncryptedAttributeLabel($iSurveyId, 'Token', 'firstname'),
                 'name'              => 'firstname',
                 'value'             => '$data->firstname',
                 'headerHtmlOptions' => ['class' => ''],
                 'htmlOptions'       => ['class' => ' name'],
             ],
             [
-                'header'            => gT('Last name') . $this->setEncryptedAttributeLabel(self::$sid, 'Token', 'lastname'),
+                'header'            => gT('Last name') . $labeler->setEncryptedAttributeLabel($iSurveyId, 'Token', 'lastname'),
                 'name'              => 'lastname',
                 'value'             => '$data->lastname',
                 'headerHtmlOptions' => ['class' => ''],
                 'htmlOptions'       => ['class' => ' name'],
             ],
             [
-                'header'            => gT('Email address') . $this->setEncryptedAttributeLabel(self::$sid, 'Token', 'email'),
+                'header'            => gT('Email address') . $labeler->setEncryptedAttributeLabel($iSurveyId, 'Token', 'email'),
                 'name'              => 'email',
                 'type'              => 'raw',
                 'value'             => '$data->emailFormated',
@@ -720,7 +735,7 @@ class TokenDynamic extends LSActiveRecord
                 'htmlOptions'       => ['class' => ' name'],
             ],
             [
-                'header'            => gT('Email status') . $this->setEncryptedAttributeLabel(self::$sid, 'Token', 'emailstatus'),
+                'header'            => gT('Email status') . $labeler->setEncryptedAttributeLabel($iSurveyId, 'Token', 'emailstatus'),
                 'name'              => 'emailstatus',
                 'value'             => '$data->emailstatusFormated',
                 'type'              => 'raw',
@@ -803,9 +818,24 @@ class TokenDynamic extends LSActiveRecord
      */
     public function getAttributesForGrid()
     {
+        return self::buildAttributesForGrid(self::$sid, $this);
+    }
+
+    /**
+     * Builds the full grid column set (standard + custom attributes + action column) for a survey.
+     *
+     * Extracted as static so it can be reused for the empty-state grid rendered before the
+     * participant table exists. $labeler is any LSActiveRecord used only for encryption labels.
+     *
+     * @param int $iSurveyId
+     * @param LSActiveRecord $labeler
+     * @return array
+     */
+    public static function buildAttributesForGrid($iSurveyId, $labeler)
+    {
         $aCustomAttributesCols = array();
 
-        $oSurvey = Survey::model()->findByAttributes(array("sid" => self::$sid));
+        $oSurvey = Survey::model()->findByAttributes(array("sid" => $iSurveyId));
         $aCustomAttributes = $oSurvey->tokenAttributes;
 
         // Custom attributes
@@ -820,7 +850,7 @@ class TokenDynamic extends LSActiveRecord
             }
 
             $aCustomAttributesCols[] = array(
-                'header' => $desc . $this->setEncryptedAttributeLabel(self::$sid, 'Token', $sColName), // $aAttributedescriptions->$sColName->description,
+                'header' => $desc . $labeler->setEncryptedAttributeLabel($iSurveyId, 'Token', $sColName), // $aAttributedescriptions->$sColName->description,
                 'name' => $sColName,
                 'type' => $type,
                 'value' => $value,
@@ -841,7 +871,7 @@ class TokenDynamic extends LSActiveRecord
             ]
         ];
 
-        return array_merge($this->getStandardColsForGrid(), $aCustomAttributesCols, $actionColumn);
+        return array_merge(self::buildStandardColsForGrid($iSurveyId, $labeler), $aCustomAttributesCols, $actionColumn);
     }
 
     /**

--- a/application/models/TokenEmptyGridFilter.php
+++ b/application/models/TokenEmptyGridFilter.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+   * LimeSurvey
+   * Copyright (C) 2013-2026 The LimeSurvey Project Team
+   * All rights reserved.
+   * License: GNU/GPL License v2 or later, see LICENSE.php
+   * LimeSurvey is free software. This version may have been modified pursuant
+   * to the GNU General Public License, and as distributed it includes or
+   * is derivative of works licensed under the GNU General Public License or
+   * other free or open source software licenses.
+   * See COPYRIGHT.php for copyright notices and details.
+   *
+*/
+
+/**
+ * Class TokenEmptyGridFilter
+ *
+ * Lightweight form model used as the filter for the empty participant grid shown before
+ * the participant table exists. The real grid filters with TokenDynamic, but that model
+ * can't be instantiated without a physical table. This model just needs to expose the
+ * grid's column names as attributes so CGridView can render the standard filter inputs.
+ * The inputs are only presentational here — there's no data to filter yet.
+ */
+class TokenEmptyGridFilter extends CFormModel
+{
+    /** @var array<string,mixed> attribute name => value */
+    private $attributeValues = array();
+
+    /** @var string[] ordered attribute names */
+    private $attributeNamesList = array();
+
+    /**
+     * @param string[] $attributeNames the grid column names to expose as filterable attributes
+     */
+    public function __construct(array $attributeNames)
+    {
+        $this->attributeNamesList = $attributeNames;
+        foreach ($attributeNames as $name) {
+            $this->attributeValues[$name] = null;
+        }
+        parent::__construct();
+    }
+
+    /** @inheritdoc */
+    public function attributeNames()
+    {
+        return $this->attributeNamesList;
+    }
+
+    /** @inheritdoc */
+    public function rules()
+    {
+        if (empty($this->attributeNamesList)) {
+            return array();
+        }
+        return array(
+            array(implode(',', $this->attributeNamesList), 'safe'),
+        );
+    }
+
+    /** @inheritdoc */
+    public function __get($name)
+    {
+        if (array_key_exists($name, $this->attributeValues)) {
+            return $this->attributeValues[$name];
+        }
+        return parent::__get($name);
+    }
+
+    /** @inheritdoc */
+    public function __set($name, $value)
+    {
+        if (array_key_exists($name, $this->attributeValues)) {
+            $this->attributeValues[$name] = $value;
+            return;
+        }
+        parent::__set($name, $value);
+    }
+
+    /** @inheritdoc */
+    public function __isset($name)
+    {
+        if (array_key_exists($name, $this->attributeValues)) {
+            return isset($this->attributeValues[$name]);
+        }
+        return parent::__isset($name);
+    }
+}

--- a/application/views/admin/token/surveyParticipantView.php
+++ b/application/views/admin/token/surveyParticipantView.php
@@ -86,13 +86,13 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
             </div>
         </div>
     </div>
-    <h2 class="summary-title mt-4 pb-2 mb-3"><?php $model && eT("All participants"); ?></h2>
+    <h2 class="summary-title mt-4 pb-2 mb-3"><?php ($model || !empty($emptyGridDataProvider)) && eT("All participants"); ?></h2>
     <div class='side-body'>
         <input type='hidden' id="dateFormatDetails" name='dateFormatDetails' value='<?php echo json_encode($dateformatdetails); ?>' />
         <input type="hidden" id="locale" name="locale" value="<?= convertLStoDateTimePickerLocale(Yii::app()->session['adminlang']) ?>" />
         <input type='hidden' name='rtl' value='<?php echo getLanguageRTL($_SESSION['adminlang']) ? '1' : '0'; ?>' />
         <?php
-        $model && $this->widget('ext.AlertWidget.AlertWidget', [
+        ($model || !empty($emptyGridDataProvider)) && $this->widget('ext.AlertWidget.AlertWidget', [
             'tag'  => 'p',
             'text' => gT(
                 "You can use operators in the search filters (eg: >, <, >=, <=, = )"
@@ -113,36 +113,52 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
         <div class="row">
             <div class="content-right">
                 <?php
-                $model && $this->widget('application.extensions.admin.grid.CLSGridView', [
-                    'dataProvider'          => $model->search(),
-                    'filter'                => $model,
-                    'id'                    => 'token-grid',
-                    'emptyText'             => gT('No survey participants found.'),
-                    'massiveActionTemplate' => $massiveAction,
-                    'summaryText'           => gT('Displaying {start}-{end} of {count} result(s).') . ' ' . sprintf(
-                        gT('%s rows per page'),
-                        CHtml::dropDownList(
-                            'pageSizeTokenView',
-                            $pageSizeTokenView,
-                            Yii::app()->params['pageSizeOptionsTokens'],
-                            ['class' => 'changePageSize form-select', 'style' => 'display: inline; width: auto']
-                        )
-                    ),
-                    'columns'               => $model->getAttributesForGrid(),
-                    'ajaxUpdate'            => 'token-grid',
-                    'ajaxType'              => 'POST',
-                    'lsSelectAllEnabled'    => true,
-                    'lsAfterAjaxUpdate'     => ['onUpdateTokenGrid();', 'switchStatusOfListActions();', 'LS.restoreFocusAfterSort("token-grid");']
-                ]);
+                if ($model) {
+                    $this->widget('application.extensions.admin.grid.CLSGridView', [
+                        'dataProvider'          => $model->search(),
+                        'filter'                => $model,
+                        'id'                    => 'token-grid',
+                        'emptyText'             => gT('No survey participants found.'),
+                        'massiveActionTemplate' => $massiveAction,
+                        'summaryText'           => gT('Displaying {start}-{end} of {count} result(s).') . ' ' . sprintf(
+                            gT('%s rows per page'),
+                            CHtml::dropDownList(
+                                'pageSizeTokenView',
+                                $pageSizeTokenView,
+                                Yii::app()->params['pageSizeOptionsTokens'],
+                                ['class' => 'changePageSize form-select', 'style' => 'display: inline; width: auto']
+                            )
+                        ),
+                        'columns'               => $model->getAttributesForGrid(),
+                        'ajaxUpdate'            => 'token-grid',
+                        'ajaxType'              => 'POST',
+                        'lsSelectAllEnabled'    => true,
+                        'lsAfterAjaxUpdate'     => ['onUpdateTokenGrid();', 'switchStatusOfListActions();', 'LS.restoreFocusAfterSort("token-grid");']
+                    ]);
+                } elseif (!empty($emptyGridDataProvider)) {
+                    $this->widget('application.extensions.admin.grid.CLSGridView', [
+                        'dataProvider'          => $emptyGridDataProvider,
+                        'filter'                => $emptyGridFilter,
+                        'id'                    => 'token-grid',
+                        'emptyText'             => gT('No survey participants found.'),
+                        'massiveActionTemplate' => $massiveAction,
+                        'columns'               => $emptyGridColumns,
+                        'showTableOnEmpty'      => true,
+                        'ajaxUpdate'            => 'token-grid',
+                        'ajaxType'              => 'POST',
+                        'lsAfterAjaxUpdate'     => [],
+                    ]);
+                }
                 ?>
             </div>
         </div>
 
         <?php
         if ((!$oSurvey->hasTokens()) && (Permission::model()->hasSurveyPermission($oSurvey->sid, 'surveysettings', 'update') || Permission::model()->hasSurveyPermission($oSurvey->sid, 'tokens','create'))):
-            echo eT("No survey participants found.");
         ?>
-                <input class="btn btn-large btn-block btn-outline-secondary" type='button' value='<?php eT("Add participants"); ?>' onclick="window.open('<?php echo $this->createUrl("admin/tokens/sa/addnew/surveyid/" . $surveyid); ?>', '_top')" />
+                <a href="<?php echo $this->createUrl('admin/tokens/sa/addnew', ['surveyid' => $surveyid]); ?>" class="btn btn-large btn-block btn-outline-secondary" target="_top">
+                    <?php eT("Add participants"); ?>
+                </a>
                 <?php
                 if (isset($oldlist)) {
                 ?>

--- a/application/views/surveyAdministration/partial/topbar_tokens/leftSideButtons.php
+++ b/application/views/surveyAdministration/partial/topbar_tokens/leftSideButtons.php
@@ -23,24 +23,26 @@ if ($hasTokensCreatePermission || $hasTokensImportPermission) {
     <?php
 }
 
+// Managing attributes is allowed even before the participant table exists
+if ($hasTokensUpdatePermission || $hasSurveySettingsUpdatePermission) {
+    $this->widget(
+        'ext.ButtonWidget.ButtonWidget',
+        [
+            'name' => 'tokens-manage-attributes',
+            'id' => 'tokens-manage-attributes',
+            'text' => gT('Manage attributes'),
+            'icon' => 'ri-server-fill',
+            'link' => Yii::App()->createUrl("admin/tokens/sa/managetokenattributes/surveyid/$oSurvey->sid"),
+            'htmlOptions' => [
+                'class' => 'btn btn-outline-secondary',
+                'role' => 'button'
+            ],
+        ]
+    );
+}
+
 if ($tokenexists) {
-    if ($hasTokensUpdatePermission || $hasSurveySettingsUpdatePermission) {
-        $this->widget(
-            'ext.ButtonWidget.ButtonWidget',
-            [
-                'name' => 'tokens-manage-attributes',
-                'id' => 'tokens-manage-attributes',
-                'text' => gT('Manage attributes'),
-                'icon' => 'ri-server-fill',
-                'link' => Yii::App()->createUrl("admin/tokens/sa/managetokenattributes/surveyid/$oSurvey->sid"),
-                'htmlOptions' => [
-                    'class' => 'btn btn-outline-secondary',
-                    'role' => 'button'
-                ],
-            ]
-        );
-    }
-    
+
     if ($hasTokensExportPermission) {
         $this->widget(
             'ext.ButtonWidget.ButtonWidget',


### PR DESCRIPTION
AT-2112: included AT-2114 and AT-2115 
Create participant table when click on participants tab, and when adding first participants from CPDB - v6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added participants can now be prepared for surveys before a participant table exists.
  * Survey participant pages display an empty, filterable grid before participants are added.
  * Custom participant attributes can be managed and configured before table creation.
  * Added a direct “Add participants” action when no participants are available.

* **Bug Fixes**
  * Added permission checks before creating participant tables.
  * Improved handling of encrypted participant attribute labels and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->