### PR TITLE
Fixed issue #20608: datasecurity is not rendered correctly with "All in one" survey

### DIFF
--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -739,16 +739,10 @@ window.addEventListener('message', function(event) {
          * operation runs only once per request; subsequent calls return the input unchanged.
          *
          * @param array $aSurveyInfo Survey rendering data; must contain at least `sid` when available.
-         * @return array The updated `$aSurveyInfo` array with `datasecurity_notice_label` and `datasecurity_error` ensured and the notice label rendered as HTML.
+         * @return array The updated `$aSurveyInfo` array with `datasecurity_notice_label` and `datasecurity_error` ensured.
          */
     private function setDefaultPrivacyText($aSurveyInfo)
     {
-        /* Do it one time only (and do not recall self when using renderPartial) */
-        static $DefaultPrivacyDone = false;
-        if ($DefaultPrivacyDone) {
-            return $aSurveyInfo;
-        }
-        $DefaultPrivacyDone = true;
         if (empty($aSurveyInfo['datasecurity_notice_label'])) {
             $aSurveyInfo['datasecurity_notice_label'] = gT("To continue please first accept our survey privacy policy.");
         }
@@ -759,13 +753,6 @@ window.addEventListener('message', function(event) {
         $translation = [
             "Show policy" => gT("Show policy")
         ];
-        $aSurveyInfo['datasecurity_notice_label'] =  $this->renderPartial(
-            './subviews/privacy/privacy_datasecurity_notice_label.twig',
-            [
-                'dataSecurityNoticeLabel' => $aSurveyInfo['datasecurity_notice_label'],
-                'sid' => $aSurveyInfo['sid'],
-            ]
-        );
         return $aSurveyInfo;
     }
 

--- a/application/core/LSETwigViewRenderer.php
+++ b/application/core/LSETwigViewRenderer.php
@@ -732,15 +732,14 @@ window.addEventListener('message', function(event) {
     }
 
     /**
-         * Ensure privacy text strings exist and render the privacy notice label.
-         *
-         * If specific privacy strings are empty, sets sensible defaults and renders
-         * the `datasecurity_notice_label` using the privacy twig partial. This
-         * operation runs only once per request; subsequent calls return the input unchanged.
-         *
-         * @param array $aSurveyInfo Survey rendering data; must contain at least `sid` when available.
-         * @return array The updated `$aSurveyInfo` array with `datasecurity_notice_label` and `datasecurity_error` ensured.
-         */
+     * Ensure privacy text strings exist.
+     *
+     * If specific privacy strings are empty, sets sensible defaults. The theme
+     * renders `datasecurity_notice_label` through its privacy subview.
+     *
+     * @param array $aSurveyInfo Survey rendering data; must contain at least `sid` when available.
+     * @return array The updated `$aSurveyInfo` array with `datasecurity_notice_label` and `datasecurity_error` ensured.
+     */
     private function setDefaultPrivacyText($aSurveyInfo)
     {
         if (empty($aSurveyInfo['datasecurity_notice_label'])) {
@@ -757,14 +756,14 @@ window.addEventListener('message', function(event) {
     }
 
     /**
-         * Ensure option flags that depend on files are coherent.
-         *
-         * If a file-related option (e.g., `brandlogofile`, `backgroundimagefile`) is empty,
-         * the corresponding boolean-like option (`brandlogo`, `backgroundimage`) is set to `"false"`.
-         *
-         * @param array $aData Rendering data (expects `aSurveyInfo['options']` when present).
-         * @return array The input `$aData` with corrected option flags where applicable.
-         */
+     * Ensure option flags that depend on files are coherent.
+     *
+     * If a file-related option (e.g., `brandlogofile`, `backgroundimagefile`) is empty,
+     * the corresponding boolean-like option (`brandlogo`, `backgroundimage`) is set to `"false"`.
+     *
+     * @param array $aData Rendering data (expects `aSurveyInfo['options']` when present).
+     * @return array The input `$aData` with corrected option flags where applicable.
+     */
     private function fixDataCoherence($aData)
     {
         // Clean option with files

--- a/application/models/Survey.php
+++ b/application/models/Survey.php
@@ -2247,24 +2247,6 @@ class Survey extends LSActiveRecord implements PermissionInterface
     }
 
     /**
-     * Get the final label for survey ID
-     * @param string $dataSecurityNoticeLabel current label
-     * @param integer $surveyId
-     * @deprecated 6.16.1 replaced by private function in LSETwigViewRenderer
-     * @return string
-     */
-    public static function replacePolicyLink($dataSecurityNoticeLabel, $surveyId)
-    {
-        return App()->twigRenderer->renderPartial(
-            '/subviews/privacy/privacy_datasecurity_notice_label.twig',
-            [
-                'dataSecurityNoticeLabel' => $dataSecurityNoticeLabel,
-                'sid' => $surveyId,
-            ]
-        );
-    }
-
-    /**
      * @param string $type Question->type
      * @param bool $includeSubquestions
      * @return Question

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_datasecurity_notice_label.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_datasecurity_notice_label.twig
@@ -1,6 +1,7 @@
 {# 
     use aSurveyInfo datasecurity_notice_label
 #}
+{% set dataSecurityNoticeLabel = aSurveyInfo.datasecurity_notice_label %}
 {% set STARTPOLICYLINK = "" %}
 {% set ENDPOLICYLINK = "" %}
 {% if(aSurveyInfo.showsurveypolicynotice == 2) %}

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
@@ -34,9 +34,10 @@ Show the privacy message and the data security message will be available in a mo
     <div class="row row-cols-lg-auto align-items-center datasecurity-checkbox-container">
         <div class="col-12 checkbox-item">
             <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" {{ privacychecked }} type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
+            {% set dataSecurityNoticeLabel = include('./subviews/privacy/privacy_datasecurity_notice_label.twig') %}
             <label for="datasecurity_accepted"
                    class="control-label checkbox-label form-check-label datasecurity-checkbox-label {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">
-                {{ aSurveyInfo.datasecurity_notice_label }}
+                {{ dataSecurityNoticeLabel }}
             </label>
         </div>
     </div>

--- a/themes/survey/vanilla/views/subviews/privacy/privacy_datasecurity_notice_label.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy_datasecurity_notice_label.twig
@@ -1,6 +1,7 @@
 {# 
     use aSurveyInfo datasecurity_notice_label
 #}
+{% set dataSecurityNoticeLabel = aSurveyInfo.datasecurity_notice_label %}
 {% set STARTPOLICYLINK = "" %}
 {% set ENDPOLICYLINK = "" %}
 {% if(aSurveyInfo.showsurveypolicynotice == 2) %}

--- a/themes/survey/vanilla/views/subviews/privacy/privacy_modal.twig
+++ b/themes/survey/vanilla/views/subviews/privacy/privacy_modal.twig
@@ -29,8 +29,9 @@
 	{% endif %}
 {% endif %}
 <div class="form-check">
+    {% set dataSecurityNoticeLabel = include('./subviews/privacy/privacy_datasecurity_notice_label.twig') %}
     <input required class="{{ aSurveyInfo.class.privacydataseccheckbox }} form-check-input" {{ privacychecked }} type="checkbox" name="datasecurity_accepted" id="datasecurity_accepted" aria-describedby="{{ describedbyprivacy }}"/>
-    <label for="datasecurity_accepted" class="form-check-label fw-bold {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">{{ aSurveyInfo.datasecurity_notice_label }}</label>
+    <label for="datasecurity_accepted" class="form-check-label fw-bold {{ aSurveyInfo.class.privacydataseccheckboxlabel }}">{{ dataSecurityNoticeLabel }}</label>
 </div>
 <div class="collapse fade mb-3" id="data-security-modal-{{aSurveyInfo.sid}}">
     <div class="card card-primary">


### PR DESCRIPTION
Fixed issue #20608: datasecurity_notice_label is not rendered correctly with "Collapsible text" and "All in one" survey format
Dev: move logic to theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of data privacy consent labels in survey forms across supported themes.
  * Privacy modals now consistently source the data security checkbox label from the dedicated privacy subview.
  * Privacy notices now properly apply placeholder replacements and policy-link augmentation based on the configured label text.
  * Fixed cases where privacy notice label content could be missing or not processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->