### PR TITLE
AT-2214 Fix: New Editor map browser detection question type does not show correct map in response detail view

### DIFF
--- a/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import Bowser from 'bowser'
 import {
@@ -6,6 +6,7 @@ import {
   TileLayer,
   Popup,
   Marker as LeafLetMarker,
+  useMapEvents,
 } from 'react-leaflet'
 import L from 'leaflet'
 
@@ -14,7 +15,9 @@ import { getAttributeValue } from 'helpers'
 
 import './TextQuestion.scss'
 
-const LeafletMapComponent = (value = {}) => {
+const DEFAULT_CENTER = [53.61422133647984, 9.972816890552014]
+
+const LeafletMapComponent = ({ value, onChange }) => {
   const customIcon = new L.Icon({
     iconUrl: 'https://unpkg.com/leaflet@1.5.1/dist/images/marker-icon.png',
     iconSize: [25, 41],
@@ -22,27 +25,69 @@ const LeafletMapComponent = (value = {}) => {
     popupAnchor: [0, -41],
   })
 
-  const valueCords = value?.value?.split(';')
+  const initialPosition = useMemo(() => {
+    const coords = value?.split(';').map(Number)
+    return coords?.length === 2 && coords.every((n) => !Number.isNaN(n))
+      ? coords
+      : DEFAULT_CENTER
+  }, [value])
 
-  const center = valueCords
-    ? valueCords
-    : [53.61422133647984, 9.972816890552014]
+  const [position, setPosition] = useState(initialPosition)
+  const markerRef = useRef(null)
+
+  const updatePosition = ({ lat, lng }) => {
+    const newPosition = [lat, lng]
+    setPosition(newPosition)
+    onChange?.(`${lat};${lng}`)
+  }
+
+  const MapClickHandler = () => {
+    useMapEvents({
+      click: (event) => updatePosition(event.latlng),
+    })
+    return null
+  }
+
+  const markerEventHandlers = useMemo(
+    () => ({
+      dragend: () => {
+        const marker = markerRef.current
+        if (marker) {
+          updatePosition(marker.getLatLng())
+        }
+      },
+    }),
+    []
+  )
 
   return (
     <MapContainer
-      center={center}
+      center={position}
       zoom={8}
       style={{ height: '350px', width: '100%' }}
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      <LeafLetMarker icon={customIcon} position={center}>
-        <Popup>{t('You are here!')}</Popup>
+      <MapClickHandler />
+      <LeafLetMarker
+        icon={customIcon}
+        position={position}
+        draggable={true}
+        eventHandlers={markerEventHandlers}
+        ref={markerRef}
+      >
+        <Popup>
+          {t('Drag the marker or click the map to set the location')}
+        </Popup>
       </LeafLetMarker>
     </MapContainer>
   )
 }
 
-export const BrowserDetectionTextAnswer = ({ attributes = {}, value }) => {
+export const BrowserDetectionTextAnswer = ({
+  attributes = {},
+  value,
+  onLocationChange,
+}) => {
   const [browserInfo, setBrowserInfo] = useState(false)
   const locationMapService = getAttributeValue(attributes.location_mapservice)
 
@@ -87,7 +132,9 @@ export const BrowserDetectionTextAnswer = ({ attributes = {}, value }) => {
           loading="lazy"
         ></iframe>
       )}
-      {locationMapService === '100' && <LeafletMapComponent value={value} />}
+      {locationMapService === '100' && (
+        <LeafletMapComponent value={value} onChange={onLocationChange} />
+      )}
     </div>
   )
 }

--- a/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
@@ -14,7 +14,7 @@ import { getAttributeValue } from 'helpers'
 
 import './TextQuestion.scss'
 
-const LeafletMapComponent = () => {
+const LeafletMapComponent = (value = {}) => {
   const customIcon = new L.Icon({
     iconUrl: 'https://unpkg.com/leaflet@1.5.1/dist/images/marker-icon.png',
     iconSize: [25, 41],
@@ -22,24 +22,27 @@ const LeafletMapComponent = () => {
     popupAnchor: [0, -41],
   })
 
+  const valueCords = value?.value?.split(';')
+
+  const center = valueCords
+    ? valueCords
+    : [53.61422133647984, 9.972816890552014]
+
   return (
     <MapContainer
-      center={[53.61422133647984, 9.972816890552014]}
+      center={center}
       zoom={8}
       style={{ height: '350px', width: '100%' }}
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      <LeafLetMarker
-        icon={customIcon}
-        position={[53.61422133647984, 9.972816890552014]}
-      >
+      <LeafLetMarker icon={customIcon} position={center}>
         <Popup>{t('You are here!')}</Popup>
       </LeafLetMarker>
     </MapContainer>
   )
 }
 
-export const BrowserDetectionTextAnswer = ({ attributes = {} }) => {
+export const BrowserDetectionTextAnswer = ({ attributes = {}, value }) => {
   const [browserInfo, setBrowserInfo] = useState(false)
   const locationMapService = getAttributeValue(attributes.location_mapservice)
 
@@ -84,7 +87,7 @@ export const BrowserDetectionTextAnswer = ({ attributes = {} }) => {
           loading="lazy"
         ></iframe>
       )}
-      {locationMapService === '100' && <LeafletMapComponent />}
+      {locationMapService === '100' && <LeafletMapComponent value={value} />}
     </div>
   )
 }

--- a/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import Bowser from 'bowser'
 import {
@@ -6,6 +6,7 @@ import {
   TileLayer,
   Popup,
   Marker as LeafLetMarker,
+  useMap,
   useMapEvents,
 } from 'react-leaflet'
 import L from 'leaflet'
@@ -35,16 +36,31 @@ const LeafletMapComponent = ({ value, onChange }) => {
   const [position, setPosition] = useState(initialPosition)
   const markerRef = useRef(null)
 
-  const updatePosition = ({ lat, lng }) => {
-    const newPosition = [lat, lng]
-    setPosition(newPosition)
-    onChange?.(`${lat};${lng}`)
-  }
+  useEffect(() => {
+    setPosition(initialPosition)
+  }, [initialPosition])
+
+  const updatePosition = useCallback(
+    ({ lat, lng }) => {
+      const newPosition = [lat, lng]
+      setPosition(newPosition)
+      onChange?.(`${lat};${lng}`)
+    },
+    [onChange]
+  )
 
   const MapClickHandler = () => {
     useMapEvents({
       click: (event) => updatePosition(event.latlng),
     })
+    return null
+  }
+
+  const MapViewSyncer = () => {
+    const map = useMap()
+    useEffect(() => {
+      map.setView(position)
+    }, [map, position])
     return null
   }
 
@@ -57,7 +73,7 @@ const LeafletMapComponent = ({ value, onChange }) => {
         }
       },
     }),
-    []
+    [updatePosition]
   )
 
   return (
@@ -68,6 +84,7 @@ const LeafletMapComponent = ({ value, onChange }) => {
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       <MapClickHandler />
+      <MapViewSyncer />
       <LeafLetMarker
         icon={customIcon}
         position={position}

--- a/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.test.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.test.js
@@ -1,0 +1,125 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { BrowserDetectionTextAnswer } from './BrowserDetectionTextAnswer'
+
+// Capture the props/handlers passed to the (mocked) react-leaflet primitives so
+// the tests can simulate map clicks and marker drags.
+let capturedMapEvents = {}
+let capturedMarkerProps = {}
+
+jest.mock('leaflet', () => ({
+  __esModule: true,
+  default: {
+    Icon: class {
+      constructor(options) {
+        this.options = options
+      }
+    },
+  },
+}))
+
+jest.mock('react-leaflet', () => {
+  const ReactMock = require('react')
+  return {
+    __esModule: true,
+    MapContainer: ({ children, center }) => (
+      <div data-testid="map" data-center={JSON.stringify(center)}>
+        {children}
+      </div>
+    ),
+    TileLayer: () => <div data-testid="tile-layer" />,
+    Popup: ({ children }) => <div data-testid="popup">{children}</div>,
+    Marker: ReactMock.forwardRef((props, ref) => {
+      capturedMarkerProps = props
+      if (ref) {
+        // Fake leaflet marker instance used by the dragend handler.
+        ref.current = { getLatLng: () => ({ lat: 10.5, lng: 20.25 }) }
+      }
+      return (
+        <div
+          data-testid="marker"
+          data-position={JSON.stringify(props.position)}
+          data-draggable={String(props.draggable)}
+        >
+          {props.children}
+        </div>
+      )
+    }),
+    useMapEvents: (handlers) => {
+      capturedMapEvents = handlers
+      return null
+    },
+  }
+})
+
+const renderMap = (props = {}) =>
+  render(
+    <BrowserDetectionTextAnswer
+      attributes={{ location_mapservice: '100' }}
+      {...props}
+    />
+  )
+
+beforeEach(() => {
+  global.t = (key) => key
+  global.st = (key) => key
+  capturedMapEvents = {}
+  capturedMarkerProps = {}
+})
+
+describe('BrowserDetectionTextAnswer - editable location map', () => {
+  it('renders the map with a draggable marker when location_mapservice is 100', () => {
+    renderMap()
+
+    expect(screen.getByTestId('map')).toBeInTheDocument()
+    expect(screen.getByTestId('marker')).toHaveAttribute(
+      'data-draggable',
+      'true'
+    )
+  })
+
+  it('uses the provided value as the initial marker position', () => {
+    renderMap({ value: '48.1;16.3' })
+
+    expect(screen.getByTestId('marker')).toHaveAttribute(
+      'data-position',
+      JSON.stringify([48.1, 16.3])
+    )
+  })
+
+  it('falls back to the default center when no valid value is provided', () => {
+    renderMap({ value: 'not-a-coordinate' })
+
+    expect(screen.getByTestId('marker')).toHaveAttribute(
+      'data-position',
+      JSON.stringify([53.61422133647984, 9.972816890552014])
+    )
+  })
+
+  it('calls onChange with the clicked coordinates', () => {
+    const onLocationChange = jest.fn()
+    renderMap({ onLocationChange })
+
+    capturedMapEvents.click({ latlng: { lat: 12.34, lng: 56.78 } })
+
+    expect(onLocationChange).toHaveBeenCalledWith('12.34;56.78')
+  })
+
+  it('calls onChange with the marker position after dragging', () => {
+    const onLocationChange = jest.fn()
+    renderMap({ onLocationChange })
+
+    capturedMarkerProps.eventHandlers.dragend()
+
+    expect(onLocationChange).toHaveBeenCalledWith('10.5;20.25')
+  })
+
+  it('does not render the map when location_mapservice is not 100', () => {
+    render(
+      <BrowserDetectionTextAnswer attributes={{ location_mapservice: '0' }} />
+    )
+
+    expect(screen.queryByTestId('map')).not.toBeInTheDocument()
+  })
+})

--- a/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.test.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/BrowserDetectionTextAnswer.test.js
@@ -50,6 +50,7 @@ jest.mock('react-leaflet', () => {
       capturedMapEvents = handlers
       return null
     },
+    useMap: () => ({ setView: jest.fn() }),
   }
 })
 

--- a/editor/src/components/QuestionTypes/TextQuestion/TextQuestion.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/TextQuestion.js
@@ -45,6 +45,7 @@ export const TextQuestion = ({
         <BrowserDetectionTextAnswer
           value={value.value}
           attributes={attributes}
+          onLocationChange={handleOnChange}
         />
       )}
     </div>

--- a/editor/src/components/QuestionTypes/TextQuestion/TextQuestion.js
+++ b/editor/src/components/QuestionTypes/TextQuestion/TextQuestion.js
@@ -42,7 +42,10 @@ export const TextQuestion = ({
         />
       )}
       {questionThemeName === getQuestionTypeInfo().BROWSER_DETECTION.theme && (
-        <BrowserDetectionTextAnswer attributes={attributes} />
+        <BrowserDetectionTextAnswer
+          value={value.value}
+          attributes={attributes}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive location map for browser-detection questions.
  * Users can set a location by clicking the map or dragging the marker.
  * Existing location values are displayed when valid, with a default location used when unavailable.
  * Location updates are automatically saved in `latitude;longitude` format.

* **Tests**
  * Added coverage for map rendering, initial locations, fallback behavior, clicks, and marker dragging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->