### PR TITLE
Fixed issue #20624: Error when updating to 7.0.7 due to missing DB version check

### DIFF
--- a/application/helpers/DbVersionHelper.php
+++ b/application/helpers/DbVersionHelper.php
@@ -52,7 +52,8 @@ class DbVersionHelper
         // MariaDB 10+ prepends a "5.5.5-" replication compatibility prefix to its
         // reported version. Strip it so the real version can be extracted.
         $cleanVersion = preg_replace('/^5\.5\.5-/', '', (string)$serverVersion);
-        $currentVersion = preg_match('/\d+(\.\d+)+/', $cleanVersion, $matches) ? $matches[0] : $cleanVersion;
+        // Accept both multi-segment ("10.3.38") and single-segment ("14") versions.
+        $currentVersion = preg_match('/\d+(\.\d+)*/', $cleanVersion, $matches) ? $matches[0] : '';
 
         if (in_array($driverName, ['mysql', 'mysqli'])) {
             if ($isMariaDb) {
@@ -104,7 +105,8 @@ class DbVersionHelper
             'minimum' => $minimum,
             'minimumLabel' => $minimumLabel ?? $minimum,
             'current' => $currentVersion,
-            'supported' => version_compare($currentVersion, $minimum, '>='),
+            // If the version can't be detected, don't block the connection.
+            'supported' => $currentVersion === '' || version_compare($currentVersion, $minimum, '>='),
         ];
     }
 }

--- a/application/helpers/DbVersionHelper.php
+++ b/application/helpers/DbVersionHelper.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * LimeSurvey
+ * Copyright (C) 2007-2026 The LimeSurvey Project Team
+ * All rights reserved.
+ * License: GNU/GPL License v2 or later, see LICENSE.php
+ * LimeSurvey is free software. This version may have been modified pursuant
+ * to the GNU General Public License, and as distributed it includes or
+ * is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ * See COPYRIGHT.php for copyright notices and details.
+ *
+ */
+
+namespace LimeSurvey\Helpers;
+
+/**
+ * Helper to verify that the connected database server meets the documented
+ * minimum version requirements for LimeSurvey.
+ *
+ * @link https://www.limesurvey.org/manual/Installation_-_LimeSurvey_CE
+ */
+class DbVersionHelper
+{
+    /** @var string Minimum supported MariaDB version */
+    public const MINIMUM_MARIADB_VERSION = '10.3.38';
+
+    /** @var string Minimum supported MySQL version */
+    public const MINIMUM_MYSQL_VERSION = '8.0.0';
+
+    /** @var string Minimum supported PostgreSQL version */
+    public const MINIMUM_PGSQL_VERSION = '14';
+
+    /** @var string Minimum supported Microsoft SQL Server version (comparison value) */
+    public const MINIMUM_MSSQL_VERSION = '15.0';
+    /** @var string Minimum supported Microsoft SQL Server version (shown to the user) */
+    public const MINIMUM_MSSQL_LABEL = '2019';
+
+    /**
+     * Inspects the given driver name and server version string and returns
+     * the minimum requirement details for that database type.
+     *
+     * @param string $driverName the PDO driver name (e.g. 'mysql', 'pgsql', 'sqlsrv')
+     * @param string $serverVersion the raw server version string
+     * @return array{type:string, minimum:string, minimumLabel:string, current:string, supported:bool}
+     */
+    public static function getRequirement($driverName, $serverVersion)
+    {
+        $driverName = strtolower((string)$driverName);
+        $isMariaDb = stripos((string)$serverVersion, 'mariadb') !== false;
+        // MariaDB 10+ prepends a "5.5.5-" replication compatibility prefix to its
+        // reported version. Strip it so the real version can be extracted.
+        $cleanVersion = preg_replace('/^5\.5\.5-/', '', (string)$serverVersion);
+        $currentVersion = preg_match('/\d+(\.\d+)+/', $cleanVersion, $matches) ? $matches[0] : $cleanVersion;
+
+        if (in_array($driverName, ['mysql', 'mysqli'])) {
+            if ($isMariaDb) {
+                return self::buildRequirement('MariaDB', self::MINIMUM_MARIADB_VERSION, $currentVersion);
+            }
+            return self::buildRequirement('MySQL', self::MINIMUM_MYSQL_VERSION, $currentVersion);
+        }
+        if ($driverName === 'pgsql') {
+            return self::buildRequirement('PostgreSQL', self::MINIMUM_PGSQL_VERSION, $currentVersion);
+        }
+        if (in_array($driverName, ['sqlsrv', 'dblib', 'mssql'])) {
+            return self::buildRequirement('Microsoft SQL Server', self::MINIMUM_MSSQL_VERSION, $currentVersion, self::MINIMUM_MSSQL_LABEL);
+        }
+
+        // Unknown driver: do not block, treat as supported.
+        return [
+            'type' => $driverName,
+            'minimum' => '',
+            'minimumLabel' => '',
+            'current' => $currentVersion,
+            'supported' => true,
+        ];
+    }
+
+    /**
+     * Convenience wrapper returning only whether the version is supported.
+     *
+     * @param string $driverName
+     * @param string $serverVersion
+     * @return bool
+     */
+    public static function isSupported($driverName, $serverVersion)
+    {
+        $requirement = self::getRequirement($driverName, $serverVersion);
+        return $requirement['supported'];
+    }
+
+    /**
+     * @param string $type human readable database type
+     * @param string $minimum the version used for comparison
+     * @param string $currentVersion the detected server version
+     * @param string|null $minimumLabel the version shown to the user, defaults to $minimum
+     * @return array{type:string, minimum:string, minimumLabel:string, current:string, supported:bool}
+     */
+    private static function buildRequirement($type, $minimum, $currentVersion, $minimumLabel = null)
+    {
+        return [
+            'type' => $type,
+            'minimum' => $minimum,
+            'minimumLabel' => $minimumLabel ?? $minimum,
+            'current' => $currentVersion,
+            'supported' => version_compare($currentVersion, $minimum, '>='),
+        ];
+    }
+}

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -71,11 +71,16 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
     // before starting any migration. Otherwise a migration can fail halfway
     // through (e.g. adding a JSON column on an unsupported MariaDB version) and
     // leave the database in an inconsistent state.
-    $oDbConnection = Yii::app()->getDb();
-    $requirement = \LimeSurvey\Helpers\DbVersionHelper::getRequirement(
-        $oDbConnection->getDriverName(),
-        $oDbConnection->getServerVersion()
-    );
+    try {
+        $oDbConnection = Yii::app()->getDb();
+        $requirement = \LimeSurvey\Helpers\DbVersionHelper::getRequirement(
+            $oDbConnection->getDriverName(),
+            $oDbConnection->getServerVersion()
+        );
+    } catch (CDbException $e) {
+        Yii::log('Could not verify database version before update: ' . $e->getMessage(), 'error', 'application.db.update');
+        return false;
+    }
     if (!$requirement['supported']) {
         $message = sprintf(
             gT('The database update was aborted because your database server does not meet the minimum requirements. %s %s or newer is required, but the server reports version %s. Please upgrade your database server and try again.'),

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -67,6 +67,29 @@ function db_upgrade_all($iOldDBVersion, $bSilent = false)
         return false;
     }
 
+    // Make sure the database server meets the documented minimum requirements
+    // before starting any migration. Otherwise a migration can fail halfway
+    // through (e.g. adding a JSON column on an unsupported MariaDB version) and
+    // leave the database in an inconsistent state.
+    $oDbConnection = Yii::app()->getDb();
+    $requirement = \LimeSurvey\Helpers\DbVersionHelper::getRequirement(
+        $oDbConnection->getDriverName(),
+        $oDbConnection->getServerVersion()
+    );
+    if (!$requirement['supported']) {
+        $message = sprintf(
+            gT('The database update was aborted because your database server does not meet the minimum requirements. %s %s or newer is required, but the server reports version %s. Please upgrade your database server and try again.'),
+            $requirement['type'],
+            $requirement['minimumLabel'],
+            $requirement['current']
+        );
+        if (!$bSilent && Yii::app()->hasComponent('user')) {
+            Yii::app()->user->setFlash('error', $message);
+        }
+        Yii::log($message, 'error', 'application.db.update');
+        return false;
+    }
+
     // Try to acquire database update lock
     if (!getDatabaseUpdateLock()) {
         return false;

--- a/application/models/InstallerConfigForm.php
+++ b/application/models/InstallerConfigForm.php
@@ -167,6 +167,7 @@ class InstallerConfigForm extends CFormModel
             array('dbtype, dblocation, dbname, dbuser', 'required', 'on' => 'database'),
             array('dbpwd, dbprefix', 'safe', 'on' => 'database'),
             array('dbtype', 'in', 'range' => array_keys($this->supportedDbTypes), 'on' => 'database'),
+            array('dbtype', 'validateDBVersion', 'on' => 'database'),
             array('dbengine', 'validateDBEngine', 'on' => 'database'),
             array('dbengine', 'in', 'range' => array_keys($this->dbEngines), 'on' => 'database'),
             //Optional
@@ -284,6 +285,39 @@ class InstallerConfigForm extends CFormModel
     public function getMemoryLimit()
     {
         return convertPHPSizeToBytes(ini_get('memory_limit')) / 1024 / 1024;
+    }
+
+    /**
+     * Verifies that the connected database server meets the documented minimum
+     * version requirements. Adds a validation error if it does not.
+     * @param string $attribute
+     * @return void
+     */
+    public function validateDBVersion($attribute)
+    {
+        // Skip if the connection could not be established (a connection error is
+        // already reported in that case).
+        if (empty($this->db)) {
+            return;
+        }
+        try {
+            $driverName = $this->db->getDriverName();
+            $serverVersion = $this->db->getServerVersion();
+        } catch (\Exception $e) {
+            return;
+        }
+        $requirement = \LimeSurvey\Helpers\DbVersionHelper::getRequirement($driverName, $serverVersion);
+        if (!$requirement['supported']) {
+            $this->addError(
+                $attribute,
+                sprintf(
+                    gT('Your database server does not meet the minimum requirements. %s %s or newer is required, but the server reports version %s.'),
+                    $requirement['type'],
+                    $requirement['minimumLabel'],
+                    $requirement['current']
+                )
+            );
+        }
     }
 
     public function validateDBEngine($attribute)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database compatibility checks for MariaDB, MySQL, PostgreSQL, and Microsoft SQL Server.
  * Installer validation now alerts users when the connected database version is unsupported.
  * Compatibility checks account for recognized server version formats and database-specific requirements.

* **Bug Fixes**
  * Database upgrades now stop safely on unsupported server versions before migrations begin.
  * Upgrade attempts provide an error message when compatibility requirements are not met.
  * Failures while detecting database version information are handled safely and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->