### PR TITLE
AT-2222: fix persist question attributes when exporting as TXT

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -4284,6 +4284,9 @@ function TSVImportSurvey($sFullFilePath)
     $quota_languagesettings = array();
     $output = array();
     foreach ($adata as $row) {
+        if (!isset($row['class'])) {
+            continue; // skip blank rows (e.g. a trailing newline in the file)
+        }
         switch ($row['class']) {
             case 'S':
                 if (isset($row['text']) && $row['name'] != 'datecreated') {
@@ -4346,6 +4349,9 @@ function TSVImportSurvey($sFullFilePath)
     $iGroupcounter = 1;
     foreach ($adata as $row) {
         $rownumber += 1;
+        if (!isset($row['class'])) {
+            continue; // skip blank rows (e.g. a trailing newline in the file)
+        }
         switch ($row['class']) {
             case 'G':
                 // insert group
@@ -4765,7 +4771,7 @@ function createXMLfromData($aData = array())
                             foreach ($value4 as $key5 => $value5) {
                                 if (!is_array($value5)) {
                                     $xml->startElement($key5);
-                                    $xml->writeCdata($value5);
+                                    $xml->writeCdata((string) $value5);
                                     $xml->endElement();
                                 }
                             }
@@ -4779,7 +4785,7 @@ function createXMLfromData($aData = array())
                                         $xml->startElement($key3);
                                     }
                                     $xml->startElement($key4);
-                                    $xml->writeCdata($value4);
+                                    $xml->writeCdata((string) $value4);
                                     $xml->endElement();
                                     $index3 += 1;
                                     if ($index3 === count($value3)) {

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -4464,6 +4464,7 @@ function TSVImportSurvey($sFullFilePath)
                         case 'help':
                         case 'language':
                         case 'mandatory':
+                        case 'encrypted':
                         case 'other':
                         case 'same_default':
                         case 'question_theme_name':

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -648,8 +648,8 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
         array_unshift(
             $results['importwarnings'],
             "<span class='warningtitle'>"
-            . gT('Attention: Several question codes were updated. Please check these carefully as the update  may not be perfect with customized expressions.')
-            . '</span>'
+                . gT('Attention: Several question codes were updated. Please check these carefully as the update  may not be perfect with customized expressions.')
+                . '</span>'
         );
     }
 
@@ -671,7 +671,7 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
  * @return array
  * @throws CException
  */
-function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array('autorename' => false,'translinkfields' => true), $supportArchivedFields = true)
+function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array('autorename' => false, 'translinkfields' => true), $supportArchivedFields = true)
 {
     $sBaseLanguage = Survey::model()->findByPk($iNewSID)->language;
     $sXMLdata = file_get_contents($sFullFilePath);
@@ -1203,12 +1203,12 @@ function XMLImportQuestion($sFullFilePath, $iNewSID, $iNewGID, $options = array(
 }
 
 /**
-* XMLImportLabelsets()
-* Function resp[onsible to import a labelset from XML format.
-* @param string $sFullFilePath
-* @param mixed $options
-* @return array Array with count of imported labelsets, labels, warning, etc.
-*/
+ * XMLImportLabelsets()
+ * Function resp[onsible to import a labelset from XML format.
+ * @param string $sFullFilePath
+ * @param mixed $options
+ * @return array Array with count of imported labelsets, labels, warning, etc.
+ */
 function XMLImportLabelsets($sFullFilePath, $options)
 {
     $sXMLdata = (string) file_get_contents($sFullFilePath);
@@ -1368,7 +1368,7 @@ function getTableArchivesAndTimestamps(int $sid)
     asort($keys);
     $finalResult = [];
     foreach ($keys as $key) {
-        $finalResult [] = $result[$key];
+        $finalResult[] = $result[$key];
     }
     return $finalResult;
 }
@@ -1753,8 +1753,7 @@ function getUnchangedColumns($sid, $sTimestamp, $qTimestamp)
         JOIN old_s_c
         ON old_s_c.COLUMN_NAME = new_s_c.COLUMN_NAME
         ;
-        "
-            ;
+        ";
             break;
         case 'pgsql':
             $command = "
@@ -1767,8 +1766,7 @@ function getUnchangedColumns($sid, $sTimestamp, $qTimestamp)
         JOIN old_s_c
         ON old_s_c.COLUMN_NAME = new_s_c.COLUMN_NAME
         ;
-        "
-            ;
+        ";
             break;
         case 'mssql':
         case 'sqlsrv':
@@ -1782,8 +1780,7 @@ function getUnchangedColumns($sid, $sTimestamp, $qTimestamp)
         JOIN old_s_c_{$sid} old_s_c
         ON old_s_c.COLUMN_NAME = new_s_c.COLUMN_NAME
         ;
-        "
-            ;
+        ";
             break;
     }
 
@@ -1810,7 +1807,7 @@ function generateTemporaryTableCreates(array $sourceTables, array $destinationTa
 {
     $output = [];
     for ($index = 0; $index < count($sourceTables); $index++) {
-        $output [] = generateTemporaryTableCreate($sourceTables[$index], $destinationTables[$index], $sid);
+        $output[] = generateTemporaryTableCreate($sourceTables[$index], $destinationTables[$index], $sid);
     }
     return $output;
 }
@@ -1826,7 +1823,7 @@ function generateTemporaryTableDrops(array $tables, int $sid)
 {
     $output = [];
     foreach ($tables as $table) {
-        $output [] = generateTemporaryTableDrop($table, $sid);
+        $output[] = generateTemporaryTableDrop($table, $sid);
     }
     return $output;
 }
@@ -1885,8 +1882,7 @@ function getDeactivatedArchives($sid)
         ((n <> 'responses') OR (TABLE_NAME NOT LIKE '%timings%'))
         ORDER BY TABLE_NAME) t
         GROUP BY n;
-            "
-            ;
+            ";
             break;
         case 'mssql':
         case 'sqlsrv':
@@ -1908,8 +1904,7 @@ function getDeactivatedArchives($sid)
         ((n <> 'responses') OR (TABLE_NAME NOT LIKE '%timings%'))
         ) t
         GROUP BY n;
-        "
-            ;
+        ";
             break;
     }
     $rawResults = Yii::app()->db->createCommand($command)->queryAll();
@@ -1975,11 +1970,11 @@ function copyFromOneTableToTheOther($source, $destination, $preserveIDs = false)
         foreach ($rawResults as $rawResult) {
             if (intval($rawResult['tid']) > 0) {
                 $responseidresult = Yii::app()->db->createCommand()
-                ->select('id ')
-                ->from($newResponsesTable)
-                ->limit(1, $offset)
-                ->query()
-                ->readAll();
+                    ->select('id ')
+                    ->from($newResponsesTable)
+                    ->limit(1, $offset)
+                    ->query()
+                    ->readAll();
                 $newID = $responseidresult[0]['id'];
                 $oldID = $offset + 1;
                 $command = "
@@ -2069,7 +2064,7 @@ function recoverSurveyResponses(int $surveyId, string $archivedResponseTableName
                 if (!isset($rankingJSONs[$newFieldName])) {
                     $rankingJSONs[$newFieldName] = [];
                 }
-                
+
                 $rankingJSONs[$newFieldName][] = $archivedResponse[$oldFieldName];
             }
         }
@@ -3101,8 +3096,8 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
             if (
                 $insertdata['attribute'] == 'alphasort'
                 || (
-                $insertdata['attribute'] == 'random_order'
-                && in_array($importedQuestions[$insertdata['qid']]->type, ['!', 'L', 'O', 'R'])
+                    $insertdata['attribute'] == 'random_order'
+                    && in_array($importedQuestions[$insertdata['qid']]->type, ['!', 'L', 'O', 'R'])
                 )
             ) {
                 $answerOrderAttributes[$insertdata['qid']][$insertdata['attribute']] = $insertdata['value'];
@@ -3134,9 +3129,9 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
         foreach ($answerOrderAttributes as $importedQid => $questionAttributes) {
             if (!empty($questionAttributes['random_order'])) {
                 $insertdata = [
-                'qid' => $importedQid,
-                'attribute' => 'answer_order',
-                'value' => 'random',
+                    'qid' => $importedQid,
+                    'attribute' => 'answer_order',
+                    'value' => 'random',
                 ];
                 App()->db->createCommand()->insert('{{question_attributes}}', $insertdata);
                 $results['question_attributes']++;
@@ -3144,9 +3139,9 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
             }
             if (!empty($questionAttributes['alphasort'])) {
                 $insertdata = [
-                'qid' => $importedQid,
-                'attribute' => 'answer_order',
-                'value' => 'alphabetical',
+                    'qid' => $importedQid,
+                    'attribute' => 'answer_order',
+                    'value' => 'alphabetical',
                 ];
                 App()->db->createCommand()->insert('{{question_attributes}}', $insertdata);
                 $results['question_attributes']++;
@@ -3575,11 +3570,27 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
 function checkWrongQuestionAttributes($questionId)
 {
     //these attributes could be wrongly set to 'Y' or 'N' instead of 1 and 0
-    $attributesTobeChecked = ['statistics_showgraph', 'public_statistics' , 'page_break' , 'other_numbers_only',
-        'other_comment_mandatory', 'hide_tip' , 'hidden', 'exclude_all_others_auto',
-        'commented_checkbox_auto', 'num_value_int_only', 'alphasort', 'use_dropdown',
-        'slider_default_set', 'slider_layout', 'slider_middlestart', 'slider_reset',
-        'slider_reversed', 'slider_showminmax', 'value_range_allows_missing'];
+    $attributesTobeChecked = [
+        'statistics_showgraph',
+        'public_statistics',
+        'page_break',
+        'other_numbers_only',
+        'other_comment_mandatory',
+        'hide_tip',
+        'hidden',
+        'exclude_all_others_auto',
+        'commented_checkbox_auto',
+        'num_value_int_only',
+        'alphasort',
+        'use_dropdown',
+        'slider_default_set',
+        'slider_layout',
+        'slider_middlestart',
+        'slider_reset',
+        'slider_reversed',
+        'slider_showminmax',
+        'value_range_allows_missing'
+    ];
     $questionAttributes = QuestionAttribute::model()->findAllByAttributes(['qid' => $questionId]);
     foreach ($questionAttributes as $questionAttribute) {
         if (in_array($questionAttribute->attribute, $attributesTobeChecked)) {
@@ -3759,8 +3770,7 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                                                 "X" .
                                                 $newGid .
                                                 "X" .
-                                                $qidCandidate
-                                            ;
+                                                $qidCandidate;
                                             if (strlen($fieldnameEnd) > $endIndex + 1) {
                                                 $oldFieldName .= substr($fieldnameEnd, $endIndex + 1);
                                             }
@@ -4107,7 +4117,7 @@ function CSVImportResponses($sFullFilePath, $iSurveyId, $aOptions = array())
                 $aResponsesError[] = $aResponses[$iIdResponsesKey];
                 // Show some error to user ?
                 $CSVImportResult['errors'][] = $oException->getMessage(); // Show it in view
-                tracevar($oException->getMessage());// Show it in console (if debug is set)
+                tracevar($oException->getMessage()); // Show it in console (if debug is set)
             }
         }
     }
@@ -4208,16 +4218,16 @@ function XMLImportTimings($sFullFilePath, $iSurveyID, $aFieldReMap = array())
 }
 
 /**
-* Import survey from an TSV file template that does not require assigning of GID or QID values.
-* If ID's are presented, they would be respected and used
-* Multilanguage imports are supported
-* Original function is changed to allow generating of XML instead of creating database objects directly
-* Generated XML code is send to existing lss import function
-* @param string $sFullFilePath
-* @return string XML data
-*
-* @author TMSWhite
-*/
+ * Import survey from an TSV file template that does not require assigning of GID or QID values.
+ * If ID's are presented, they would be respected and used
+ * Multilanguage imports are supported
+ * Original function is changed to allow generating of XML instead of creating database objects directly
+ * Generated XML code is send to existing lss import function
+ * @param string $sFullFilePath
+ * @return string XML data
+ *
+ * @author TMSWhite
+ */
 function TSVImportSurvey($sFullFilePath)
 {
     $aAttributeList = array(); //QuestionAttribute::getQuestionAttributesSettings();
@@ -4255,7 +4265,7 @@ function TSVImportSurvey($sFullFilePath)
         return $results;
     }
     unset($rowheaders);
-    unset($rowarray) ;
+    unset($rowarray);
 
     // collect information about survey and its language settings
     $surveyinfo = array();
@@ -4263,6 +4273,8 @@ function TSVImportSurvey($sFullFilePath)
     $groups = array();
     $questions = array();
     $attributes = array();
+    $seenAttributes = array();
+    $aAllAttributes = questionHelper::getAttributesDefinitions();
     $subquestions = array();
     $defaultvalues = array();
     $answers = array();
@@ -4458,7 +4470,9 @@ function TSVImportSurvey($sFullFilePath)
                                 $attribute['qid'] = $qid;
                                 // check if attribute is a i18n attribute. If yes, set language, else set language to null in attribute table
                                 $aAttributeList[$qtype] = QuestionAttribute::getQuestionAttributesSettings($qtype);
-                                if (!empty($aAttributeList[$qtype][$key]['i18n'])) {
+                                // The authoritative i18n flag is in the attribute definitions; the type-specific list omits attributes stored on a mismatched question type.
+                                $isI18n = !empty($aAttributeList[$qtype][$key]['i18n']) || !empty($aAllAttributes[$key]['i18n']);
+                                if ($isI18n) {
                                     $attribute['language'] = ($row['language'] ?? $baselang);
                                 } else {
                                     $attribute['language'] = null;
@@ -4466,7 +4480,12 @@ function TSVImportSurvey($sFullFilePath)
                                 $attribute['attribute'] = $key;
                                 $attribute['value'] = $val;
 
-                                $attributes[] = $attribute;
+                                // Non-i18n attributes are exported on every language row; keep one per qid/attribute/language.
+                                $dedupeKey = $attribute['qid'] . '|' . $key . '|' . ($attribute['language'] ?? '');
+                                if (!isset($seenAttributes[$dedupeKey])) {
+                                    $seenAttributes[$dedupeKey] = true;
+                                    $attributes[] = $attribute;
+                                }
                             }
                             break;
                     }
@@ -4486,8 +4505,7 @@ function TSVImportSurvey($sFullFilePath)
             case 'SQ':
                 $sqname = ($row['name'] ?? 'SQ' . $sqseq);
                 $sqid = '';
-                if ($qtype == Question::QT_O_LIST_WITH_COMMENT || $qtype == Question::QT_VERTICAL_FILE_UPLOAD) {
-                    ;   // these are fake rows to show naming of comment and filecount fields
+                if ($qtype == Question::QT_O_LIST_WITH_COMMENT || $qtype == Question::QT_VERTICAL_FILE_UPLOAD) {;   // these are fake rows to show naming of comment and filecount fields
                 } elseif ($sqname == 'other' && $lastother == "Y") {
                     // If last question have other to Y : it's not a real SQ row
                     if ($qtype == Question::QT_EXCLAMATION_LIST_DROPDOWN || $qtype == Question::QT_L_LIST) {
@@ -5046,7 +5064,7 @@ function processPendingInsertansUpdates(&$pendingInsertansUpdates, $allImportedQ
                     }
                 }
                 if ($changed) {
-                    $onlyChangedModels [] = $model;
+                    $onlyChangedModels[] = $model;
                 }
             }
         }

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -3099,7 +3099,8 @@ function tsvSurveyExport($surveyid)
                             }
 
                             foreach ($mergedAttributes as $attributeName => $attributeValue) {
-                                if (array_key_exists($attributeName, $fields)) {
+                                // Never let a stray same-named question attribute overwrite a base question column (e.g. 'encrypted').
+                                if (array_key_exists($attributeName, $fields) && !in_array($attributeName, $aBaseFields, true)) {
                                     if (is_array($attributeValue)) {
                                         if (safecount($attributeValue) > 0) {
                                             $tsv_output[$attributeName] = implode(' ', $attributeValue);

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -14,12 +14,12 @@
 */
 
 /**
-* Strips html tags and replaces new lines
-*
-* @param string $string
-* @param boolean $removeOther   if 'true', removes '-oth-' from the string.
-* @return string
-*/
+ * Strips html tags and replaces new lines
+ *
+ * @param string $string
+ * @param boolean $removeOther   if 'true', removes '-oth-' from the string.
+ * @return string
+ */
 function stripTagsFull($string, $removeOther = true)
 {
     $string = flattenText($string, false, true); // stripo whole + html_entities
@@ -32,11 +32,11 @@ function stripTagsFull($string, $removeOther = true)
 }
 
 /**
-* Returns true if passed $value is numeric
-*
-* @param $value
-* @return bool
-*/
+ * Returns true if passed $value is numeric
+ *
+ * @param $value
+ * @return bool
+ */
 function isNumericExtended(string $value)
 {
     if (empty($value)) {
@@ -54,13 +54,13 @@ function isNumericExtended(string $value)
 }
 
 /**
-* Returns splitted unicode string correctly
-* source: http://www.php.net/manual/en/function.str-split.php#107658
-*
-* @param string $str
-* @param $l
-* @return string
-*/
+ * Returns splitted unicode string correctly
+ * source: http://www.php.net/manual/en/function.str-split.php#107658
+ *
+ * @param string $str
+ * @param $l
+ * @return string
+ */
 function strSplitUnicode($str, $l = 0)
 {
     if ($l > 0) {
@@ -75,12 +75,12 @@ function strSplitUnicode($str, $l = 0)
 }
 
 /**
-* Quotes a string with surrounding quotes and masking inside quotes by doubling them
-*
-* @param string|null $sText Text to quote
-* @param string $sQuoteChar The quote character (Use ' for SPSS and " for R)
-* @param string $aField General field information from SPSSFieldmap
-*/
+ * Quotes a string with surrounding quotes and masking inside quotes by doubling them
+ *
+ * @param string|null $sText Text to quote
+ * @param string $sQuoteChar The quote character (Use ' for SPSS and " for R)
+ * @param string $aField General field information from SPSSFieldmap
+ */
 function quoteSPSS($sText, $sQuoteChar, $aField)
 {
     $sText = trim((string) $sText);
@@ -3169,7 +3169,7 @@ function tsvSurveyExport($surveyid)
                                 $tsv_output['mandatory'] = !empty($subquestion['mandatory']) ? $subquestion['mandatory'] : '';
                                 $tsv_output['other'] = $subquestion['other'];
                                 $tsv_output['same_default'] = $subquestion['same_default'];
-                                $tsv_output['question_theme_name'] = $subquestion['question_theme_name'];
+                                $tsv_output['question_theme_name'] = $subquestion['question_theme_name'] ?? '';
                                 $tsv_output['same_script'] = $subquestion['same_script'];
 
                                 if (array_key_exists($language, $defaultvalues) && array_key_exists($subquestion['qid'], $defaultvalues[$language])) {

--- a/application/helpers/export_helper.php
+++ b/application/helpers/export_helper.php
@@ -44,10 +44,10 @@ function isNumericExtended(string $value)
     }
     $eng_or_world = preg_match(
         '/^[+-]?' . // start marker and sign prefix
-        '(((([0-9]+)|([0-9]{1,4}(,[0-9]{3,4})+)))?(\\.[0-9])?([0-9]*)|' . // american
-        '((([0-9]+)|([0-9]{1,4}(\\.[0-9]{3,4})+)))?(,[0-9])?([0-9]*))' . // world
-        '(e[0-9]+)?' . // exponent
-        '$/', // end marker
+            '(((([0-9]+)|([0-9]{1,4}(,[0-9]{3,4})+)))?(\\.[0-9])?([0-9]*)|' . // american
+            '((([0-9]+)|([0-9]{1,4}(\\.[0-9]{3,4})+)))?(,[0-9])?([0-9]*))' . // world
+            '(e[0-9]+)?' . // exponent
+            '$/', // end marker
         $value
     ) == 1;
     return ($eng_or_world);
@@ -155,7 +155,7 @@ function SPSSExportData($iSurveyID, $iLength, $na = '', $sEmptyAnswerValue = '',
                     }
                     $i++;
                 }
-                echo("\n");
+                echo ("\n");
             }
         }
         $row = array_change_key_case($row, CASE_UPPER);
@@ -275,12 +275,12 @@ function SPSSExportData($iSurveyID, $iLength, $na = '', $sEmptyAnswerValue = '',
 }
 
 /**
-* Check it the gives field has a labelset and return it as an array if true
-*
-* @param $field array field from SPSSFieldMap
-* @param string $language
-* @return array|bool
-*/
+ * Check it the gives field has a labelset and return it as an array if true
+ *
+ * @param $field array field from SPSSFieldMap
+ * @param string $language
+ * @return array|bool
+ */
 function SPSSGetValues($field, $qidattributes, $language)
 {
     $language = \LSYii_Validators::languageCodeFilter($language);
@@ -462,11 +462,11 @@ function SPSSGetValues($field, $qidattributes, $language)
 }
 
 /**
-* Creates a fieldmap with all information necessary to output the fields
-*
-* @param $prefix string prefix for the variable ID
-* @return array
-*/
+ * Creates a fieldmap with all information necessary to output the fields
+ *
+ * @param $prefix string prefix for the variable ID
+ * @return array
+ */
 function SPSSFieldMap($iSurveyID, $prefix = 'V', $sLanguage = '')
 {
     $survey = Survey::model()->findByPk($iSurveyID);
@@ -541,7 +541,7 @@ function SPSSFieldMap($iSurveyID, $prefix = 'V', $sLanguage = '')
     $fieldnames = array_keys($fieldmap);
     $num_results = safecount($fieldnames);
     $diff = 0;
-    $noQID = array('id', 'token', 'datestamp', 'submitdate', 'startdate', 'startlanguage', 'ipaddr', 'refurl', 'lastpage','seed');
+    $noQID = array('id', 'token', 'datestamp', 'submitdate', 'startdate', 'startlanguage', 'ipaddr', 'refurl', 'lastpage', 'seed');
     # Build array that has to be returned
     for ($i = 0; $i < $num_results; $i++) {
         #Condition for SPSS fields:
@@ -706,10 +706,10 @@ function SPSSFieldMap($iSurveyID, $prefix = 'V', $sLanguage = '')
 }
 
 /**
-* Creates a query string with all fields for the export
-* @param
-* @return CDbCommand
-*/
+ * Creates a query string with all fields for the export
+ * @param
+ * @return CDbCommand
+ */
 function SPSSGetQuery($iSurveyID, $limit = null, $offset = null)
 {
 
@@ -752,13 +752,13 @@ function SPSSGetQuery($iSurveyID, $limit = null, $offset = null)
 }
 
 /**
-* buildXMLFromQuery() creates a datadump of a table in XML using XMLWriter
-*
-* @param mixed $xmlwriter  The existing XMLWriter object
-* @param mixed $Query  The table query to build from
-* @param string $tagname  If the XML tag of the resulting question should be named differently than the table name set it here
-* @param string[] $excludes array of columnames not to include in export
-*/
+ * buildXMLFromQuery() creates a datadump of a table in XML using XMLWriter
+ *
+ * @param mixed $xmlwriter  The existing XMLWriter object
+ * @param mixed $Query  The table query to build from
+ * @param string $tagname  If the XML tag of the resulting question should be named differently than the table name set it here
+ * @param string[] $excludes array of columnames not to include in export
+ */
 function buildXMLFromQuery($xmlwriter, $Query, $tagname = '', $excludes = array(), $iSurveyID = 0)
 {
     $iChunkSize = 1000; // This works even for very large result sets and leaves a minimal memory footprint
@@ -1025,8 +1025,8 @@ function surveyGetXMLStructure($iSurveyID, $xmlwriter, $exclude = array())
 
     // Survey plugin(s)
     $slsquery = " SELECT settings.id,name," . Yii::app()->db->quoteColumnName("key") . "," . Yii::app()->db->quoteColumnName("value")
-                . " FROM {{plugin_settings}} as settings JOIN {{plugins}} as plugins ON plugins.id = settings.plugin_id"
-                . " WHERE model='Survey' and model_id=$iSurveyID";
+        . " FROM {{plugin_settings}} as settings JOIN {{plugins}} as plugins ON plugins.id = settings.plugin_id"
+        . " WHERE model='Survey' and model_id=$iSurveyID";
     buildXMLFromQuery($xmlwriter, $slsquery);
 
     // Survey Group
@@ -1039,8 +1039,8 @@ function surveyGetXMLStructure($iSurveyID, $xmlwriter, $exclude = array())
 }
 
 /**
-* from export_structure_xml.php
-*/
+ * from export_structure_xml.php
+ */
 function surveyGetXMLData($iSurveyID, $exclude = array())
 {
     $xml = getXMLWriter();
@@ -1068,14 +1068,14 @@ function surveyGetXMLData($iSurveyID, $exclude = array())
 }
 
 /**
-* Exports a single table to XML
-*
-* @param integer $iSurveyID The survey ID
-* @param string $sTableName The database table name of the table to be export
-* @param string $sDocType What doctype should be written
-* @param string $sXMLTableTagName Name of the tag table name in the XML file
-* @return string|boolean XMLWriter object
-*/
+ * Exports a single table to XML
+ *
+ * @param integer $iSurveyID The survey ID
+ * @param string $sTableName The database table name of the table to be export
+ * @param string $sDocType What doctype should be written
+ * @param string $sXMLTableTagName Name of the tag table name in the XML file
+ * @return string|boolean XMLWriter object
+ */
 function getXMLDataSingleTable($iSurveyID, $sTableName, $sDocType, $sXMLTableTagName = '', $sFileName = '', $bSetIndent = true)
 {
     $xml = getXMLWriter();
@@ -1110,12 +1110,12 @@ function getXMLDataSingleTable($iSurveyID, $sTableName, $sDocType, $sXMLTableTag
 
 
 /**
-* from export_structure_quexml.php
-*
-* @param ?string $string
-* @param ?string $allow
-* @return string
-*/
+ * from export_structure_quexml.php
+ *
+ * @param ?string $string
+ * @param ?string $allow
+ * @return string
+ */
 function QueXMLCleanup($string, $allow = '<p><b><u><i><em>')
 {
     $string = (string) $string;
@@ -1136,8 +1136,8 @@ function QueXMLCleanup($string, $allow = '<p><b><u><i><em>')
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function QueXMLCreateFree($f, $len, $lab = "")
 {
     global $dom;
@@ -1158,8 +1158,8 @@ function QueXMLCreateFree($f, $len, $lab = "")
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function QueXMLFixedArray($array)
 {
     global $dom;
@@ -1183,26 +1183,26 @@ function QueXMLFixedArray($array)
 }
 
 /**
-* Calculate if this item should have a QueXMLSkipTo element attached to it
-*
-* from export_structure_quexml.php
-*
-* @param mixed $qid
-* @param mixed $value
-*
-* @return bool|string Text of item to skip to otherwise false if nothing to skip to
-* @author Adam Zammit <adam.zammit@acspri.org.au>
-* @since  2010-10-28
-* @TODO Correctly handle conditions in a database agnostic way
-*/
+ * Calculate if this item should have a QueXMLSkipTo element attached to it
+ *
+ * from export_structure_quexml.php
+ *
+ * @param mixed $qid
+ * @param mixed $value
+ *
+ * @return bool|string Text of item to skip to otherwise false if nothing to skip to
+ * @author Adam Zammit <adam.zammit@acspri.org.au>
+ * @since  2010-10-28
+ * @TODO Correctly handle conditions in a database agnostic way
+ */
 function QueXMLSkipTo($qid, $value, $cfieldname = "")
 {
     return false;
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function QueXMLCreateFixed($qid, $iResponseID, $fieldmap, $rotate = false, $labels = true, $scale = 0, $other = false, $varname = "", $EMreplace = false)
 {
     global $dom;
@@ -1297,36 +1297,36 @@ function QueXMLCreateFixed($qid, $iResponseID, $fieldmap, $rotate = false, $labe
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function quexml_get_lengthth($qid, $attribute, $default, $quexmllang = false)
 {
     global $dom;
     if ($quexmllang != false) {
-            $Row = Yii::app()->db->createCommand()
-                ->select('value')
-                ->from("{{question_attributes}}")
-                ->where(" qid=:qid   AND language=:language AND attribute = :attribute ", array(':qid' => $qid, ':language' => $quexmllang, ':attribute' => $attribute))
-                ->queryRow();
+        $Row = Yii::app()->db->createCommand()
+            ->select('value')
+            ->from("{{question_attributes}}")
+            ->where(" qid=:qid   AND language=:language AND attribute = :attribute ", array(':qid' => $qid, ':language' => $quexmllang, ':attribute' => $attribute))
+            ->queryRow();
     } else {
         $Row = Yii::app()->db->createCommand()
-          ->select('value')
-          ->from("{{question_attributes}}")
-          ->where(" qid=:qid     AND attribute = :attribute ", array(':qid' => $qid,  ':attribute' => $attribute))
-          ->queryRow();
+            ->select('value')
+            ->from("{{question_attributes}}")
+            ->where(" qid=:qid     AND attribute = :attribute ", array(':qid' => $qid,  ':attribute' => $attribute))
+            ->queryRow();
     }
 
 
     if ($Row && !empty($Row['value'])) {
-            return $Row['value'];
+        return $Row['value'];
     } else {
-            return $default;
+        return $default;
     }
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function quexml_create_multi(&$question, $qid, $varname, $iResponseID, $fieldmap, $scale_id = false, $free = false, $other = false, $yesvalue = "1", $comment = false, $EMreplace = false)
 {
     global $dom;
@@ -1413,9 +1413,9 @@ function quexml_create_multi(&$question, $qid, $varname, $iResponseID, $fieldmap
 
         //Get next code
         if (is_numeric($nextcode)) {
-                    $nextcode++;
+            $nextcode++;
         } elseif (is_string($nextcode)) {
-                        $nextcode = chr(ord($nextcode) + 1);
+            $nextcode = chr(ord($nextcode) + 1);
         }
 
         $category->appendChild($label);
@@ -1450,8 +1450,8 @@ function quexml_create_multi(&$question, $qid, $varname, $iResponseID, $fieldmap
 }
 
 /**
-* from export_structure_quexml.php
-*/
+ * from export_structure_quexml.php
+ */
 function quexml_create_subQuestions(&$question, $qid, $varname, $iResponseID, $fieldmap, $use_answers = false, $aid = false, $scale = false, $EMreplace = false, $isRanking = false)
 {
     global $dom;
@@ -1662,8 +1662,8 @@ function quexml_create_question($RowQ, $additional = false)
 
 
 /**
-* Export quexml survey.
-*/
+ * Export quexml survey.
+ */
 function quexml_export($surveyi, $quexmllan, $iResponseID = false, $EMreplace = false)
 {
     global $dom, $quexmllang, $iSurveyID;
@@ -1860,7 +1860,7 @@ function quexml_export($surveyi, $quexmllan, $iResponseID = false, $EMreplace = 
                         //get multiflexible_checkbox - if set then each box is a checkbox (single fixed response)
                         $mcb = quexml_get_lengthth($qid, 'multiflexible_checkbox', -1);
                         if ($mcb != -1) {
-                                                    quexml_create_multi($question, $qid, $sgq . "_S" . $SRow['qid'], $iResponseID, $fieldmap, 1, false, false, 1, false, $EMreplace);
+                            quexml_create_multi($question, $qid, $sgq . "_S" . $SRow['qid'], $iResponseID, $fieldmap, 1, false, false, 1, false, $EMreplace);
                         } else {
                             //get multiflexible_max and maximum_chars - if set then make boxes of max of these widths
                             $mcm = max(quexml_get_lengthth($qid, 'maximum_chars', 1), strlen((string) quexml_get_lengthth($qid, 'multiflexible_max', 1)));
@@ -1875,7 +1875,7 @@ function quexml_export($surveyi, $quexmllan, $iResponseID = false, $EMreplace = 
                     $section->appendChild($question);
                 }
             } elseif ($type == '1') {
-              //dual scale array need to split into two questions
+                //dual scale array need to split into two questions
                 $QROW = Yii::app()->db->createCommand()
                     ->select('value')
                     ->from("{{question_attributes}}")
@@ -2298,7 +2298,7 @@ function questionGetXMLStructure($xml, $gid, $qid)
     WHERE qid = $qid order by scale_id, sortorder";
     buildXMLFromQuery($xml, $aquery);
 
-        // Answer localizations
+    // Answer localizations
     $aquery = "SELECT ls.*
     FROM {{answer_l10ns}} ls
     join {{answers}} a on ls.aid=a.aid
@@ -2431,7 +2431,7 @@ function tokensExport($iSurveyID)
     foreach ($attrfieldnames as $attr_name) {
         $tokenoutput .= ", $attr_name";
         if (isset($attrfielddescr[$attr_name])) {
-                    $tokenoutput .= " <" . str_replace(",", " ", (string) $attrfielddescr[$attr_name]['description']) . ">";
+            $tokenoutput .= " <" . str_replace(",", " ", (string) $attrfielddescr[$attr_name]['description']) . ">";
         }
     }
     $tokenoutput .= "\n";
@@ -2561,10 +2561,10 @@ function stringSize(string $sColumn)
             $lengthWord = 'LENGTH';
     }
     $lengthReal = Yii::app()->db->createCommand()
-    ->select("MAX({$lengthWord}(" . Yii::app()->db->quoteColumnName($sColumn) . "))")
-    ->from("{{responses_" . $sid . "}}")
-    ->where(Yii::app()->db->quoteColumnName($sColumn) . " IS NOT NULL ")
-    ->queryScalar();
+        ->select("MAX({$lengthWord}(" . Yii::app()->db->quoteColumnName($sColumn) . "))")
+        ->from("{{responses_" . $sid . "}}")
+        ->where(Yii::app()->db->quoteColumnName($sColumn) . " IS NOT NULL ")
+        ->queryScalar();
     // PSPP didn't accept A0 then min value to 1, see bug #13008
     return max(1, (int) $lengthReal);
 }
@@ -2589,13 +2589,13 @@ function numericSize(string $sColumn, $decimal = false)
     $sColumn = Yii::app()->db->quoteColumnName($sColumn);
     /* Find the max len of integer part for positive value*/
     $maxInteger = Yii::app()->db
-    ->createCommand("SELECT MAX($sColumn) FROM {{responses_" . $iSurveyId . "}}")
-    ->queryScalar();
+        ->createCommand("SELECT MAX($sColumn) FROM {{responses_" . $iSurveyId . "}}")
+        ->queryScalar();
     $integerMaxLen = strlen(intval($maxInteger));
     /* Find the max len of integer part for negative value including minus when export (adding 1 to length) */
     $minInteger = Yii::app()->db
-    ->createCommand("SELECT MIN($sColumn) FROM {{responses_" . $iSurveyId . "}}")
-    ->queryScalar();
+        ->createCommand("SELECT MIN($sColumn) FROM {{responses_" . $iSurveyId . "}}")
+        ->queryScalar();
     $integerMinLen = strlen(intval($minInteger));
     /* Get size of integer part */
     $maxIntegerLen = max([$integerMaxLen, $integerMinLen]);
@@ -2608,37 +2608,37 @@ function numericSize(string $sColumn, $decimal = false)
             $castedColumnString = "CAST($sColumn as text)";
         }
         $maxDecimal = Yii::app()->db
-        ->createCommand("SELECT MAX(REVERSE(RIGHT($castedColumnString, 10))) FROM {{responses_" . $iSurveyId . "}}")
-        ->queryScalar();
+            ->createCommand("SELECT MAX(REVERSE(RIGHT($castedColumnString, 10))) FROM {{responses_" . $iSurveyId . "}}")
+            ->queryScalar();
     } else {
         /* Didn't work with text, when datatype are updated to text, but in such case : there are no good solution, except return string …*/
         $castedColumnString = $sColumn;
         if (Yii::app()->db->driverName == 'pgsql') {
             $castedColumnString = "CAST($sColumn as VARCHAR)";
         }
-    /* pgsql */
+        /* pgsql */
         if (Yii::app()->db->driverName == 'pgsql') {
             $maxDecimal = Yii::app()->db
-            ->createCommand("SELECT MAX(CAST(nullif(split_part($castedColumnString, '.', 2),'') as integer))
+                ->createCommand("SELECT MAX(CAST(nullif(split_part($castedColumnString, '.', 2),'') as integer))
 			    FROM {{responses_" . $iSurveyId . "}}")
-            ->queryScalar();
-    /* mssql */
+                ->queryScalar();
+            /* mssql */
         } elseif (Yii::app()->db->driverName == 'mssql') {
             $maxDecimal = Yii::app()->db
-            ->createCommand("SELECT MAX(CASE
+                ->createCommand("SELECT MAX(CASE
 			     WHEN charindex('.',$castedColumnString) > 0 THEN
                              CAST(SUBSTRING($castedColumnString ,charindex('.',$castedColumnString)+1 , Datalength($castedColumnString)-charindex('.',$castedColumnString) ) AS INT)
                              ELSE null END)
 			    FROM {{responses_" . $iSurveyId . "}}")
-            ->queryScalar();
-        /* mysql */
+                ->queryScalar();
+            /* mysql */
         } else {
             $maxDecimal = Yii::app()->db
-            ->createCommand("SELECT MAX(CASE
+                ->createCommand("SELECT MAX(CASE
                              WHEN INSTR($castedColumnString, '.') THEN CAST(SUBSTRING_INDEX($castedColumnString, '.', -1) as UNSIGNED)
 			     ELSE NULL END)
 			     FROM {{responses_" . $iSurveyId . "}}")
-            ->queryScalar();
+                ->queryScalar();
         }
     }
     // With integer : Decimal return 00000000000 and float return 0
@@ -2699,6 +2699,19 @@ function tsvSurveyExport($surveyid)
     $xml = simplexml_load_string((string) surveyGetXMLData($surveyid), null, LIBXML_NOCDATA);
     $xmlData = json_decode(json_encode($xml), true);
 
+    // Include attributes present in the survey but missing from the global definitions (e.g. question-theme attributes), otherwise they are dropped on export.
+    if (array_key_exists('question_attributes', $xmlData)) {
+        $attributeRows = $xmlData['question_attributes']['rows']['row'];
+        if (!array_key_exists('0', $attributeRows)) {
+            $attributeRows = array($attributeRows);
+        }
+        foreach ($attributeRows as $attributeRow) {
+            if (isset($attributeRow['attribute']) && !is_array($attributeRow['attribute']) && !in_array($attributeRow['attribute'], $fields, true)) {
+                $fields[] = $attributeRow['attribute'];
+            }
+        }
+    }
+
     // creating an array where attributes are keys, to be reused for each row
     // flip keys and values, fields becoming keys, values are cleared with array_map function
     $fields = array_map(function () {
@@ -2735,7 +2748,7 @@ function tsvSurveyExport($surveyid)
         fputcsv(
             stream: $out,
             fields: array_map('MaskFormula', $tsv_output),
-            separator:  chr(9),
+            separator: chr(9),
             escape: "\\"
         );
     }
@@ -2853,8 +2866,8 @@ function tsvSurveyExport($surveyid)
         }
     }
 
-        $groups = array();
-        $index_languages = 0;
+    $groups = array();
+    $index_languages = 0;
     foreach ($aSurveyLanguages as $key => $language) {
         // groups data
         if (array_key_exists('groups', $xmlData)) {
@@ -3264,9 +3277,9 @@ function tsvSurveyExport($surveyid)
         }
     }
 
-        $output = $out;
-        fclose($out);
-        return $output;
+    $output = $out;
+    fclose($out);
+    return $output;
 }
 
 /**
@@ -3290,11 +3303,11 @@ function sortArrayByColumn($array, $column_name)
 }
 
 /**
-* Write XML from Associative Array, recursive function
-* @param object $xml XMLWriter Object
-* @param array $aData Associative Data Array
-* @param int $sParentKey parent key
-*/
+ * Write XML from Associative Array, recursive function
+ * @param object $xml XMLWriter Object
+ * @param array $aData Associative Data Array
+ * @param int $sParentKey parent key
+ */
 function writeXmlFromArray(XMLWriter $xml, $aData, $sParentKey = '')
 {
     $bCloseElement = false;
@@ -3338,12 +3351,12 @@ function writeXmlFromArray(XMLWriter $xml, $aData, $sParentKey = '')
 }
 
 /**
-* Write XML structure for themes
-* @param int $iSurveyId Survey ID
-* @param object $oXml XMLWriter Object
-* @param bool $bInherit should theme configuration be inherited?
-* @param string $sElementName name for XML element
-*/
+ * Write XML structure for themes
+ * @param int $iSurveyId Survey ID
+ * @param object $oXml XMLWriter Object
+ * @param bool $bInherit should theme configuration be inherited?
+ * @param string $sElementName name for XML element
+ */
 function surveyGetThemeConfiguration($iSurveyId = null, $oXml = null, $bInherit = false, $sElementName = 'themes')
 {
 

--- a/editor/src/components/QuestionSettings/attributes/getOtherAttributes.js
+++ b/editor/src/components/QuestionSettings/attributes/getOtherAttributes.js
@@ -47,6 +47,7 @@ export const getOtherAttributes = () => ({
   CHOICE_HEADER: {
     component: Input,
     attributePath: 'attributes.choice_title',
+    languageBased: true,
     props: {
       labelText: t('Choice header'),
       dataTestId: 'choice-header',
@@ -55,6 +56,7 @@ export const getOtherAttributes = () => ({
   RANK_HEADER: {
     component: Input,
     attributePath: 'attributes.rank_title',
+    languageBased: true,
     props: {
       labelText: t('Rank header'),
       dataTestId: 'rank-header',


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TSV survey exports now include survey-specific question attributes missing from global definitions.
  * Exported question attributes no longer overwrite existing base columns.
  * TSV survey imports better recognize localized attributes and prevent duplicate entries.
  * Blank rows, including trailing empty lines, are skipped during TSV imports.
  * XML exports now handle CDATA values consistently.
  * Choice and ranking attributes now support language-specific values.

* **Style**
  * Improved formatting, indentation, and comment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->