### PR TITLE
Fixed issue #AT-2226: clear other input on option change for image select and singlechoice bootstrap buttons

### DIFF
--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/assets/scripts/bootstrapbuttons.js
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/assets/scripts/bootstrapbuttons.js
@@ -9,6 +9,7 @@ function doBootstrapRadioOther() {
             copyOtherInputToHiddenField(name);
         } else {
             $("#div" + name + "other").addClass('ls-js-hidden');
+            $("#answer" + name + "othertext").val("");
             $("#answer" + name + "othertextaux").val('');
         }
     });

--- a/themes/question/image_select-listradio/survey/questions/answer/listradio/rows/answer_row.twig
+++ b/themes/question/image_select-listradio/survey/questions/answer/listradio/rows/answer_row.twig
@@ -44,9 +44,9 @@ question_template_attribute.horizontal_scroll   : {{question_template_attribute.
             id="answer{{ name}}{{ code }}"
             value="{{code}}"
             {{ checkedState }}
-            onclick='cancelBubbleThis(event); {{ sCheckconditionFunction }}'
+            onclick='cancelBubbleThis(event); if (document.getElementById("answer{{ name }}othertext") != null) document.getElementById("answer{{ name }}othertext").value=""; {{ sCheckconditionFunction }}'
         />
-        <label for="answer{{ name }}{{ code }}" class="imageselect-label" onclick='cancelBubbleThis(event); {{ sCheckconditionFunction }}'>
+        <label for="answer{{ name }}{{ code }}" class="imageselect-label" onclick='cancelBubbleThis(event); if (document.getElementById("answer{{ name }}othertext") != null) document.getElementById("answer{{ name }}othertext").value=""; {{ sCheckconditionFunction }}'>
 
          <img class="unforce-height" src="{{ answer|escape('html_attr') }}"
          style="{%if question_template_attribute.fix_width > 1%} 


### PR DESCRIPTION


<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a standard radio option now clears previously entered text in the “Other” field of Bootstrap buttons (Type: L).
  * Image select list (Radio) (Type: L) radio options consistently clear the associated “Other” field before applying conditional checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->