### PR TITLE
Fixed issue #20613: Survey logic overview option shows error 500

### DIFF
--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -9261,7 +9261,6 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         // End Message
 
         $LEM =& LimeExpressionManager::singleton();
-        $LEM->sPreviewMode = 'logic';
         // We set $LEM->em->resetErrorsAndWarningsOnEachPart = false because, if a string has more than one expression, error information could be lost
         $LEM->em->resetErrorsAndWarningsOnEachPart = false;
         $aSurveyInfo = getSurveyInfo($sid, $_SESSION['LEMlang']);
@@ -9281,6 +9280,7 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
         $surveyOptions = [
             'assessments'                 => $assessments === null ? ($aSurveyInfo['assessments'] == 'Y') : $assessments,
             'hyperlinkSyntaxHighlighting' => true,
+            'previewmode'                 => 'logic',
         ];
 
         $varNamesUsed = []; // keeps track of whether variables have been declared


### PR DESCRIPTION
This got broken on commit dc13703 (Fixed issue #AT-2085: Empty responses were created when going to theme options preview (#5050)).
On dc13703 StartSurvey starts doing self::SetPreviewMode($aSurveyOptions['previewmode'] ?? false).
So if $aSurveyOptions['previewmode'] was not set, it was set to false.

LimeExpressionManager::ShowSurveyLogicFile sets $LEM->sPreviewMode = 'logic', mechanism which got outdated after dc13703.
Now it sets $aSurveyOptions['previewmode']