### PR TITLE
Fixed issue #20570: When not unchecking the "unseen or not answered" checkbox but editing a data set the screen freezes on save

### DIFF
--- a/application/views/admin/dataentry/dataentry_header_view.php
+++ b/application/views/admin/dataentry/dataentry_header_view.php
@@ -12,5 +12,18 @@
         <div class="row">
             <div class="col-12 content-right">
         
-                <?php echo CHtml::form(array("admin/dataentry/sa/update"), 'post', array('name' => 'editresponse', 'id' => 'editresponse'));?>
+                <?php echo CHtml::form(
+                    ["admin/dataentry/sa/update"],
+                    'post',
+                    [
+                        'name' => 'editresponse',
+                        'id' => 'editresponse',
+                        /**
+                         * Validation is actually handled by the submit handler, but we need data-trigger-validation
+                         * so that the SaveController doesn't show the spinner when the form is already invalid (from
+                         * a previous submit attempt).
+                         */
+                        'data-trigger-validation' => 'true',
+                    ]
+                ); ?>
                    <table id='responsedetail' class="table" width='99%' align='center'>

--- a/assets/scripts/admin/dataentry.js
+++ b/assets/scripts/admin/dataentry.js
@@ -55,6 +55,12 @@ $(document).on('submit', '#editresponse', function (event) {
 
     if (hasInconsistentUnseenStatus) {
         event.preventDefault();
+        // Save is handled by the global SaveController, which shows the loading indicator on
+        // displayLoadingState, but never hides it. So we need to hide it here to avoid the
+        // loading indicator being shown indefinitely.
+        // Note that the button is re-enabled by the 'invalid' event handler in SaveController,
+        // so we don't need to re-enable it here.
+        $('#ls-loading').hide();
         return false;
     }
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data entry validation behavior when an invalid submission is retried.
  * Prevented the loading indicator from remaining visible when submission is blocked by an inconsistent unseen status.
  * Submit button behavior remains managed correctly during validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->