### PR TITLE
Fixed issue #20607: Placeholder fields are empty in the Email Templates editor

### DIFF
--- a/application/controllers/LimereplacementfieldsController.php
+++ b/application/controllers/LimereplacementfieldsController.php
@@ -305,8 +305,8 @@ class LimeReplacementFieldsController extends LSBaseController
             $replFields['ADMINEMAIL'] = gT("Email address of the survey administrator");
             return array($replFields, false);
         } elseif (
-            strpos($fieldtype, 'email_admin_notification') !== false
-            || strpos($fieldtype, 'email_admin_detailed_notification') !== false
+            strpos($fieldtype, 'email-admin-notification') !== false
+            || strpos($fieldtype, 'email-admin-detailed-notification') !== false
         ) {
             $replFields['VIEWRESPONSEURL'] = gT("View response URL");
             $replFields['EDITRESPONSEURL'] = gT("Edit response URL");
@@ -379,7 +379,7 @@ class LimeReplacementFieldsController extends LSBaseController
             return array($replFields, false);
 
             // $replFields['SID']= gT("Survey ID");
-        } elseif (strpos($fieldtype, 'email_registration') !== false) {
+        } elseif (strpos($fieldtype, 'email-registration') !== false) {
             $replFields['FIRSTNAME'] = gT("Participant - First name");
             $replFields['LASTNAME'] = gT("Participant - Last name");
             $replFields['SURVEYNAME'] = gT("Survey title");
@@ -397,7 +397,7 @@ class LimeReplacementFieldsController extends LSBaseController
             $replFields['SURVEYIDURL'] = gT("Survey URL based on survey ID");
             $replFields['EXPIRY'] = gT("Survey expiration date");
             return array($replFields, false);
-        } elseif (strpos($fieldtype, 'email_confirmation') !== false) {
+        } elseif (strpos($fieldtype, 'email-confirmation') !== false) {
             $replFields['TOKEN'] = gT("Participant - Access code");
             $replFields['FIRSTNAME'] = gT("Participant - First name");
             $replFields['LASTNAME'] = gT("Participant - Last name");
@@ -429,9 +429,9 @@ class LimeReplacementFieldsController extends LSBaseController
             || strpos($fieldtype, 'question-text') !== false
             || strpos($fieldtype, 'question-help') !== false
             || strpos($fieldtype, 'editgroup') !== false                // for translation
-            || strpos($fieldtype, 'editgroup_desc') !== false           // for translation
+            || strpos($fieldtype, 'editgroup-desc') !== false           // for translation
             || strpos($fieldtype, 'editquestion') !== false             // for translation
-            || strpos($fieldtype, 'editquestion_help') !== false        // for translation
+            || strpos($fieldtype, 'editquestion-help') !== false        // for translation
         ) {
             $replFields['TOKEN:FIRSTNAME'] = gT("Participant - First name");
             $replFields['TOKEN:LASTNAME'] = gT("Participant - Last name");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of replacement fields for email and translation content.
  * Fixed matching for admin notifications, registration and confirmation messages, group descriptions, and question help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->