### PR TITLE
Fixed issue #AT-1331: Open thank-you URLs outside the editor

### DIFF
--- a/editor/src/components/Survey/SurveyFooter.js
+++ b/editor/src/components/Survey/SurveyFooter.js
@@ -164,7 +164,11 @@ export const SurveyFooter = ({
                         testId="survey-footer-finish-button"
                       >
                         {finishButtonForwardingUrl ? (
-                          <a href={finishButtonForwardingUrl}>
+                          <a 
+                            href={finishButtonForwardingUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
                             {finishButtonTitle}
                           </a>
                         ) : (

--- a/editor/src/components/Survey/SurveyFooter.js
+++ b/editor/src/components/Survey/SurveyFooter.js
@@ -164,7 +164,7 @@ export const SurveyFooter = ({
                         testId="survey-footer-finish-button"
                       >
                         {finishButtonForwardingUrl ? (
-                          <a 
+                          <a
                             href={finishButtonForwardingUrl}
                             target="_blank"
                             rel="noopener noreferrer"


### PR DESCRIPTION
Fixed issue #AT-1331: Thank-you page URLs should not open inside the editor

## Description

Links configured for the survey thank-you page were opened inside the
survey editor. This change ensures that these URLs are opened outside the
editor.

## Changes

- Updated the URL behavior in `SurveyFooter`.
- Added automated tests for the corrected behavior.

## How to test

1. Open a survey in the survey editor.
2. Configure a URL for the thank-you/end screen.
3. Preview and complete the survey.
4. Click the URL on the thank-you screen.
5. Verify that the destination does not open inside the survey editor.

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the survey finish link to open forwarding destinations in a new tab.
  * Added security protections to prevent the new tab from accessing the originating page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->