### PR TITLE
Fixed issue #20635  replacement fields not inserted correctly in templates with multiple editors

### DIFF
--- a/application/controllers/LimereplacementfieldsController.php
+++ b/application/controllers/LimereplacementfieldsController.php
@@ -305,8 +305,8 @@ class LimeReplacementFieldsController extends LSBaseController
             $replFields['ADMINEMAIL'] = gT("Email address of the survey administrator");
             return array($replFields, false);
         } elseif (
-            strpos($fieldtype, 'email_admin_notification') !== false
-            || strpos($fieldtype, 'email_admin_detailed_notification') !== false
+            strpos($fieldtype, 'email-admin-notification') !== false
+            || strpos($fieldtype, 'email-admin-detailed-notification') !== false
         ) {
             $replFields['VIEWRESPONSEURL'] = gT("View response URL");
             $replFields['EDITRESPONSEURL'] = gT("Edit response URL");
@@ -379,7 +379,7 @@ class LimeReplacementFieldsController extends LSBaseController
             return array($replFields, false);
 
             // $replFields['SID']= gT("Survey ID");
-        } elseif (strpos($fieldtype, 'email_registration') !== false) {
+        } elseif (strpos($fieldtype, 'email-registration') !== false) {
             $replFields['FIRSTNAME'] = gT("Participant - First name");
             $replFields['LASTNAME'] = gT("Participant - Last name");
             $replFields['SURVEYNAME'] = gT("Survey title");
@@ -397,7 +397,7 @@ class LimeReplacementFieldsController extends LSBaseController
             $replFields['SURVEYIDURL'] = gT("Survey URL based on survey ID");
             $replFields['EXPIRY'] = gT("Survey expiration date");
             return array($replFields, false);
-        } elseif (strpos($fieldtype, 'email_confirmation') !== false) {
+        } elseif (strpos($fieldtype, 'email-confirmation') !== false) {
             $replFields['TOKEN'] = gT("Participant - Access code");
             $replFields['FIRSTNAME'] = gT("Participant - First name");
             $replFields['LASTNAME'] = gT("Participant - Last name");
@@ -429,9 +429,9 @@ class LimeReplacementFieldsController extends LSBaseController
             || strpos($fieldtype, 'question-text') !== false
             || strpos($fieldtype, 'question-help') !== false
             || strpos($fieldtype, 'editgroup') !== false                // for translation
-            || strpos($fieldtype, 'editgroup_desc') !== false           // for translation
+            || strpos($fieldtype, 'editgroup-desc') !== false           // for translation
             || strpos($fieldtype, 'editquestion') !== false             // for translation
-            || strpos($fieldtype, 'editquestion_help') !== false        // for translation
+            || strpos($fieldtype, 'editquestion-help') !== false        // for translation
         ) {
             $replFields['TOKEN:FIRSTNAME'] = gT("Participant - First name");
             $replFields['TOKEN:LASTNAME'] = gT("Participant - Last name");

--- a/assets/packages/ckeditor/plugins/limereplacementfields/dialogs/limereplacementfields.js
+++ b/assets/packages/ckeditor/plugins/limereplacementfields/dialogs/limereplacementfields.js
@@ -9,6 +9,12 @@
         {
             var lang = editor.lang.limereplacementfields,
             generalLabel = editor.lang.common.generalTab;
+
+            function getReplacementFieldsSelect( dialog )
+            {
+                return $( dialog.getElement().$ ).find( '#cquestions' );
+            }
+
             return {
                 title : lang.title,
                 minWidth : 400,
@@ -30,18 +36,22 @@
                                 html : CKEDITOR.ajax.load(editor.config.LimeReplacementFieldsUrl),
                                 setup : function( element )
                                 {
+                                    var replacementFieldsSelect = getReplacementFieldsSelect( this.getDialog() );
+
                                     if ( isEdit )
                                     {
-                                        $('#cquestions').val( element.getText().slice( 1, -1 ) );
+                                        replacementFieldsSelect.val( element.getText().slice( 1, -1 ) );
                                     }
                                     else
                                     {
-                                        $("#cquestions")[0].selectedIndex = 0;
+                                        replacementFieldsSelect[0].selectedIndex = 0;
                                     }
                                 },
                                 commit : function( element )
                                 {
-                                    var text = '{' + $('#cquestions').val() + '}';
+                                    var replacementFieldsSelect = getReplacementFieldsSelect( this.getDialog() );
+
+                                    var text = '{' + replacementFieldsSelect.val() + '}';
                                     // The limereplacementfields must be recreated.
                                     CKEDITOR.plugins.limereplacementfields.createlimereplacementfields( editor, element, text );
                                 }
@@ -50,7 +60,8 @@
                     }
                 ],
                 onFocus : function() {
-                    $('#cquestions').focus();
+                    var replacementFieldsSelect = getReplacementFieldsSelect( this );
+                    replacementFieldsSelect.focus();
                 },
                 onShow : function()
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replacement-field matching for administrator notifications, registration, confirmations, group descriptions, and question help or edit fields.
  * Improved replacement-field selection behavior in the editor dialog, including setup, editing, default selection, and focus handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->