### PR TITLE
Fixed issue #20640: "Error saving results" on surveys active before update to version 7 on PostgreSQL

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '7.0.8';
-$config['dbversionnumber'] = 709;
+$config['dbversionnumber'] = 710;
 $config['buildnumber'] = '';
 $config['updatable'] = true;
 $config['templateapiversion']  = 3;

--- a/application/helpers/update/updatedb_helper.php
+++ b/application/helpers/update/updatedb_helper.php
@@ -3231,7 +3231,7 @@ function fixPostgresSequence($tableName = null)
     if ($tableName != null) {
         $query .= " AND PGT.tablename= '{{" . $tableName . "}}' ";
     }
-    $query .= "ORDER BY S.relname;";
+    $query .= " ORDER BY S.relname;";
     $FixingQueries = Yii::app()->db->createCommand($query)->queryColumn();
     foreach ($FixingQueries as $fixingQuery) {
         $oDB->createCommand($fixingQuery)->execute();

--- a/application/helpers/update/updates/Update_700.php
+++ b/application/helpers/update/updates/Update_700.php
@@ -1466,6 +1466,13 @@ class Update_700 extends DatabaseUpdateBase
             }
         }
 
+        // Rebuilding the response/timing tables with a fresh serial "id" leaves the new
+        // PostgreSQL sequences at 1 while rows were copied in with their original ids;
+        // advance every sequence past MAX(id) to avoid duplicate key errors (bug #20640).
+        if (Yii::app()->db->getDriverName() === 'pgsql') {
+            \fixPostgresSequence();
+        }
+
         $archivedSettings = ArchivedTableSettings::model()->findAll();
         foreach ($archivedSettings as $archivedSetting) {
             if (strpos($archivedSetting->tbl_name, 'survey') !== false) {

--- a/application/helpers/update/updates/Update_710.php
+++ b/application/helpers/update/updates/Update_710.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+use CException;
+
+class Update_710 extends DatabaseUpdateBase
+{
+    /**
+     * Repairs PostgreSQL databases already migrated to LS7 with stale sequences. Update_700
+     * rebuilt the response/timing tables with a fresh serial "id" (sequence starting at 1)
+     * and copied existing rows in with their original ids, which never advanced the sequence,
+     * causing duplicate primary key violations on the next response (bug #20640).
+     * fixPostgresSequence() advances every sequence in the database past its column MAX,
+     * which also covers any other tables affected by the same rename.
+     *
+     * @inheritDoc
+     * @throws CException
+     */
+    public function up()
+    {
+        if ($this->db->getDriverName() !== 'pgsql') {
+            return;
+        }
+        \fixPostgresSequence();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL database migrations by correcting ID sequences after data is copied or rebuilt.
  * Prevented record-creation errors caused by stale sequences and duplicate identifiers.
  * Preserved existing migration behavior for other supported database systems.
* **Chores**
  * Updated the database version to include these migration improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->