### PR TITLE
Fixed issue #AT-2192: Create default subquestions for the initial question in React editor

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -3004,25 +3004,22 @@ class SurveyAdministrationController extends LSBaseController
         $oQuestionLS->qid = $oQuestion->qid;
         $oQuestionLS->save();
 
-        $editorEnabled = Yii::app()->getConfig('editorEnabled') ?? false;
-        if (!$editorEnabled) {
-            $this->createSampleSubquestion(
-                1,
-                $iSurveyID,
-                $iGroupID,
-                $oQuestion->qid,
-                $sLanguage,
-                gT('Option A')
-            );
-            $this->createSampleSubquestion(
-                2,
-                $iSurveyID,
-                $iGroupID,
-                $oQuestion->qid,
-                $sLanguage,
-                gT('Option B')
-            );
-        }
+        $this->createSampleSubquestion(
+            1,
+            $iSurveyID,
+            $iGroupID,
+            $oQuestion->qid,
+            $sLanguage,
+            gT('Option A')
+        );
+        $this->createSampleSubquestion(
+            2,
+            $iSurveyID,
+            $iGroupID,
+            $oQuestion->qid,
+            $sLanguage,
+            gT('Option B')
+        );
 
         return $oQuestion->qid;
     }

--- a/application/helpers/remotecontrol/remotecontrol_handle.php
+++ b/application/helpers/remotecontrol/remotecontrol_handle.php
@@ -1785,11 +1785,11 @@ class remotecontrol_handle
                 foreach ($aQuestionSettings as $sPropertyName) {
                     if ($sPropertyName == 'available_answers' || $sPropertyName == 'subquestions') {
                         $oSubQuestions = Question::model()->with('questionl10ns')
-                                                          ->findAll(
-                                                              't.parent_qid = :parent_qid and questionl10ns.language = :language',
-                                                              array(':parent_qid' => $iQuestionID, ':language' => $sLanguage),
-                                                              array('order' => 'title')
-                                                          );
+                                                          ->findAll(array(
+                                                              'condition' => 't.parent_qid = :parent_qid and questionl10ns.language = :language',
+                                                              'params' => array(':parent_qid' => $iQuestionID, ':language' => $sLanguage),
+                                                              'order' => 't.title',
+                                                          ));
 
                         if (count($oSubQuestions) > 0) {
                             $aData = array();


### PR DESCRIPTION
Fixed issue #AT-2192: Create default subquestions for the initial question in React editor

## Problem

When creating a survey with the React editor enabled, the initial multiple-choice question was created without the default subquestions available in the core editor.

## Solution

Create the existing “Option A” and “Option B” sample subquestions regardless of which editor is enabled.

## Testing

1. Enable the React editor.
2. Create a new survey.
3. Open the automatically created question.
4. Confirm that it contains:
   - `SQ001` — Option A
   - `SQ002` — Option B
5. Refresh the page and confirm both options remain available.

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sample questions now consistently include both sample subquestions, regardless of editor configuration.
  * Improved remote retrieval of subquestion properties, including correct language filtering and title ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->