### PR TITLE
Fixed issue #AT-2109: Multiple choice: Allow checking other option before entering text

### DIFF
--- a/application/core/QuestionTypes/MultipleChoice/RenderMultipleChoice.php
+++ b/application/core/QuestionTypes/MultipleChoice/RenderMultipleChoice.php
@@ -196,7 +196,9 @@ class RenderMultipleChoice extends QuestionBaseRenderer
             'oth_checkconditionFunction' => $oth_checkconditionFunction,
             'checkconditionFunction'     => "checkconditions",
             'sValueHidden'               => $sValueHidden,
-            'checkedState'               => ($mSessionValue != '' ? CHECKED : ''),
+            'checkedState'               => (
+                $mSessionValue != '' || LimeExpressionManager::isOtherCheckedWithoutValue($myfname) ? CHECKED : ''
+            ),
             'relevanceClass'             => $this->getCurrentRelevecanceClass($myfname),
             'other'                      => true,
             'anscount'                   => $this->getQuestionCount(),

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6363,10 +6363,28 @@ class LimeExpressionManager
                 case Question::QT_EXCLAMATION_LIST_DROPDOWN: //List - dropdown
                 case Question::QT_L_LIST: //LIST drop-down/radio-button list
                     // If at least one checkbox is checked, we're OK
-                    if (count($relevantSQs) > 0 && (count($relevantSQs) == count($unansweredSQs))) {
+                    $bNoneChecked = count($relevantSQs) > 0 && (count($relevantSQs) == count($unansweredSQs));
+                    if ($bNoneChecked) {
                         $qmandViolation = true;
                     }
-                    if (!($qInfo['type'] == Question::QT_EXCLAMATION_LIST_DROPDOWN || $qInfo['type'] == Question::QT_L_LIST)) {
+                    if ($qInfo['type'] == Question::QT_M_MULTIPLE_CHOICE && $qInfo['other'] == 'Y') {
+                        foreach ($sgqas as $s) {
+                            if (
+                                str_ends_with($s, '_Cother')
+                                && in_array($s, $relevantSQs)
+                                && in_array($s, $unansweredSQs)
+                                && self::isOtherCheckedWithoutValue($s)
+                            ) {
+                                $qmandViolation = true;
+                            }
+                        }
+                    }
+
+                    $bShowCheckAnItem = $qInfo['type'] != Question::QT_M_MULTIPLE_CHOICE || $bNoneChecked;
+                    if (
+                        !($qInfo['type'] == Question::QT_EXCLAMATION_LIST_DROPDOWN || $qInfo['type'] == Question::QT_L_LIST)
+                        && $bShowCheckAnItem
+                    ) {
                         $sMandatoryText = $LEM->gT('Please check at least one item.');
                         $mandatoryTip .= App()->twigRenderer->renderPartial(
                             '/survey/questions/question_help/mandatory_tip.twig',
@@ -8866,6 +8884,18 @@ report~numKids > 0~message~{name}, you said you are {age} and that you have {num
             $_SESSION[$LEM->sessid][$_POST['timerquestion']] = sanitize_float($_POST[$_POST['timerquestion']]);
         }
         return $updatedValues;
+    }
+
+    /**
+     * @param string $sq
+     * @return boolean
+     */
+    public static function isOtherCheckedWithoutValue($sq)
+    {
+        if (empty($_POST[$sq . 'cbox'])) {
+            return false;
+        }
+        return trim((string) ($_POST[$sq] ?? '')) === '';
     }
 
     public static function isValidVariable($varName)

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -6362,11 +6362,7 @@ class LimeExpressionManager
                 case Question::QT_P_MULTIPLE_CHOICE_WITH_COMMENTS:
                 case Question::QT_EXCLAMATION_LIST_DROPDOWN: //List - dropdown
                 case Question::QT_L_LIST: //LIST drop-down/radio-button list
-                    // If at least one checkbox is checked, we're OK
-                    $bNoneChecked = count($relevantSQs) > 0 && (count($relevantSQs) == count($unansweredSQs));
-                    if ($bNoneChecked) {
-                        $qmandViolation = true;
-                    }
+                    $bOtherCheckedWithoutValue = false;
                     if ($qInfo['type'] == Question::QT_M_MULTIPLE_CHOICE && $qInfo['other'] == 'Y') {
                         foreach ($sgqas as $s) {
                             if (
@@ -6375,9 +6371,17 @@ class LimeExpressionManager
                                 && in_array($s, $unansweredSQs)
                                 && self::isOtherCheckedWithoutValue($s)
                             ) {
+                                $bOtherCheckedWithoutValue = true;
                                 $qmandViolation = true;
                             }
                         }
+                    }
+
+                    $bNoneChecked = !$bOtherCheckedWithoutValue
+                        && count($relevantSQs) > 0
+                        && (count($relevantSQs) == count($unansweredSQs));
+                    if ($bNoneChecked) {
+                        $qmandViolation = true;
                     }
 
                     $bShowCheckAnItem = $qInfo['type'] != Question::QT_M_MULTIPLE_CHOICE || $bNoneChecked;

--- a/application/views/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
+++ b/application/views/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
@@ -31,7 +31,6 @@
                     name="{{ myfname }}cbox"
                     id="answer{{ myfname }}cbox"
                     {{ checkedState }}
-                    aria-hidden="true"
                 />
                 <label for="answer{{ myfname }}cbox" class="checkbox-label control-label answertext"
                        id="label-{{ myfname }}-other">{{ processString(othertext) }}</label>
@@ -71,11 +70,15 @@
         />
     </div>
     <script type='text/javascript'>
+        $(function () {
+            if ($('#answer{{ myfname }}cbox').is(':checked') && $.trim($('#answer{{ myfname }}').val()).length == 0) {
+                LEMflagMandOther("{{ myfname }}", true);
+            }
+        });
+
         $('#answer{{ myfname }}').on('keyup focusout', function (event) {
             if ($.trim($(this).val()).length > 0) {
                 $("#answer{{ myfname }}cbox").prop("checked", true);
-            } else {
-                $("#answer{{ myfname }}cbox").prop("checked", false);
             }
             $("#java{{ myfname }}").val($(this).val());
             LEMflagMandOther("{{ myfname }}", $('#answer{{ myfname }}cbox').is(":checked"));
@@ -83,17 +86,15 @@
         });
 
         $('#answer{{ myfname }}cbox').click(function (event) {
-            if (($(this)).is(':checked') && $.trim($("#answer{{ myfname }}").val()).length == 0) {
+            if (($(this)).is(':checked')) {
                 $("#answer{{ myfname }}").focus();
                 LEMflagMandOther("{{ myfname }}", true);
-                return false;
             } else {
                 $("#answer{{ myfname }}").val('');
+                $("#java{{ myfname }}").val('');
                 {{ checkconditionFunction }}("", "{{ myfname }}", "text");
                 LEMflagMandOther("{{ myfname }}", false);
-                return true;
             }
-            ;
         });
     </script>
 </li> <!-- Form group ; item row -->

--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/assets/scripts/bootstrapbuttons.js
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/assets/scripts/bootstrapbuttons.js
@@ -16,6 +16,9 @@ $(document).ready(function () {
         if ($(this).val()) {
             // "other" input field
             $("#answer" + baseName + "other").val($(this).val());
+        }
+        // the "Other" button can be checked without a value, so also rely on its state
+        if ($(this).val() || $("#answer" + myfname + "cbox").is(':checked')) {
             $("#" + baseName + "other-div").removeClass('d-none');
         }
         // execute validation

--- a/themes/question/image_select-multiplechoice/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
+++ b/themes/question/image_select-multiplechoice/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
@@ -32,7 +32,6 @@
                         name="{{ myfname }}cbox"
                         id="answer{{ myfname }}cbox"
                         {{ checkedState }}
-                        aria-hidden="true"
                     />
                     <label for="answer{{ myfname }}cbox" class="checkbox-label control-label answertext" id="label-{{ myfname }}-other">{{ processString(othertext) }}</label>
                 </div>
@@ -73,15 +72,19 @@
             />
         </div>
 <script type='text/javascript'>
+    $(function()
+    {
+        if ($('#answer{{ myfname }}cbox').is(':checked') && $.trim($('#answer{{ myfname }}').val()).length==0)
+        {
+            LEMflagMandOther("{{ myfname }}",true);
+        }
+    });
+
     $('#answer{{ myfname }}').on('keyup focusout',function(event)
     {
         if ($.trim($(this).val()).length>0)
         {
             $("#answer{{ myfname }}cbox").prop("checked",true);
-        }
-        else
-        {
-            $("#answer{{ myfname }}cbox").prop("checked",false);
         }
         $("#java{{ myfname }}").val($(this).val());
         LEMflagMandOther("{{ myfname }}",$('#answer{{ myfname }}cbox').is(":checked"));
@@ -90,19 +93,18 @@
 
     $('#answer{{ myfname }}cbox').click(function(event)
     {
-        if (($(this)).is(':checked') && $.trim($("#answer{{ myfname }}").val()).length==0)
+        if (($(this)).is(':checked'))
         {
             $("#answer{{ myfname }}").focus();
             LEMflagMandOther("{{ myfname }}",true);
-            return false;
         }
         else
         {
             $("#answer{{ myfname }}").val('');
+            $("#java{{ myfname }}").val('');
             {{ checkconditionFunction }}("", "{{ myfname }}", "text");
             LEMflagMandOther("{{ myfname }}",false);
-            return true;
-        };
+        }
     });
 </script>
 </li> <!-- Form group ; item row -->


### PR DESCRIPTION
Fixed issue #AT-2109: Multiple choice: Allow checking other option before entering text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiple-choice “Other” answers when selected without text.
  * Mandatory validation now correctly prompts for missing “Other” details while accepting completed responses.
  * The “Other” text field remains available when its option is selected, including after clearing the text.
  * Unchecking “Other” now consistently clears the associated visible and hidden values.
  * Improved accessibility and interaction behavior for “Other” checkboxes across supported question themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->