### PR TITLE
Fixed issue #20642: [security] Unauthenticated arbitrary plugin-method invocation

### DIFF
--- a/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
+++ b/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
@@ -35,6 +35,39 @@ class TwoFactorAdminLogin extends AuthPluginBase
         'index'
     ];
 
+    /**
+     * Methods invokable through the public web 'newDirectRequest' event
+     * (plugins/direct endpoint). Each performs its own permission check.
+     * Any method not listed here must never be dispatchable from an
+     * attacker-controlled 'function' parameter.
+     * @var string[]
+     */
+    private $allowedDirectMethods = [
+        'directCallCreateNewKey',
+        'directCallConfirmKey',
+        'directCallDeleteKey',
+    ];
+
+    /**
+     * Web direct methods that mutate data and therefore must only be reachable
+     * through an unsafe HTTP method (POST/PATCH), never GET.
+     * @var string[]
+     */
+    private $writeDirectMethods = [
+        'directCallConfirmKey',
+        'directCallDeleteKey',
+    ];
+
+    /**
+     * Methods invokable through the CLI-only 'direct' event
+     * (console command "plugin index --target=... --function=...").
+     * @var string[]
+     */
+    private $allowedCliMethods = [
+        'deleteKeyForUserId',
+        'deleteKeyForUserName',
+    ];
+
     protected $storage = 'DbStorage';
     protected $settings = array(
         'force2fa' => array(
@@ -147,9 +180,14 @@ class TwoFactorAdminLogin extends AuthPluginBase
         }
 
         $action = $oEvent->get('function');
-        if (method_exists($this, $action)) {
-            call_user_func([$this, $action], $oEvent, $request);
+        if (!in_array($action, $this->allowedDirectMethods, true) || !method_exists($this, $action)) {
+            return;
         }
+        // Data-modifying actions must never run on a safe (GET) request.
+        if (in_array($action, $this->writeDirectMethods, true) && !$request->getIsPostRequest()) {
+            throw new CHttpException(405, gT('This action requires a POST request.'));
+        }
+        call_user_func([$this, $action], $oEvent, $request);
     }
 
     /**
@@ -165,7 +203,7 @@ class TwoFactorAdminLogin extends AuthPluginBase
         }
         $option = $this->event->get("option");
         $action = $oEvent->get('function');
-        if (method_exists($this, $action)) {
+        if (in_array($action, $this->allowedCliMethods, true) && method_exists($this, $action)) {
             call_user_func([$this, $action], $oEvent, $option);
         }
     }

--- a/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
+++ b/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
@@ -166,8 +166,9 @@ class TwoFactorAdminLogin extends AuthPluginBase
 
     //##############  Plugin event handlers ##############//
     /**
-     * Listen to direct requests
-     * Necessary for the getMetadata function
+     * Handle public web direct requests (plugins/direct endpoint).
+     * Only methods in $allowedDirectMethods are dispatchable; data-modifying
+     * ones additionally require a POST request.
      *
      * @return void
      */

--- a/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
+++ b/application/core/plugins/TwoFactorAdminLogin/TwoFactorAdminLogin.php
@@ -50,7 +50,7 @@ class TwoFactorAdminLogin extends AuthPluginBase
 
     /**
      * Web direct methods that mutate data and therefore must only be reachable
-     * through an unsafe HTTP method (POST/PATCH), never GET.
+     * through a safe HTTP method (POST/PATCH), never GET.
      * @var string[]
      */
     private $writeDirectMethods = [


### PR DESCRIPTION

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Restricted web and command-line access to approved direct actions.
  - Web-based write actions now require POST requests; other methods receive an HTTP 405 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->