### PR TITLE
Fixed issue #19622: Mail not possible if name contains a < char

### DIFF
--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -398,16 +398,19 @@ class LimeMailer extends PHPMailer
     public function setFrom($from, $fromname = null, $auto = true)
     {
         $fromemail = $from;
-        if (strpos($from, '<') !== false) {
+        /* Email is always the last «<email>» part: use the last angle brackets so a name containing '<' is kept intact */
+        $ltPosition = strrpos($from, '<');
+        if ($ltPosition !== false) {
             if (is_null($fromname)) {
-                if (strpos($from, '<')) {
-                    $fromname = trim(substr($from, 0, strpos($from, '<') - 1));
+                if ($ltPosition > 0) {
+                    $fromname = trim(substr($from, 0, $ltPosition));
                 } else {
                     /* Allow to force empty name in token email */
                     $fromname = '';
                 }
             }
-            $fromemail = substr($from, strpos($from, '<') + 1, strpos($from, '>') - 1 - strpos($from, '<'));
+            $gtPosition = strrpos($from, '>');
+            $fromemail = substr($from, $ltPosition + 1, $gtPosition - 1 - $ltPosition);
         }
         if (is_null($fromname)) {
             $fromname = $this->FromName;
@@ -435,10 +438,13 @@ class LimeMailer extends PHPMailer
     public function addAddress($addressTo, $name = '')
     {
         $address = $addressTo;
-        if (strpos($address, '<')) {
-            $address = substr($addressTo, strpos($addressTo, '<') + 1, strpos($addressTo, '>') - 1 - strpos($addressTo, '<'));
+        /* Email is always the last «<email>» part: use the last angle brackets so a name containing '<' is kept intact */
+        $ltPosition = strrpos($addressTo, '<');
+        if ($ltPosition !== false) {
+            $gtPosition = strrpos($addressTo, '>');
+            $address = substr($addressTo, $ltPosition + 1, $gtPosition - 1 - $ltPosition);
             if (empty($name)) {
-                $name = trim(substr($addressTo, 0, strpos($addressTo, '<') - 1));
+                $name = trim(substr($addressTo, 0, $ltPosition));
             }
         }
         return parent::addAddress($address, $name);


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of email addresses that include display names containing `<` characters.
  * Correctly preserves names when parsing sender and recipient details.
  * Supports explicitly empty sender names when an address begins with `<`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->