### PR TITLE
Fixed issue #AT-2238: Translate aria labels on modal close buttons

### DIFF
--- a/themes/survey/fruity_twentythree/views/subviews/messages/bootstrap_alert_modal.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/messages/bootstrap_alert_modal.twig
@@ -59,7 +59,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="exampleModalLabel">{{ gT("Exit and clear survey" ) }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ gT('Close') }}"></button>
             </div>
             <div class="modal-body">
                 <p>{{ gT("Please confirm you want to clear your response?") }}</p>

--- a/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/privacy/privacy_modal.twig
@@ -46,7 +46,7 @@ Show the privacy message and the data security message will be available in a mo
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{{ gT('Privacy policy') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ gT('Close') }}"></button>
             </div>
             <div id="datasecurity_notice" class="modal-body {{ aSurveyInfo.class.privacydatasecmodalbody }}">
                 {{ aSurveyInfo.datasecurity_notice }}


### PR DESCRIPTION
Fixed issue #AT-2238: Translate aria labels on modal close buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Close buttons in the clear-all and privacy modals now provide translated labels.
  * Improved support for users who rely on assistive technologies and non-English translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->