### PR TITLE
Fixed issue #AT-2239: Render answer options as semantic lists

### DIFF
--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/answer.twig
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/answer.twig
@@ -11,9 +11,10 @@
 <!-- answer -->
 {{ sTimer }}
 <div class="container-fluid">
-    <div class="row {{coreClass}} " data-bs-toggle="buttons" role="radiogroup" aria-labelledby="ls-question-text-{{name }}">
+    <ul class="row {{coreClass}} list-unstyled" data-bs-toggle="buttons" role="radiogroup" aria-labelledby="ls-question-text-{{name }}">
     {# rows/answer_row.php #}
     {{ sRows }}
+    </ul>
 
     {# Value for expression manager javascript (use id) ; no need to submit #}
     {{ C.Html.hiddenField("java"~name,value,({
@@ -21,7 +22,6 @@
         'disabled' : true,
     }))
     }}
-    </div>
     {# Must add it only of other is set ! #}
     <div class="row row-cols-lg-auto align-items-center mb-3 ls-js-hidden answer-item" id="div{{ name }}other">
         <label for="answer{{ name }}othertext" class="col-form-label" id="label-id-{{ name }}">{{ othertext }}</label>

--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row.twig
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row.twig
@@ -14,7 +14,7 @@
 {% set max_buttons_row = (question_template_attribute.max_buttons_row == 'default' or question_template_attribute.max_buttons_row is empty) ? 'col-md-2' : question_template_attribute.max_buttons_row %}
 
 <!-- answer_row -->
-<div id="javatbd{{ myfname }}" class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
+<li id="javatbd{{ myfname }}" class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
     <div class="form-check col-12 {% if checkedState!='' %} active {% endif %}">
         <input
             class="btn-check visually-hidden button-item"
@@ -27,5 +27,5 @@
         <label class="btn btn-primary w-100 {{ button_size_class }}" for="answer{{ name }}{{ code }}"> {{ processString(answer) }}
         </label>
     </div>
-</div>
+</li>
 <!-- end of answer_row -->

--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_noanswer.twig
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_noanswer.twig
@@ -12,7 +12,7 @@
 {% set max_buttons_row = (question_template_attribute.max_buttons_row == 'default' or question_template_attribute.max_buttons_row is empty) ? 'col-md-2' : question_template_attribute.max_buttons_row %}
 
 <!-- answer_row_noanswer -->
-<div class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
+<li class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
     <div id="javatbd{{ name }}" class="form-check col-12 {% if check_ans!='' %} active {% endif %} col-12">
         <input
             class="btn-check visually-hidden button-item"
@@ -26,5 +26,5 @@
             <span class="" aria-hidden="true"></span> {{ gT('No answer') }}
         </label>
     </div>
-</div>
+</li>
 <!-- endof answer_row_noanswer -->

--- a/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_other.twig
+++ b/themes/question/bootstrap_buttons/survey/questions/answer/listradio/rows/answer_row_other.twig
@@ -20,7 +20,7 @@
 
 <!-- answer_row_other -->
 <!-- Checkbox + label -->
-<div class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
+<li class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
     <div id="javatbd{{ name }}_Cother" class="form-check bootstrap-buttons-div col-12 {% if checkedState!='' %} active focus {% endif %}"  {{ sDisplayStyle }}>
         <input
             class="btn-check visually-hidden button-item"
@@ -39,5 +39,5 @@
         {{ answer_other }}
         >
     </div>
-</div>
+</li>
 <!-- end of answer_row_other -->

--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/answer.twig
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/answer.twig
@@ -17,13 +17,13 @@
 {% set max_buttons_row = (question_template_attribute.max_buttons_row == 'default' or question_template_attribute.max_buttons_row is empty) ? 'col-md-2' : question_template_attribute.max_buttons_row %}
 <input type="hidden" name="MULTI{{name}}" value="{{anscount}}" />
 <div class="{{coreClass}} row {{ extraclass }}" >
-    <div class="list-unstyled form-inline btn-toolbar col-12 " data-bs-toggle="buttons" role="group" aria-labelledby="ls-question-text-{{basename }}">
+    <ul class="list-unstyled form-inline btn-toolbar col-12 " data-bs-toggle="buttons" role="group" aria-labelledby="ls-question-text-{{basename }}">
         {% for aRow in aRows %}
             {% set aRow = aRow|merge({'button_size_class': button_size_class})|merge({'max_buttons_row': max_buttons_row}) %}
             {% set rowTemplate = aRow.other ? './survey/questions/answer/multiplechoice/rows/answer_row_other.twig' : './survey/questions/answer/multiplechoice/rows/answer_row.twig' %}
             {% include rowTemplate with aRow %}
         {% endfor %}
-    </div>
+    </ul>
     <!-- other -->
     {% if other in aRows|keys %}
     <div class="d-none col-12" id="{{ name }}other-div">

--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row.twig
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row.twig
@@ -20,7 +20,7 @@
 #}
 
 <!-- answer_row -->
-<div id='javatbd{{ myfname }}' class="bootstrap-buttons-div question-item answer-item col-12 {{ max_buttons_row }} mb-1">
+<li id='javatbd{{ myfname }}' class="bootstrap-buttons-div question-item answer-item col-12 {{ max_buttons_row }} mb-1">
     <div class="form-check col-12 {% if checkedState!='' %} active {% endif %}">
     <input
         type="checkbox"
@@ -40,5 +40,5 @@
         value="{{ C.Html.encode( sValue ) }}"
     />
     </div>
-</div>
+</li>
 <!-- end of answer_row -->

--- a/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
+++ b/themes/question/bootstrap_buttons_multi/survey/questions/answer/multiplechoice/rows/answer_row_other.twig
@@ -15,7 +15,7 @@
 #}
 
 <!-- answer_row_other -->
-<div class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
+<li class="bootstrap-buttons-div col-12 {{ max_buttons_row }}">
     <div id='javatbd{{ myfname }}' class="form-check col-12 {% if checkedState!='' %} active {% endif %}">
 
         <!-- Checkbox + label -->
@@ -41,6 +41,6 @@
             data-name="{{myfname}}"
         />
     </div>
-</div>
+</li>
  <!-- Form group ; item row -->
 <!-- end of answer_row_other -->


### PR DESCRIPTION
Fixed issue #AT-2239: Render answer options as semantic lists - Bootstrap buttons (single and multiple selection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated radio-button and multiple-choice answer groups to use semantic list markup.
  * Improved structural consistency for standard, “Other,” and “No answer” options while preserving existing controls and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->