### PR TITLE
Fixed issue #AT-2246: Move focus to the newly added line in the Input on demand question theme name

### DIFF
--- a/themes/question/inputondemand/survey/questions/answer/multipleshorttext/answer.twig
+++ b/themes/question/inputondemand/survey/questions/answer/multipleshorttext/answer.twig
@@ -24,7 +24,7 @@
             </ul>
         </div>
         <div class="col-12 text-end">
-            <button class="btn btn-outline-secondary selector--inputondemand-addlinebutton">
+            <button type="button" class="btn btn-outline-secondary selector--inputondemand-addlinebutton">
                 {% set riClass = '' %}
                 {% if question_template_attribute.addlineicon is same as("plus") %}
                     {% set riClass = 'ri-add-line' %}

--- a/themes/question/inputondemand/survey/questions/answer/multipleshorttext/assets/scripts/inputondemand.js
+++ b/themes/question/inputondemand/survey/questions/answer/multipleshorttext/assets/scripts/inputondemand.js
@@ -29,6 +29,7 @@ var InputOnDemanControlGenerator = function(containerId, options){
 
     var addLine = function() {
         var last = null;
+        var revealed = null;
         $list.find('.selector--inputondemand-list-input').each(function(itrt, listItem){
             if(!$(listItem).closest('.selector--inputondemand-list-item').hasClass('d-none')) {
                 last = listItem;
@@ -36,10 +37,15 @@ var InputOnDemanControlGenerator = function(containerId, options){
             }
             if(last !== null) {
                 $(listItem).closest('.selector--inputondemand-list-item').removeClass('d-none');
+                revealed = listItem;
                 last = null;
                 return false;
             }
         });
+        // Move the focus into the line we just revealed.
+        if(revealed !== null) {
+            $(revealed).trigger('focus');
+        }
         if(!$list.find('.selector--inputondemand-list-item').last().hasClass('d-none')) {
             $button.addClass('d-none');
         }


### PR DESCRIPTION
Fixed issue #AT-2246: Move focus to the newly added line in the Input on demand question theme name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the add-line control from unintentionally submitting the form.
  * Automatically moves focus to newly revealed fields when adding another response line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->