### PR TITLE
Fixed issue #AT-2250: Dropdown options not reachable via keyboard

### DIFF
--- a/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
+++ b/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
@@ -75,11 +75,10 @@
             var $bsToggle  = $bsWrapper.find('.dropdown-toggle').first();
 
             $bsToggle.attr('data-toggle', 'dropdown');
+            var handledKeys = ['ArrowUp', 'ArrowDown', 'Escape', 'Enter'];
 
             window.addEventListener('keydown', function (event) {
-                // Only the keys Bootstrap swallows; everything else already reaches
-                // bootstrap-select on its own.
-                if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Escape') {
+                if (handledKeys.indexOf(event.key) === -1) {
                     return;
                 }
                 // Ignore other widgets on the page; each one binds its own listener.
@@ -98,11 +97,16 @@
 
                 var $listbox = $bsWrapper.find('[role="listbox"]').first();
                 var target = (isOpen && $listbox.length) ? $listbox.get(0) : $bsToggle.get(0);
+                var keyCode = (event.key === 'Enter' && !isOpen) ? 40 : event.keyCode;
 
                 $.fn.selectpicker.Constructor.prototype.keydown.call(
                     target,
-                    $.Event('keydown', { which: event.keyCode, keyCode: event.keyCode })
+                    $.Event('keydown', { which: keyCode, keyCode: keyCode })
                 );
+
+                if (event.key === 'Enter' && isOpen && $bsToggle.attr('aria-expanded') === 'true') {
+                    $bsToggle.trigger('click.bs.dropdown.data-api').trigger('focus');
+                }
             }, true);
         });
 

--- a/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
+++ b/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
@@ -66,6 +66,39 @@
                 }, 200);
             });
             {% endif %}
+
+            {#
+                Keyboard access for the answer options (WCAG 2.1 SC 2.1.1).
+
+            #}
+            var $bsWrapper = $('#answer{{ name }}').closest('.bootstrap-select');
+            var $bsToggle  = $bsWrapper.find('.dropdown-toggle').first();
+
+            $bsToggle.attr('data-toggle', 'dropdown');
+
+            window.addEventListener('keydown', function (event) {
+                // Only the keys Bootstrap swallows; everything else already reaches
+                // bootstrap-select on its own.
+                if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Escape') {
+                    return;
+                }
+                // Ignore other widgets on the page; each one binds its own listener.
+                if (!event.target || typeof event.target.closest !== 'function'
+                    || event.target.closest('.bootstrap-select') !== $bsWrapper.get(0)) {
+                    return;
+                }
+                event.stopPropagation();
+                event.preventDefault();
+
+                var isOpen = $bsToggle.attr('aria-expanded') === 'true';
+                var $listbox = $bsWrapper.find('[role="listbox"]').first();
+                var target = (isOpen && $listbox.length) ? $listbox.get(0) : $bsToggle.get(0);
+
+                $.fn.selectpicker.Constructor.prototype.keydown.call(
+                    target,
+                    $.Event('keydown', { which: event.keyCode, keyCode: event.keyCode })
+                );
+            }, true);
         });
 
     </script>

--- a/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
+++ b/themes/question/bootstrap_dropdown/survey/questions/answer/list_dropdown/answer.twig
@@ -87,10 +87,15 @@
                     || event.target.closest('.bootstrap-select') !== $bsWrapper.get(0)) {
                     return;
                 }
+                var isOpen = $bsToggle.attr('aria-expanded') === 'true';
+
+                if (event.key === 'Escape' && !isOpen) {
+                    return;
+                }
+
                 event.stopPropagation();
                 event.preventDefault();
 
-                var isOpen = $bsToggle.attr('aria-expanded') === 'true';
                 var $listbox = $bsWrapper.find('[role="listbox"]').first();
                 var target = (isOpen && $listbox.length) ? $listbox.get(0) : $bsToggle.get(0);
 


### PR DESCRIPTION
Fixed issue #AT-2250: Dropdown options not reachable via keyboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Expanded keyboard navigation for select dropdowns to support Enter alongside Arrow Up, Arrow Down, and Escape.
  * Pressing Enter now opens closed dropdowns and confirms selections when a dropdown is open.
  * Improved focus and toggle behavior after keyboard selection, with interactions limited to the active dropdown control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->