### PR TITLE
AT-2171: floating menu for survey menu

### DIFF
--- a/application/extensions/admin/grid/FloatingActionsWidget/actions/SurveyMenuListMassiveActions.php
+++ b/application/extensions/admin/grid/FloatingActionsWidget/actions/SurveyMenuListMassiveActions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace actions;
+
+/**
+ * Action definitions for the Survey Menus floating action bar.
+ */
+class SurveyMenuListMassiveActions
+{
+    /**
+     * @return array
+     */
+    public static function getActions(): array
+    {
+        $buttons = [];
+
+        if (\Permission::model()->hasGlobalPermission('settings', 'update')) {
+            $buttons[] = [
+                'type' => 'action',
+                'action' => 'batchEdit',
+                'url' => \App()->createUrl('/admin/menus/sa/batchEdit/'),
+                'iconClasses' => 'ri-download-fill',
+                'text' => \gT('Batch edit'),
+                'grid-reload' => 'yes',
+                'actionType' => 'modal',
+                'modalType' => 'cancel-save',
+                'keepopen' => 'yes',
+                'yes' => \gT('Save'),
+                'no' => \gT('Cancel'),
+                'sModalTitle' => \gT('Batch edit the menus'),
+                'htmlModalBody' => \Yii::app()->getController()->renderPartial(
+                    './surveymenu/massive_action/_update',
+                    [],
+                    true
+                ),
+            ];
+        }
+
+        if (\Permission::model()->hasGlobalPermission('settings', 'delete')) {
+            $buttons[] = [
+                'type' => 'action',
+                'action' => 'delete',
+                'url' => \App()->createUrl('/admin/menus/sa/massDelete/'),
+                'iconClasses' => 'ri-delete-bin-fill',
+                'btnClass' => 'text-danger',
+                'text' => \gT('Delete'),
+                'grid-reload' => 'yes',
+                'actionType' => 'modal',
+                'modalType' => 'cancel-delete',
+                'keepopen' => 'no',
+                'sModalTitle' => \gT('Delete menus'),
+                'htmlModalBody' => \gT('Are you sure you want to delete the selected menus and all related submenus and entries?'),
+                'aCustomDatas' => [],
+            ];
+        }
+
+        return $buttons;
+    }
+}
+

--- a/application/models/Surveymenu.php
+++ b/application/models/Surveymenu.php
@@ -392,7 +392,7 @@ class Surveymenu extends LSActiveRecord
                 'class'               => 'CCheckBoxColumn',
                 'selectableRows'      => 2,
                 'name'                => 'id',
-                'checkBoxHtmlOptions' => ['name' => 'id[]', 'class' => 'action_selectthismenu'],
+                'checkBoxHtmlOptions' => ['name' => 'id[]', 'class' => 'massiveActionsCheckbox action_selectthismenu'],
                 'headerHtmlOptions'   => ['class' => 'ls-sticky-column'],
                 'filterHtmlOptions'   => ['class' => 'ls-sticky-column'],
                 'htmlOptions'         => ['class' => 'ls-sticky-column'],

--- a/application/views/admin/surveymenu/index.php
+++ b/application/views/admin/surveymenu/index.php
@@ -7,7 +7,6 @@
  */
 
 $pageSize = Yii::app()->user->getState('pageSize', Yii::app()->params['defaultPageSize']);
-$massiveAction = App()->getController()->renderPartial('/admin/surveymenu/massive_action/_selector', [], true, false);
 
 // DO NOT REMOVE This is for automated testing to validate we see that page
 echo viewHelper::getViewTestTag('surveyMenus');
@@ -36,6 +35,14 @@ echo viewHelper::getViewTestTag('surveyMenus');
                 <div class="col-12 ls-space margin top-15">
                     <div class="col-12 ls-flex-item">
                         <?php
+                        require_once Yii::app()->getBasePath() . '/extensions/admin/grid/FloatingActionsWidget/actions/SurveyMenuListMassiveActions.php';
+                        $floatingActions = \actions\SurveyMenuListMassiveActions::getActions();
+                        $this->widget('ext.admin.grid.FloatingActionsWidget.FloatingActionsWidget', [
+                            'pk' => 'id',
+                            'gridId' => 'surveymenu-grid',
+                            'aActions' => $floatingActions,
+                        ]);
+
                         $this->widget(
                             'application.extensions.admin.grid.CLSGridView',
                             [
@@ -57,8 +64,8 @@ echo viewHelper::getViewTestTag('surveyMenus');
                                 'rowHtmlOptionsExpression' => '["data-surveymenu-id" => $data->id]',
                                 'ajaxType' => 'POST',
                                 'ajaxUpdate' => 'surveymenu-grid',
-                                'massiveActionTemplate' => $massiveAction,
-                                'lsAfterAjaxUpdate'  => ['bindListItemclick();', 'surveyMenuFunctions();'],
+                                'showSelectionBar' => false,
+                                'lsAfterAjaxUpdate'  => ['surveyMenuFunctions();'],
                             ]
                         ); ?>
                     </div>


### PR DESCRIPTION
New feature #AT-2171: floating menu for survey menus


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bulk actions for survey menus, including batch editing and deletion.
  - Actions are displayed based on the permissions available to the current user.

- **Improvements**
  - Updated survey menu selection controls to support the new bulk-action interface.
  - Streamlined the survey menu grid interactions and AJAX updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->