### PR TITLE
Fixed issue #AT-2247: a11y add visible border to expanded dropdown

### DIFF
--- a/assets/survey_themes/fruity_twentythree/questiontypes/bootstrap_select/bootstrap_select_colors.scss
+++ b/assets/survey_themes/fruity_twentythree/questiontypes/bootstrap_select/bootstrap_select_colors.scss
@@ -1,9 +1,11 @@
 .dropdown-menu {
     background-color : $white;
     // The box-shadow alone does not separate the expanded menu from the content
-    // it overlays (WCAG 2.1 SC 1.4.11 Non-text Contrast). $g-700 is the same
-    // colour the theme uses for input borders and gives 4.6:1 against $white.
-    border           : 1px solid $g-700;
+    // it overlays (WCAG 2.1 SC 1.4.11 Non-text Contrast, which wants 3:1).
+    // $g-600 is the lightest tone in the palette that clears that bar, at
+    // 3.01:1 — and only because the background above is pure $white. Tinting
+    // that background, or lightening $g-600, drops this below 3:1.
+    border           : 1px solid $g-600;
     box-shadow       : 0px 2px 6px rgba(0, 0, 0, 0.2);
     border-radius: $border-radius;
     .divider {

--- a/assets/survey_themes/fruity_twentythree/questiontypes/bootstrap_select/bootstrap_select_colors.scss
+++ b/assets/survey_themes/fruity_twentythree/questiontypes/bootstrap_select/bootstrap_select_colors.scss
@@ -1,6 +1,9 @@
 .dropdown-menu {
     background-color : $white;
-    border           : none;
+    // The box-shadow alone does not separate the expanded menu from the content
+    // it overlays (WCAG 2.1 SC 1.4.11 Non-text Contrast). $g-700 is the same
+    // colour the theme uses for input borders and gives 4.6:1 against $white.
+    border           : 1px solid $g-700;
     box-shadow       : 0px 2px 6px rgba(0, 0, 0, 0.2);
     border-radius: $border-radius;
     .divider {

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_apple.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_apple.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_blueberry.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_grape.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_grape.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango-rtl.css
@@ -15412,7 +15412,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: 1px solid #6E748C;
+  border: 1px solid #9094A7;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }

--- a/themes/survey/fruity_twentythree/css/variations/theme_mango.css
+++ b/themes/survey/fruity_twentythree/css/variations/theme_mango.css
@@ -15435,7 +15435,7 @@ body .imageselect-listitem label::after {
 
 .dropdown-menu {
   background-color: #ffffff;
-  border: none;
+  border: 1px solid #6E748C;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }


### PR DESCRIPTION
Fixed issue #AT-2247: a11y add visible border to expanded dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a subtle 1px border to dropdown menus across Fruity Twentythree theme variations.
  * Applied the same visual update to both standard and right-to-left layouts.
  * Existing dropdown shadows and other styling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->