### PR TITLE
Dev: Improve duplicate label set import feedback

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1081,6 +1081,7 @@ function XMLImportLabelsets($sFullFilePath, $options)
     $aLSIDReplacements = $results = [];
     $results['labelsets'] = 0;
     $results['labels'] = 0;
+    $results['duplicates'] = 0;
     $results['warnings'] = array();
     $aImportedLabelSetIDs = array();
 
@@ -1167,8 +1168,28 @@ function XMLImportLabelsets($sFullFilePath, $options)
         $aCounts = array_count_values($aLabelSetCheckSums);
         foreach ($aImportedLabelSetIDs as $iLabelSetID) {
             if ($aCounts[$aLabelSetCheckSums[$iLabelSetID]] > 1) {
-                LabelSet::model()->deleteLabelSet($iLabelSetID);
+                $labelSet = LabelSet::model()->findByPk($iLabelSetID);
+                if ($labelSet !== null) {
+                    $labelCount = count($labelSet->labels);
+                    if ($labelSet->deleteLabelSet($iLabelSetID)) {
+                        $results['labelsets']--;
+                        $results['labels'] -= $labelCount;
+                        $results['duplicates']++;
+                    } else {
+                        $results['warnings'][] = sprintf(
+                            gT('Duplicate label set with ID %d could not be removed.'),
+                            $iLabelSetID
+                        );
+                    }
+                }
             }
+        }
+
+        if ($results['duplicates'] > 0) {
+            $results['warnings'][] = ngT(
+                '{n} duplicate label set was not imported.|{n} duplicate label sets were not imported.',
+                $results['duplicates']
+            );
         }
 
         //END CHECK FOR DUPLICATES

--- a/application/views/admin/labels/import_view.php
+++ b/application/views/admin/labels/import_view.php
@@ -13,7 +13,11 @@
 <?php else:?>
     <div class="jumbotron message-box">
             <h2 class="text-success"><?php eT("Import Label Set") ?></h2>
-            <p class="lead"><?php eT("File upload succeeded.") ?></p>
+            <?php if ($aImportResults['labelsets'] > 0): ?>
+                <p class="lead text-success"><?php eT("File upload succeeded.") ?></p>
+            <?php else: ?>
+                <p class="lead text-danger"><?php eT("No new label sets were imported.") ?></p>
+            <?php endif; ?>
             <?php if (count($aImportResults['warnings']) > 0): ?>
                 <p  class="lead text-danger">
                     <?php eT("Warnings") ?>
@@ -35,11 +39,18 @@
                 <ul class="list-unstyled">
                     <li><?php echo gT("Label sets") . ": {$aImportResults['labelsets']}" ?></li>
                     <li><?php echo gT("Labels") . ": {$aImportResults['labels']}" ?></li>
+                    <?php if (!empty($aImportResults['duplicates'])): ?>
+                        <li><?php echo gT("Duplicate label sets skipped") . ": {$aImportResults['duplicates']}" ?></li>
+                    <?php endif; ?>
                 </ul>
             </p>
 
             <p>
-                <strong><?php eT("Import of label set(s) is completed.") ?></strong>
+                <?php if ($aImportResults['labelsets'] > 0): ?>
+                    <strong><?php eT("Import of label set(s) is completed.") ?></strong>
+                <?php else: ?>
+                    <strong><?php eT("Import completed without adding new label sets.") ?></strong>
+                <?php endif; ?>
             </p>
 
             <p>


### PR DESCRIPTION
Dev: Improve duplicate label set import feedback

## What was changed?

Label set imports with duplicate checking enabled currently report a successful import even when the newly imported label set is subsequently removed because it already exists.

This change:

- tracks skipped duplicate label sets separately;
- corrects the imported label set and label counters;
- deletes duplicates through the loaded `LabelSet` instance so existing cleanup logic is applied;
- reports that no new label sets were imported when all imported sets were duplicates;
- shows the number of skipped duplicate label sets in the import summary.

## Steps to reproduce

1. Import an LSL file with "Don't import if label set already exists" enabled.
2. Import the same LSL file again.
3. Observe that the current summary reports a successful import even though no additional label set appears in the overview.

## Expected result

The second import reports that the duplicate was skipped and that no new label sets were imported.

## Tests

- Imported a new LSL file with duplicate checking enabled.
- Imported the same file again and confirmed that only one label set exists.
- Confirmed that the second import reports zero imported label sets and one skipped duplicate.
- PHP syntax checks passed for both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label-set imports now detect and remove duplicate label sets.
  * Import results report how many duplicate label sets were skipped.
  * Completion messages now distinguish between imports that added label sets and those that did not.

* **Bug Fixes**
  * Counts are updated only after duplicate removal succeeds.
  * Failed duplicate removals now generate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->