### PR TITLE
Dev: Add bulk delete action for label sets

### DIFF
--- a/application/controllers/admin/Labels.php
+++ b/application/controllers/admin/Labels.php
@@ -425,6 +425,7 @@ class Labels extends SurveyCommonAction
         $labelSetIds = json_decode(App()->getRequest()->getPost('sItems', ''), true);
         if (!is_array($labelSetIds)) {
             \ls\ajax\AjaxHelper::outputError(gT('Please select at least one item'));
+            return;
         }
 
         $labelSetIds = array_values(array_unique(array_filter(
@@ -441,6 +442,7 @@ class Labels extends SurveyCommonAction
 
         if (empty($labelSetIds)) {
             \ls\ajax\AjaxHelper::outputError(gT('Please select at least one item'));
+            return;
         }
 
         $deleted = 0;
@@ -462,12 +464,14 @@ class Labels extends SurveyCommonAction
             \ls\ajax\AjaxHelper::outputSuccess(
                 ngT('{n} label set deleted successfully.|{n} label sets deleted successfully.', $deleted)
             );
+            return;
         }
 
         if ($deleted === 0) {
             \ls\ajax\AjaxHelper::outputError(
                 ngT('{n} label set could not be deleted.|{n} label sets could not be deleted.', $failed)
             );
+            return;
         }
 
         \ls\ajax\AjaxHelper::outputError(

--- a/application/controllers/admin/Labels.php
+++ b/application/controllers/admin/Labels.php
@@ -413,6 +413,71 @@ class Labels extends SurveyCommonAction
     }
 
     /**
+     * Delete selected label sets independently.
+     *
+     * @return void
+     */
+    public function massDelete()
+    {
+        $this->requirePostRequest();
+        Yii::import('application.helpers.admin.ajax_helper', true);
+
+        $labelSetIds = json_decode(App()->getRequest()->getPost('sItems', ''), true);
+        if (!is_array($labelSetIds)) {
+            \ls\ajax\AjaxHelper::outputError(gT('Please select at least one item'));
+        }
+
+        $labelSetIds = array_values(array_unique(array_filter(
+            array_map(
+                static function ($labelSetId) {
+                    if (!is_int($labelSetId) && !is_string($labelSetId)) {
+                        return false;
+                    }
+                    return filter_var($labelSetId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+                },
+                $labelSetIds
+            )
+        )));
+
+        if (empty($labelSetIds)) {
+            \ls\ajax\AjaxHelper::outputError(gT('Please select at least one item'));
+        }
+
+        $deleted = 0;
+        $failed = 0;
+        foreach ($labelSetIds as $labelSetId) {
+            $labelSet = LabelSet::model()->findByPk((int) $labelSetId);
+            if (
+                $labelSet === null
+                || !$labelSet->hasPermission('labelset', 'delete')
+                || !$labelSet->deleteLabelSet((int) $labelSetId)
+            ) {
+                $failed++;
+                continue;
+            }
+            $deleted++;
+        }
+
+        if ($failed === 0) {
+            \ls\ajax\AjaxHelper::outputSuccess(
+                ngT('{n} label set deleted successfully.|{n} label sets deleted successfully.', $deleted)
+            );
+        }
+
+        if ($deleted === 0) {
+            \ls\ajax\AjaxHelper::outputError(
+                ngT('{n} label set could not be deleted.|{n} label sets could not be deleted.', $failed)
+            );
+        }
+
+        \ls\ajax\AjaxHelper::outputError(
+            ngT('{n} label set deleted successfully.|{n} label sets deleted successfully.', $deleted)
+            . ' '
+            . ngT('{n} label set could not be deleted.|{n} label sets could not be deleted.', $failed)
+        );
+    }
+
+    /**
      * Multi label export
      *
      * @return void
@@ -792,7 +857,7 @@ class Labels extends SurveyCommonAction
         if (empty(LabelSet::model()->findByPk($lid))) {
             throw new CHttpException(404, gT("Label set not found"));
         }
-        if (!LabelSet::model()->findByPk($lid)->hasPermission($permission)) {
+        if (!LabelSet::model()->findByPk($lid)->hasPermission('labelset', $permission)) {
             throw new CHttpException(403);
         }
         return $lid;

--- a/application/views/admin/labels/labelsets_view.php
+++ b/application/views/admin/labels/labelsets_view.php
@@ -11,6 +11,7 @@ echo viewHelper::getViewTestTag('viewLabelSets');
 
 ?>
 <?php $pageSize = Yii::app()->user->getState('pageSize', Yii::app()->params['defaultPageSize']); ?>
+<?php $massiveAction = $this->renderPartial('/admin/labels/massive_actions/_selector', [], true); ?>
 <div class="row">
     <div class="col-12 content-right">
         <?php
@@ -22,6 +23,7 @@ echo viewHelper::getViewTestTag('viewLabelSets');
                 'id' => 'labelsets-grid',
                 'emptyText' => gT('No label sets found.'),
                 'ajaxUpdate' => 'labelsets-grid',
+                'massiveActionTemplate' => $massiveAction,
                 'summaryText' => gT('Displaying {start}-{end} of {count} result(s).') . ' ' . sprintf(
                         gT('%s rows per page'),
                         CHtml::dropDownList(
@@ -32,6 +34,11 @@ echo viewHelper::getViewTestTag('viewLabelSets');
                         )
                     ),
                 'columns' => [
+                    [
+                        'id' => 'lid',
+                        'class' => 'CCheckBoxColumn',
+                        'selectableRows' => 100,
+                    ],
                     [
                         'header' => gT('Label set ID'),
                         'name' => 'labelset_id',

--- a/application/views/admin/labels/massive_actions/_selector.php
+++ b/application/views/admin/labels/massive_actions/_selector.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Massive actions for the label sets grid.
+ */
+
+$this->widget(
+    'ext.admin.grid.MassiveActionsWidget.MassiveActionsWidget',
+    [
+        'pk' => 'lid',
+        'gridid' => 'labelsets-grid',
+        'dropupId' => 'labelSetsListActions',
+        'dropUpText' => gT('Selected label set(s)...'),
+        'aActions' => [
+            [
+                'type' => 'action',
+                'action' => 'delete',
+                'url' => App()->createUrl('/admin/labels/sa/massDelete'),
+                'iconClasses' => 'ri-delete-bin-fill text-danger',
+                'text' => gT('Delete'),
+                'grid-reload' => 'yes',
+                'on-success' => '(function(result) { LS.AjaxHelper.onSuccess(result); })',
+                'actionType' => 'modal',
+                'modalType' => 'cancel-delete',
+                'keepopen' => 'no',
+                'sModalTitle' => gT('Delete label sets'),
+                'htmlModalBody' => gT('Are you sure you want to delete the selected label sets?'),
+            ],
+        ],
+    ]
+);


### PR DESCRIPTION
Dev: Add bulk delete action for label sets

## What was changed?

The label sets overview currently supports deleting label sets only one at a time. This change adds the standard LimeSurvey massive-action workflow to the existing `CLSGridView`.

The implementation:

- adds a checkbox column with the standard header select-all behavior;
- adds a translated massive-action selector and deletion confirmation modal;
- accepts selected IDs through the existing `sItems` POST payload;
- validates and de-duplicates positive integer IDs;
- checks the `labelset/delete` permission for every selected label set;
- calls the existing `LabelSet::deleteLabelSet()` method for each item so labels, translations and uploaded resources use the canonical cleanup path;
- processes deletions independently and reports complete, failed and partial-success results;
- corrects the existing label set validation helper to use the intended permission entity and CRUD operation.

## Expected result

Administrators can select one or more label sets in the overview, confirm the destructive action and delete all authorized selections. Failed or unauthorized items are not deleted and are included in the result message.

## Tests

- PHP syntax checks passed for all three changed files.
- `git diff --check` passed.
- Invalid JSON values and non-integer IDs are rejected by the server-side validation.
- Manual verification is recommended for selection, confirmation, permissions, pagination and partial failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk deletion for label sets from the administration grid.
  * Added checkboxes to select up to 100 label sets at once.
  * Added a confirmation dialog before deleting selected label sets.
  * Deletions are processed individually, with clear success, failure, or mixed-result feedback.
  * The grid refreshes automatically after successful deletions.
  * Actions are restricted to label sets the administrator is authorized to delete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->