### PR TITLE
Fixed issue #20519: When importing a question group (or old survey) codes are badly replaced

### DIFF
--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -3551,8 +3551,10 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
     $results['FieldReMap'] = $aOldNewFieldmap;
     LimeExpressionManager::SetSurveyId($iNewSID);
     translateInsertansTags($iNewSID, $iOldSID, $aOldNewFieldmap);
-    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
-    replaceExpressionCodes($iNewSID, $aQuestionsMapping); // replace question codes in format "38612X105X3011"
+    // Restrict the replacement to the newly imported group(s) so expressions/conditions in other groups are left untouched.
+    $aImportedGids = array_values($aGIDReplacements);
+    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements, $aImportedGids);
+    replaceExpressionCodes($iNewSID, $aQuestionsMapping, $aImportedGids); // replace question codes in format "38612X105X3011"
     if (count($aQuestionCodeReplacements)) {
         array_unshift($results['importwarnings'], "<span class='warningtitle'>" . gT('Attention: Several question codes were updated. Please check these carefully as the update  may not be perfect with customized expressions.') . '</span>');
     }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -638,7 +638,8 @@ function XMLImportGroup($sFullFilePath, $iNewSID, $bTranslateLinksFields, $suppo
     }
 
     // Update question code references in custom conditions and relevance expressions
-    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
+    // Restrict to the imported group so expressions/conditions in other groups of the target survey are left untouched.
+    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements, array($newgid));
     replaceExpressionFieldnames($newgid, $aQIDReplacements);
 
     LimeExpressionManager::RevertUpgradeConditionsToRelevance($iNewSID);
@@ -3551,10 +3552,8 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
     $results['FieldReMap'] = $aOldNewFieldmap;
     LimeExpressionManager::SetSurveyId($iNewSID);
     translateInsertansTags($iNewSID, $iOldSID, $aOldNewFieldmap);
-    // Restrict the replacement to the newly imported group(s) so expressions/conditions in other groups are left untouched.
-    $aImportedGids = array_values($aGIDReplacements);
-    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements, $aImportedGids);
-    replaceExpressionCodes($iNewSID, $aQuestionsMapping, $aImportedGids); // replace question codes in format "38612X105X3011"
+    replaceExpressionCodes($iNewSID, $aQuestionCodeReplacements);
+    replaceExpressionCodes($iNewSID, $aQuestionsMapping); // replace question codes in format "38612X105X3011"
     if (count($aQuestionCodeReplacements)) {
         array_unshift($results['importwarnings'], "<span class='warningtitle'>" . gT('Attention: Several question codes were updated. Please check these carefully as the update  may not be perfect with customized expressions.') . '</span>');
     }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -4149,17 +4149,24 @@ function translateInsertansTags($newsid, $oldsid, $fieldnames)
 *
 * @param integer $iSurveyID The survey ID
 * @param mixed $aCodeMap The codemap array (old_code=>new_code)
+* @param int[]|null $aRestrictToGids When set, only questions/groups in these group IDs are updated (e.g. when importing a single group). The survey end text is left untouched in that case.
 */
-function replaceExpressionCodes($iSurveyID, $aCodeMap)
+function replaceExpressionCodes($iSurveyID, $aCodeMap, $aRestrictToGids = null)
 {
-    $arQuestions = Question::model()->findAll("sid=:sid", array(':sid' => $iSurveyID));
+    $bRestrictToGroups = is_array($aRestrictToGids);
+    $questionCriteria = new CDbCriteria();
+    $questionCriteria->addColumnCondition(['sid' => $iSurveyID]);
+    if ($bRestrictToGroups) {
+        $questionCriteria->addInCondition('gid', $aRestrictToGids);
+    }
+    $arQuestions = Question::model()->findAll($questionCriteria);
     foreach ($arQuestions as $arQuestion) {
         $bModified = false;
         foreach ($aCodeMap as $sOldCode => $sNewCode) {
             // Don't search/replace old codes that are too short or were numeric (because they would not have been usable in EM expressions anyway)
             if (strlen((string) $sOldCode) > 1 && !is_numeric($sOldCode)) {
                 $sOldCode = preg_quote((string) $sOldCode, '~');
-                $arQuestion->relevance = preg_replace("~\b{$sOldCode}~", (string) $sNewCode, (string) $arQuestion->relevance, -1, $iCount);
+                $arQuestion->relevance = preg_replace("~\b{$sOldCode}(?![a-zA-Z0-9])~", (string) $sNewCode, (string) $arQuestion->relevance, -1, $iCount);
                 $bModified = $bModified || $iCount;
             }
         }
@@ -4174,10 +4181,10 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
                     $sOldCode = preg_quote((string) $sOldCode, '~');
                     // The following regex only matches the last occurrence of the old code within each pair of brackets, so we apply the replace recursively
                     // to catch all occurrences.
-                    $arQuestionLS->question = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?=[^}]*?})~", $sNewCode, $arQuestionLS->question, -1, $iCount);
+                    $arQuestionLS->question = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?![a-zA-Z0-9])(?=[^}]*?})~", $sNewCode, $arQuestionLS->question, -1, $iCount);
                     $bModified = $bModified || $iCount;
                     // Apply the replacement on question help text
-                    $arQuestionLS->help = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?=[^}]*?})~", $sNewCode, $arQuestionLS->help, -1, $iCount);
+                    $arQuestionLS->help = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?![a-zA-Z0-9])(?=[^}]*?})~", $sNewCode, $arQuestionLS->help, -1, $iCount);
                     $bModified = $bModified || $iCount;
                 }
             }
@@ -4198,7 +4205,7 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
                         continue;
                     }
                     $sOldCode = preg_quote((string) $sOldCode, '~');
-                    $defaultValueL10n->defaultvalue = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?=[^}]*?})~", $sNewCode, $defaultValueL10n->defaultvalue, -1, $iCount);
+                    $defaultValueL10n->defaultvalue = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?![a-zA-Z0-9])(?=[^}]*?})~", $sNewCode, $defaultValueL10n->defaultvalue, -1, $iCount);
                     $bModified = $bModified || $iCount;
                 }
                 if ($bModified > 0) {
@@ -4207,12 +4214,17 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
             }
         }
     }
-    $arGroups = QuestionGroup::model()->findAll("sid=:sid", array(':sid' => $iSurveyID));
+    $groupCriteria = new CDbCriteria();
+    $groupCriteria->addColumnCondition(['sid' => $iSurveyID]);
+    if ($bRestrictToGroups) {
+        $groupCriteria->addInCondition('gid', $aRestrictToGids);
+    }
+    $arGroups = QuestionGroup::model()->findAll($groupCriteria);
     foreach ($arGroups as $arGroup) {
         $bModified = false;
         foreach ($aCodeMap as $sOldCode => $sNewCode) {
             $sOldCode = preg_quote((string) $sOldCode, '~');
-            $arGroup->grelevance = preg_replace("~\b{$sOldCode}~", (string) $sNewCode, (string) $arGroup->grelevance, -1, $iCount);
+            $arGroup->grelevance = preg_replace("~\b{$sOldCode}(?![a-zA-Z0-9])~", (string) $sNewCode, (string) $arGroup->grelevance, -1, $iCount);
             $bModified = $bModified || $iCount;
         }
         if ($bModified) {
@@ -4221,7 +4233,7 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
         foreach ($arGroup->questiongroupl10ns as $arQuestionGroupLS) {
             foreach ($aCodeMap as $sOldCode => $sNewCode) {
                 $sOldCode = preg_quote((string) $sOldCode, '~');
-                $arQuestionGroupLS->description = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?=[^}]*?})~", $sNewCode, $arQuestionGroupLS->description, -1, $iCount);
+                $arQuestionGroupLS->description = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?![a-zA-Z0-9])(?=[^}]*?})~", $sNewCode, $arQuestionGroupLS->description, -1, $iCount);
                 $bModified = $bModified || $iCount;
             }
             if ($bModified) {
@@ -4229,20 +4241,22 @@ function replaceExpressionCodes($iSurveyID, $aCodeMap)
             }
         }
     }
-    // Apply the replacement on survey's end message
-    $surveyLanguageSettings = SurveyLanguageSetting::model()->findAllByAttributes(array('surveyls_survey_id' => $iSurveyID));
-    foreach ($surveyLanguageSettings as $surveyLanguageSetting) {
-        $bModified = false;
-        foreach ($aCodeMap as $sOldCode => $sNewCode) {
-            if (strlen((string) $sOldCode) <= 1 || is_numeric($sOldCode)) {
-                continue;
+    // Apply the replacement on survey's end message (survey-wide, so skip it when restricting to specific groups)
+    if (!$bRestrictToGroups) {
+        $surveyLanguageSettings = SurveyLanguageSetting::model()->findAllByAttributes(array('surveyls_survey_id' => $iSurveyID));
+        foreach ($surveyLanguageSettings as $surveyLanguageSetting) {
+            $bModified = false;
+            foreach ($aCodeMap as $sOldCode => $sNewCode) {
+                if (strlen((string) $sOldCode) <= 1 || is_numeric($sOldCode)) {
+                    continue;
+                }
+                $sOldCode = preg_quote((string) $sOldCode, '~');
+                $surveyLanguageSetting->surveyls_endtext = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?![a-zA-Z0-9])(?=[^}]*?})~", $sNewCode, $surveyLanguageSetting->surveyls_endtext, -1, $iCount);
+                $bModified = $bModified || $iCount;
             }
-            $sOldCode = preg_quote((string) $sOldCode, '~');
-            $surveyLanguageSetting->surveyls_endtext = recursive_preg_replace("~{[^}]*\K{$sOldCode}(?=[^}]*?})~", $sNewCode, $surveyLanguageSetting->surveyls_endtext, -1, $iCount);
-            $bModified = $bModified || $iCount;
-        }
-        if ($bModified) {
-            $surveyLanguageSetting->save();
+            if ($bModified) {
+                $surveyLanguageSetting->save();
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed survey imports so expression-code replacements are limited to newly imported groups when appropriate.
  * Prevented unintended updates to expressions, conditions, relevance settings, localized content, default values, and group descriptions in unrelated groups.
  * Improved matching accuracy by enforcing identifier boundaries during replacements.
  * Preserved survey end messages when replacements are restricted to selected groups.
  * Restored survey-wide replacements for imports that require updates across the entire survey.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->