### PR TITLE
Fixed issue #19391: CKEditor is loaded on all admin pages, not just where needed

### DIFF
--- a/application/config/packages.php
+++ b/application/config/packages.php
@@ -125,6 +125,7 @@ return [
     'ckeditor'          => [
         'devBaseUrl' => 'assets/packages/ckeditor',
         'basePath'   => 'core.ckeditor',
+        'position'   => CClientScript::POS_BEGIN,
         'js'         => [
             'ckeditor.js',
             'config.js',
@@ -136,6 +137,7 @@ return [
     'ckeditoradditions' => [
         'devBaseUrl' => 'assets/packages/ckeditoradditions/',
         'basePath'   => 'core.ckeditoradditions',
+        'position'   => CClientScript::POS_BEGIN,
         'js'         => [
             'ckeditoradditions.js',
         ],

--- a/application/models/AdminTheme.php
+++ b/application/models/AdminTheme.php
@@ -149,9 +149,8 @@ class AdminTheme extends CFormModel
             App()->getClientScript()->registerPackage('adminbasics'); // Combined scripts and style
             App()->getClientScript()->registerPackage('adminsidepanel'); // The new admin panel
             App()->getClientScript()->registerPackage('lstutorial'); // Tutorial scripts
-            App()->getClientScript()->registerPackage('ckeditor'); //
-            App()->getClientScript()->registerPackage('ckeditoradditions'); // CKEDITOR in a global scope
-            App()->getClientScript()->registerPackage('modaleditor');
+            // CKEditor (and the modaleditor, which depends on it) is only registered on pages
+            // that actually use an editor, via PrepareEditorScript(). See bug #19391.
         }
         App()->getClientScript()->registerPackage('select2-bootstrap');
         // Then we add the different CSS/JS files to load in arrays

--- a/application/views/admin/survey/prepareEditorScript_view.php
+++ b/application/views/admin/survey/prepareEditorScript_view.php
@@ -1,6 +1,13 @@
 <!--<script type="text/javascript" src="<?php echo Yii::app()->getConfig('sCKEditorURL'); ?>/ckeditor.js"></script>-->
 <?php
-$script = "
+// Register the editor packages here (not globally) so they are only loaded on pages that use an editor. See bug #19391.
+Yii::app()->getClientScript()->registerPackage('ckeditor');
+Yii::app()->getClientScript()->registerPackage('ckeditoradditions'); // CKEDITOR in a global scope
+Yii::app()->getClientScript()->registerPackage('modaleditor');
+
+// CKEDITOR event handlers. Under PJAX ckeditor.js is loaded asynchronously, so these are deferred
+// (see the guard at the end of this script) until CKEDITOR is available. See bug #19391.
+$ckeditorHandlers = "
     CKEDITOR.on('dialogDefinition', function (ev) {
         var dialogName = ev.data.name;
         var dialogDefinition = ev.data.definition;
@@ -27,12 +34,14 @@ $script = "
 * with LimeReplacementFields and in general use ProtectSource for ExpressionScript
 * See https://stackoverflow.com/questions/2851068/prevent-ckeditor-from-formatting-code-in-source-mode
 */
-$script .= "CKEDITOR.on('instanceReady', function(event) {
+$ckeditorHandlers .= "CKEDITOR.on('instanceReady', function(event) {
         var textareaId = event.editor.element.getId();
         $('#'+textareaId+'_htmleditor_loader').remove();
         event.editor.dataProcessor.writer.setRules( 'br', { breakAfterOpen: 0 } );
-    });    
+    });
+    ";
 
+$script = "
     var sReplacementFieldTitle = '" . gT('Placeholder fields', 'js') . "';
     var sReplacementFieldButton = '" . gT('Insert/edit placeholder field', 'js') . "';
     var sSwitchToolbarFullTitle = '" . gT('Show full toolbar', 'js') . "';
@@ -103,6 +112,17 @@ $script .= "CKEDITOR.on('instanceReady', function(event) {
         gid : '" . sanitize_int(App()->request->getQuery('gid', 0)) . "',
         qid : '" . sanitize_int(App()->request->getQuery('qid', 0)) . "',
         replacementFieldsPath : '" . $this->createUrl("/limereplacementfields/index") . "',
+    }
+
+    // CKEDITOR loads synchronously on a full page load but asynchronously under PJAX,
+    // so only register its event handlers once it is actually available. See bug #19391.
+    var lsRegisterCKEditorHandlers = function() {
+        $ckeditorHandlers
+    };
+    if (typeof CKEDITOR !== 'undefined') {
+        lsRegisterCKEditorHandlers();
+    } else {
+        jQuery(document).one('pjax:scriptcomplete', lsRegisterCKEditorHandlers);
     }
 ";
 


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CKEditor loading on survey editor pages, including navigation through PJAX.
  - Ensured editor dialogs and initialization handlers run reliably whether CKEditor loads immediately or afterward.
  - Prevented unnecessary editor resources from loading across unrelated admin pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->