### PR TITLE
Fixed issue #20533: When uploading an image in theme it does not appear in image select until manual refresh

### DIFF
--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -1673,7 +1673,8 @@ class SurveyAdministrationController extends LSBaseController
                         $templateName = App()->request->getPost('templatename');
                         $themeConfiguration = Template::model()->getInstance($templateName, $iSurveyID);
                         if ($themeConfiguration !== null && method_exists($themeConfiguration, 'getImageFileListEntry')) {
-                            $fileData = $themeConfiguration->getImageFileListEntry($returnedData['fileName']);
+                            $uploadedFilePath = $destDir . DIRECTORY_SEPARATOR . $returnedData['fileName'];
+                            $fileData = $themeConfiguration->getImageFileListEntry($returnedData['fileName'], $uploadedFilePath);
                         }
                     }
                 } else {

--- a/application/controllers/SurveyAdministrationController.php
+++ b/application/controllers/SurveyAdministrationController.php
@@ -1643,6 +1643,7 @@ class SurveyAdministrationController extends LSBaseController
         $iSurveyID = (int)Yii::app()->request->getPost('surveyid');
         $success = false;
         $debug = [];
+        $fileData = null;
         if (
             Permission::model()->hasSurveyPermission(
                 $iSurveyID,
@@ -1667,6 +1668,14 @@ class SurveyAdministrationController extends LSBaseController
                     $message = $returnedData['uploadResultMessage'];
                     $debug = $returnedData['debug'];
                     $success = $returnedData['success'];
+                    // Return the uploaded file's dropdown entry so the image selectors can be updated client-side.
+                    if ($success) {
+                        $templateName = App()->request->getPost('templatename');
+                        $themeConfiguration = Template::model()->getInstance($templateName, $iSurveyID);
+                        if ($themeConfiguration !== null && method_exists($themeConfiguration, 'getImageFileListEntry')) {
+                            $fileData = $themeConfiguration->getImageFileListEntry($returnedData['fileName']);
+                        }
+                    }
                 } else {
                     $message = sprintf(
                         gT("Incorrect permissions in your %s folder."),
@@ -1689,7 +1698,8 @@ class SurveyAdministrationController extends LSBaseController
                 'data' => [
                     'success' => $success,
                     'message' => $message,
-                    'debug' => $debug
+                    'debug' => $debug,
+                    'file' => $fileData
                 ]
             ),
         );

--- a/application/controllers/admin/Themes.php
+++ b/application/controllers/admin/Themes.php
@@ -271,9 +271,15 @@ class Themes extends SurveyCommonAction
             $success = true;
         };
 
+        // Return the uploaded file's dropdown entry so the image selectors can be updated client-side.
+        $fileData = null;
+        if ($success && method_exists($oTemplateConfiguration, 'getImageFileListEntry')) {
+            $fileData = $oTemplateConfiguration->getImageFileListEntry($filename);
+        }
+
         return App()->getController()->renderPartial(
             '/admin/super/_renderJson',
-            array('data' => ['success' => $success, 'message' => $uploadresult, 'debug' => $debug]),
+            array('data' => ['success' => $success, 'message' => $uploadresult, 'debug' => $debug, 'file' => $fileData]),
             false,
             false
         );

--- a/application/controllers/admin/Themes.php
+++ b/application/controllers/admin/Themes.php
@@ -274,7 +274,7 @@ class Themes extends SurveyCommonAction
         // Return the uploaded file's dropdown entry so the image selectors can be updated client-side.
         $fileData = null;
         if ($success && method_exists($oTemplateConfiguration, 'getImageFileListEntry')) {
-            $fileData = $oTemplateConfiguration->getImageFileListEntry($filename);
+            $fileData = $oTemplateConfiguration->getImageFileListEntry($filename, $fullfilepath);
         }
 
         return App()->getController()->renderPartial(

--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -1001,23 +1001,46 @@ class TemplateConfiguration extends TemplateConfig
      * matching the format used in the theme options image selectors. Used to update the selectors
      * client-side right after an image upload, without a full page reload.
      *
+     * The same filename can exist in several categories (theme, generalfiles, survey), so when the
+     * uploaded file's destination path is known, the entry whose real path matches it is preferred,
+     * falling back to the first filename match otherwise.
+     *
      * @param string $fileName
+     * @param string|null $destinationFilePath absolute path where the uploaded file was stored
      * @return array|null the dropdown entry, or null if the file is not found in the image file list.
      */
-    public function getImageFileListEntry($fileName)
+    public function getImageFileListEntry($fileName, $destinationFilePath = null)
     {
         $attributes = $this->getOptionPageAttributes();
+        $targetRealPath = empty($destinationFilePath) ? false : realpath($destinationFilePath);
+        $matchedImage = null;
         foreach ($attributes['imageFileList'] as $image) {
-            if ($image['filename'] === $fileName) {
-                return [
-                    'group' => $image['group'],
-                    'filename' => $image['filename'],
-                    'filepath' => $image['filepath'],
-                    'preview' => $image['preview'],
-                ];
+            if ($image['filename'] !== $fileName) {
+                continue;
             }
+            if ($targetRealPath !== false) {
+                $imageRealPath = realpath(App()->getConfig('rootdir') . DIRECTORY_SEPARATOR . $image['filepathOptions']);
+                if ($imageRealPath === $targetRealPath) {
+                    $matchedImage = $image;
+                    break;
+                }
+                if ($matchedImage === null) {
+                    $matchedImage = $image;
+                }
+                continue;
+            }
+            $matchedImage = $image;
+            break;
         }
-        return null;
+        if ($matchedImage === null) {
+            return null;
+        }
+        return [
+            'group' => $matchedImage['group'],
+            'filename' => $matchedImage['filename'],
+            'filepath' => $matchedImage['filepath'],
+            'preview' => $matchedImage['preview'],
+        ];
     }
 
     /**

--- a/application/models/TemplateConfiguration.php
+++ b/application/models/TemplateConfiguration.php
@@ -997,6 +997,30 @@ class TemplateConfiguration extends TemplateConfig
     }
 
     /**
+     * Returns the image dropdown entry (group, filename, filepath, preview) for a given file name,
+     * matching the format used in the theme options image selectors. Used to update the selectors
+     * client-side right after an image upload, without a full page reload.
+     *
+     * @param string $fileName
+     * @return array|null the dropdown entry, or null if the file is not found in the image file list.
+     */
+    public function getImageFileListEntry($fileName)
+    {
+        $attributes = $this->getOptionPageAttributes();
+        foreach ($attributes['imageFileList'] as $image) {
+            if ($image['filename'] === $fileName) {
+                return [
+                    'group' => $image['group'],
+                    'filename' => $image['filename'],
+                    'filepath' => $image['filepath'],
+                    'preview' => $image['preview'],
+                ];
+            }
+        }
+        return null;
+    }
+
+    /**
      * Resolves the file path for an option image by walking up the theme inheritance chain.
      *
      * @param string $imageFileName The image file name (e.g. 'cornerradius_0.svg')

--- a/application/models/services/FileUploadService.php
+++ b/application/models/services/FileUploadService.php
@@ -178,6 +178,7 @@ class FileUploadService
             'debug' => $debugInfoArray,
             'uploadResultMessage' => $uploadResult,
             'success' => $success,
+            'fileName' => $fileName,
         ];
     }
 

--- a/assets/packages/themeoptions-core/themeoptions-core.js
+++ b/assets/packages/themeoptions-core/themeoptions-core.js
@@ -617,7 +617,7 @@ $(function () {
                         LS.LsGlobalNotifier.createAlert(data.message, 'success', {showCloseButton: true});
                         $progressBar.css('width', '0%');
                         $progressBar.find('span.visually-hidden').text('0%');
-                        onSuccess(options.input);
+                        onSuccess(options.input, data);
                     } else {
                         LS.LsGlobalNotifier.createAlert(data.message, 'danger', {showCloseButton: true});
                         $progressBar.css('width', '0%');
@@ -642,7 +642,10 @@ $(function () {
     new BindUpload({
         form: '#upload_frontend',
         input: '#upload_image',
-        progress: '#upload_progress'
+        progress: '#upload_progress',
+        onSuccess: function (inputId, data) {
+            addUploadedImageToSelectors(data && data.file);
+        }
     });
     new BindUpload({
         form: '#upload_frontend',
@@ -651,18 +654,54 @@ $(function () {
         onBeforeSend: function () {
             $('.simple-template-edit-loading').css('display', 'block');
         },
-        onSuccess: function (inputId) {
-            let url = new URL(window.location.href);
-            let inputElement = document.querySelector(inputId);
-            if (inputElement !== null) {
-                url.hash = inputElement.closest('.CoreThemeOptions--settingsTab') !== null
-                    ? inputElement.closest('.CoreThemeOptions--settingsTab').id
-                    : '';
-            }
-            $(document).trigger('pjax:load', {
-                url: url.href
-            });
+        onSuccess: function (inputId, data) {
+            $('.simple-template-edit-loading').css('display', 'none');
+            addUploadedImageToSelectors(data && data.file);
         }
     });
+
+    // Adds a freshly uploaded image to the theme options image selectors so it becomes
+    // selectable immediately, without a full page reload. Falls back to a reload if the
+    // server didn't return the file info.
+    function addUploadedImageToSelectors(file) {
+        if (!file || !file.filepath) {
+            let url = new URL(window.location.href);
+            let activeTab = document.querySelector('.CoreThemeOptions--settingsTab.active');
+            url.hash = activeTab !== null ? activeTab.id : '';
+            $(document).trigger('pjax:load', { url: url.href });
+            return;
+        }
+        // Group options by their virtual path prefix (e.g. "image::generalfiles::").
+        let prefixMatch = String(file.filepath).match(/^(image::\w+::)/);
+        let prefix = prefixMatch ? prefixMatch[1] : null;
+        $('.selector_image_selector').each(function () {
+            let select = this;
+            // Skip if the image is already listed (e.g. an existing file was overwritten).
+            let exists = Array.prototype.some.call(select.options, function (opt) {
+                return opt.value === file.filepath;
+            });
+            if (exists) {
+                return;
+            }
+            let option = new Option(file.filename, file.filepath);
+            option.setAttribute('data-lightbox-src', file.preview || '');
+            // Insert after the last option of the same group, otherwise append.
+            let insertAfter = null;
+            if (prefix) {
+                Array.prototype.forEach.call(select.options, function (opt) {
+                    if (opt.value.indexOf(prefix) === 0) {
+                        insertAfter = opt;
+                    }
+                });
+            }
+            if (insertAfter && insertAfter.nextSibling) {
+                insertAfter.parentNode.insertBefore(option, insertAfter.nextSibling);
+            } else if (insertAfter) {
+                insertAfter.parentNode.appendChild(option);
+            } else {
+                select.appendChild(option);
+            }
+        });
+    }
 });
 


### PR DESCRIPTION


<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image uploads now return metadata for successfully uploaded files.
  - Theme image selectors update immediately after upload, including previews and file details.
  - Added fallback page refresh behavior when upload metadata is unavailable.

- **Bug Fixes**
  - Improved file matching when duplicate image filenames exist across categories.
  - Upload responses now consistently report the resolved filename.
  - Loading indicators clear correctly after frontend image uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->