### PR TITLE
Test show_comment in the data entry header, the condition repeated show_title

### DIFF
--- a/application/views/admin/dataentry/content_view.php
+++ b/application/views/admin/dataentry/content_view.php
@@ -421,7 +421,7 @@ echo viewHelper::getViewTestTag('dataEntryView');
         </script>
 
         <table border='0'>
-                <?php if ($qidattributes['show_title'] && $qidattributes['show_title']) { ?>
+                <?php if ($qidattributes['show_title'] && $qidattributes['show_comment']) { ?>
                 <tr><th>Title</th><th>Comment</th>
                 <?php } elseif ($qidattributes['show_title']) { ?>
                     <tr><th>Title</th>

--- a/application/views/admin/dataentry/content_view.php
+++ b/application/views/admin/dataentry/content_view.php
@@ -433,15 +433,13 @@ echo viewHelper::getViewTestTag('dataEntryView');
 
                 <?php for ($i = 0; $i < $maxfiles; $i++) { ?>
                 <tr>
-                    <?php if ($qidattributes['show_title']) {
-                        ;
-                    }  ?>
+                    <?php if ($qidattributes['show_title']) { ?>
                     <td align='center'><input type='text' id='<?php echo $fieldname; ?>_title_<?php echo $i; ?>' maxlength='100' onChange='updateJSON<?php echo $fieldname; ?>()' /></td>
+                    <?php } ?>
 
-                    <?php if ($qidattributes['show_comment']) {
-                        ;
-                    } ?>
+                    <?php if ($qidattributes['show_comment']) { ?>
                     <td align='center'><input type='text' id='<?php echo $fieldname; ?>_comment_<?php echo $i; ?>' maxlength='100' onChange='updateJSON<?php echo $fieldname; ?>()' /></td>
+                    <?php } ?>
 
                     <td align='center'><input type='file' name='<?php echo $fieldname; ?>_file_<?php echo $i; ?>' id='<?php echo $fieldname; ?>_file_<?php echo $i; ?>' onChange='updateJSON<?php echo $fieldname; ?>()' /></td></tr>
                 <?php } ?>


### PR DESCRIPTION
The header row for the data entry table tests `show_title` twice, so the branch that prints both `<th>Title</th>` and `<th>Comment</th>` is taken whenever the title is shown, and the `elseif` below it that prints the title alone can never be reached. A question with `show_title` on and `show_comment` off therefore gets a Comment column header with nothing under it.

The rest of the chain says what the first test was meant to be: the second branch handles title only, the third handles comment only, so the first is the both case and the second operand is `show_comment`.

I have not filed a ticket on bugs.limesurvey.org because I do not have an account there. Say the word and I will open one and rename the commit to your `Fixed issue #NNNNN` form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected vertical file upload question headers so the combined “Title” and “Comment” row appears only when both fields are enabled.
  - Ensured title and comment fields appear only when their corresponding options are selected.
  - Improved table alignment by keeping header columns and input cells consistent with the configured question settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->