### PR TITLE
Fixed issue #20670: PDF export displays file path instead of selected  image for image-select question types

### DIFF
--- a/application/config/internal.php
+++ b/application/config/internal.php
@@ -319,6 +319,7 @@ $internalConfig = array(
                 't'     => 'gT',
                 'gT'    => 'gT',
                 'isAbsoluteUrl' => 'check_absolute_url',
+                'isImageUrl' => 'check_image_url',
             ),
 
             'sandboxConfig' => array(
@@ -348,7 +349,8 @@ $internalConfig = array(
                     'upper',
                     'striptags',
                     'number_format',
-                    'isAbsoluteUrl'
+                    'isAbsoluteUrl',
+                    'isImageUrl'
                 ),
                 'methods' => array(
                     'ETwigViewRendererStaticClassProxy' =>  array("encode", "textfield", "form", "link", "emailField", "beginForm", "endForm", "dropDownList", "htmlButton", "passwordfield", "hiddenfield", "textArea", "checkBox", "tag"),

--- a/application/helpers/sanitize_helper.php
+++ b/application/helpers/sanitize_helper.php
@@ -574,6 +574,21 @@ function check_absolute_url($string)
 }
 
 /**
+ * Returns true if the argument looks like a path/URL to an image file (absolute or relative).
+ * @param string $string
+ * @return boolean
+ */
+function check_image_url($string)
+{
+    if (!is_string($string) || $string === '') {
+        return false;
+    }
+    // Strip query string/fragment before checking the file extension.
+    $path = strtok($string, '?#');
+    return (bool) preg_match('/\.(jpe?g|png|gif|bmp|webp|svg)$/i', (string) $path);
+}
+
+/**
  * Remove all chars from $value that are not alphanumeric or dash or underscore
  *
  * @param string $value

--- a/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_list-radio.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_list-radio.twig
@@ -5,6 +5,8 @@
         <div class="col-lg-4 text-end">
             {% if question.answercode == '-oth-' %}
                 {{question.answeroption.answer|escape}}
+            {% elseif question.question_theme_name == 'image_select-listradio' and question.answeroption.answer|isImageUrl %}
+                <img src="{{ question.answeroption.answer|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
             {% else %}
                 {{question.answeroption.answer}}
             {%endif %}

--- a/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_list-radio.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_list-radio.twig
@@ -6,7 +6,7 @@
             {% if question.answercode == '-oth-' %}
                 {{question.answeroption.answer|escape}}
             {% elseif question.question_theme_name == 'image_select-listradio' and question.answeroption.answer|isImageUrl %}
-                <img src="{{ question.answeroption.answer|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                <img src="{{ question.answeroption.answer|escape('html') }}" style="max-width:150px;max-height:150px;" />
             {% else %}
                 {{question.answeroption.answer}}
             {%endif %}

--- a/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_multiple-opt.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_multiple-opt.twig
@@ -11,7 +11,14 @@
                 {% endif %}
             </div>
             <div class="col-lg-8 text-start">
-                <b>{{subquestion.question}} {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}</b>
+                <b>
+                    {% if question.question_theme_name == 'image_select-multiplechoice' and subquestion.question|isImageUrl %}
+                        <img src="{{ subquestion.question|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                    {% else %}
+                        {{subquestion.question}}
+                    {% endif %}
+                    {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}
+                </b>
             </div>
         </div>
     {% endfor %}

--- a/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_multiple-opt.twig
+++ b/themes/survey/fruity_twentythree/views/subviews/printanswers/question_types/template_multiple-opt.twig
@@ -13,11 +13,11 @@
             <div class="col-lg-8 text-start">
                 <b>
                     {% if question.question_theme_name == 'image_select-multiplechoice' and subquestion.question|isImageUrl %}
-                        <img src="{{ subquestion.question|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                        <img src="{{ subquestion.question|escape('html') }}" style="max-width:150px;max-height:150px;" />
                     {% else %}
                         {{subquestion.question}}
                     {% endif %}
-                    {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}
+                    {% if subquestion.qid != 'other' %} ({{subquestion.qid}}){% endif %}
                 </b>
             </div>
         </div>

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-radio.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-radio.twig
@@ -5,6 +5,8 @@
         <div class="col-lg-4 text-end">
             {% if question.answercode == '-oth-' %}
                 {{question.answeroption.answer|escape}}
+            {% elseif question.question_theme_name == 'image_select-listradio' and question.answeroption.answer|isImageUrl %}
+                <img src="{{ question.answeroption.answer|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
             {% else %}
                 {{question.answeroption.answer}}
             {%endif %}

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-radio.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_list-radio.twig
@@ -6,7 +6,7 @@
             {% if question.answercode == '-oth-' %}
                 {{question.answeroption.answer|escape}}
             {% elseif question.question_theme_name == 'image_select-listradio' and question.answeroption.answer|isImageUrl %}
-                <img src="{{ question.answeroption.answer|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                <img src="{{ question.answeroption.answer|escape('html') }}" style="max-width:150px;max-height:150px;" />
             {% else %}
                 {{question.answeroption.answer}}
             {%endif %}

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_multiple-opt.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_multiple-opt.twig
@@ -11,7 +11,14 @@
                 {% endif %}
             </div>
             <div class="col-lg-8 text-start">
-                <b>{{subquestion.question}} {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}</b>
+                <b>
+                    {% if question.question_theme_name == 'image_select-multiplechoice' and subquestion.question|isImageUrl %}
+                        <img src="{{ subquestion.question|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                    {% else %}
+                        {{subquestion.question}}
+                    {% endif %}
+                    {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}
+                </b>
             </div>
         </div>
     {% endfor %}

--- a/themes/survey/vanilla/views/subviews/printanswers/question_types/template_multiple-opt.twig
+++ b/themes/survey/vanilla/views/subviews/printanswers/question_types/template_multiple-opt.twig
@@ -13,11 +13,11 @@
             <div class="col-lg-8 text-start">
                 <b>
                     {% if question.question_theme_name == 'image_select-multiplechoice' and subquestion.question|isImageUrl %}
-                        <img src="{{ subquestion.question|escape('html_attr') }}" style="max-width:150px;max-height:150px;" />
+                        <img src="{{ subquestion.question|escape('html') }}" style="max-width:150px;max-height:150px;" />
                     {% else %}
                         {{subquestion.question}}
                     {% endif %}
-                    {% if subquestion.qid != 'other' %}({{subquestion.qid}}){% endif %}
+                    {% if subquestion.qid != 'other' %} ({{subquestion.qid}}){% endif %}
                 </b>
             </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image URL recognition for supported image formats, including URLs with query strings or fragments.
  * Survey answer printouts now display valid image URLs as escaped, size-limited images for image-based question types.
  * Non-image answers continue to display as text across supported themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->