### PR TITLE
JD-124: stack bar chart as default for arrays

### DIFF
--- a/editor/src/pages/Responses/components/ResponsesStatistics/ChartRenderV2.js
+++ b/editor/src/pages/Responses/components/ResponsesStatistics/ChartRenderV2.js
@@ -95,7 +95,8 @@ const VIEWS = [
     label: () => t('Stacked bar chart'),
     icon: (props) => <StackedBarIcon width="20" height="22" {...props} />,
     // Array numbers shows means, which don't stack — grouped only.
-    isAvailable: ({ isArray, isArrayNumbers }) => isArray && !isArrayNumbers,
+    isAvailable: ({ isArray, isArrayText, isArrayNumbers }) =>
+      isArray && !isArrayText && !isArrayNumbers,
     render: ({ data, valueType, isDualScale }) => (
       <StackedBarChart
         data={data}
@@ -108,7 +109,8 @@ const VIEWS = [
     value: VIEW.GROUPED_BAR,
     label: () => t('Grouped bar chart'),
     icon: () => <i className="ri-bar-chart-horizontal-line"></i>,
-    isAvailable: ({ isArray, isDualScale }) => isArray && !isDualScale,
+    isAvailable: ({ isArray, isArrayText, isDualScale }) =>
+      isArray && !isArrayText && !isDualScale,
     render: ({ data, valueType }) => (
       <GroupedBarChart
         data={getSegmentedCategories(data)}
@@ -280,6 +282,25 @@ const writeHiddenCharts = (hidden) => {
 const getStorageKey = (surveyId, chartId, index) =>
   `${surveyId ?? 'unknown'}:${chartId ?? `index-${index}`}`
 
+const getDefaultView = (availableViews, viewContext) => {
+  const preferredViews = [
+    viewContext.isArrayText && VIEW.TABLE,
+    viewContext.isArray && !viewContext.isArrayNumbers && VIEW.STACKED_BAR,
+    viewContext.isNumerical && VIEW.TABLE,
+    viewContext.isMultiNumerical && VIEW.GRID,
+    VIEW.BAR_CHART,
+    VIEW.TABLE,
+  ].filter(Boolean)
+
+  return (
+    preferredViews.find((view) =>
+      availableViews.some(({ value }) => value === view)
+    ) ??
+    availableViews[0]?.value ??
+    VIEW.TABLE
+  )
+}
+
 export const ChartRendererV2 = ({
   data,
   index = 0,
@@ -308,22 +329,6 @@ export const ChartRendererV2 = ({
   const isText = TEXT_QUESTION_TYPES.includes(question?.type)
   const isArrayNumbers = question?.type === QT_COLON_ARRAY_NUMBERS
   const isDualScale = question?.type === QT_1_ARRAY_DUAL
-  const getDefaultView = () => {
-    if (isArray && !isArrayNumbers) {
-      return VIEW.STACKED_BAR
-    }
-
-    if (isNumerical) {
-      return VIEW.TABLE
-    }
-
-    if (isMultiNumerical) {
-      return VIEW.GRID
-    }
-
-    return VIEW.BAR_CHART
-  }
-  const [view, setView] = useState(getDefaultView)
   const effectiveValueType =
     isArrayNumbers || isRanking ? VALUE_TYPE.COUNT : valueType
   // No responses for this question when every answer option has a zero count.
@@ -348,6 +353,9 @@ export const ChartRendererV2 = ({
 
   const availableViews = VIEWS.filter(
     ({ isAvailable }) => isAvailable?.(viewContext) ?? true
+  )
+  const [view, setView] = useState(() =>
+    getDefaultView(availableViews, viewContext)
   )
   // `menuOnly` hides a view from the quick toggle (it stays in the meatball
   // menu); it can be a flag or a predicate of the view context.

--- a/editor/src/pages/Responses/components/ResponsesStatistics/ChartRenderV2.js
+++ b/editor/src/pages/Responses/components/ResponsesStatistics/ChartRenderV2.js
@@ -296,9 +296,6 @@ export const ChartRendererV2 = ({
     [QT_S_SHORT_FREE_TEXT, QT_T_LONG_FREE_TEXT, QT_U_HUGE_FREE_TEXT].includes(
       question?.type
     )
-  const [view, setView] = useState(
-    isNumerical ? VIEW.TABLE : isMultiNumerical ? VIEW.GRID : VIEW.BAR_CHART
-  )
   const [commentsAnswer, setCommentsAnswer] = useState(null)
   const cardRef = useRef(null)
   const isImage = isImageTheme(question?.themeName)
@@ -311,6 +308,22 @@ export const ChartRendererV2 = ({
   const isText = TEXT_QUESTION_TYPES.includes(question?.type)
   const isArrayNumbers = question?.type === QT_COLON_ARRAY_NUMBERS
   const isDualScale = question?.type === QT_1_ARRAY_DUAL
+  const getDefaultView = () => {
+    if (isArray && !isArrayNumbers) {
+      return VIEW.STACKED_BAR
+    }
+
+    if (isNumerical) {
+      return VIEW.TABLE
+    }
+
+    if (isMultiNumerical) {
+      return VIEW.GRID
+    }
+
+    return VIEW.BAR_CHART
+  }
+  const [view, setView] = useState(getDefaultView)
   const effectiveValueType =
     isArrayNumbers || isRanking ? VALUE_TYPE.COUNT : valueType
   // No responses for this question when every answer option has a zero count.


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default chart selection based on question type and available views.
  * Array-text questions now remain in the table view instead of opening as stacked or grouped bar charts.
  * Numerical and multi-numerical questions continue to default to table and grid views, respectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->