### PR TITLE
Fixed issue #20626: Bounce tracking freezes at latest 6.x and 7.x version

### DIFF
--- a/application/views/admin/token/_bounceProcessingModal.php
+++ b/application/views/admin/token/_bounceProcessingModal.php
@@ -1,0 +1,22 @@
+<div id="tokenBounceModal" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><?php eT('Bounce processing');?></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Here will come the result of the ajax request -->
+                <p class='modal-body-text'>
+
+                </p>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-bs-dismiss="modal">
+                    <?php eT("Cancel");?>
+                </button>
+            </div>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/application/views/admin/token/browse.php
+++ b/application/views/admin/token/browse.php
@@ -113,3 +113,5 @@ $aLanguageNames = implode(";", $aLanguageNames);
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
+
+<?php $this->renderPartial('/admin/token/_bounceProcessingModal'); ?>

--- a/application/views/admin/token/surveyParticipantView.php
+++ b/application/views/admin/token/surveyParticipantView.php
@@ -254,3 +254,5 @@ echo viewHelper::getViewTestTag('surveyParticipantsIndex');
         </div><!-- /.modal-dialog -->
     </div><!-- /.modal -->
 </div>
+
+<?php $this->renderPartial('/admin/token/_bounceProcessingModal'); ?>

--- a/application/views/surveyAdministration/partial/topbar_tokens/rightSideButtons.php
+++ b/application/views/surveyAdministration/partial/topbar_tokens/rightSideButtons.php
@@ -70,28 +70,3 @@ if ($tokenexists) {
         );
     }
 }
-
-?>
-
-<div id="tokenBounceModal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title"><?php eT('Bounce processing');?></h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <!-- Here will come the result of the ajax request -->
-                <p class='modal-body-text'>
-
-                </p>
-
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-bs-dismiss="modal">
-                    <?php eT("Cancel");?>
-                </button>
-            </div>
-        </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bounce-processing modal to token administration and survey participant views.
  * The modal displays processing results and includes Cancel and dismiss controls.

* **Refactor**
  * Consolidated bounce-processing modal display into a shared view component across relevant token management pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->