### PR TITLE
Fixed issue #20680: update 706 fails on pgsql if index is missing

### DIFF
--- a/application/helpers/update/updates/Update_706.php
+++ b/application/helpers/update/updates/Update_706.php
@@ -113,10 +113,12 @@ class Update_706 extends DatabaseUpdateBase
      */
     private function dropOldEmailIndex()
     {
+        setTransactionBookmark();
         try {
             $this->db->createCommand()->dropIndex('{{idx2_users}}', '{{users}}');
         } catch (\Exception $e) {
             // Index may not exist in all installations.
+            rollBackToTransactionBookmark();
         }
     }
 


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database update reliability by rolling back a failed index-removal attempt to a transaction bookmark, preventing the transaction from remaining in an invalid state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->