### PR TITLE
Feature : Add route guard support for survey pages

### DIFF
--- a/editor/src/plugins/slots.js
+++ b/editor/src/plugins/slots.js
@@ -1,5 +1,6 @@
 // plugins available slots to inject custom content/logic into
 export const PLUGIN_SLOTS = {
+  APP_ROUTE_GUARD: 'app:route:guard',
   TOP_BAR_RIGHT: 'topbar:right',
   EDITOR_TOP: 'editor:top',
   EDITOR_LAYOUT_EXTRA: 'editor:layout:extra',

--- a/editor/src/routes.js
+++ b/editor/src/routes.js
@@ -10,6 +10,8 @@ import { PermissionsProvider } from 'providers/PermissionsProvider'
 import { TopBar } from 'components/TopBar'
 import { useAppState } from 'hooks'
 import { STATES } from 'helpers'
+import { PluginSlot } from 'plugins/PluginSlot'
+import { PLUGIN_SLOTS } from 'plugins/slots'
 
 const RootLayout = () => {
   const [topbarConfig] = useAppState(STATES.TOPBAR_CONFIG)
@@ -21,6 +23,14 @@ const RootLayout = () => {
     </>
   )
 }
+
+const GuardedSurveyRoute = ({ children }) => (
+  <AuthGate>
+    <PluginSlot slotName={PLUGIN_SLOTS.APP_ROUTE_GUARD} fallback={children}>
+      {children}
+    </PluginSlot>
+  </AuthGate>
+)
 
 const routes = [
   {
@@ -42,17 +52,17 @@ const routes = [
       {
         path: '/responses/:surveyId/:panel?/:menu?',
         element: (
-          <AuthGate>
+          <GuardedSurveyRoute>
             <PermissionsProvider>
               <Responses />
             </PermissionsProvider>
-          </AuthGate>
+          </GuardedSurveyRoute>
         ),
       },
       {
         path: '/survey/:surveyId/:panel?/:menu?',
         element: (
-          <AuthGate>
+          <GuardedSurveyRoute>
             <PermissionsProvider>
               <SurveyWorkspace>
                 <EditorContextController>
@@ -61,19 +71,19 @@ const routes = [
                 </EditorContextController>
               </SurveyWorkspace>
             </PermissionsProvider>
-          </AuthGate>
+          </GuardedSurveyRoute>
         ),
       },
       {
         path: '/sharing/:surveyId/:panel?/:menu?',
         element: (
-          <AuthGate>
+          <GuardedSurveyRoute>
             <PermissionsProvider>
               <SurveyWorkspace>
                 <SharingPanel />
               </SurveyWorkspace>
             </PermissionsProvider>
-          </AuthGate>
+          </GuardedSurveyRoute>
         ),
       },
       {


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an extension point for route guards, enabling plugins to participate in access control for survey, response, and sharing pages.
  - Updated protected routes to support customizable guard behavior while retaining the existing authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->