### PR TITLE
JD-121: Highlight placeholders as badges in help text and answers

### DIFF
--- a/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
+++ b/editor/src/components/UIComponents/ContentEditor/ContentEditable.js
@@ -4,8 +4,10 @@ import ReactContentEditable from 'react-contenteditable'
 import { useAppState } from 'hooks'
 import {
   RemoveHTMLTagsInString,
+  removePlaceholderBadges,
   ReplaceQuestionCodesWithAnswers,
   STATES,
+  wrapPlaceholdersInBadges,
 } from 'helpers'
 import { PluginSlot } from 'plugins/PluginSlot'
 import { PLUGIN_SLOTS } from 'plugins/slots'
@@ -28,13 +30,18 @@ export const ContentEditable = ({
   const inputRef = useRef(null)
 
   const onChange = (value) => {
-    const parsedValue = RemoveHTMLTagsInString(value, ['br', 'p'])
+    const parsedValue = RemoveHTMLTagsInString(removePlaceholderBadges(value), [
+      'br',
+      'p',
+    ])
     setQuestionTitle(parsedValue)
     handleOnChange(parsedValue)
   }
 
   const handleFocus = () => {
     setIsFocused(true)
+    // Show the raw placeholder text while editing, so the badges don't get in the way.
+    setQuestionTitle(removePlaceholderBadges(questionTitle?.toString() ?? ''))
     onFocus()
   }
 
@@ -52,7 +59,7 @@ export const ContentEditable = ({
       ? ReplaceQuestionCodesWithAnswers(value, codeToQuestion)
       : value
 
-    setQuestionTitle(title)
+    setQuestionTitle(wrapPlaceholdersInBadges(title?.toString() ?? ''))
   }, [value, codeToQuestion, isFocused])
 
   useEffect(() => {

--- a/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
+++ b/editor/src/components/UIComponents/ContentEditor/TinyMCE/TinyMCE.js
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Editor } from '@tinymce/tinymce-react'
-import { htmlPopup, RandomNumber } from 'helpers'
+import {
+  htmlPopup,
+  RandomNumber,
+  removePlaceholderBadges,
+  wrapPlaceholdersInBadges,
+} from 'helpers'
 import beautify from 'js-beautify'
 
 import { CodeEditor } from '../CodeEditor/CodeEditor'
@@ -32,7 +37,7 @@ export const TinyMCE = ({
   const [firstLoad, setFirstLoad] = useState(true)
   const [isDisabled, setIsDisabled] = useState(disabled)
   const [editorValue, setEditorValue] = useState(
-    value.replace(/(\{[^{}]+\})/g, '<badge>$1</badge>')
+    wrapPlaceholdersInBadges(value)
   )
   const [isFocused, setIsFocused] = useState(false)
   const codeToQuestionRef = useRef(codeToQuestion)
@@ -104,10 +109,7 @@ export const TinyMCE = ({
       return
     }
 
-    const normalizedContent = editorValueRef.current.replace(
-      /<badge>(\{[^{}]+\})<\/badge>/g,
-      '$1'
-    )
+    const normalizedContent = removePlaceholderBadges(editorValueRef.current)
 
     setEditorValue(normalizedContent)
   }
@@ -117,10 +119,7 @@ export const TinyMCE = ({
       return
     }
 
-    const transformedContent = editorValueRef.current.replace(
-      /(\{[^{}]+\})/g,
-      '<badge>$1</badge>'
-    )
+    const transformedContent = wrapPlaceholdersInBadges(editorValueRef.current)
 
     setEditorValue(transformedContent)
   }

--- a/editor/src/helpers/placeholder.js
+++ b/editor/src/helpers/placeholder.js
@@ -16,3 +16,20 @@ export const getQuestionPlaceholders = (language, question) => {
 export const isPlaceholderInUse = (language, question, placeholderKey) => {
   return getQuestionPlaceholders(language, question).includes(placeholderKey)
 }
+
+// Placeholders are highlighted with a <badge> tag so researchers can see at a
+// glance that a question or answer uses one. See the `badge` rule in
+// themes/contenteditor/content-editor.scss for the styling.
+const PLACEHOLDER_REGEX = /(\{[^{}]+\})/g
+const PLACEHOLDER_BADGE_REGEX = /<badge>(\{[^{}]+\})<\/badge>/g
+
+export const wrapPlaceholdersInBadges = (text = '') => {
+  return removePlaceholderBadges(text).replace(
+    PLACEHOLDER_REGEX,
+    '<badge>$1</badge>'
+  )
+}
+
+export const removePlaceholderBadges = (text = '') => {
+  return text.replace(PLACEHOLDER_BADGE_REGEX, '$1')
+}

--- a/editor/src/helpers/tests/placeholder.test.js
+++ b/editor/src/helpers/tests/placeholder.test.js
@@ -1,0 +1,50 @@
+import { removePlaceholderBadges, wrapPlaceholdersInBadges } from 'helpers'
+
+describe('wrapPlaceholdersInBadges', () => {
+  it('should wrap a participant placeholder in a badge', () => {
+    const result = wrapPlaceholdersInBadges('Dear {TOKEN:FIRSTNAME}')
+    expect(result).toBe('Dear <badge>{TOKEN:FIRSTNAME}</badge>')
+  })
+
+  it('should wrap survey and previous answer placeholders in badges', () => {
+    const result = wrapPlaceholdersInBadges('{SID} {EXPIRY} {Q00_SQ001.shown}')
+    expect(result).toBe(
+      '<badge>{SID}</badge> <badge>{EXPIRY}</badge> <badge>{Q00_SQ001.shown}</badge>'
+    )
+  })
+
+  it('should leave text without placeholders untouched', () => {
+    const result = wrapPlaceholdersInBadges('Apples')
+    expect(result).toBe('Apples')
+  })
+
+  it('should not wrap a placeholder twice when called repeatedly', () => {
+    const once = wrapPlaceholdersInBadges('Apples {TOKEN:FIRSTNAME}')
+    const twice = wrapPlaceholdersInBadges(once)
+    expect(twice).toBe(once)
+  })
+
+  it('should handle empty and missing input gracefully', () => {
+    expect(wrapPlaceholdersInBadges('')).toBe('')
+    expect(wrapPlaceholdersInBadges()).toBe('')
+  })
+})
+
+describe('removePlaceholderBadges', () => {
+  it('should unwrap a badge back to the raw placeholder', () => {
+    const result = removePlaceholderBadges(
+      'Dear <badge>{TOKEN:FIRSTNAME}</badge>'
+    )
+    expect(result).toBe('Dear {TOKEN:FIRSTNAME}')
+  })
+
+  it('should keep the original text when wrapping and unwrapping', () => {
+    const value = 'Survey ID {SID}, expires {EXPIRY}.'
+    expect(removePlaceholderBadges(wrapPlaceholdersInBadges(value))).toBe(value)
+  })
+
+  it('should handle empty and missing input gracefully', () => {
+    expect(removePlaceholderBadges('')).toBe('')
+    expect(removePlaceholderBadges()).toBe('')
+  })
+})


### PR DESCRIPTION
New feature #JD-121: Highlight placeholders as badges in help text and answers

Dev: Extracted badge wrap/strip helpers into helpers/placeholder.js and reused them in TinyMCE.
Dev: Applied them in ContentEditable so non-toolbar surfaces highlight placeholders too.
Dev: Badges are display-only and stripped before saving.

<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved placeholder rendering in the content editor.
  - Placeholders now display as raw text while editing and as visual badges when the editor is not focused.
  - Existing placeholder badges are handled cleanly, preventing duplicate badge wrapping and preserving placeholder text during editing and synchronization.

- **Bug Fixes**
  - Improved handling of participant, survey, and previous-answer placeholders, including empty or plain-text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->