### PR TITLE
Fixed issue: improved update 709 to prevent fails

### DIFF
--- a/application/helpers/update/updates/Update_709.php
+++ b/application/helpers/update/updates/Update_709.php
@@ -18,15 +18,22 @@ class Update_709 extends DatabaseUpdateBase
     {
         addColumn("{{responses_" . $sid . "}}", "Q{$parent_qid}", "JSON");
         $alterElements = [];
+        $quotedCols = [];
         foreach ($cols as $col) {
             $quotedCol = $this->db->quoteColumnName($col);
+            $quotedCols[] = $quotedCol;
             // JSON_QUOTE() both quotes AND escapes the value (", \, control chars, ...),
             // so we never build invalid JSON from the raw cell content.
             // Emit NULL (not '') for empty values so CONCAT_WS skips them and never
             // produces a leading/trailing/double comma, which would be invalid JSON.
             $alterElements[] = "CASE WHEN LENGTH({$quotedCol}) > 0 THEN JSON_QUOTE({$quotedCol}) ELSE NULL END";
         }
-        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')";
+        $concatWs = "CONCAT_WS(',', " . implode(',', $alterElements) . ")";
+        // Only store NULL when every underlying sub-question column is genuinely NULL
+        // (never answered at all). If at least one column is a non-NULL empty string,
+        // the response was recorded as "empty" and should yield '[]', not NULL.
+        $allNullCheck = "COALESCE(" . implode(',', $quotedCols) . ") IS NULL";
+        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CASE WHEN {$allNullCheck} THEN NULL ELSE CONCAT('[', {$concatWs}, ']') END";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);
@@ -44,15 +51,22 @@ class Update_709 extends DatabaseUpdateBase
     {
         addColumn("{{responses_" . $sid . "}}", "Q{$parent_qid}", "json");
         $alterElements = [];
+        $quotedCols = [];
         foreach ($cols as $col) {
             $quotedCol = $this->db->quoteColumnName($col);
+            $quotedCols[] = $quotedCol;
             // STRING_ESCAPE(..., 'json') escapes ", \, control chars, ... per JSON rules;
             // we still add the surrounding quotes ourselves since it only escapes content.
             // Emit NULL (not '') for empty values so CONCAT_WS skips them and never
             // produces a leading/trailing/double comma, which would be invalid JSON.
             $alterElements[] = "CASE WHEN LEN({$quotedCol}) > 0 THEN CONCAT('\"', STRING_ESCAPE({$quotedCol}, 'json'), '\"') ELSE NULL END";
         }
-        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')";
+        $concatWs = "CONCAT_WS(',', " . implode(',', $alterElements) . ")";
+        // Only store NULL when every underlying sub-question column is genuinely NULL
+        // (never answered at all). If at least one column is a non-NULL empty string,
+        // the response was recorded as "empty" and should yield '[]', not NULL.
+        $allNullCheck = "COALESCE(" . implode(',', $quotedCols) . ") IS NULL";
+        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CASE WHEN {$allNullCheck} THEN NULL ELSE CONCAT('[', {$concatWs}, ']') END";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);
@@ -72,16 +86,22 @@ class Update_709 extends DatabaseUpdateBase
         $this->db->createCommand("alter table {{responses_" . $sid . "}} add column {$newColumn} json")->execute();
 
         $alterElements = [];
+        $quotedCols = [];
         foreach ($cols as $col) {
             $quotedCol = $this->db->quoteColumnName($col);
+            $quotedCols[] = $quotedCol;
             // to_json() both quotes AND escapes the value (", \, control chars, ...),
             // so we never build invalid JSON from the raw cell content.
             // Emit NULL (not '') for empty values so concat_ws skips them and never
             // produces a leading/trailing/double comma, which would be invalid JSON.
             $alterElements[] = "CASE WHEN LENGTH({$quotedCol}) > 0 THEN to_json({$quotedCol})::text ELSE NULL END";
         }
-
-        $updateCommand = "UPDATE {{responses_{$sid}}} SET {$newColumn} = (CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')::json)";
+        $concatWs = "concat_ws(',', " . implode(',', $alterElements) . ")";
+        // Only store NULL when every underlying sub-question column is genuinely NULL
+        // (never answered at all). If at least one column is a non-NULL empty string,
+        // the response was recorded as "empty" and should yield '[]', not NULL.
+        $allNullCheck = "COALESCE(" . implode(',', $quotedCols) . ") IS NULL";
+        $updateCommand = "UPDATE {{responses_{$sid}}} SET {$newColumn} = (CASE WHEN {$allNullCheck} THEN NULL ELSE CONCAT('[', {$concatWs}, ']') END)::json";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);

--- a/application/helpers/update/updates/Update_709.php
+++ b/application/helpers/update/updates/Update_709.php
@@ -59,7 +59,7 @@ class Update_709 extends DatabaseUpdateBase
             // we still add the surrounding quotes ourselves since it only escapes content.
             // Emit NULL (not '') for empty values so CONCAT_WS skips them and never
             // produces a leading/trailing/double comma, which would be invalid JSON.
-            $alterElements[] = "CASE WHEN LEN({$quotedCol}) > 0 THEN CONCAT('\"', STRING_ESCAPE({$quotedCol}, 'json'), '\"') ELSE NULL END";
+            $alterElements[] = "CASE WHEN DATALENGTH({$quotedCol}) > 0 THEN CONCAT('\"', STRING_ESCAPE({$quotedCol}, 'json'), '\"') ELSE NULL END";
         }
         $concatWs = "CONCAT_WS(',', " . implode(',', $alterElements) . ")";
         // Only store NULL when every underlying sub-question column is genuinely NULL

--- a/application/helpers/update/updates/Update_709.php
+++ b/application/helpers/update/updates/Update_709.php
@@ -19,11 +19,14 @@ class Update_709 extends DatabaseUpdateBase
         addColumn("{{responses_" . $sid . "}}", "Q{$parent_qid}", "JSON");
         $alterElements = [];
         foreach ($cols as $col) {
-            $alterElements[] = (!count($alterElements) ?
-            "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT('\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END," :
-            "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT(',\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END,");
+            $quotedCol = $this->db->quoteColumnName($col);
+            // JSON_QUOTE() both quotes AND escapes the value (", \, control chars, ...),
+            // so we never build invalid JSON from the raw cell content.
+            // Emit NULL (not '') for empty values so CONCAT_WS skips them and never
+            // produces a leading/trailing/double comma, which would be invalid JSON.
+            $alterElements[] = "CASE WHEN LENGTH({$quotedCol}) > 0 THEN JSON_QUOTE({$quotedCol}) ELSE NULL END";
         }
-        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', " . implode($alterElements) . " ']')";
+        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);
@@ -42,11 +45,14 @@ class Update_709 extends DatabaseUpdateBase
         addColumn("{{responses_" . $sid . "}}", "Q{$parent_qid}", "json");
         $alterElements = [];
         foreach ($cols as $col) {
-            $alterElements[] = (!count($alterElements) ?
-            "CASE WHEN LEN(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT('\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END," :
-            "CASE WHEN LEN(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT(',\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END,");
+            $quotedCol = $this->db->quoteColumnName($col);
+            // STRING_ESCAPE(..., 'json') escapes ", \, control chars, ... per JSON rules;
+            // we still add the surrounding quotes ourselves since it only escapes content.
+            // Emit NULL (not '') for empty values so CONCAT_WS skips them and never
+            // produces a leading/trailing/double comma, which would be invalid JSON.
+            $alterElements[] = "CASE WHEN LEN({$quotedCol}) > 0 THEN CONCAT('\"', STRING_ESCAPE({$quotedCol}, 'json'), '\"') ELSE NULL END";
         }
-        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', " . implode($alterElements) . " ']')";
+        $updateCommand = "UPDATE {{responses_" . $sid . "}} SET Q{$parent_qid} = CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);
@@ -67,12 +73,15 @@ class Update_709 extends DatabaseUpdateBase
 
         $alterElements = [];
         foreach ($cols as $col) {
-            $alterElements[] = (!count($alterElements) ?
-            "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT('\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END," :
-            "CASE WHEN LENGTH(" . $this->db->quoteColumnName($col) . ") > 0 THEN CONCAT(',\"', " . $this->db->quoteColumnName($col) . ", '\"') ELSE '' END,");
+            $quotedCol = $this->db->quoteColumnName($col);
+            // to_json() both quotes AND escapes the value (", \, control chars, ...),
+            // so we never build invalid JSON from the raw cell content.
+            // Emit NULL (not '') for empty values so concat_ws skips them and never
+            // produces a leading/trailing/double comma, which would be invalid JSON.
+            $alterElements[] = "CASE WHEN LENGTH({$quotedCol}) > 0 THEN to_json({$quotedCol})::text ELSE NULL END";
         }
 
-        $updateCommand = "UPDATE {{responses_{$sid}}} SET {$newColumn} = (CONCAT('[', " . implode($alterElements) . " ']')::json)";
+        $updateCommand = "UPDATE {{responses_{$sid}}} SET {$newColumn} = (CONCAT('[', CONCAT_WS(',', " . implode(',', $alterElements) . "), ']')::json)";
         $this->db->createCommand($updateCommand)->execute();
         foreach ($cols as $col) {
             dropColumn("{{responses_" . $sid . "}}", $col);


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database updates now preserve `NULL` when all source sub-question values are `NULL`.
  * JSON arrays are built only when at least one source value is present.
  * Improved handling of empty and partially populated values across supported databases.
  * Space-only response values are now preserved correctly in SQL Server updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->