### PR TITLE
Fixed issue #14980: Multiple variation CSS files loaded for one theme

### DIFF
--- a/application/models/TemplateConfig.php
+++ b/application/models/TemplateConfig.php
@@ -1235,10 +1235,15 @@ class TemplateConfig extends CActiveRecord
 
 
     /**
-     * Change the mother template configuration depending on template settings
-     * @var $sType     string   the type of settings to change (css or js)
-     * @var $aSettings array    array of local setting
-     * @return array
+     * Reconciles this template's own file settings (add/replace) against its ancestor
+     * templates' packages: for each locally-existing file it removes the corresponding
+     * entry from every ancestor package up the inheritance chain (so the local file is
+     * the only one loaded), and for each file that doesn't exist locally it locates the
+     * nearest ancestor that provides it and registers it there instead.
+     *
+     * @param string $sType the type of settings to change ('css' or 'js')
+     * @param array $aSettings array of local file settings (file names) to reconcile
+     * @return array the (possibly reduced) array of local file settings
      */
     protected function changeMotherConfiguration($sType, $aSettings)
     {
@@ -1253,11 +1258,19 @@ class TemplateConfig extends CActiveRecord
                     continue;
                 }
                 if (file_exists($this->path . $sFileName)) {
-                    App()->clientScript->removeFileFromPackage(
-                        $this->oMotherTemplate->sPackageName,
-                        $sType,
-                        $sFileName
-                    );
+                    // The file being replaced/removed may have been declared by any ancestor
+                    // in the inheritance chain, not just the direct mother template (mantis #14980).
+                    // Walk the whole chain so it gets removed from whichever package actually
+                    // registered it, instead of leaving it (and thus loading it) further up.
+                    $oAncestorTemplate = $this->oMotherTemplate;
+                    while ($oAncestorTemplate instanceof TemplateConfiguration) {
+                        App()->clientScript->removeFileFromPackage(
+                            $oAncestorTemplate->sPackageName,
+                            $sType,
+                            $sFileName
+                        );
+                        $oAncestorTemplate = $oAncestorTemplate->oMotherTemplate;
+                    }
                 } else {
                     // File doesn't exist locally, so it should be removed
                     $key = array_search($sFileName, $aSettings);


### PR DESCRIPTION
<!-- 
# Thank you for contributing to LimeSurvey!

To make our work easier, please make sure to follow the instructions below.

## Guidelines

- A pull request to LimeSurvey can either be a **bug fix**, a **new feature**, or an **internal development fix** (refactoring etc).
- For bug fixes and new features, you must include the number to the Mantis issue from [bugs.limesurvey.org](https://bugs.limesurvey.org). If no issue exists yet, please create it.
- Make sure to write down exactly how to reproduce a bug.
- For smaller internal changes, a Mantis issue is not necessary, but bigger refactoring tasks should always be discussed in a Mantis issue before implementation.

## Branch policy

- **Fixed issues** should always go to the **master** branch, UNLESS they fix an issue in a yet unreleased feature in the develop branch.
- **New features** should always go to the **major-develop** or ***minor-develop** branches. For more information about release schedule and code requirements, please see the following manual pages:
  - [LimeSurvey roadmap - Current release schedule](https://manual.limesurvey.org/LimeSurvey_roadmap#Current_release_schedule)
  - [How to contribute new features](https://manual.limesurvey.org/How_to_contribute_new_features)

## PR type

> Keep one of the below lines and delete the others.

Fixed issue #<Mantis issue number>: <Description>
New feature #<Mantis issue number>: <Description>
Dev: <Description for a change that's neither a feature nor a bug>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template configuration changes now correctly remove locally overridden files across the full template inheritance chain, including ancestor templates.
  * Improved consistency when reconciling local and inherited file settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->